### PR TITLE
feat: load and validate workflows (#2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,10 +115,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cc"
+version = "1.2.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
 
 [[package]]
 name = "clap"
@@ -156,6 +202,23 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
+]
 
 [[package]]
 name = "difflib"
@@ -206,7 +269,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono-tz",
  "clap",
+ "cron",
  "dirs",
  "humantime",
  "predicates",
@@ -222,12 +287,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -271,6 +366,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +404,17 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -306,6 +436,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -345,6 +481,30 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "predicates"
@@ -454,6 +614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +657,24 @@ checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -615,10 +799,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -627,6 +909,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "dirs",
  "humantime",
  "predicates",
+ "rustix",
  "serde",
  "tempfile",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.20"
 toml = "0.9"
 
+[target.'cfg(unix)'.dependencies]
+rustix = { version = "1.1", features = ["fs"] }
+
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ description = "A local-first supervisor for agent workflows"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
+chrono-tz = "0.10"
+cron = "0.15"
 dirs = "6.0"
 humantime = "2.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod config;
+pub mod workflow;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use factory::config::{Config, default_config_path};
+use factory::workflow::WorkflowCatalog;
 
 #[derive(Debug, Parser)]
 #[command(name = "factory", version, about)]
@@ -20,6 +21,12 @@ enum Command {
         #[arg(long)]
         config: Option<PathBuf>,
     },
+    /// List resolved workflows without executing their prompts.
+    Workflows {
+        /// Path to the Factory configuration file.
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -30,6 +37,16 @@ fn main() -> Result<()> {
             let path = config.unwrap_or_else(default_config_path);
             let config = Config::load(&path)?;
             print!("{config}");
+        }
+        Command::Workflows { config } => {
+            let path = config.unwrap_or_else(default_config_path);
+            let config = Config::load(&path)?;
+            let catalog = WorkflowCatalog::load(&config)?;
+            print!("{catalog}");
+            let invalid = catalog.invalid_count();
+            if invalid > 0 {
+                anyhow::bail!("workflow catalog contains {invalid} invalid workflow(s)");
+            }
         }
     }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,0 +1,501 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono_tz::Tz;
