### PR TITLE
feat: persist task and run ledger (#3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "humantime",
  "nix",
  "predicates",
+ "rusqlite",
  "rustix",
  "serde",
  "serde_json",
@@ -296,6 +297,18 @@ dependencies = [
  "tokio-util",
  "toml",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -317,6 +330,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -372,9 +391,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -419,7 +456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -458,6 +495,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -559,6 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +705,20 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustix"
@@ -750,6 +818,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -896,6 +970,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ dirs = "6.0"
 humantime = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rusqlite = { version = "0.37", features = ["bundled"] }
 tempfile = "3.20"
 tokio = { version = "1.47", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,4 +4,5 @@ compile_error!("Factory v1 supports Unix-like operating systems only");
 pub mod config;
 pub mod execution;
 pub mod runtime;
+pub mod storage;
 pub mod workflow;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,611 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result, bail};
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+
+const DATABASE_NAME: &str = "factory.sqlite3";
+const SCHEMA_VERSION: i64 = 1;
+pub const MAX_RESULT_BYTES: usize = 256 * 1024;
+pub const MAX_ERROR_BYTES: usize = 64 * 1024;
+pub const MAX_SESSION_ID_BYTES: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskState {
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl TaskState {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled)
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Queued => "queued",
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+impl FromStr for TaskState {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "queued" => Ok(Self::Queued),
+            "running" => Ok(Self::Running),
+            "succeeded" => Ok(Self::Succeeded),
+            "failed" => Ok(Self::Failed),
+            "cancelled" => Ok(Self::Cancelled),
+            other => bail!("database contains unknown task state {other:?}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaskIdentity {
+    Ticket {
+        repository: String,
+        workflow: String,
+        ticket: String,
+        revision: String,
+    },
+    Scheduled {
+        repository: String,
+        workflow: String,
+        scheduled_at: String,
+    },
+}
+
+impl TaskIdentity {
+    pub fn ticket(
+        repository: impl Into<String>,
+        workflow: impl Into<String>,
+        ticket: impl Into<String>,
+        revision: impl Into<String>,
+    ) -> Result<Self> {
+        let identity = Self::Ticket {
+            repository: repository.into(),
+            workflow: workflow.into(),
+            ticket: ticket.into(),
+            revision: revision.into(),
+        };
+        identity.validate()?;
+        Ok(identity)
+    }
+
+    pub fn scheduled(
+        repository: impl Into<String>,
+        workflow: impl Into<String>,
+        scheduled_at: impl Into<String>,
+    ) -> Result<Self> {
+        let identity = Self::Scheduled {
+            repository: repository.into(),
+            workflow: workflow.into(),
+            scheduled_at: scheduled_at.into(),
+        };
+        identity.validate()?;
+        Ok(identity)
+    }
+
+    fn validate(&self) -> Result<()> {
+        let fields: &[(&str, &str)] = match self {
+            Self::Ticket {
+                repository,
+                workflow,
+                ticket,
+                revision,
+            } => &[
+                ("repository", repository),
+                ("workflow", workflow),
+                ("ticket", ticket),
+                ("revision", revision),
+            ],
+            Self::Scheduled {
+                repository,
+                workflow,
+                scheduled_at,
+            } => &[
+                ("repository", repository),
+                ("workflow", workflow),
+                ("scheduled_at", scheduled_at),
+            ],
+        };
+        for (name, value) in fields {
+            if value.trim().is_empty() {
+                bail!("task identity {name} must not be empty");
+            }
+        }
+        Ok(())
+    }
+
+    fn key(&self) -> String {
+        fn component(value: &str) -> String {
+            format!("{}:{value}", value.len())
+        }
+        match self {
+            Self::Ticket {
+                repository,
+                workflow,
+                ticket,
+                revision,
+            } => format!(
+                "ticket:{}:{}:{}:{}",
+                component(repository),
+                component(workflow),
+                component(ticket),
+                component(revision)
+            ),
+            Self::Scheduled {
+                repository,
+                workflow,
+                scheduled_at,
+            } => format!(
+                "scheduled:{}:{}:{}",
+                component(repository),
+                component(workflow),
+                component(scheduled_at)
+            ),
+        }
+    }
+
+    fn repository(&self) -> &str {
+        match self {
+            Self::Ticket { repository, .. } | Self::Scheduled { repository, .. } => repository,
+        }
+    }
+
+    fn workflow(&self) -> &str {
+        match self {
+            Self::Ticket { workflow, .. } | Self::Scheduled { workflow, .. } => workflow,
+        }
+    }
+
+    fn source_item(&self) -> Option<&str> {
+        match self {
+            Self::Ticket { ticket, .. } => Some(ticket),
+            Self::Scheduled { .. } => None,
+        }
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Ticket { .. } => "ticket",
+            Self::Scheduled { .. } => "scheduled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Task {
+    pub id: i64,
+    pub identity_key: String,
+    pub kind: String,
+    pub repository: String,
+    pub workflow: String,
+    pub source_item: Option<String>,
+    pub state: TaskState,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnqueuedTask {
+    pub task: Task,
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunOutcome {
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl RunOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Succeeded => "succeeded",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Run {
+    pub id: i64,
+    pub task_id: i64,
+    pub workflow: String,
+    pub repository: String,
+    pub source_item: Option<String>,
+    pub runtime: String,
+    pub started_at: i64,
+    pub finished_at: Option<i64>,
+    pub outcome: String,
+    pub result: Option<String>,
+    pub error: Option<String>,
+    pub session_id: Option<String>,
+}
+
+pub struct Ledger {
+    connection: Connection,
+    path: PathBuf,
+}
+
+impl Ledger {
+    pub fn open_in(data_directory: &Path) -> Result<Self> {
+        fs::create_dir_all(data_directory).with_context(|| {
+            format!(
+                "failed to create Factory data directory {}",
+                data_directory.display()
+            )
+        })?;
+        Self::open(&data_directory.join(DATABASE_NAME))
+    }
+
+    pub fn open(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create database directory {}", parent.display())
+            })?;
+        }
+        let connection = Connection::open(path)
+            .with_context(|| format!("failed to open SQLite database {}", path.display()))?;
+        connection
+            .busy_timeout(std::time::Duration::from_secs(5))
+            .context("failed to configure SQLite busy timeout")?;
+        connection
+            .execute_batch("PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL;")
+            .context("failed to configure SQLite database")?;
+        migrate(&connection)?;
+        Ok(Self {
+            connection,
+            path: path.to_owned(),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn enqueue(&mut self, identity: &TaskIdentity) -> Result<EnqueuedTask> {
+        identity.validate()?;
+        let now = now_millis()?;
+        let key = identity.key();
+        let transaction = self
+            .connection
+            .transaction()
+            .context("failed to begin task enqueue transaction")?;
+        let inserted = transaction
+            .execute(
+                "INSERT OR IGNORE INTO tasks
+                 (identity_key, kind, repository, workflow, source_item, state, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'queued', ?6, ?6)",
+                params![
+                    key,
+                    identity.kind(),
+                    identity.repository(),
+                    identity.workflow(),
+                    identity.source_item(),
+                    now
+                ],
+            )
+            .context("failed to persist queued task")?
+            == 1;
+        let task = query_task_by_key(&transaction, &identity.key())?
+            .context("task disappeared during enqueue transaction")?;
+        transaction
+            .commit()
+            .context("failed to commit task enqueue transaction")?;
+        Ok(EnqueuedTask {
+            task,
+            created: inserted,
+        })
+    }
+
+    pub fn task(&self, id: i64) -> Result<Option<Task>> {
+        query_task(&self.connection, id)
+    }
+
+    pub fn claim_next(&mut self) -> Result<Option<Task>> {
+        let now = now_millis()?;
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .context("failed to begin atomic task claim")?;
+        let id = transaction
+            .query_row(
+                "SELECT id FROM tasks WHERE state = 'queued' ORDER BY created_at, id LIMIT 1",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .context("failed to select queued task for claim")?;
+        let Some(id) = id else {
+            transaction
+                .commit()
+                .context("failed to finish empty claim")?;
+            return Ok(None);
+        };
+        let changed = transaction
+            .execute(
+                "UPDATE tasks SET state = 'running', updated_at = ?1
+                 WHERE id = ?2 AND state = 'queued'",
+                params![now, id],
+            )
+            .context("failed to claim queued task")?;
+        if changed != 1 {
+            bail!("queued task {id} could not be claimed atomically");
+        }
+        let task = query_task(&transaction, id)?.context("claimed task disappeared")?;
+        transaction
+            .commit()
+            .context("failed to commit atomic task claim")?;
+        Ok(Some(task))
+    }
+
+    pub fn start_run(&mut self, task_id: i64, runtime: &str) -> Result<Run> {
+        if runtime.trim().is_empty() {
+            bail!("run runtime must not be empty");
+        }
+        let transaction = self
+            .connection
+            .transaction()
+            .context("failed to begin run transaction")?;
+        let task = query_task(&transaction, task_id)?
+            .with_context(|| format!("task {task_id} does not exist"))?;
+        if task.state != TaskState::Running {
+            bail!("task {task_id} must be running before a run can start");
+        }
+        transaction
+            .execute(
+                "INSERT INTO runs
+                 (task_id, workflow, repository, source_item, runtime, started_at, outcome)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'running')",
+                params![
+                    task_id,
+                    task.workflow,
+                    task.repository,
+                    task.source_item,
+                    runtime.trim(),
+                    now_millis()?
+                ],
+            )
+            .context("failed to persist run attempt")?;
+        let id = transaction.last_insert_rowid();
+        let run = query_run(&transaction, id)?.context("new run disappeared")?;
+        transaction.commit().context("failed to commit run start")?;
+        Ok(run)
+    }
+
+    pub fn finish_run_and_task(
+        &mut self,
+        id: i64,
+        outcome: RunOutcome,
+        result: Option<&str>,
+        error: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Result<Run> {
+        if outcome == RunOutcome::Running {
+            bail!("finish_run_and_task requires a terminal outcome");
+        }
+        let result = result.map(|value| truncate_utf8(value, MAX_RESULT_BYTES));
+        let error = error.map(|value| truncate_utf8(value, MAX_ERROR_BYTES));
+        let session_id = session_id.map(|value| truncate_utf8(value, MAX_SESSION_ID_BYTES));
+        let transaction = self
+            .connection
+            .transaction()
+            .context("failed to begin run completion transaction")?;
+        let task_id = transaction
+            .query_row(
+                "SELECT task_id FROM runs WHERE id = ?1 AND outcome = 'running'",
+                [id],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .context("failed to resolve active run task")?
+            .with_context(|| format!("run {id} is missing or already terminal"))?;
+        let changed = transaction
+            .execute(
+                "UPDATE runs SET finished_at = ?1, outcome = ?2, result = ?3, error = ?4,
+                 session_id = ?5 WHERE id = ?6 AND outcome = 'running'",
+                params![
+                    now_millis()?,
+                    outcome.as_str(),
+                    result,
+                    error,
+                    session_id,
+                    id
+                ],
+            )
+            .context("failed to record terminal run outcome")?;
+        if changed != 1 {
+            bail!("run {id} is missing or already terminal");
+        }
+        let task_state = match outcome {
+            RunOutcome::Succeeded => TaskState::Succeeded,
+            RunOutcome::Failed => TaskState::Failed,
+            RunOutcome::Cancelled => TaskState::Cancelled,
+            RunOutcome::Running => unreachable!(),
+        };
+        let changed = transaction
+            .execute(
+                "UPDATE tasks SET state = ?1, updated_at = ?2
+                 WHERE id = ?3 AND state = 'running'",
+                params![task_state.as_str(), now_millis()?, task_id],
+            )
+            .context("failed to record terminal task state")?;
+        if changed != 1 {
+            bail!("task {task_id} is not running; run completion was not recorded");
+        }
+        let run = query_run(&transaction, id)?.context("completed run disappeared")?;
+        transaction
+            .commit()
+            .context("failed to commit run completion")?;
+        Ok(run)
+    }
+
+    pub fn runs_for_task(&self, task_id: i64) -> Result<Vec<Run>> {
+        let mut statement = self
+            .connection
+            .prepare("SELECT * FROM runs WHERE task_id = ?1 ORDER BY id")
+            .context("failed to prepare run history query")?;
+        let runs = statement
+            .query_map([task_id], row_to_run)
+            .context("failed to query run history")?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("failed to read run history")?;
+        Ok(runs)
+    }
+}
+
+fn migrate(connection: &Connection) -> Result<()> {
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .context("failed to read SQLite schema version")?;
+    if version > SCHEMA_VERSION {
+        bail!("SQLite schema version {version} is newer than supported version {SCHEMA_VERSION}");
+    }
+    if version == SCHEMA_VERSION {
+        return Ok(());
+    }
+    connection
+        .execute_batch(
+            "BEGIN IMMEDIATE;
+             CREATE TABLE IF NOT EXISTS schema_migrations (
+                 version INTEGER PRIMARY KEY,
+                 applied_at INTEGER NOT NULL
+             );
+             CREATE TABLE IF NOT EXISTS tasks (
+                 id INTEGER PRIMARY KEY,
+                 identity_key TEXT NOT NULL UNIQUE,
+                 kind TEXT NOT NULL CHECK (kind IN ('ticket', 'scheduled')),
+                 repository TEXT NOT NULL,
+                 workflow TEXT NOT NULL,
+                 source_item TEXT,
+                 state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+                 created_at INTEGER NOT NULL,
+                 updated_at INTEGER NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS tasks_state_created_idx ON tasks(state, created_at, id);
+             CREATE TABLE IF NOT EXISTS runs (
+                 id INTEGER PRIMARY KEY,
+                 task_id INTEGER NOT NULL REFERENCES tasks(id),
+                 workflow TEXT NOT NULL,
+                 repository TEXT NOT NULL,
+                 source_item TEXT,
+                 runtime TEXT NOT NULL,
+                 started_at INTEGER NOT NULL,
+                 finished_at INTEGER,
+                 outcome TEXT NOT NULL CHECK (outcome IN ('running', 'succeeded', 'failed', 'cancelled')),
+                 result TEXT,
+                 error TEXT,
+                 session_id TEXT
+             );
+             CREATE INDEX IF NOT EXISTS runs_task_idx ON runs(task_id, id);
+             CREATE UNIQUE INDEX IF NOT EXISTS runs_one_active_per_task_idx
+                 ON runs(task_id) WHERE outcome = 'running';
+             INSERT OR IGNORE INTO schema_migrations(version, applied_at)
+                 VALUES (1, unixepoch('subsec') * 1000);
+             PRAGMA user_version = 1;
+             COMMIT;",
+        )
+        .context("failed to initialize or migrate SQLite ledger")?;
+    Ok(())
+}
+
+fn query_task(connection: &Connection, id: i64) -> Result<Option<Task>> {
+    connection
+        .query_row("SELECT * FROM tasks WHERE id = ?1", [id], row_to_task)
+        .optional()
+        .context("failed to query task")
+}
+
+fn query_task_by_key(connection: &Connection, key: &str) -> Result<Option<Task>> {
+    connection
+        .query_row(
+            "SELECT * FROM tasks WHERE identity_key = ?1",
+            [key],
+            row_to_task,
+        )
+        .optional()
+        .context("failed to query task identity")
+}
+
+fn row_to_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<Task> {
+    let state: String = row.get("state")?;
+    let state = state.parse().map_err(|error: anyhow::Error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            state.len(),
+            rusqlite::types::Type::Text,
+            error.into(),
+        )
+    })?;
+    Ok(Task {
+        id: row.get("id")?,
+        identity_key: row.get("identity_key")?,
+        kind: row.get("kind")?,
+        repository: row.get("repository")?,
+        workflow: row.get("workflow")?,
+        source_item: row.get("source_item")?,
+        state,
+        created_at: row.get("created_at")?,
+        updated_at: row.get("updated_at")?,
+    })
+}
+
+fn query_run(connection: &Connection, id: i64) -> Result<Option<Run>> {
+    connection
+        .query_row("SELECT * FROM runs WHERE id = ?1", [id], row_to_run)
+        .optional()
+        .context("failed to query run")
+}
+
+fn row_to_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<Run> {
+    Ok(Run {
+        id: row.get("id")?,
+        task_id: row.get("task_id")?,
+        workflow: row.get("workflow")?,
+        repository: row.get("repository")?,
+        source_item: row.get("source_item")?,
+        runtime: row.get("runtime")?,
+        started_at: row.get("started_at")?,
+        finished_at: row.get("finished_at")?,
+        outcome: row.get("outcome")?,
+        result: row.get("result")?,
+        error: row.get("error")?,
+        session_id: row.get("session_id")?,
+    })
+}
+
+fn now_millis() -> Result<i64> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_millis();
+    i64::try_from(millis).context("system time cannot be represented by SQLite")
+}
+
+fn truncate_utf8(value: &str, maximum_bytes: usize) -> String {
+    if value.len() <= maximum_bytes {
+        return value.to_owned();
+    }
+    let mut end = maximum_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_owned()
+}

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -1,0 +1,187 @@
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use factory::storage::{
+    Ledger, MAX_ERROR_BYTES, MAX_RESULT_BYTES, RunOutcome, TaskIdentity, TaskState,
+};
+use rusqlite::Connection;
+
+fn ticket(revision: &str) -> TaskIdentity {
+    TaskIdentity::ticket(
+        "owainlewis/factory",
+        "implement-ready-ticket",
+        "3",
+        revision,
+    )
+    .unwrap()
+}
+
+#[test]
+fn initializes_in_data_directory_and_persists_across_reopen() {
+    let temp = tempfile::tempdir().unwrap();
+    let data = temp.path().join("nested/data");
+    let mut ledger = Ledger::open_in(&data).unwrap();
+    let enqueued = ledger.enqueue(&ticket("revision-1")).unwrap();
+    assert!(enqueued.created);
+    let path = ledger.path().to_owned();
+    drop(ledger);
+
+    let reopened = Ledger::open(&path).unwrap();
+    let persisted = reopened.task(enqueued.task.id).unwrap().unwrap();
+
+    assert_eq!(persisted.state, TaskState::Queued);
+    assert_eq!(persisted.repository, "owainlewis/factory");
+    assert_eq!(persisted.source_item.as_deref(), Some("3"));
+}
+
+#[test]
+fn ticket_and_schedule_identities_deduplicate_exact_triggers() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(temp.path().join("ledger.db").as_path()).unwrap();
+
+    let first = ledger.enqueue(&ticket("revision-1")).unwrap();
+    let duplicate = ledger.enqueue(&ticket("revision-1")).unwrap();
+    let changed = ledger.enqueue(&ticket("revision-2")).unwrap();
+    let scheduled =
+        TaskIdentity::scheduled("owainlewis/factory", "find-bugs", "2026-07-20T09:00:00Z").unwrap();
+    let first_schedule = ledger.enqueue(&scheduled).unwrap();
+    let duplicate_schedule = ledger.enqueue(&scheduled).unwrap();
+
+    assert!(first.created);
+    assert!(!duplicate.created);
+    assert_eq!(duplicate.task.id, first.task.id);
+    assert!(changed.created);
+    assert_ne!(changed.task.id, first.task.id);
+    assert!(first_schedule.created);
+    assert!(!duplicate_schedule.created);
+    assert_eq!(duplicate_schedule.task.id, first_schedule.task.id);
+}
+
+#[test]
+fn concurrent_claim_has_exactly_one_winner() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut setup = Ledger::open(&path).unwrap();
+    let task_id = setup.enqueue(&ticket("claim-revision")).unwrap().task.id;
+    drop(setup);
+    let barrier = Arc::new(Barrier::new(9));
+    let handles = (0..8)
+        .map(|_| {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let mut ledger = Ledger::open(&path).unwrap();
+                barrier.wait();
+                ledger.claim_next().unwrap().map(|task| task.id)
+            })
+        })
+        .collect::<Vec<_>>();
+    barrier.wait();
+    let claims = handles
+        .into_iter()
+        .filter_map(|handle| handle.join().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(claims, vec![task_id]);
+}
+
+#[test]
+fn records_bounded_run_history_and_terminal_tasks_cannot_be_reclaimed() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    let task = ledger.enqueue(&ticket("run-revision")).unwrap().task;
+    assert_eq!(ledger.claim_next().unwrap().unwrap().id, task.id);
+    let run = ledger.start_run(task.id, "codex").unwrap();
+
+    let result = "é".repeat(MAX_RESULT_BYTES);
+    let error = "x".repeat(MAX_ERROR_BYTES + 100);
+    let completed = ledger
+        .finish_run_and_task(
+            run.id,
+            RunOutcome::Failed,
+            Some(&result),
+            Some(&error),
+            Some("thread-123"),
+        )
+        .unwrap();
+    let task = ledger.task(task.id).unwrap().unwrap();
+
+    assert_eq!(task.state, TaskState::Failed);
+    assert!(completed.finished_at.is_some());
+    assert_eq!(completed.outcome, "failed");
+    assert!(completed.result.unwrap().len() <= MAX_RESULT_BYTES);
+    assert_eq!(completed.error.unwrap().len(), MAX_ERROR_BYTES);
+    assert_eq!(completed.session_id.as_deref(), Some("thread-123"));
+    assert!(ledger.claim_next().unwrap().is_none());
+    assert!(
+        ledger
+            .finish_run_and_task(run.id, RunOutcome::Succeeded, None, None, None)
+            .is_err()
+    );
+    assert_eq!(ledger.runs_for_task(task.id).unwrap().len(), 1);
+}
+
+#[test]
+fn only_one_active_run_can_start_for_a_claimed_task() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut setup = Ledger::open(&path).unwrap();
+    let task = setup.enqueue(&ticket("active-run-revision")).unwrap().task;
+    setup.claim_next().unwrap().unwrap();
+    drop(setup);
+    let barrier = Arc::new(Barrier::new(3));
+    let handles = (0..2)
+        .map(|_| {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let mut ledger = Ledger::open(&path).unwrap();
+                barrier.wait();
+                ledger.start_run(task.id, "codex").is_ok()
+            })
+        })
+        .collect::<Vec<_>>();
+    barrier.wait();
+    let winners = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .filter(|started| *started)
+        .count();
+
+    assert_eq!(winners, 1);
+}
+
+#[test]
+fn rejects_a_database_from_a_newer_factory_version_without_changing_it() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("future.db");
+    let connection = Connection::open(&path).unwrap();
+    connection.pragma_update(None, "user_version", 99).unwrap();
+    drop(connection);
+
+    let error = Ledger::open(&path).err().unwrap();
+
+    assert!(error.to_string().contains("newer than supported"));
+    let connection = Connection::open(path).unwrap();
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, 99);
+}
+
+#[test]
+fn failed_writes_do_not_damage_prior_state() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    let task = ledger.enqueue(&ticket("safe-revision")).unwrap().task;
+
+    let error = ledger.start_run(task.id, "codex").unwrap_err();
+
+    assert!(error.to_string().contains("must be running"));
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Queued
+    );
+    assert!(ledger.runs_for_task(task.id).unwrap().is_empty());
+}


### PR DESCRIPTION
Closes #3

## Summary
- initialize and version a SQLite ledger in the Factory data directory
- deduplicate ticket revisions and scheduled instants with durable task identities
- atomically claim queued tasks and atomically terminalize task/run outcomes
- bound stored result, error, and session metadata
- prevent multiple active runs for one task at the database layer

## Acceptance proof
- persistence and migration: reopen and unsupported-version tests
- deduplication: ticket-revision and scheduled-instant tests
- lifecycle and bounded history: terminal run/task test
- atomicity: eight-claimant race and two-runner uniqueness tests
- transaction safety: failed-write preservation test

## Checks
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## Review
A fresh agent reviewed the diff. Three valid durability findings were fixed and re-reviewed with no remaining blockers.