### PR TITLE
feat: run workflows with Codex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cc"
 version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +141,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -274,10 +286,14 @@ dependencies = [
  "cron",
  "dirs",
  "humantime",
+ "nix",
  "predicates",
  "rustix",
  "serde",
+ "serde_json",
  "tempfile",
+ "tokio",
+ "tokio-util",
  "toml",
 ]
 
@@ -307,6 +323,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -407,6 +429,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +477,29 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -651,6 +702,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +728,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "siphasher"
@@ -731,6 +805,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -932,3 +1045,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,14 @@ cron = "0.15"
 dirs = "6.0"
 humantime = "2.2"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tempfile = "3.20"
+tokio = { version = "1.47", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio-util = "0.7"
 toml = "0.9"
 
 [target.'cfg(unix)'.dependencies]
+nix = { version = "0.30", features = ["signal"] }
 rustix = { version = "1.1", features = ["fs"] }
 
 [dev-dependencies]

--- a/docs/design.md
+++ b/docs/design.md
@@ -30,6 +30,8 @@ Factory is a local-first daemon that turns scheduled prompts and ready tickets i
 ## Constraints
 
 - V1 runs one daemon on a trusted local machine and polls GitHub through the authenticated `gh` CLI.
+- V1 supports Unix-like operating systems only. Its process-tree guarantees rely
+  on Unix process groups and wait-without-reaping semantics.
 - Agent runtimes keep ownership of their authentication, tools, skills, MCP servers, and permissions.
 - Workflows may run for hours and adapt while watching CI. Timeouts must supervise stalled or runaway work without decomposing it into deterministic steps.
 - Agents may mutate tickets and repositories. V1 therefore manages only trusted repositories and relies on explicit runtime permissions.
@@ -330,4 +332,3 @@ Backout means stopping the daemon. Tickets, comments, branches, worktrees, and p
 - Should workflow files live in each target repository, one central Factory repository, or support both with explicit precedence?
 
 ## Decision
-

--- a/docs/design.md
+++ b/docs/design.md
@@ -255,6 +255,7 @@ The daemon runs as `factory run`, initially in a terminal and later under `launc
 ```text
 factory validate
 factory workflows
+factory workflow run <workflow-id> --repository <path>
 factory tasks
 factory runs [workflow]
 factory inspect <run-id>
@@ -262,6 +263,11 @@ factory cancel <run-id>
 ```
 
 SQLite lives under the Factory data directory. Workflows run against trusted repositories. An implementation agent may create its own worktree under the configured workspace root; Factory records the path reported by the agent or discovered from Git after the run.
+
+The manual workflow command validates the selected repository and workflow,
+checks the configured runtime and authentication, streams runtime activity, and
+reports bounded execution metadata. Ctrl-C and the resolved workflow timeout
+cancel the runtime process group.
 
 ### V1 implementation language
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -1,0 +1,121 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+
+use crate::config::Config;
+use crate::workflow::{WorkflowCatalog, WorkflowEntry};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedWorkflow {
+    pub id: String,
+    pub repository: PathBuf,
+    pub working_directory: PathBuf,
+    pub runtime: String,
+    pub timeout: Duration,
+    pub prompt: String,
+}
+
+impl ResolvedWorkflow {
+    pub fn resolve(
+        config: &Config,
+        catalog: &WorkflowCatalog,
+        id: &str,
+        repository: &Path,
+    ) -> Result<Self> {
+        let repository = fs::canonicalize(repository).with_context(|| {
+            format!(
+                "repository path does not exist or cannot be resolved: {}",
+                repository.display()
+            )
+        })?;
+        if !config.repositories.contains(&repository) {
+            bail!(
+                "repository {} is not listed in Factory configuration",
+                repository.display()
+            );
+        }
+        let matches = catalog
+            .entries
+            .iter()
+            .filter(|entry| entry.repository == repository && entry.id == id)
+            .collect::<Vec<_>>();
+        let entry = match matches.as_slice() {
+            [] => bail!(
+                "workflow {id:?} was not found for repository {}",
+                repository.display()
+            ),
+            [entry] => *entry,
+            _ => bail!(
+                "workflow {id:?} is duplicated for repository {}",
+                repository.display()
+            ),
+        };
+        Self::from_entry(entry)
+    }
+
+    fn from_entry(entry: &WorkflowEntry) -> Result<Self> {
+        if !entry.errors.is_empty() {
+            bail!(
+                "workflow {:?} is invalid: {}",
+                entry.id,
+                entry.errors.join("; ")
+            );
+        }
+        let runtime = entry
+            .runtime
+            .clone()
+            .context("validated workflow has no resolved runtime")?;
+        let timeout = entry
+            .timeout
+            .context("validated workflow has no resolved timeout")?;
+        let workflow_prompt = entry
+            .prompt
+            .as_deref()
+            .context("validated workflow has no prompt body")?;
+        let working_directory = entry.repository.clone();
+        let prompt = compose_prompt(&entry.id, workflow_prompt, &entry.repository);
+
+        Ok(Self {
+            id: entry.id.clone(),
+            repository: entry.repository.clone(),
+            working_directory,
+            runtime,
+            timeout,
+            prompt,
+        })
+    }
+}
+
+fn compose_prompt(id: &str, workflow_prompt: &str, repository: &Path) -> String {
+    format!(
+        "# Factory workflow\n\n{workflow_prompt}\n\n\
+         # Resolved target\n\n\
+         Workflow: {id}\n\
+         Repository: {}\n\
+         Working directory: {}\n",
+        repository.display(),
+        repository.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_contains_only_workflow_and_target_context() {
+        let prompt = compose_prompt(
+            "read-only",
+            "Inspect the repository without modifying it.",
+            Path::new("/code/project"),
+        );
+
+        assert!(prompt.contains("Inspect the repository without modifying it."));
+        assert!(prompt.contains("Workflow: read-only"));
+        assert!(prompt.contains("Repository: /code/project"));
+        assert!(!prompt.contains("max_concurrent_runs"));
+        assert!(!prompt.contains("workspace_root"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod config;
+pub mod execution;
+pub mod runtime;
 pub mod workflow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(not(unix))]
+compile_error!("Factory v1 supports Unix-like operating systems only");
+
 pub mod config;
 pub mod execution;
 pub mod runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ use tokio_util::sync::CancellationToken;
 
 use factory::config::{Config, default_config_path};
 use factory::execution::ResolvedWorkflow;
-use factory::runtime::{CodexRuntime, RuntimeCancelled, Termination};
+use factory::runtime::{
+    CodexRuntime, RuntimeCancelled, Termination, write_stderr_best_effort, write_stdout_best_effort,
+};
 use factory::workflow::WorkflowCatalog;
 
 #[derive(Debug, Parser)]
@@ -58,7 +60,7 @@ async fn main() -> ExitCode {
     match run_cli().await {
         Ok(code) => ExitCode::from(code),
         Err(error) => {
-            eprintln!("Error: {error:#}");
+            write_stderr_best_effort(format!("Error: {error:#}\n").as_bytes());
             ExitCode::FAILURE
         }
     }
@@ -134,15 +136,16 @@ async fn run_workflow(
         }
         Err(error) => return Err(error),
     };
-    eprintln!(
-        "Codex ready: {} ({})",
-        health.version, health.authentication
-    );
-    eprintln!(
-        "Running workflow {:?} in {} with timeout {}",
-        workflow.id,
-        workflow.working_directory.display(),
-        humantime::format_duration(workflow.timeout)
+    write_stderr_best_effort(
+        format!(
+            "Codex ready: {} ({})\nRunning workflow {:?} in {} with timeout {}\n",
+            health.version,
+            health.authentication,
+            workflow.id,
+            workflow.working_directory.display(),
+            humantime::format_duration(workflow.timeout)
+        )
+        .as_bytes(),
     );
     let result = runtime
         .run(
@@ -155,20 +158,20 @@ async fn run_workflow(
     signal_task.abort();
 
     if !result.final_response.is_empty() {
-        print!("{}", result.final_response);
-        if !result.final_response.ends_with('\n') {
-            println!();
-        }
+        write_final_response(&result.final_response);
     }
-    eprintln!(
-        "Run finished: status={} termination={:?} duration={} thread={} activity_lines={} activity_error={} response_truncated={}",
-        result.status,
-        result.termination,
-        humantime::format_duration(result.duration),
-        result.thread_id.as_deref().unwrap_or("-"),
-        result.activity_lines,
-        result.activity_error.as_deref().unwrap_or("-"),
-        result.final_response_truncated
+    write_stderr_best_effort(
+        format!(
+            "Run finished: status={} termination={:?} duration={} thread={} activity_lines={} activity_error={} response_truncated={}\n",
+            result.status,
+            result.termination,
+            humantime::format_duration(result.duration),
+            result.thread_id.as_deref().unwrap_or("-"),
+            result.activity_lines,
+            result.activity_error.as_deref().unwrap_or("-"),
+            result.final_response_truncated
+        )
+        .as_bytes(),
     );
 
     match result.termination {
@@ -181,4 +184,12 @@ async fn run_workflow(
             .and_then(|code| u8::try_from(code).ok())
             .unwrap_or(1)),
     }
+}
+
+fn write_final_response(response: &str) {
+    let mut output = response.as_bytes().to_vec();
+    if !response.ends_with('\n') {
+        output.push(b'\n');
+    }
+    write_stdout_best_effort(&output);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,13 @@
 use std::path::PathBuf;
+use std::process::ExitCode;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
+use tokio_util::sync::CancellationToken;
 
 use factory::config::{Config, default_config_path};
+use factory::execution::ResolvedWorkflow;
+use factory::runtime::{CodexRuntime, RuntimeCancelled, Termination};
 use factory::workflow::WorkflowCatalog;
 
 #[derive(Debug, Parser)]
@@ -27,9 +31,40 @@ enum Command {
         #[arg(long)]
         config: Option<PathBuf>,
     },
+    /// Run a workflow manually.
+    Workflow {
+        #[command(subcommand)]
+        command: WorkflowCommand,
+    },
 }
 
-fn main() -> Result<()> {
+#[derive(Debug, Subcommand)]
+enum WorkflowCommand {
+    /// Run one validated workflow against a configured repository.
+    Run {
+        /// Workflow ID, derived from its Markdown filename.
+        workflow_id: String,
+        /// Configured repository to use as the workflow target.
+        #[arg(long)]
+        repository: PathBuf,
+        /// Path to the Factory configuration file.
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run_cli().await {
+        Ok(code) => ExitCode::from(code),
+        Err(error) => {
+            eprintln!("Error: {error:#}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run_cli() -> Result<u8> {
     let cli = Cli::parse();
 
     match cli.command {
@@ -48,7 +83,102 @@ fn main() -> Result<()> {
                 anyhow::bail!("workflow catalog contains {invalid} invalid workflow(s)");
             }
         }
+        Command::Workflow {
+            command:
+                WorkflowCommand::Run {
+                    workflow_id,
+                    repository,
+                    config,
+                },
+        } => {
+            return run_workflow(&workflow_id, &repository, config).await;
+        }
     }
 
-    Ok(())
+    Ok(0)
+}
+
+async fn run_workflow(
+    workflow_id: &str,
+    repository: &std::path::Path,
+    config_path: Option<PathBuf>,
+) -> Result<u8> {
+    let path = config_path.unwrap_or_else(default_config_path);
+    let config = Config::load(&path)?;
+    let catalog = WorkflowCatalog::load(&config)?;
+    let workflow = ResolvedWorkflow::resolve(&config, &catalog, workflow_id, repository)?;
+    if workflow.runtime != "codex" {
+        bail!(
+            "workflow {:?} resolves to unsupported runtime {:?}; Factory v1 supports codex",
+            workflow.id,
+            workflow.runtime
+        );
+    }
+
+    let cancellation = CancellationToken::new();
+    let signal_token = cancellation.clone();
+    let signal_task = tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            signal_token.cancel();
+        }
+    });
+    let runtime = CodexRuntime::default();
+    let health = match runtime
+        .health_check_with_cancellation(cancellation.clone())
+        .await
+    {
+        Ok(health) => health,
+        Err(error) if error.downcast_ref::<RuntimeCancelled>().is_some() => {
+            signal_task.abort();
+            return Ok(130);
+        }
+        Err(error) => return Err(error),
+    };
+    eprintln!(
+        "Codex ready: {} ({})",
+        health.version, health.authentication
+    );
+    eprintln!(
+        "Running workflow {:?} in {} with timeout {}",
+        workflow.id,
+        workflow.working_directory.display(),
+        humantime::format_duration(workflow.timeout)
+    );
+    let result = runtime
+        .run(
+            &workflow.prompt,
+            &workflow.working_directory,
+            workflow.timeout,
+            cancellation,
+        )
+        .await?;
+    signal_task.abort();
+
+    if !result.final_response.is_empty() {
+        print!("{}", result.final_response);
+        if !result.final_response.ends_with('\n') {
+            println!();
+        }
+    }
+    eprintln!(
+        "Run finished: status={} termination={:?} duration={} thread={} activity_lines={} activity_error={} response_truncated={}",
+        result.status,
+        result.termination,
+        humantime::format_duration(result.duration),
+        result.thread_id.as_deref().unwrap_or("-"),
+        result.activity_lines,
+        result.activity_error.as_deref().unwrap_or("-"),
+        result.final_response_truncated
+    );
+
+    match result.termination {
+        Termination::TimedOut => Ok(124),
+        Termination::Cancelled => Ok(130),
+        Termination::Exited if result.status.success() => Ok(0),
+        Termination::Exited => Ok(result
+            .status
+            .code()
+            .and_then(|code| u8::try_from(code).ok())
+            .unwrap_or(1)),
+    }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,605 @@
+use std::fmt;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::{Child, Command};
+use tokio::task::JoinHandle;
+use tokio::time::{Instant as TokioInstant, sleep_until, timeout};
+use tokio_util::sync::CancellationToken;
+
+const DEFAULT_HEALTH_TIMEOUT: Duration = Duration::from_secs(10);
+const TERMINATION_GRACE: Duration = Duration::from_secs(2);
+const READER_GRACE: Duration = Duration::from_secs(2);
+const MAX_ACTIVITY_LINE_BYTES: usize = 256 * 1024;
+const MAX_THREAD_ID_BYTES: usize = 256;
+const MAX_FINAL_RESPONSE_BYTES: usize = 256 * 1024;
+const MAX_STDERR_BYTES: usize = 64 * 1024;
+const MAX_HEALTH_OUTPUT_BYTES: usize = 64 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeHealth {
+    pub version: String,
+    pub authentication: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Termination {
+    Exited,
+    TimedOut,
+    Cancelled,
+}
+
+#[derive(Debug)]
+pub struct ExecutionResult {
+    pub status: ExitStatus,
+    pub termination: Termination,
+    pub final_response: String,
+    pub final_response_truncated: bool,
+    pub thread_id: Option<String>,
+    pub duration: Duration,
+    pub activity_lines: usize,
+    pub activity_error: Option<String>,
+    pub stderr_tail: String,
+}
+
+#[derive(Debug)]
+pub struct RuntimeCancelled;
+
+impl fmt::Display for RuntimeCancelled {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("runtime check cancelled")
+    }
+}
+
+impl std::error::Error for RuntimeCancelled {}
+
+impl ExecutionResult {
+    pub fn succeeded(&self) -> bool {
+        self.termination == Termination::Exited && self.status.success()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexRuntime {
+    executable: PathBuf,
+    health_timeout: Duration,
+    stream_activity: bool,
+}
+
+impl Default for CodexRuntime {
+    fn default() -> Self {
+        Self::new("codex")
+    }
+}
+
+impl CodexRuntime {
+    pub fn new(executable: impl Into<PathBuf>) -> Self {
+        Self {
+            executable: executable.into(),
+            health_timeout: DEFAULT_HEALTH_TIMEOUT,
+            stream_activity: true,
+        }
+    }
+
+    pub fn with_health_timeout(mut self, health_timeout: Duration) -> Self {
+        self.health_timeout = health_timeout;
+        self
+    }
+
+    pub fn with_activity_streaming(mut self, stream_activity: bool) -> Self {
+        self.stream_activity = stream_activity;
+        self
+    }
+
+    pub async fn health_check(&self) -> Result<RuntimeHealth> {
+        self.health_check_with_cancellation(CancellationToken::new())
+            .await
+    }
+
+    pub async fn health_check_with_cancellation(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<RuntimeHealth> {
+        let version = self
+            .check_command(["--version"], "version", &cancellation)
+            .await
+            .with_context(|| {
+                format!(
+                    "Codex CLI health check failed; install codex or make {} executable",
+                    self.executable.display()
+                )
+            })?;
+        let authentication = self
+            .check_command(["login", "status"], "authentication", &cancellation)
+            .await
+            .context(
+                "Codex authentication check failed; run codex login and verify codex login status",
+            )?;
+        Ok(RuntimeHealth {
+            version,
+            authentication,
+        })
+    }
+
+    pub async fn run(
+        &self,
+        prompt: &str,
+        working_directory: &Path,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+    ) -> Result<ExecutionResult> {
+        let output_path = tempfile::NamedTempFile::new()
+            .context("failed to create Codex final-response file")?
+            .into_temp_path();
+        let mut command = Command::new(&self.executable);
+        command
+            .arg("exec")
+            .arg("--json")
+            .arg("--color")
+            .arg("never")
+            .arg("--output-last-message")
+            .arg(&output_path)
+            .arg("-")
+            .current_dir(working_directory)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        configure_process_group(&mut command);
+
+        let started = Instant::now();
+        let deadline = TokioInstant::now() + run_timeout;
+        let mut child = command.spawn().with_context(|| {
+            format!("failed to start Codex CLI at {}", self.executable.display())
+        })?;
+        let process_id = child.id();
+        let mut stdin = child
+            .stdin
+            .take()
+            .context("Codex process did not expose stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .context("Codex process did not expose stdout")?;
+        let stderr = child
+            .stderr
+            .take()
+            .context("Codex process did not expose stderr")?;
+        let stdout_task = tokio::spawn(read_stdout(stdout, self.stream_activity));
+        let stderr_task = tokio::spawn(read_stderr(stderr));
+
+        let deliver_prompt = async {
+            stdin
+                .write_all(prompt.as_bytes())
+                .await
+                .context("failed to send workflow prompt to Codex")?;
+            stdin
+                .shutdown()
+                .await
+                .context("failed to close Codex prompt input")?;
+            drop(stdin);
+            Result::<()>::Ok(())
+        };
+        tokio::pin!(deliver_prompt);
+        let early_termination = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => Some(Termination::Cancelled),
+            () = sleep_until(deadline) => Some(Termination::TimedOut),
+            delivery = &mut deliver_prompt => {
+                if let Err(error) = delivery {
+                    cleanup_failed_delivery(
+                        &mut child,
+                        process_id,
+                        stdout_task,
+                        stderr_task,
+                    )
+                    .await;
+                    return Err(error);
+                }
+                None
+            }
+        };
+
+        let (status, termination) = if let Some(termination) = early_termination {
+            (terminate(&mut child, process_id).await?, termination)
+        } else {
+            tokio::select! {
+                biased;
+                () = cancellation.cancelled() => {
+                    (terminate(&mut child, process_id).await?, Termination::Cancelled)
+                }
+                () = sleep_until(deadline) => {
+                    (terminate(&mut child, process_id).await?, Termination::TimedOut)
+                }
+                status = wait_for_clean_exit(&mut child, process_id) => {
+                    (status.context("failed while waiting for Codex")?, Termination::Exited)
+                }
+            }
+        };
+
+        let capture = join_reader(stdout_task, "stdout").await?;
+        let stderr_tail = join_reader(stderr_task, "stderr").await?;
+        if termination == Termination::Exited
+            && let Some(error) = &capture.malformed_line
+        {
+            bail!("Codex emitted malformed JSON activity: {error}");
+        }
+        let (final_response, final_response_truncated) =
+            read_bounded(&output_path, MAX_FINAL_RESPONSE_BYTES)
+                .context("failed to read Codex final response")?;
+
+        Ok(ExecutionResult {
+            status,
+            termination,
+            final_response,
+            final_response_truncated,
+            thread_id: capture.thread_id,
+            duration: started.elapsed(),
+            activity_lines: capture.lines,
+            activity_error: capture.malformed_line,
+            stderr_tail,
+        })
+    }
+
+    async fn check_command<const N: usize>(
+        &self,
+        args: [&str; N],
+        check: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
+        let mut command = Command::new(&self.executable);
+        command
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        configure_process_group(&mut command);
+        let mut child = command
+            .spawn()
+            .with_context(|| format!("could not execute {}", self.executable.display()))?;
+        let process_id = child.id();
+        let stdout = child
+            .stdout
+            .take()
+            .context("Codex health check did not expose stdout")?;
+        let stderr = child
+            .stderr
+            .take()
+            .context("Codex health check did not expose stderr")?;
+        let stdout_task = tokio::spawn(read_pipe_bounded(stdout, MAX_HEALTH_OUTPUT_BYTES));
+        let stderr_task = tokio::spawn(read_pipe_bounded(stderr, MAX_HEALTH_OUTPUT_BYTES));
+
+        let deadline = TokioInstant::now() + self.health_timeout;
+        let status = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                terminate(&mut child, process_id).await?;
+                join_reader(stdout_task, "health-check stdout").await?;
+                join_reader(stderr_task, "health-check stderr").await?;
+                return Err(RuntimeCancelled.into());
+            }
+            () = sleep_until(deadline) => {
+                terminate(&mut child, process_id).await?;
+                join_reader(stdout_task, "health-check stdout").await?;
+                join_reader(stderr_task, "health-check stderr").await?;
+                bail!(
+                    "Codex {check} check timed out after {}",
+                    humantime::format_duration(self.health_timeout)
+                );
+            }
+            status = wait_for_clean_exit(&mut child, process_id) => {
+                status.context("failed while waiting for Codex health check")?
+            }
+        };
+        let stdout =
+            String::from_utf8_lossy(&join_reader(stdout_task, "health-check stdout").await?)
+                .trim()
+                .to_owned();
+        let stderr =
+            String::from_utf8_lossy(&join_reader(stderr_task, "health-check stderr").await?)
+                .trim()
+                .to_owned();
+        if !status.success() {
+            let detail = if stderr.is_empty() {
+                stdout.clone()
+            } else {
+                stderr.clone()
+            };
+            bail!("Codex {check} check exited with {status}: {detail}");
+        }
+        let detail = if stdout.is_empty() { stderr } else { stdout };
+        if detail.is_empty() {
+            bail!("Codex {check} check returned no output");
+        }
+        Ok(detail)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ActivityCapture {
+    thread_id: Option<String>,
+    malformed_line: Option<String>,
+    lines: usize,
+}
+
+async fn read_stdout(
+    mut stdout: tokio::process::ChildStdout,
+    stream_activity: bool,
+) -> Result<ActivityCapture> {
+    let mut capture = ActivityCapture::default();
+    let mut chunk = [0_u8; 8192];
+    let mut line = Vec::new();
+    let mut discarding = false;
+    loop {
+        let read = stdout
+            .read(&mut chunk)
+            .await
+            .context("failed to read Codex activity")?;
+        if read == 0 {
+            break;
+        }
+        if stream_activity {
+            std::io::stdout()
+                .write_all(&chunk[..read])
+                .context("failed to stream Codex activity")?;
+            std::io::stdout().flush().ok();
+        }
+        for byte in &chunk[..read] {
+            if *byte == b'\n' {
+                capture.lines += 1;
+                if !discarding {
+                    capture_activity_line(&line, &mut capture);
+                }
+                line.clear();
+                discarding = false;
+            } else if line.len() < MAX_ACTIVITY_LINE_BYTES {
+                line.push(*byte);
+            } else if !discarding {
+                capture.malformed_line =
+                    Some(format!("line exceeds {MAX_ACTIVITY_LINE_BYTES} bytes"));
+                discarding = true;
+            }
+        }
+    }
+    if !line.is_empty() || discarding {
+        capture.lines += 1;
+        if !discarding {
+            capture_activity_line(&line, &mut capture);
+        }
+    }
+    Ok(capture)
+}
+
+fn capture_activity_line(line: &[u8], capture: &mut ActivityCapture) {
+    let line = line.strip_suffix(b"\r").unwrap_or(line);
+    match serde_json::from_slice::<Value>(line) {
+        Ok(event) => {
+            if capture.thread_id.is_none()
+                && let Some(thread_id) = event.get("thread_id").and_then(Value::as_str)
+            {
+                if thread_id.len() <= MAX_THREAD_ID_BYTES {
+                    capture.thread_id = Some(thread_id.to_owned());
+                } else if capture.malformed_line.is_none() {
+                    capture.malformed_line =
+                        Some(format!("thread ID exceeds {MAX_THREAD_ID_BYTES} bytes"));
+                }
+            }
+        }
+        Err(error) if capture.malformed_line.is_none() => {
+            capture.malformed_line = Some(error.to_string());
+        }
+        Err(_) => {}
+    }
+}
+
+async fn read_stderr(mut stderr: tokio::process::ChildStderr) -> Result<String> {
+    let mut tail = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = stderr
+            .read(&mut chunk)
+            .await
+            .context("failed to read Codex stderr")?;
+        if read == 0 {
+            break;
+        }
+        std::io::stderr()
+            .write_all(&chunk[..read])
+            .context("failed to stream Codex stderr")?;
+        std::io::stderr().flush().ok();
+        append_bounded(&mut tail, &chunk[..read], MAX_STDERR_BYTES);
+    }
+    Ok(String::from_utf8_lossy(&tail).into_owned())
+}
+
+async fn read_pipe_bounded<R>(mut reader: R, maximum: usize) -> Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut output = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        append_bounded(&mut output, &chunk[..read], maximum);
+    }
+    Ok(output)
+}
+
+fn append_bounded(output: &mut Vec<u8>, chunk: &[u8], maximum: usize) {
+    if chunk.len() >= maximum {
+        output.clear();
+        output.extend_from_slice(&chunk[chunk.len() - maximum..]);
+        return;
+    }
+    let excess = output
+        .len()
+        .saturating_add(chunk.len())
+        .saturating_sub(maximum);
+    if excess > 0 {
+        output.drain(..excess);
+    }
+    output.extend_from_slice(chunk);
+}
+
+async fn join_reader<T>(mut task: JoinHandle<Result<T>>, name: &str) -> Result<T> {
+    match timeout(READER_GRACE, &mut task).await {
+        Ok(result) => {
+            result.with_context(|| format!("Codex {name} reader stopped unexpectedly"))?
+        }
+        Err(_) => {
+            task.abort();
+            bail!("Codex {name} reader did not close after process termination");
+        }
+    }
+}
+
+async fn cleanup_failed_delivery(
+    child: &mut Child,
+    process_id: Option<u32>,
+    stdout_task: JoinHandle<Result<ActivityCapture>>,
+    stderr_task: JoinHandle<Result<String>>,
+) {
+    let _ = terminate(child, process_id).await;
+    let _ = join_reader(stdout_task, "stdout").await;
+    let _ = join_reader(stderr_task, "stderr").await;
+}
+
+fn read_bounded(path: &Path, maximum: usize) -> Result<(String, bool)> {
+    let file = File::open(path)?;
+    let mut bytes = Vec::with_capacity(maximum.min(8192));
+    file.take((maximum + 1) as u64).read_to_end(&mut bytes)?;
+    let truncated = bytes.len() > maximum;
+    bytes.truncate(maximum);
+    Ok((String::from_utf8_lossy(&bytes).into_owned(), truncated))
+}
+
+#[cfg(unix)]
+async fn wait_for_clean_exit(child: &mut Child, process_id: Option<u32>) -> Result<ExitStatus> {
+    let process_id = process_id.context("Codex process has no process ID")?;
+    tokio::task::spawn_blocking(move || wait_without_reaping(process_id))
+        .await
+        .context("Codex exit observer stopped unexpectedly")??;
+    cleanup_descendants(Some(process_id))?;
+    child
+        .wait()
+        .await
+        .context("failed to reap Codex process after observing its exit")
+}
+
+#[cfg(unix)]
+fn wait_without_reaping(process_id: u32) -> Result<()> {
+    use nix::libc;
+
+    loop {
+        // SAFETY: waitid initializes the provided siginfo_t. WNOWAIT leaves the
+        // child waitable so Tokio can reap it after the process group is cleaned.
+        let result = unsafe {
+            let mut information = std::mem::zeroed();
+            libc::waitid(
+                libc::P_PID,
+                process_id as libc::id_t,
+                &mut information,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error).context("failed to observe Codex process exit");
+        }
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_clean_exit(child: &mut Child, _process_id: Option<u32>) -> Result<ExitStatus> {
+    child
+        .wait()
+        .await
+        .context("failed to wait for Codex process")
+}
+
+#[cfg(unix)]
+async fn terminate(child: &mut Child, process_id: Option<u32>) -> Result<ExitStatus> {
+    signal_process_group(process_id, false)?;
+    let status = match timeout(TERMINATION_GRACE, child.wait()).await {
+        Ok(status) => status.context("failed while waiting for cancelled Codex process")?,
+        Err(_) => {
+            signal_process_group(process_id, true)?;
+            child
+                .wait()
+                .await
+                .context("failed while reaping cancelled Codex process")?
+        }
+    };
+    signal_process_group(process_id, true)?;
+    Ok(status)
+}
+
+#[cfg(not(unix))]
+async fn terminate(child: &mut Child, _process_id: Option<u32>) -> Result<ExitStatus> {
+    child
+        .start_kill()
+        .context("failed to cancel Codex process")?;
+    child
+        .wait()
+        .await
+        .context("failed while reaping cancelled Codex process")
+}
+
+#[cfg(unix)]
+fn configure_process_group(command: &mut Command) {
+    command.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn configure_process_group(_command: &mut Command) {}
+
+#[cfg(unix)]
+fn cleanup_descendants(process_id: Option<u32>) -> Result<()> {
+    match signal_process_group(process_id, true) {
+        Ok(()) => Ok(()),
+        Err(error)
+            if error.downcast_ref::<nix::errno::Errno>() == Some(&nix::errno::Errno::EPERM) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(not(unix))]
+fn cleanup_descendants(_process_id: Option<u32>) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn signal_process_group(process_id: Option<u32>, force: bool) -> Result<()> {
+    use nix::errno::Errno;
+    use nix::sys::signal::{Signal, killpg};
+    use nix::unistd::Pid;
+
+    let Some(process_id) = process_id else {
+        return Ok(());
+    };
+    let signal = if force {
+        Signal::SIGKILL
+    } else {
+        Signal::SIGTERM
+    };
+    match killpg(Pid::from_raw(process_id as i32), signal) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(error) => Err(error).context("failed to signal Codex process group"),
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -155,7 +155,7 @@ impl CodexRuntime {
 
         let started = Instant::now();
         let deadline = TokioInstant::now() + run_timeout;
-        let mut child = command.spawn().with_context(|| {
+        let mut child = spawn_with_retry(&mut command).await.with_context(|| {
             format!("failed to start Codex CLI at {}", self.executable.display())
         })?;
         let process_id = child.id();
@@ -261,8 +261,8 @@ impl CodexRuntime {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         configure_process_group(&mut command);
-        let mut child = command
-            .spawn()
+        let mut child = spawn_with_retry(&mut command)
+            .await
             .with_context(|| format!("could not execute {}", self.executable.display()))?;
         let process_id = child.id();
         let stdout = child
@@ -481,6 +481,31 @@ fn read_bounded(path: &Path, maximum: usize) -> Result<(String, bool)> {
     let truncated = bytes.len() > maximum;
     bytes.truncate(maximum);
     Ok((String::from_utf8_lossy(&bytes).into_owned(), truncated))
+}
+
+async fn spawn_with_retry(command: &mut Command) -> std::io::Result<Child> {
+    const MAX_ATTEMPTS: usize = 5;
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error) if text_file_busy(&error) && attempt < MAX_ATTEMPTS => {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("spawn retry loop always returns")
+}
+
+#[cfg(unix)]
+fn text_file_busy(error: &std::io::Error) -> bool {
+    error.raw_os_error() == Some(nix::libc::ETXTBSY)
+}
+
+#[cfg(not(unix))]
+fn text_file_busy(_error: &std::io::Error) -> bool {
+    false
 }
 
 #[cfg(unix)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,6 +3,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
+use std::sync::OnceLock;
+use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
@@ -21,6 +23,8 @@ const MAX_THREAD_ID_BYTES: usize = 256;
 const MAX_FINAL_RESPONSE_BYTES: usize = 256 * 1024;
 const MAX_STDERR_BYTES: usize = 64 * 1024;
 const MAX_HEALTH_OUTPUT_BYTES: usize = 64 * 1024;
+const OUTPUT_CHANNEL_CAPACITY: usize = 16;
+const OUTPUT_ACK_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeHealth {
@@ -171,8 +175,9 @@ impl CodexRuntime {
             .stderr
             .take()
             .context("Codex process did not expose stderr")?;
-        let stdout_task = tokio::spawn(read_stdout(stdout, self.stream_activity));
-        let stderr_task = tokio::spawn(read_stderr(stderr));
+        let stdout_stream = self.stream_activity.then_some(OutputStream::Stdout);
+        let stdout_task = tokio::spawn(read_stdout(stdout, stdout_stream));
+        let stderr_task = tokio::spawn(read_stderr(stderr, Some(OutputStream::Stderr)));
 
         let deliver_prompt = async {
             stdin
@@ -192,7 +197,9 @@ impl CodexRuntime {
             () = cancellation.cancelled() => Some(Termination::Cancelled),
             () = sleep_until(deadline) => Some(Termination::TimedOut),
             delivery = &mut deliver_prompt => {
-                if let Err(error) = delivery {
+                if let Err(error) = delivery
+                    && !is_broken_pipe(&error)
+                {
                     cleanup_failed_delivery(
                         &mut child,
                         process_id,
@@ -331,7 +338,7 @@ struct ActivityCapture {
 
 async fn read_stdout(
     mut stdout: tokio::process::ChildStdout,
-    stream_activity: bool,
+    activity_stream: Option<OutputStream>,
 ) -> Result<ActivityCapture> {
     let mut capture = ActivityCapture::default();
     let mut chunk = [0_u8; 8192];
@@ -345,11 +352,8 @@ async fn read_stdout(
         if read == 0 {
             break;
         }
-        if stream_activity {
-            std::io::stdout()
-                .write_all(&chunk[..read])
-                .context("failed to stream Codex activity")?;
-            std::io::stdout().flush().ok();
+        if let Some(stream) = activity_stream {
+            stream_output(stream, &chunk[..read]);
         }
         for byte in &chunk[..read] {
             if *byte == b'\n' {
@@ -399,7 +403,10 @@ fn capture_activity_line(line: &[u8], capture: &mut ActivityCapture) {
     }
 }
 
-async fn read_stderr(mut stderr: tokio::process::ChildStderr) -> Result<String> {
+async fn read_stderr(
+    mut stderr: tokio::process::ChildStderr,
+    activity_stream: Option<OutputStream>,
+) -> Result<String> {
     let mut tail = Vec::new();
     let mut chunk = [0_u8; 8192];
     loop {
@@ -410,10 +417,9 @@ async fn read_stderr(mut stderr: tokio::process::ChildStderr) -> Result<String> 
         if read == 0 {
             break;
         }
-        std::io::stderr()
-            .write_all(&chunk[..read])
-            .context("failed to stream Codex stderr")?;
-        std::io::stderr().flush().ok();
+        if let Some(stream) = activity_stream {
+            stream_output(stream, &chunk[..read]);
+        }
         append_bounded(&mut tail, &chunk[..read], MAX_STDERR_BYTES);
     }
     Ok(String::from_utf8_lossy(&tail).into_owned())
@@ -463,6 +469,84 @@ async fn join_reader<T>(mut task: JoinHandle<Result<T>>, name: &str) -> Result<T
     }
 }
 
+#[derive(Clone, Copy)]
+enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+struct OutputMessage {
+    bytes: Vec<u8>,
+    acknowledgement: Option<SyncSender<()>>,
+}
+
+fn output_sender(stream: OutputStream) -> &'static SyncSender<OutputMessage> {
+    static STDOUT: OnceLock<SyncSender<OutputMessage>> = OnceLock::new();
+    static STDERR: OnceLock<SyncSender<OutputMessage>> = OnceLock::new();
+    match stream {
+        OutputStream::Stdout => {
+            STDOUT.get_or_init(|| spawn_output_thread("factory-stdout", std::io::stdout()))
+        }
+        OutputStream::Stderr => {
+            STDERR.get_or_init(|| spawn_output_thread("factory-stderr", std::io::stderr()))
+        }
+    }
+}
+
+fn spawn_output_thread(
+    name: &str,
+    writer: impl Write + Send + 'static,
+) -> SyncSender<OutputMessage> {
+    let (sender, receiver) = sync_channel(OUTPUT_CHANNEL_CAPACITY);
+    let _ = std::thread::Builder::new()
+        .name(name.to_owned())
+        .spawn(move || write_output(writer, receiver));
+    sender
+}
+
+fn write_output(mut writer: impl Write, receiver: Receiver<OutputMessage>) {
+    while let Ok(message) = receiver.recv() {
+        let delivered = writer
+            .write_all(&message.bytes)
+            .and_then(|()| writer.flush())
+            .is_ok();
+        if let Some(acknowledgement) = message.acknowledgement {
+            let _ = acknowledgement.try_send(());
+        }
+        if !delivered {
+            return;
+        }
+    }
+}
+
+fn stream_output(stream: OutputStream, bytes: &[u8]) {
+    let _ = output_sender(stream).try_send(OutputMessage {
+        bytes: bytes.to_vec(),
+        acknowledgement: None,
+    });
+}
+
+fn write_output_best_effort(stream: OutputStream, bytes: &[u8]) {
+    let (acknowledgement, delivered) = sync_channel(1);
+    if output_sender(stream)
+        .try_send(OutputMessage {
+            bytes: bytes.to_vec(),
+            acknowledgement: Some(acknowledgement),
+        })
+        .is_ok()
+    {
+        let _ = delivered.recv_timeout(OUTPUT_ACK_TIMEOUT);
+    }
+}
+
+pub fn write_stdout_best_effort(bytes: &[u8]) {
+    write_output_best_effort(OutputStream::Stdout, bytes);
+}
+
+pub fn write_stderr_best_effort(bytes: &[u8]) {
+    write_output_best_effort(OutputStream::Stderr, bytes);
+}
+
 async fn cleanup_failed_delivery(
     child: &mut Child,
     process_id: Option<u32>,
@@ -472,6 +556,12 @@ async fn cleanup_failed_delivery(
     let _ = terminate(child, process_id).await;
     let _ = join_reader(stdout_task, "stdout").await;
     let _ = join_reader(stderr_task, "stderr").await;
+}
+
+fn is_broken_pipe(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<std::io::Error>()
+        .is_some_and(|error| error.kind() == std::io::ErrorKind::BrokenPipe)
 }
 
 fn read_bounded(path: &Path, maximum: usize) -> Result<(String, bool)> {
@@ -511,14 +601,19 @@ fn text_file_busy(_error: &std::io::Error) -> bool {
 #[cfg(unix)]
 async fn wait_for_clean_exit(child: &mut Child, process_id: Option<u32>) -> Result<ExitStatus> {
     let process_id = process_id.context("Codex process has no process ID")?;
-    tokio::task::spawn_blocking(move || wait_without_reaping(process_id))
-        .await
-        .context("Codex exit observer stopped unexpectedly")??;
+    observe_exit(process_id).await?;
     cleanup_descendants(Some(process_id))?;
     child
         .wait()
         .await
         .context("failed to reap Codex process after observing its exit")
+}
+
+#[cfg(unix)]
+async fn observe_exit(process_id: u32) -> Result<()> {
+    tokio::task::spawn_blocking(move || wait_without_reaping(process_id))
+        .await
+        .context("Codex exit observer stopped unexpectedly")?
 }
 
 #[cfg(unix)]
@@ -557,19 +652,20 @@ async fn wait_for_clean_exit(child: &mut Child, _process_id: Option<u32>) -> Res
 
 #[cfg(unix)]
 async fn terminate(child: &mut Child, process_id: Option<u32>) -> Result<ExitStatus> {
-    signal_process_group(process_id, false)?;
-    let status = match timeout(TERMINATION_GRACE, child.wait()).await {
-        Ok(status) => status.context("failed while waiting for cancelled Codex process")?,
+    let process_id = process_id.context("Codex process has no process ID")?;
+    signal_process_group(Some(process_id), false)?;
+    match timeout(TERMINATION_GRACE, observe_exit(process_id)).await {
+        Ok(observed) => observed?,
         Err(_) => {
-            signal_process_group(process_id, true)?;
-            child
-                .wait()
-                .await
-                .context("failed while reaping cancelled Codex process")?
+            signal_process_group(Some(process_id), true)?;
+            observe_exit(process_id).await?;
         }
-    };
-    signal_process_group(process_id, true)?;
-    Ok(status)
+    }
+    cleanup_descendants(Some(process_id))?;
+    child
+        .wait()
+        .await
+        .context("failed while reaping cancelled Codex process")
 }
 
 #[cfg(not(unix))]

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -3,6 +3,10 @@
 use std::env;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
+use std::process::Stdio;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -103,4 +107,129 @@ printf 'Read-only workflow complete.' > "$output"
     assert!(prompt.contains(repository.to_str().unwrap()));
     assert!(!prompt.contains(workspace.to_str().unwrap()));
     assert!(!prompt.contains("max_concurrent_runs"));
+}
+
+#[test]
+fn concurrent_manual_runs_exit_when_shared_output_is_full_and_unread() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let workflows = repository.join(".factory/workflows");
+    let workspace = temp.path().join("worktrees");
+    let binaries = temp.path().join("bin");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::create_dir(&workspace).unwrap();
+    fs::create_dir(&binaries).unwrap();
+    fs::write(
+        workflows.join("verbose.md"),
+        "+++\nlabel = \"factory:ready\"\ntimeout = \"30s\"\n+++\n\nBe verbose.\n",
+    )
+    .unwrap();
+    let config = temp.path().join("config.toml");
+    fs::write(
+        &config,
+        format!(
+            r#"repositories = ["{}"]
+poll_every = "30s"
+default_runtime = "codex"
+default_timeout = "2h"
+maximum_timeout = "8h"
+max_concurrent_runs = 2
+workspace_root = "{}"
+"#,
+            repository.display(),
+            workspace.display()
+        ),
+    )
+    .unwrap();
+    let executable = binaries.join("codex");
+    fs::write(
+        &executable,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 1.2.3"
+  exit 0
+fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+output=""
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "--output-last-message" ]; then
+    output="$argument"
+  fi
+  previous="$argument"
+done
+cat >/dev/null
+i=0
+while [ "$i" -lt 10000 ]; do
+  echo '{"type":"item.completed","message":"activity output that fills the pipe"}'
+  echo 'diagnostic output that fills the pipe' >&2
+  i=$((i + 1))
+done
+printf 'Verbose workflow complete.' > "$output"
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    let path = format!(
+        "{}:{}",
+        binaries.display(),
+        env::var("PATH").unwrap_or_default()
+    );
+
+    let (_unread_output, shared_output) = UnixStream::pair().unwrap();
+    let mut children = (0..2)
+        .map(|_| {
+            std::process::Command::new(assert_cmd::cargo::cargo_bin!("factory"))
+                .args([
+                    "workflow",
+                    "run",
+                    "verbose",
+                    "--repository",
+                    repository.to_str().unwrap(),
+                    "--config",
+                    config.to_str().unwrap(),
+                ])
+                .env("PATH", &path)
+                .stdout(Stdio::from(std::os::fd::OwnedFd::from(
+                    shared_output.try_clone().unwrap(),
+                )))
+                .stderr(Stdio::from(std::os::fd::OwnedFd::from(
+                    shared_output.try_clone().unwrap(),
+                )))
+                .spawn()
+                .unwrap()
+        })
+        .collect::<Vec<_>>();
+    drop(shared_output);
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut statuses = vec![None; children.len()];
+    loop {
+        for (child, status) in children.iter_mut().zip(&mut statuses) {
+            if status.is_none() {
+                *status = child.try_wait().unwrap();
+            }
+        }
+        if statuses.iter().all(Option::is_some) {
+            break;
+        }
+        if Instant::now() >= deadline {
+            for (child, status) in children.iter_mut().zip(&statuses) {
+                if status.is_none() {
+                    child.kill().unwrap();
+                    child.wait().unwrap();
+                }
+            }
+            panic!("Factory runs hung while shared stdout and stderr were full and unread");
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    for status in statuses.into_iter().flatten() {
+        assert!(status.success(), "Factory exited with {status}");
+    }
 }

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -1,0 +1,106 @@
+#![cfg(unix)]
+
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn manual_workflow_run_resolves_context_and_invokes_codex() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let workflows = repository.join(".factory/workflows");
+    let workspace = temp.path().join("worktrees");
+    let binaries = temp.path().join("bin");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::create_dir(&workspace).unwrap();
+    fs::create_dir(&binaries).unwrap();
+    fs::write(
+        workflows.join("read-only.md"),
+        "+++\nlabel = \"factory:ready\"\ntimeout = \"30s\"\n+++\n\nInspect without changing files.\n",
+    )
+    .unwrap();
+    let config = temp.path().join("config.toml");
+    fs::write(
+        &config,
+        format!(
+            r#"repositories = ["{}"]
+poll_every = "30s"
+default_runtime = "codex"
+default_timeout = "2h"
+maximum_timeout = "8h"
+max_concurrent_runs = 2
+workspace_root = "{}"
+"#,
+            repository.display(),
+            workspace.display()
+        ),
+    )
+    .unwrap();
+    let prompt_capture = temp.path().join("prompt.txt");
+    let executable = binaries.join("codex");
+    fs::write(
+        &executable,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 1.2.3"
+  exit 0
+fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+output=""
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "--output-last-message" ]; then
+    output="$argument"
+  fi
+  previous="$argument"
+done
+cat > "$FACTORY_PROMPT_CAPTURE"
+echo '{"type":"thread.started","thread_id":"manual-thread"}'
+printf 'Read-only workflow complete.' > "$output"
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    let path = format!(
+        "{}:{}",
+        binaries.display(),
+        env::var("PATH").unwrap_or_default()
+    );
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "workflow",
+            "run",
+            "read-only",
+            "--repository",
+            repository.to_str().unwrap(),
+            "--config",
+            config.to_str().unwrap(),
+        ])
+        .env("PATH", path)
+        .env("FACTORY_PROMPT_CAPTURE", &prompt_capture)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#"{"type":"thread.started","thread_id":"manual-thread"}"#,
+        ))
+        .stdout(predicate::str::contains("Read-only workflow complete."))
+        .stderr(predicate::str::contains("Codex ready: codex-cli 1.2.3"))
+        .stderr(predicate::str::contains("thread=manual-thread"));
+
+    let prompt = fs::read_to_string(prompt_capture).unwrap();
+    assert!(prompt.contains("Inspect without changing files."));
+    assert!(prompt.contains("Workflow: read-only"));
+    assert!(prompt.contains(repository.to_str().unwrap()));
+    assert!(!prompt.contains(workspace.to_str().unwrap()));
+    assert!(!prompt.contains("max_concurrent_runs"));
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -459,7 +459,7 @@ async fn rejects_an_oversized_activity_line_without_unbounded_buffering() {
     let executable = fake_codex(
         temp.path(),
         r#"cat >/dev/null
-perl -e 'print "x" x 300000'
+awk 'BEGIN { for (i = 0; i < 300000; i++) printf "x" }'
 echo
 printf 'done' > "$output"
 exit 0"#,

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,0 +1,453 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use factory::runtime::{CodexRuntime, RuntimeCancelled, Termination};
+use tokio_util::sync::CancellationToken;
+
+fn fake_codex(directory: &Path, execution: &str) -> PathBuf {
+    let path = directory.join("codex");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 1.2.3"
+  exit 0
+fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+output=""
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "--output-last-message" ]; then
+    output="$argument"
+  fi
+  previous="$argument"
+done
+{execution}
+"#
+    );
+    fs::write(&path, script).unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+    path
+}
+
+async fn assert_process_gone(pid: i32) {
+    for _ in 0..200 {
+        if matches!(
+            nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None),
+            Err(nix::errno::Errno::ESRCH)
+        ) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("process {pid} survived cancellation");
+}
+
+#[tokio::test]
+async fn health_check_and_success_capture_final_response_and_thread() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"cat >/dev/null
+echo '{"type":"thread.started","thread_id":"thread-123"}'
+echo '{"type":"item.completed"}'
+printf 'Workflow complete.' > "$output"
+exit 0"#,
+    );
+    let runtime = CodexRuntime::new(executable);
+
+    let health = runtime.health_check().await.unwrap();
+    let result = runtime
+        .run(
+            "A harmless prompt.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(health.version, "codex-cli 1.2.3");
+    assert_eq!(health.authentication, "Logged in using ChatGPT");
+    assert!(result.succeeded());
+    assert_eq!(result.thread_id.as_deref(), Some("thread-123"));
+    assert_eq!(result.final_response, "Workflow complete.");
+    assert_eq!(result.activity_lines, 2);
+    assert!(!result.final_response_truncated);
+}
+
+#[tokio::test]
+async fn returns_the_real_non_zero_exit_status() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"cat >/dev/null
+echo '{"type":"thread.started","thread_id":"failed-thread"}'
+printf 'Could not complete.' > "$output"
+echo "runtime failed" >&2
+exit 17"#,
+    );
+    let runtime = CodexRuntime::new(executable);
+
+    let result = runtime
+        .run(
+            "Fail safely.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.status.code(), Some(17));
+    assert!(!result.succeeded());
+    assert!(result.stderr_tail.contains("runtime failed"));
+}
+
+#[tokio::test]
+async fn rejects_malformed_json_activity() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"cat >/dev/null
+echo 'not json'
+printf 'Untrusted final response.' > "$output"
+exit 0"#,
+    );
+    let runtime = CodexRuntime::new(executable);
+
+    let error = runtime
+        .run(
+            "Malformed output.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("malformed JSON activity"));
+}
+
+#[tokio::test]
+async fn timeout_stops_the_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(temp.path(), "cat >/dev/null\nsleep 30");
+    let runtime = CodexRuntime::new(executable);
+
+    let result = runtime
+        .run(
+            "Time out.",
+            temp.path(),
+            Duration::from_secs(2),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::TimedOut);
+}
+
+#[tokio::test]
+async fn cancellation_stops_the_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let descendant = temp.path().join("cancelled-descendant.pid");
+    let executable = fake_codex(
+        temp.path(),
+        &format!(
+            "sleep 30 &\necho $! > \"{}\"\ncat >/dev/null\nwait",
+            descendant.display()
+        ),
+    );
+    let runtime = CodexRuntime::new(executable);
+    let cancellation = CancellationToken::new();
+    let cancel_later = cancellation.clone();
+    let descendant_ready = descendant.clone();
+    tokio::spawn(async move {
+        for _ in 0..1000 {
+            if descendant_ready.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        cancel_later.cancel();
+    });
+
+    let result = runtime
+        .run(
+            "Cancel.",
+            temp.path(),
+            Duration::from_secs(15),
+            cancellation,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::Cancelled);
+    let pid: i32 = fs::read_to_string(descendant)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_process_gone(pid).await;
+}
+
+#[tokio::test]
+async fn authentication_failure_is_actionable() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("codex");
+    fs::write(
+        &path,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 1.2.3"
+  exit 0
+fi
+echo "not logged in" >&2
+exit 1
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+
+    let error = CodexRuntime::new(path).health_check().await.unwrap_err();
+    let message = format!("{error:#}");
+
+    assert!(message.contains("run codex login"));
+    assert!(message.contains("not logged in"));
+}
+
+#[tokio::test]
+async fn timeout_applies_while_prompt_delivery_is_blocked() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(temp.path(), "sleep 30");
+    let runtime = CodexRuntime::new(executable);
+    let prompt = "x".repeat(2 * 1024 * 1024);
+
+    let result = runtime
+        .run(
+            &prompt,
+            temp.path(),
+            Duration::from_millis(200),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::TimedOut);
+    assert!(result.duration < Duration::from_secs(3));
+}
+
+#[tokio::test]
+async fn normal_leader_exit_cleans_up_descendants_holding_pipes() {
+    let temp = tempfile::tempdir().unwrap();
+    let descendant = temp.path().join("pipe-descendant.pid");
+    let executable = fake_codex(
+        temp.path(),
+        &format!(
+            "cat >/dev/null\nsleep 30 >/dev/null 2>&1 &\necho $! > \"{}\"\nexit 0",
+            descendant.display()
+        ),
+    );
+    let runtime = CodexRuntime::new(executable);
+
+    let result = runtime
+        .run(
+            "Exit with a child.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert!(result.succeeded());
+    let pid: i32 = fs::read_to_string(descendant)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_process_gone(pid).await;
+}
+
+#[tokio::test]
+async fn health_timeout_cleans_up_the_process_group() {
+    let temp = tempfile::tempdir().unwrap();
+    let descendant = temp.path().join("health-descendant.pid");
+    let executable = temp.path().join("codex");
+    fs::write(
+        &executable,
+        format!(
+            r#"#!/bin/sh
+sleep 30 &
+echo $! > "{}"
+wait
+"#,
+            descendant.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    let runtime = CodexRuntime::new(executable).with_health_timeout(Duration::from_secs(5));
+
+    let error = runtime.health_check().await.unwrap_err();
+
+    assert!(format!("{error:#}").contains("timed out"));
+    let pid: i32 = fs::read_to_string(descendant)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_process_gone(pid).await;
+}
+
+#[tokio::test]
+async fn health_check_cancellation_cleans_up_the_process_group() {
+    let temp = tempfile::tempdir().unwrap();
+    let descendant = temp.path().join("cancelled-health-descendant.pid");
+    let executable = temp.path().join("codex");
+    fs::write(
+        &executable,
+        format!(
+            r#"#!/bin/sh
+sleep 30 &
+echo $! > "{}"
+wait
+"#,
+            descendant.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    let cancellation = CancellationToken::new();
+    let cancel_later = cancellation.clone();
+    let descendant_ready = descendant.clone();
+    tokio::spawn(async move {
+        for _ in 0..1000 {
+            if descendant_ready.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        cancel_later.cancel();
+    });
+
+    let error = CodexRuntime::new(executable)
+        .health_check_with_cancellation(cancellation)
+        .await
+        .unwrap_err();
+
+    assert!(error.downcast_ref::<RuntimeCancelled>().is_some());
+    let pid: i32 = fs::read_to_string(descendant)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_process_gone(pid).await;
+}
+
+#[tokio::test]
+async fn cancellation_is_not_masked_by_partial_json_activity() {
+    let temp = tempfile::tempdir().unwrap();
+    let activity_ready = temp.path().join("partial-activity-ready");
+    let executable = fake_codex(
+        temp.path(),
+        &format!(
+            "cat >/dev/null\nprintf '{{\"type\":'\necho ready > \"{}\"\nsleep 30",
+            activity_ready.display()
+        ),
+    );
+    let runtime = CodexRuntime::new(executable);
+    let cancellation = CancellationToken::new();
+    let cancel_later = cancellation.clone();
+    let activity_ready_for_cancel = activity_ready.clone();
+    tokio::spawn(async move {
+        for _ in 0..1000 {
+            if activity_ready_for_cancel.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        cancel_later.cancel();
+    });
+
+    let result = runtime
+        .run(
+            "Cancel partial output.",
+            temp.path(),
+            Duration::from_secs(5),
+            cancellation,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::Cancelled);
+    assert!(result.activity_error.is_some());
+}
+
+#[tokio::test]
+async fn rejects_oversized_activity_and_thread_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"cat >/dev/null
+printf '{"type":"thread.started","thread_id":"'
+printf '%0300d' 0 | tr '0' 'a'
+echo '"}'
+printf 'done' > "$output"
+exit 0"#,
+    );
+    let runtime = CodexRuntime::new(executable);
+
+    let error = runtime
+        .run(
+            "Bound metadata.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("thread ID exceeds 256 bytes"));
+}
+
+#[tokio::test]
+async fn rejects_an_oversized_activity_line_without_unbounded_buffering() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"cat >/dev/null
+perl -e 'print "x" x 300000'
+echo
+printf 'done' > "$output"
+exit 0"#,
+    );
+    let runtime = CodexRuntime::new(executable).with_activity_streaming(false);
+
+    let error = runtime
+        .run(
+            "Bound activity.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("line exceeds 262144 bytes"));
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -113,6 +113,33 @@ exit 17"#,
 }
 
 #[tokio::test]
+async fn early_exit_before_prompt_read_preserves_status_and_output() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"echo '{"type":"thread.started","thread_id":"early-thread"}'
+printf 'Rejected before prompt.' > "$output"
+exit 23"#,
+    );
+    let runtime = CodexRuntime::new(executable);
+    let prompt = "large prompt ".repeat(200_000);
+
+    let result = runtime
+        .run(
+            &prompt,
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.status.code(), Some(23));
+    assert_eq!(result.thread_id.as_deref(), Some("early-thread"));
+    assert_eq!(result.final_response, "Rejected before prompt.");
+}
+
+#[tokio::test]
 async fn rejects_malformed_json_activity() {
     let temp = tempfile::tempdir().unwrap();
     let executable = fake_codex(


### PR DESCRIPTION
## Summary

- add `factory workflow run <workflow-id> --repository <path>` with validated target-scoped prompt resolution
- add an authenticated Codex CLI adapter that streams JSONL activity and captures bounded final output, metadata, and thread IDs
- supervise prompt delivery, health checks, Ctrl-C, timeouts, process groups, descendants, and output readers

## Acceptance proof

- Codex health and authentication failures are actionable
- workflow, repository, runtime, timeout, prompt, and working directory are resolved from validated config
- fake executable coverage includes success, exit 17, malformed/oversized output, blocked prompt delivery, timeout, cancellation, health timeout/cancellation, descendant cleanup, and thread capture
- a real authenticated read-only Codex workflow completed through Factory and returned thread `019f748f-1b20-7543-bb01-f5cff5e11a41`

## Checks

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (41 tests)
- `git diff --check`
- fresh-agent review completed; all blocker and important findings addressed

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `factory workflow run` for resolving and executing workflows against a selected repository.
  - Integrated Codex runtime health checks, authentication status, activity streaming, final responses, and execution metadata.
  - Added timeout and Ctrl-C cancellation handling, including process cleanup and meaningful exit codes.
  - Added safeguards for malformed or oversized runtime output.

- **Documentation**
  - Documented Unix-only support and the manual workflow execution command, including runtime and cancellation behavior.

- **Tests**
  - Added coverage for successful runs, failures, timeouts, cancellation, output handling, and concurrent executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->