+use cron::Schedule;
+use serde::Deserialize;
+
+use crate::config::Config;
+
+const WORKFLOW_DIRECTORY: &str = ".factory/workflows";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowCatalog {
+    pub entries: Vec<WorkflowEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowEntry {
+    pub repository: PathBuf,
+    pub path: PathBuf,
+    pub id: String,
+    pub trigger: Option<Trigger>,
+    pub runtime: Option<String>,
+    pub timeout: Option<Duration>,
+    pub prompt: Option<String>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Trigger {
+    Schedule { expression: String, timezone: Tz },
+    Label(String),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Frontmatter {
+    schedule: Option<String>,
+    timezone: Option<String>,
+    label: Option<String>,
+    runtime: Option<String>,
+    timeout: Option<String>,
+}
+
+impl WorkflowCatalog {
+    pub fn load(config: &Config) -> Result<Self> {
+        let mut entries = Vec::new();
+        for repository in &config.repositories {
+            entries.extend(load_repository(repository, config));
+        }
+        mark_duplicate_ids(&mut entries);
+        entries.sort_by(|left, right| {
+            (&left.repository, &left.id, &left.path).cmp(&(
+                &right.repository,
+                &right.id,
+                &right.path,
+            ))
+        });
+        Ok(Self { entries })
+    }
+
+    pub fn invalid_count(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|entry| !entry.errors.is_empty())
+            .count()
+    }
+}
+
+impl fmt::Display for WorkflowCatalog {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            formatter,
+            "REPOSITORY\tWORKFLOW\tTRIGGER\tRUNTIME\tTIMEOUT\tVALIDITY"
+        )?;
+        for entry in &self.entries {
+            let trigger = entry
+                .trigger
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "-".to_owned());
+            let runtime = entry.runtime.as_deref().unwrap_or("-");
+            let timeout = entry
+                .timeout
+                .map(humantime::format_duration)
+                .map(|duration| duration.to_string())
+                .unwrap_or_else(|| "-".to_owned());
+            let validity = if entry.errors.is_empty() {
+                "valid".to_owned()
+            } else {
+                format!("invalid: {}", entry.errors.join("; "))
+            };
+            writeln!(
+                formatter,
+                "{}\t{}\t{}\t{}\t{}\t{}",
+                entry.repository.display(),
+                entry.id,
+                trigger,
+                runtime,
+                timeout,
+                validity
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Trigger {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Schedule {
+                expression,
+                timezone,
+            } => write!(formatter, "schedule {expression:?} ({timezone})"),
+            Self::Label(label) => write!(formatter, "label {label:?}"),
+        }
+    }
+}
+
+fn load_repository(repository: &Path, config: &Config) -> Vec<WorkflowEntry> {
+    let directory = repository.join(WORKFLOW_DIRECTORY);
+    let metadata = match fs::symlink_metadata(&directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(error) => {
+            return vec![invalid_entry(
+                repository,
+                &directory,
+                "<workflow-directory>",
+                &format!("could not inspect workflow directory: {error}"),
+            )];
+        }
+    };
+    if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
+        return vec![invalid_entry(
+            repository,
+            &directory,
+            "<workflow-directory>",
+            "workflow path must be a regular directory and not a symlink",
+        )];
+    }
+
+    let read_dir = match fs::read_dir(&directory) {
+        Ok(read_dir) => read_dir,
+        Err(error) => {
+            return vec![invalid_entry(
+                repository,
+                &directory,
+                "<workflow-directory>",
+                &format!("could not read workflow directory: {error}"),
+            )];
+        }
+    };
+    let mut paths = Vec::new();
+    let mut entries = Vec::new();
+    for (index, result) in read_dir.enumerate() {
+        match result {
+            Ok(entry) => paths.push(entry.path()),
+            Err(error) => entries.push(invalid_entry(
+                repository,
+                &directory,
+                &format!("<unreadable-entry-{index}>"),
+                &format!("could not read workflow directory entry: {error}"),
+            )),
+        }
+    }
+    paths.sort();
+
+    entries.extend(
+        paths
+            .into_iter()
+            .filter(|path| is_markdown_path(path))
+            .map(|path| load_file(repository, &path, config)),
+    );
+    entries
+}
+
+fn load_file(repository: &Path, path: &Path, config: &Config) -> WorkflowEntry {
+    let id = workflow_id(path);
+    let mut entry = WorkflowEntry {
+        repository: repository.to_path_buf(),
+        path: path.to_path_buf(),
+        id,
+        trigger: None,
+        runtime: None,
+        timeout: None,
+        prompt: None,
+        errors: Vec::new(),
+    };
+
+    if !valid_workflow_id(&entry.id) {
+        entry.errors.push(format!(
+            "filename must produce a lowercase kebab-case workflow ID, got {:?}",
+            entry.id
+        ));
+    }
+
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) => {
+            entry
+                .errors
+                .push(format!("could not inspect file: {error}"));
+            return entry;
+        }
+    };
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        entry
+            .errors
+            .push("workflow must be a regular file and not a symlink".to_owned());
+        return entry;
+    }
+
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            entry
+                .errors
+                .push(format!("could not read workflow as UTF-8: {error}"));
+            return entry;
+        }
+    };
+    let (frontmatter, prompt) = match split_frontmatter(&contents) {
+        Ok(parts) => parts,
+        Err(error) => {
+            entry.errors.push(error);
+            return entry;
+        }
+    };
+    if prompt.trim().is_empty() {
+        entry
+            .errors
+            .push("prompt body must not be empty".to_owned());
+    } else {
+        entry.prompt = Some(prompt);
+    }
+
+    let raw: Frontmatter = match toml::from_str(&frontmatter) {
+        Ok(raw) => raw,
+        Err(error) => {
+            entry
+                .errors
+                .push(format!("invalid TOML frontmatter: {error}"));
+            return entry;
+        }
+    };
+    let Frontmatter {
+        schedule,
+        timezone,
+        label,
+        runtime,
+        timeout,
+    } = raw;
+    entry.runtime = resolve_runtime(runtime, &config.default_runtime, &mut entry.errors);
+    entry.timeout = resolve_timeout(
+        timeout,
+        config.default_timeout,
+        config.maximum_timeout,
+        &mut entry.errors,
+    );
+    entry.trigger = resolve_trigger(schedule, timezone, label, &mut entry.errors);
+    entry
+}
+
+fn split_frontmatter(contents: &str) -> std::result::Result<(String, String), String> {
+    let contents = contents.replace("\r\n", "\n");
+    let Some(after_opening) = contents.strip_prefix("+++\n") else {
+        return Err("workflow must begin with TOML frontmatter delimited by +++".to_owned());
+    };
+    let Some(closing) = after_opening
+        .lines()
+        .scan(0, |offset, line| {
+            let start = *offset;
+            *offset += line.len() + 1;
+            Some((start, line))
+        })
+        .find_map(|(offset, line)| (line == "+++").then_some(offset))
+    else {
+        return Err("workflow frontmatter is missing its closing +++ delimiter".to_owned());
+    };
+    let prompt_start = closing + "+++".len();
+    let prompt_start = if after_opening.as_bytes().get(prompt_start) == Some(&b'\n') {
+        prompt_start + 1
+    } else {
+        prompt_start
+    };
+    Ok((
+        after_opening[..closing].to_owned(),
+        after_opening[prompt_start..].to_owned(),
+    ))
+}
+
+fn resolve_runtime(
+    runtime: Option<String>,
+    default: &str,
+    errors: &mut Vec<String>,
+) -> Option<String> {
+    let runtime = runtime.as_deref().unwrap_or(default).trim();
+    if runtime.is_empty() {
+        errors.push("runtime must not be empty".to_owned());
+        None
+    } else {
+        Some(runtime.to_owned())
+    }
+}
+
+fn resolve_timeout(
+    timeout: Option<String>,
+    default: Duration,
+    maximum: Duration,
+    errors: &mut Vec<String>,
+) -> Option<Duration> {
+    let Some(timeout) = timeout else {
+        return Some(default);
+    };
+    match humantime::parse_duration(&timeout) {
+        Ok(duration) if duration.is_zero() => {
+            errors.push("timeout must be greater than zero".to_owned());
+            None
+        }
+        Ok(duration) if duration > maximum => {
+            errors.push(format!(
+                "timeout {} exceeds maximum_timeout {}",
+                humantime::format_duration(duration),
+                humantime::format_duration(maximum)
+            ));
+            None
+        }
+        Ok(duration) => Some(duration),
+        Err(error) => {
+            errors.push(format!("timeout has invalid duration {timeout:?}: {error}"));
+            None
+        }
+    }
+}
+
+fn resolve_trigger(
+    schedule: Option<String>,
+    timezone: Option<String>,
+    label: Option<String>,
+    errors: &mut Vec<String>,
+) -> Option<Trigger> {
+    match (schedule, label) {
+        (Some(_), Some(_)) => {
+            errors.push("workflow must declare exactly one trigger, not schedule and label".into());
+            None
+        }
+        (None, None) => {
+            errors.push("workflow must declare exactly one trigger: schedule or label".into());
+            None
+        }
+        (Some(schedule), None) => {
+            let error_count = errors.len();
+            let timezone = match timezone {
+                Some(timezone) => match Tz::from_str(timezone.trim()) {
+                    Ok(timezone) => Some(timezone),
+                    Err(_) => {
+                        errors.push(format!("timezone is invalid: {timezone:?}"));
+                        None
+                    }
+                },
+                None => {
+                    errors.push("scheduled workflow must declare timezone".to_owned());
+                    None
+                }
+            };
+            if !valid_cron(&schedule) {
+                errors.push(format!(
+                    "schedule must be a valid five-field cron expression: {schedule:?}"
+                ));
+            }
+            if errors.len() == error_count {
+                Some(Trigger::Schedule {
+                    expression: schedule,
+                    timezone: timezone.expect("timezone was validated"),
+                })
+            } else {
+                None
+            }
+        }
+        (None, Some(label)) => {
+            let error_count = errors.len();
+            if timezone.is_some() {
+                errors.push("timezone is only valid with a schedule trigger".to_owned());
+            }
+            if !valid_label(&label) {
+                errors.push(
+                    "label must be 1-50 characters without leading, trailing, or control whitespace"
+                        .to_owned(),
+                );
+            }
+            if errors.len() == error_count {
+                Some(Trigger::Label(label))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+fn valid_cron(value: &str) -> bool {
+    value.split_whitespace().count() == 5 && Schedule::from_str(&format!("0 {value}")).is_ok()
+}
+
+fn valid_label(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().count() <= 50
+        && value.trim() == value
+        && !value.chars().any(char::is_control)
+}
+
+fn is_markdown_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+}
+
+fn workflow_id(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("<invalid-filename>")
+        .to_ascii_lowercase()
+}
+
+fn valid_workflow_id(id: &str) -> bool {
+    !id.is_empty()
+        && id != "<invalid-filename>"
+        && id.split('-').all(|part| {
+            !part.is_empty()
+                && part
+                    .chars()
+                    .all(|character| character.is_ascii_lowercase() || character.is_ascii_digit())
+        })
+}
+
+fn mark_duplicate_ids(entries: &mut [WorkflowEntry]) {
+    let mut groups: HashMap<(PathBuf, String), Vec<usize>> = HashMap::new();
+    for (index, entry) in entries.iter().enumerate() {
+        groups
+            .entry((entry.repository.clone(), entry.id.clone()))
+            .or_default()
+            .push(index);
+    }
+    for ((_, id), indices) in groups {
+        if indices.len() > 1 {
+            for index in indices {
+                entries[index]
+                    .errors
+                    .push(format!("duplicate workflow ID {id:?} in repository"));
+            }
+        }
+    }
+}
+
+fn invalid_entry(repository: &Path, path: &Path, id: &str, error: &str) -> WorkflowEntry {
+    WorkflowEntry {
+        repository: repository.to_path_buf(),
+        path: path.to_path_buf(),
+        id: id.to_owned(),
+        trigger: None,
+        runtime: None,
+        timeout: None,
+        prompt: None,
+        errors: vec![error.to_owned()],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_five_field_cron() {
+        assert!(valid_cron("0 9 * * 1"));
+        assert!(!valid_cron("0 0 9 * * 1"));
+        assert!(!valid_cron("eventually"));
+    }
+
+    #[test]
+    fn marks_every_duplicate_invalid() {
+        let repository = PathBuf::from("/repo");
+        let mut entries = vec![
+            invalid_entry(&repository, Path::new("one.md"), "same", "first"),
+            invalid_entry(&repository, Path::new("two.md"), "same", "second"),
+        ];
+
+        mark_duplicate_ids(&mut entries);
+
+        assert!(entries.iter().all(|entry| {
+            entry
+                .errors
+                .iter()
+                .any(|error| error.contains("duplicate workflow ID"))
+        }));
+    }
+}

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::fs;
+use std::fs::{self, File};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
@@ -74,10 +75,16 @@ impl WorkflowCatalog {
 
 impl fmt::Display for WorkflowCatalog {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(
-            formatter,
-            "REPOSITORY\tWORKFLOW\tTRIGGER\tRUNTIME\tTIMEOUT\tVALIDITY"
-        )?;
+        let headers = [
+            "REPOSITORY",
+            "WORKFLOW",
+            "TRIGGER",
+            "RUNTIME",
+            "TIMEOUT",
+            "VALIDITY",
+        ]
+        .map(sanitize_catalog_cell);
+        writeln!(formatter, "{}", headers.join("\t"))?;
         for entry in &self.entries {
             let trigger = entry
                 .trigger
@@ -95,16 +102,16 @@ impl fmt::Display for WorkflowCatalog {
             } else {
                 format!("invalid: {}", entry.errors.join("; "))
             };
-            writeln!(
-                formatter,
-                "{}\t{}\t{}\t{}\t{}\t{}",
-                entry.repository.display(),
-                entry.id,
+            let cells = [
+                entry.repository.display().to_string(),
+                entry.id.clone(),
                 trigger,
-                runtime,
+                runtime.to_owned(),
                 timeout,
-                validity
-            )?;
+                validity,
+            ]
+            .map(|cell| sanitize_catalog_cell(&cell));
+            writeln!(formatter, "{}", cells.join("\t"))?;
         }
         Ok(())
     }
@@ -277,15 +284,37 @@ fn load_file(repository: &Path, path: &Path, config: &Config) -> WorkflowEntry {
         }
     }
 
-    let contents = match fs::read_to_string(path) {
-        Ok(contents) => contents,
+    let mut file = match open_workflow_file(path) {
+        Ok(file) => file,
         Err(error) => {
             entry
                 .errors
-                .push(format!("could not read workflow as UTF-8: {error}"));
+                .push(format!("could not safely open workflow: {error}"));
             return entry;
         }
     };
+    match file.metadata() {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => {
+            entry
+                .errors
+                .push("opened workflow is not a regular file".to_owned());
+            return entry;
+        }
+        Err(error) => {
+            entry
+                .errors
+                .push(format!("could not inspect opened workflow: {error}"));
+            return entry;
+        }
+    }
+    let mut contents = String::new();
+    if let Err(error) = file.read_to_string(&mut contents) {
+        entry
+            .errors
+            .push(format!("could not read workflow as UTF-8: {error}"));
+        return entry;
+    }
     let (frontmatter, prompt) = match split_frontmatter(&contents) {
         Ok(parts) => parts,
         Err(error) => {
@@ -499,6 +528,35 @@ fn valid_workflow_id(id: &str) -> bool {
         })
 }
 
+fn sanitize_catalog_cell(value: &str) -> String {
+    let mut sanitized = String::with_capacity(value.len());
+    for character in value.chars() {
+        if character.is_control() {
+            sanitized.extend(character.escape_default());
+        } else {
+            sanitized.push(character);
+        }
+    }
+    sanitized
+}
+
+#[cfg(unix)]
+fn open_workflow_file(path: &Path) -> std::io::Result<File> {
+    use rustix::fs::{Mode, OFlags, open};
+
+    let descriptor = open(
+        path,
+        OFlags::RDONLY | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::empty(),
+    )?;
+    Ok(descriptor.into())
+}
+
+#[cfg(not(unix))]
+fn open_workflow_file(path: &Path) -> std::io::Result<File> {
+    File::open(path)
+}
+
 fn mark_duplicate_ids(entries: &mut [WorkflowEntry]) {
     let mut groups: HashMap<(PathBuf, String), Vec<usize>> = HashMap::new();
     for (index, entry) in entries.iter().enumerate() {
@@ -558,5 +616,19 @@ mod tests {
                 .iter()
                 .any(|error| error.contains("duplicate workflow ID"))
         }));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn no_follow_open_rejects_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target.md");
+        let link = temp.path().join("link.md");
+        fs::write(&target, "prompt").unwrap();
+        symlink(target, &link).unwrap();
+
+        assert!(open_workflow_file(&link).is_err());
     }
 }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -123,10 +123,37 @@ impl fmt::Display for Trigger {
 }
 
 fn load_repository(repository: &Path, config: &Config) -> Vec<WorkflowEntry> {
+    let factory_directory = repository.join(".factory");
     let directory = repository.join(WORKFLOW_DIRECTORY);
-    let metadata = match fs::symlink_metadata(&directory) {
+    let factory_metadata = match fs::symlink_metadata(&factory_directory) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(error) => {
+            return vec![invalid_entry(
+                repository,
+                &directory,
+                "<workflow-directory>",
+                &format!("could not inspect .factory directory: {error}"),
+            )];
+        }
+    };
+    if !factory_metadata.file_type().is_dir() && !factory_metadata.file_type().is_symlink() {
+        return vec![invalid_entry(
+            repository,
+            &directory,
+            "<workflow-directory>",
+            ".factory path must be a directory",
+        )];
+    }
+
+    let metadata = match fs::symlink_metadata(&directory) {
+        Ok(metadata) => metadata,
+        Err(error)
+            if error.kind() == std::io::ErrorKind::NotFound
+                && !factory_metadata.file_type().is_symlink() =>
+        {
+            return Vec::new();
+        }
         Err(error) => {
             return vec![invalid_entry(
                 repository,
@@ -144,8 +171,27 @@ fn load_repository(repository: &Path, config: &Config) -> Vec<WorkflowEntry> {
             "workflow path must be a regular directory and not a symlink",
         )];
     }
+    let canonical_directory = match directory.canonicalize() {
+        Ok(directory) => directory,
+        Err(error) => {
+            return vec![invalid_entry(
+                repository,
+                &directory,
+                "<workflow-directory>",
+                &format!("could not resolve workflow directory: {error}"),
+            )];
+        }
+    };
+    if !canonical_directory.starts_with(repository) {
+        return vec![invalid_entry(
+            repository,
+            &directory,
+            "<workflow-directory>",
+            "workflow directory resolves outside the configured repository",
+        )];
+    }
 
-    let read_dir = match fs::read_dir(&directory) {
+    let read_dir = match fs::read_dir(&canonical_directory) {
         Ok(read_dir) => read_dir,
         Err(error) => {
             return vec![invalid_entry(
@@ -214,6 +260,21 @@ fn load_file(repository: &Path, path: &Path, config: &Config) -> WorkflowEntry {
             .errors
             .push("workflow must be a regular file and not a symlink".to_owned());
         return entry;
+    }
+    match path.canonicalize() {
+        Ok(canonical) if canonical.starts_with(repository) => {}
+        Ok(_) => {
+            entry
+                .errors
+                .push("workflow resolves outside the configured repository".to_owned());
+            return entry;
+        }
+        Err(error) => {
+            entry
+                .errors
+                .push(format!("could not resolve workflow file: {error}"));
+            return entry;
+        }
     }
 
     let contents = match fs::read_to_string(path) {

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -288,6 +288,37 @@ fn unsafe_workflow_directory_does_not_hide_other_repositories() {
     assert!(catalog.to_string().contains("not a symlink"));
 }
 
+#[cfg(unix)]
+#[test]
+fn rejects_workflows_reached_through_symlinked_factory_ancestor() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let outside_factory = temp.path().join("outside-factory");
+    let outside_workflows = outside_factory.join("workflows");
+    let workspace = temp.path().join("worktrees");
+    fs::create_dir(&repository).unwrap();
+    fs::create_dir_all(&outside_workflows).unwrap();
+    fs::create_dir(&workspace).unwrap();
+    fs::write(
+        outside_workflows.join("escaped.md"),
+        label_workflow("This prompt is outside the repository."),
+    )
+    .unwrap();
+    symlink(&outside_factory, repository.join(".factory")).unwrap();
+    let config_path = temp.path().join("config.toml");
+    write_config(&config_path, &[&repository], &workspace);
+
+    let config = Config::load(&config_path).unwrap();
+    let catalog = WorkflowCatalog::load(&config).unwrap();
+
+    assert_eq!(catalog.invalid_count(), 1);
+    assert_eq!(catalog.entries[0].id, "<workflow-directory>");
+    assert!(catalog.entries[0].prompt.is_none());
+    assert!(catalog.entries[0].errors[0].contains("resolves outside the configured repository"));
+}
+
 #[test]
 fn workflows_command_lists_resolved_catalog_and_fails_for_invalid_entries() {
     let fixture = Fixture::new();

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -1,0 +1,331 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use assert_cmd::Command;
+use factory::config::Config;
+use factory::workflow::{Trigger, WorkflowCatalog};
+use predicates::prelude::*;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    repository: PathBuf,
+    config: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repository");
+        let workflows = repository.join(".factory/workflows");
+        let workspace = temp.path().join("worktrees");
+        fs::create_dir_all(&workflows).unwrap();
+        fs::create_dir(&workspace).unwrap();
+        let config = temp.path().join("config.toml");
+        write_config(&config, &[&repository], &workspace);
+        Self {
+            _temp: temp,
+            repository,
+            config,
+        }
+    }
+
+    fn workflow(&self, name: &str, contents: &str) -> PathBuf {
+        let path = self.repository.join(".factory/workflows").join(name);
+        fs::write(&path, contents).unwrap();
+        path
+    }
+
+    fn catalog(&self) -> WorkflowCatalog {
+        let config = Config::load(&self.config).unwrap();
+        WorkflowCatalog::load(&config).unwrap()
+    }
+}
+
+fn write_config(path: &Path, repositories: &[&Path], workspace: &Path) {
+    let repositories = repositories
+        .iter()
+        .map(|repository| format!("\"{}\"", repository.display()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        path,
+        format!(
+            r#"repositories = [{repositories}]
+poll_every = "30s"
+default_runtime = "codex"
+default_timeout = "2h"
+maximum_timeout = "8h"
+max_concurrent_runs = 2
+workspace_root = "{}"
+"#,
+            workspace.display()
+        ),
+    )
+    .unwrap();
+}
+
+fn scheduled_workflow(prompt: &str) -> String {
+    format!(
+        r#"+++
+schedule = "0 9 * * 1"
+timezone = "Europe/London"
++++
+
+{prompt}
+"#
+    )
+}
+
+fn label_workflow(prompt: &str) -> String {
+    format!(
+        r#"+++
+label = "factory:ready"
++++
+
+{prompt}
+"#
+    )
+}
+
+#[test]
+fn loads_valid_schedule_and_label_workflows_with_resolved_defaults() {
+    let fixture = Fixture::new();
+    fixture.workflow(
+        "Find-Bugs.md",
+        r#"+++
+schedule = "0 9 * * 1"
+timezone = "Europe/London"
+runtime = "claude"
+timeout = "45m"
++++
+
+Review the code for verified bugs.
+"#,
+    );
+    fixture.workflow(
+        "implement-ready-ticket.md",
+        &label_workflow("Take the ticket to a green pull request."),
+    );
+
+    let catalog = fixture.catalog();
+
+    assert_eq!(catalog.invalid_count(), 0);
+    assert_eq!(catalog.entries.len(), 2);
+    let scheduled = &catalog.entries[0];
+    assert_eq!(scheduled.id, "find-bugs");
+    assert_eq!(scheduled.runtime.as_deref(), Some("claude"));
+    assert_eq!(scheduled.timeout, Some(Duration::from_secs(45 * 60)));
+    assert!(matches!(
+        scheduled.trigger,
+        Some(Trigger::Schedule { ref expression, timezone })
+            if expression == "0 9 * * 1" && timezone.name() == "Europe/London"
+    ));
+    let labelled = &catalog.entries[1];
+    assert_eq!(labelled.runtime.as_deref(), Some("codex"));
+    assert_eq!(labelled.timeout, Some(Duration::from_secs(2 * 60 * 60)));
+    assert_eq!(
+        labelled.trigger,
+        Some(Trigger::Label("factory:ready".to_owned()))
+    );
+}
+
+#[test]
+fn reports_all_invalid_workflows_without_hiding_valid_entries() {
+    let fixture = Fixture::new();
+    fixture.workflow("valid.md", &label_workflow("A useful prompt."));
+    fixture.workflow("missing-prompt.md", "+++\nlabel = \"factory:ready\"\n+++\n");
+    fixture.workflow(
+        "unknown-field.md",
+        "+++\nlabel = \"factory:ready\"\nsurprise = true\n+++\nPrompt.\n",
+    );
+    fixture.workflow(
+        "invalid-cron.md",
+        &scheduled_workflow("Prompt.").replace("0 9 * * 1", "eventually"),
+    );
+    fixture.workflow(
+        "invalid-timezone.md",
+        &scheduled_workflow("Prompt.").replace("Europe/London", "Middle/Earth"),
+    );
+    fixture.workflow(
+        "invalid-label.md",
+        "+++\nlabel = \" factory:ready \"\n+++\nPrompt.\n",
+    );
+    fixture.workflow(
+        "two-triggers.md",
+        "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nlabel = \"factory:ready\"\n+++\nPrompt.\n",
+    );
+
+    let catalog = fixture.catalog();
+
+    assert_eq!(catalog.entries.len(), 7);
+    assert_eq!(catalog.invalid_count(), 6);
+    assert!(catalog.entries.iter().any(|entry| entry.id == "valid"));
+    let output = catalog.to_string();
+    for expected in [
+        "prompt body must not be empty",
+        "unknown field `surprise`",
+        "valid five-field cron expression",
+        "timezone is invalid",
+        "label must be 1-50 characters",
+        "not schedule and label",
+    ] {
+        assert!(
+            output.contains(expected),
+            "missing {expected:?} in {output}"
+        );
+    }
+}
+
+#[test]
+fn rejects_missing_trigger_timezone_and_invalid_timeout() {
+    let fixture = Fixture::new();
+    fixture.workflow("no-trigger.md", "+++\n+++\nPrompt.\n");
+    fixture.workflow(
+        "no-timezone.md",
+        "+++\nschedule = \"0 9 * * 1\"\n+++\nPrompt.\n",
+    );
+    fixture.workflow(
+        "bad-timeout.md",
+        "+++\nlabel = \"factory:ready\"\ntimeout = \"forever\"\n+++\nPrompt.\n",
+    );
+    fixture.workflow(
+        "long-timeout.md",
+        "+++\nlabel = \"factory:ready\"\ntimeout = \"9h\"\n+++\nPrompt.\n",
+    );
+
+    let output = fixture.catalog().to_string();
+
+    assert!(output.contains("exactly one trigger"));
+    assert!(output.contains("must declare timezone"));
+    assert!(output.contains("timeout has invalid duration"));
+    assert!(output.contains("exceeds maximum_timeout"));
+}
+
+#[test]
+fn duplicate_ids_are_reported_for_every_duplicate_entry() {
+    let fixture = Fixture::new();
+    fixture.workflow("same.md", &label_workflow("Prompt."));
+    let workspace = fixture._temp.path().join("worktrees");
+    write_config(
+        &fixture.config,
+        &[&fixture.repository, &fixture.repository],
+        &workspace,
+    );
+
+    let catalog = fixture.catalog();
+
+    assert_eq!(catalog.entries.len(), 2);
+    assert_eq!(catalog.invalid_count(), 2);
+    assert!(catalog.entries.iter().all(|entry| {
+        entry
+            .errors
+            .iter()
+            .any(|error| error.contains("duplicate workflow ID"))
+    }));
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_symlinked_workflow_files() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = Fixture::new();
+    let outside = fixture._temp.path().join("outside.md");
+    fs::write(&outside, label_workflow("Do not load me.")).unwrap();
+    let workflow = fixture.repository.join(".factory/workflows/unsafe.md");
+    symlink(outside, workflow).unwrap();
+
+    let catalog = fixture.catalog();
+
+    assert_eq!(catalog.invalid_count(), 1);
+    assert!(catalog.entries[0].prompt.is_none());
+    assert!(catalog.entries[0].errors[0].contains("not a symlink"));
+}
+
+#[cfg(unix)]
+#[test]
+fn unsafe_workflow_directory_does_not_hide_other_repositories() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().unwrap();
+    let valid_repository = temp.path().join("valid-repository");
+    let valid_workflows = valid_repository.join(".factory/workflows");
+    fs::create_dir_all(&valid_workflows).unwrap();
+    fs::write(
+        valid_workflows.join("valid.md"),
+        label_workflow("A valid prompt."),
+    )
+    .unwrap();
+
+    let unsafe_repository = temp.path().join("unsafe-repository");
+    let unsafe_factory = unsafe_repository.join(".factory");
+    let outside = temp.path().join("outside-workflows");
+    fs::create_dir_all(&unsafe_factory).unwrap();
+    fs::create_dir(&outside).unwrap();
+    symlink(&outside, unsafe_factory.join("workflows")).unwrap();
+
+    let workspace = temp.path().join("worktrees");
+    fs::create_dir(&workspace).unwrap();
+    let config_path = temp.path().join("config.toml");
+    write_config(
+        &config_path,
+        &[&valid_repository, &unsafe_repository],
+        &workspace,
+    );
+
+    let config = Config::load(&config_path).unwrap();
+    let catalog = WorkflowCatalog::load(&config).unwrap();
+
+    assert_eq!(catalog.entries.len(), 2);
+    assert_eq!(catalog.invalid_count(), 1);
+    assert!(
+        catalog
+            .entries
+            .iter()
+            .any(|entry| entry.id == "valid" && entry.errors.is_empty())
+    );
+    assert!(catalog.to_string().contains("not a symlink"));
+}
+
+#[test]
+fn workflows_command_lists_resolved_catalog_and_fails_for_invalid_entries() {
+    let fixture = Fixture::new();
+    fixture.workflow("find-bugs.md", &scheduled_workflow("Review the code."));
+    fixture.workflow("broken.md", "+++\nlabel = \"factory:ready\"\n+++\n");
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["workflows", "--config", fixture.config.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("REPOSITORY\tWORKFLOW"))
+        .stdout(predicate::str::contains(
+            fixture.repository.to_str().unwrap(),
+        ))
+        .stdout(predicate::str::contains("find-bugs"))
+        .stdout(predicate::str::contains(
+            "schedule \"0 9 * * 1\" (Europe/London)",
+        ))
+        .stdout(predicate::str::contains("codex\t2h\tvalid"))
+        .stdout(predicate::str::contains("broken"))
+        .stdout(predicate::str::contains("prompt body must not be empty"))
+        .stderr(predicate::str::contains(
+            "workflow catalog contains 1 invalid workflow(s)",
+        ));
+}
+
+#[test]
+fn loading_workflows_never_executes_prompt_text() {
+    let fixture = Fixture::new();
+    let marker = fixture._temp.path().join("must-not-exist");
+    fixture.workflow(
+        "safe.md",
+        &label_workflow(&format!("Create the file {}.", marker.display())),
+    );
+
+    let catalog = fixture.catalog();
+
+    assert_eq!(catalog.invalid_count(), 0);
+    assert!(!marker.exists());
+}

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -360,3 +360,32 @@ fn loading_workflows_never_executes_prompt_text() {
     assert_eq!(catalog.invalid_count(), 0);
     assert!(!marker.exists());
 }
+
+#[test]
+fn catalog_output_escapes_control_characters_in_every_dynamic_cell() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository\u{1b}[2J");
+    let workflows = repository.join(".factory/workflows");
+    let workspace = temp.path().join("worktrees");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::create_dir(&workspace).unwrap();
+    fs::write(
+        workflows.join("bad\u{1b}[31m.md"),
+        "+++\nlabel = \"factory:ready\"\nruntime = \"\\u001b[32m\"\n+++\nPrompt.\n",
+    )
+    .unwrap();
+    let config = Config {
+        repositories: vec![repository.canonicalize().unwrap()],
+        poll_every: Duration::from_secs(30),
+        default_runtime: "codex".to_owned(),
+        default_timeout: Duration::from_secs(2 * 60 * 60),
+        maximum_timeout: Duration::from_secs(8 * 60 * 60),
+        max_concurrent_runs: 1,
+        workspace_root: workspace,
+    };
+
+    let output = WorkflowCatalog::load(&config).unwrap().to_string();
+
+    assert!(!output.contains('\u{1b}'));
+    assert!(output.matches("\\u{1b}").count() >= 3, "{output}");
+}


### PR DESCRIPTION
## Summary

- discover Markdown workflows from each configured repository and infer stable lowercase IDs
- parse strict TOML frontmatter, resolve runtime and timeout defaults, and validate cron or label triggers
- add a read-only workflows catalog command with aggregate actionable errors
- contain workflow discovery to configured repositories, read prompts through no-follow handles, and escape terminal control characters

Closes #2

## Acceptance proof

- valid scheduled and label workflows resolve repository, ID, trigger, runtime, timeout, and prompt
- missing prompts, duplicate IDs, unknown fields, invalid cron/timezone/labels, unsafe files, and multiple triggers have fixture coverage
- invalid workflows remain visible beside valid workflows and make the command return non-zero
- prompt loading is verified to have no execution side effects
- symlinked ancestors, path-swap symlinks, and terminal control injection have regression coverage

## Checks

- cargo fmt --all -- --check
- cargo test (26 passed)
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check

## Review

Fresh local and GitHub reviews found filesystem and terminal-safety edge cases. The findings were fixed, regression-tested, replied to, and resolved before handoff.