### PR TITLE
feat: poll GitHub ready tickets (#4)

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,402 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::Config;
+use crate::storage::{Ledger, ObservedTicket};
+use crate::workflow::{Trigger, WorkflowCatalog, WorkflowEntry};
+
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TicketContext {
+    pub number: u64,
+    pub url: String,
+    pub title: String,
+    pub body: String,
+    pub labels: Vec<String>,
+    pub comments: Vec<TicketComment>,
+    pub observed_revision: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TicketComment {
+    pub id: u64,
+    pub url: String,
+    pub author: String,
+    pub body: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryPoll {
+    pub repository: PathBuf,
+    pub name_with_owner: Option<String>,
+    pub issues_seen: usize,
+    pub tasks_created: usize,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PollReport {
+    pub repositories: Vec<RepositoryPoll>,
+}
+
+impl PollReport {
+    pub fn tasks_created(&self) -> usize {
+        self.repositories
+            .iter()
+            .map(|item| item.tasks_created)
+            .sum()
+    }
+
+    pub fn failures(&self) -> usize {
+        self.repositories
+            .iter()
+            .filter(|item| item.error.is_some())
+            .count()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubClient {
+    executable: PathBuf,
+    command_timeout: Duration,
+}
+
+impl Default for GitHubClient {
+    fn default() -> Self {
+        Self::new("gh")
+    }
+}
+
+impl GitHubClient {
+    pub fn new(executable: impl Into<PathBuf>) -> Self {
+        Self {
+            executable: executable.into(),
+            command_timeout: DEFAULT_COMMAND_TIMEOUT,
+        }
+    }
+
+    pub fn with_command_timeout(mut self, command_timeout: Duration) -> Self {
+        self.command_timeout = command_timeout;
+        self
+    }
+
+    pub async fn validate_global(&self, cancellation: &CancellationToken) -> Result<()> {
+        self.run(None, &["--version"], cancellation)
+            .await
+            .context("GitHub CLI is unavailable; install gh and ensure it is executable")?;
+        self.run(None, &["auth", "status"], cancellation)
+            .await
+            .context("GitHub CLI is not authenticated; run gh auth login")?;
+        Ok(())
+    }
+
+    pub async fn validate_repository(
+        &self,
+        repository: &Path,
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
+        let output = self
+            .run(
+                Some(repository),
+                &[
+                    "repo",
+                    "view",
+                    "--json",
+                    "nameWithOwner",
+                    "--jq",
+                    ".nameWithOwner",
+                ],
+                cancellation,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "GitHub CLI cannot read configured repository {}",
+                    repository.display()
+                )
+            })?;
+        let name = output.trim();
+        if !valid_name_with_owner(name) {
+            bail!("gh returned invalid repository identity {name:?}");
+        }
+        Ok(name.to_owned())
+    }
+
+    pub async fn poll_once(
+        &self,
+        config: &Config,
+        catalog: &WorkflowCatalog,
+        ledger: &mut Ledger,
+    ) -> Result<PollReport> {
+        self.poll_once_with_cancellation(config, catalog, ledger, CancellationToken::new())
+            .await
+    }
+
+    async fn poll_once_with_cancellation(
+        &self,
+        config: &Config,
+        catalog: &WorkflowCatalog,
+        ledger: &mut Ledger,
+        cancellation: CancellationToken,
+    ) -> Result<PollReport> {
+        self.validate_global(&cancellation).await?;
+        let workflows = label_workflows(catalog);
+        let mut repositories = Vec::with_capacity(config.repositories.len());
+        for repository in &config.repositories {
+            let result = self
+                .poll_repository(repository, workflows.get(repository), ledger, &cancellation)
+                .await;
+            repositories.push(match result {
+                Ok(report) => report,
+                Err(error) => RepositoryPoll {
+                    repository: repository.clone(),
+                    name_with_owner: None,
+                    issues_seen: 0,
+                    tasks_created: 0,
+                    error: Some(format!("{error:#}")),
+                },
+            });
+        }
+        Ok(PollReport { repositories })
+    }
+
+    pub async fn poll_until_cancelled<F>(
+        &self,
+        config: &Config,
+        catalog: &WorkflowCatalog,
+        ledger: &mut Ledger,
+        cancellation: CancellationToken,
+        mut on_poll: F,
+    ) -> Result<()>
+    where
+        F: FnMut(&PollReport),
+    {
+        loop {
+            if cancellation.is_cancelled() {
+                return Ok(());
+            }
+            let report = match self
+                .poll_once_with_cancellation(config, catalog, ledger, cancellation.clone())
+                .await
+            {
+                Ok(report) => report,
+                Err(_) if cancellation.is_cancelled() => return Ok(()),
+                Err(error) => return Err(error),
+            };
+            on_poll(&report);
+            tokio::select! {
+                _ = cancellation.cancelled() => return Ok(()),
+                _ = tokio::time::sleep(config.poll_every) => {}
+            }
+        }
+    }
+
+    async fn poll_repository(
+        &self,
+        repository: &Path,
+        workflows: Option<&Vec<&WorkflowEntry>>,
+        ledger: &mut Ledger,
+        cancellation: &CancellationToken,
+    ) -> Result<RepositoryPoll> {
+        let name = self.validate_repository(repository, cancellation).await?;
+        let issues: Vec<ApiIssue> = self
+            .api_pages(
+                repository,
+                &format!("repos/{name}/issues?state=open&per_page=100"),
+                cancellation,
+            )
+            .await?;
+        let issues = issues
+            .into_iter()
+            .filter(|issue| issue.pull_request.is_none())
+            .collect::<Vec<_>>();
+        let mut tasks_created = 0;
+        for workflow in workflows.into_iter().flatten() {
+            let Trigger::Label(label) = workflow.trigger.as_ref().expect("filtered workflow")
+            else {
+                unreachable!();
+            };
+            let mut observations = Vec::with_capacity(issues.len());
+            for issue in &issues {
+                let eligible = issue.labels.iter().any(|item| item.name == *label);
+                let comments = if eligible {
+                    self.api_pages::<ApiComment>(
+                        repository,
+                        &format!("repos/{name}/issues/{}/comments?per_page=100", issue.number),
+                        cancellation,
+                    )
+                    .await?
+                    .into_iter()
+                    .map(TicketComment::from)
+                    .collect()
+                } else {
+                    Vec::new()
+                };
+                let context = TicketContext {
+                    number: issue.number,
+                    url: issue.html_url.clone(),
+                    title: issue.title.clone(),
+                    body: issue.body.clone().unwrap_or_default(),
+                    labels: issue.labels.iter().map(|item| item.name.clone()).collect(),
+                    comments,
+                    observed_revision: issue.updated_at.clone(),
+                };
+                observations.push(ObservedTicket {
+                    source_item: issue.number.to_string(),
+                    revision: issue.updated_at.clone(),
+                    eligible,
+                    payload: serde_json::to_string(&context)
+                        .context("failed to serialize ticket context")?,
+                });
+            }
+            tasks_created += ledger
+                .reconcile_ticket_poll(&name, &workflow.id, &observations)?
+                .into_iter()
+                .filter(|task| task.created)
+                .count();
+        }
+        Ok(RepositoryPoll {
+            repository: repository.to_owned(),
+            name_with_owner: Some(name),
+            issues_seen: issues.len(),
+            tasks_created,
+            error: None,
+        })
+    }
+
+    async fn api_pages<T: DeserializeOwned>(
+        &self,
+        repository: &Path,
+        endpoint: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<Vec<T>> {
+        let output = self
+            .run(
+                Some(repository),
+                &["api", "--paginate", "--slurp", endpoint],
+                cancellation,
+            )
+            .await?;
+        let pages: Vec<Vec<T>> = serde_json::from_str(&output)
+            .with_context(|| format!("gh returned malformed paginated JSON for {endpoint}"))?;
+        Ok(pages.into_iter().flatten().collect())
+    }
+
+    async fn run(
+        &self,
+        repository: Option<&Path>,
+        arguments: &[&str],
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
+        let mut command = Command::new(&self.executable);
+        command.args(arguments);
+        if let Some(repository) = repository {
+            command.current_dir(repository);
+        }
+        command
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let child = command.spawn().with_context(|| {
+            format!(
+                "failed to start GitHub CLI at {}",
+                self.executable.display()
+            )
+        })?;
+        let output = tokio::select! {
+            _ = cancellation.cancelled() => bail!("GitHub CLI command cancelled"),
+            result = tokio::time::timeout(self.command_timeout, child.wait_with_output()) => {
+                match result {
+                    Ok(output) => output.context("failed to wait for GitHub CLI")?,
+                    Err(_) => bail!(
+                        "gh {} timed out after {}",
+                        arguments.join(" "),
+                        humantime::format_duration(self.command_timeout)
+                    ),
+                }
+            }
+        };
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!(
+                "gh {} failed with status {}: {}",
+                arguments.join(" "),
+                output.status,
+                stderr.trim()
+            );
+        }
+        String::from_utf8(output.stdout).context("gh output was not valid UTF-8")
+    }
+}
+
+fn label_workflows(catalog: &WorkflowCatalog) -> HashMap<PathBuf, Vec<&WorkflowEntry>> {
+    let mut workflows = HashMap::<PathBuf, Vec<&WorkflowEntry>>::new();
+    for workflow in &catalog.entries {
+        if workflow.errors.is_empty() && matches!(workflow.trigger, Some(Trigger::Label(_))) {
+            workflows
+                .entry(workflow.repository.clone())
+                .or_default()
+                .push(workflow);
+        }
+    }
+    workflows
+}
+
+fn valid_name_with_owner(value: &str) -> bool {
+    let mut parts = value.split('/');
+    matches!((parts.next(), parts.next(), parts.next()), (Some(owner), Some(repository), None) if !owner.is_empty() && !repository.is_empty())
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiIssue {
+    number: u64,
+    html_url: String,
+    title: String,
+    body: Option<String>,
+    labels: Vec<ApiLabel>,
+    updated_at: String,
+    pull_request: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiLabel {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiComment {
+    id: u64,
+    html_url: String,
+    user: ApiUser,
+    body: Option<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiUser {
+    login: String,
+}
+
+impl From<ApiComment> for TicketComment {
+    fn from(comment: ApiComment) -> Self {
+        Self {
+            id: comment.id,
+            url: comment.html_url,
+            author: comment.user.login,
+            body: comment.body.unwrap_or_default(),
+            created_at: comment.created_at,
+            updated_at: comment.updated_at,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ compile_error!("Factory v1 supports Unix-like operating systems only");
 
 pub mod config;
 pub mod execution;
+pub mod github;
 pub mod runtime;
 pub mod storage;
 pub mod workflow;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,11 @@ use tokio_util::sync::CancellationToken;
 
 use factory::config::{Config, default_config_path};
 use factory::execution::ResolvedWorkflow;
+use factory::github::{GitHubClient, PollReport};
 use factory::runtime::{
     CodexRuntime, RuntimeCancelled, Termination, write_stderr_best_effort, write_stdout_best_effort,
 };
+use factory::storage::Ledger;
 use factory::workflow::WorkflowCatalog;
 
 #[derive(Debug, Parser)]
@@ -21,6 +23,18 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Poll configured repositories and persist eligible ticket tasks.
+    Run {
+        /// Poll once and exit without waiting for the next interval.
+        #[arg(long)]
+        once: bool,
+        /// Path to the Factory configuration file.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Directory containing the durable Factory database.
+        #[arg(long)]
+        data_directory: Option<PathBuf>,
+    },
     /// Validate configuration without starting workers or network activity.
     Validate {
         /// Path to the Factory configuration file.
@@ -70,6 +84,13 @@ async fn run_cli() -> Result<u8> {
     let cli = Cli::parse();
 
     match cli.command {
+        Command::Run {
+            once,
+            config,
+            data_directory,
+        } => {
+            return run_poller(config, data_directory, once).await;
+        }
         Command::Validate { config } => {
             let path = config.unwrap_or_else(default_config_path);
             let config = Config::load(&path)?;
@@ -98,6 +119,75 @@ async fn run_cli() -> Result<u8> {
     }
 
     Ok(0)
+}
+
+async fn run_poller(
+    config_path: Option<PathBuf>,
+    data_directory: Option<PathBuf>,
+    once: bool,
+) -> Result<u8> {
+    let path = config_path.unwrap_or_else(default_config_path);
+    let config = Config::load(&path)?;
+    let catalog = WorkflowCatalog::load(&config)?;
+    let invalid = catalog.invalid_count();
+    if invalid > 0 {
+        bail!("workflow catalog contains {invalid} invalid workflow(s)");
+    }
+    let data_directory = data_directory.unwrap_or_else(|| {
+        path.parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .to_path_buf()
+    });
+    let mut ledger = Ledger::open_in(&data_directory)?;
+    let github = GitHubClient::default();
+    if once {
+        let report = github.poll_once(&config, &catalog, &mut ledger).await?;
+        print_poll_report(&report);
+        return Ok(u8::from(report.failures() > 0));
+    }
+
+    let cancellation = CancellationToken::new();
+    let signal_token = cancellation.clone();
+    let signal_task = tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            signal_token.cancel();
+        }
+    });
+    github
+        .poll_until_cancelled(
+            &config,
+            &catalog,
+            &mut ledger,
+            cancellation,
+            print_poll_report,
+        )
+        .await?;
+    signal_task.abort();
+    Ok(0)
+}
+
+fn print_poll_report(report: &PollReport) {
+    for repository in &report.repositories {
+        if let Some(error) = &repository.error {
+            write_stderr_best_effort(
+                format!(
+                    "Poll failed for {}: {error}\n",
+                    repository.repository.display()
+                )
+                .as_bytes(),
+            );
+        } else {
+            write_stdout_best_effort(
+                format!(
+                    "repository={} issues_seen={} tasks_created={}\n",
+                    repository.name_with_owner.as_deref().unwrap_or("-"),
+                    repository.issues_seen,
+                    repository.tasks_created
+                )
+                .as_bytes(),
+            );
+        }
+    }
 }
 
 async fn run_workflow(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -7,7 +8,7 @@ use anyhow::{Context, Result, bail};
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 
 const DATABASE_NAME: &str = "factory.sqlite3";
-const SCHEMA_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 2;
 pub const MAX_RESULT_BYTES: usize = 256 * 1024;
 pub const MAX_ERROR_BYTES: usize = 64 * 1024;
 pub const MAX_SESSION_ID_BYTES: usize = 1024;
@@ -194,6 +195,7 @@ pub struct Task {
     pub repository: String,
     pub workflow: String,
     pub source_item: Option<String>,
+    pub payload: Option<String>,
     pub state: TaskState,
     pub created_at: i64,
     pub updated_at: i64,
@@ -203,6 +205,14 @@ pub struct Task {
 pub struct EnqueuedTask {
     pub task: Task,
     pub created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservedTicket {
+    pub source_item: String,
+    pub revision: String,
+    pub eligible: bool,
+    pub payload: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -282,6 +292,14 @@ impl Ledger {
     }
 
     pub fn enqueue(&mut self, identity: &TaskIdentity) -> Result<EnqueuedTask> {
+        self.enqueue_with_payload(identity, None)
+    }
+
+    pub fn enqueue_with_payload(
+        &mut self,
+        identity: &TaskIdentity,
+        payload: Option<&str>,
+    ) -> Result<EnqueuedTask> {
         identity.validate()?;
         let now = now_millis()?;
         let key = identity.key();
@@ -292,15 +310,16 @@ impl Ledger {
         let inserted = transaction
             .execute(
                 "INSERT OR IGNORE INTO tasks
-                 (identity_key, kind, repository, workflow, source_item, state, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, 'queued', ?6, ?6)",
+                 (identity_key, kind, repository, workflow, source_item, payload, state, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'queued', ?7, ?7)",
                 params![
                     key,
                     identity.kind(),
                     identity.repository(),
                     identity.workflow(),
                     identity.source_item(),
-                    now
+                    payload,
+                    now,
                 ],
             )
             .context("failed to persist queued task")?
@@ -314,6 +333,123 @@ impl Ledger {
             task,
             created: inserted,
         })
+    }
+
+    pub fn reconcile_ticket_poll(
+        &mut self,
+        repository: &str,
+        workflow: &str,
+        observations: &[ObservedTicket],
+    ) -> Result<Vec<EnqueuedTask>> {
+        if repository.trim().is_empty() || workflow.trim().is_empty() {
+            bail!("poll repository and workflow must not be empty");
+        }
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .context("failed to begin ticket poll transaction")?;
+        let previous = {
+            let mut statement = transaction
+                .prepare(
+                    "SELECT source_item, eligible FROM trigger_observations
+                     WHERE repository = ?1 AND workflow = ?2",
+                )
+                .context("failed to prepare prior ticket eligibility query")?;
+            statement
+                .query_map(params![repository, workflow], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?))
+                })
+                .context("failed to query prior ticket eligibility")?
+                .collect::<rusqlite::Result<HashMap<_, _>>>()
+                .context("failed to read prior ticket eligibility")?
+        };
+        transaction
+            .execute(
+                "UPDATE trigger_observations SET eligible = 0
+                 WHERE repository = ?1 AND workflow = ?2",
+                params![repository, workflow],
+            )
+            .context("failed to reset ticket eligibility observations")?;
+        let mut enqueued = Vec::new();
+        for observation in observations {
+            if observation.source_item.trim().is_empty() || observation.revision.trim().is_empty() {
+                bail!("observed ticket source item and revision must not be empty");
+            }
+            let was_eligible = previous
+                .get(&observation.source_item)
+                .copied()
+                .unwrap_or(false);
+            if observation.eligible && !was_eligible {
+                let identity = TaskIdentity::ticket(
+                    repository,
+                    workflow,
+                    &observation.source_item,
+                    &observation.revision,
+                )?;
+                let active_exists = transaction
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM tasks
+                            WHERE repository = ?1 AND workflow = ?2 AND source_item = ?3
+                              AND state IN ('queued', 'running')
+                        )",
+                        params![repository, workflow, observation.source_item],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .context("failed to check for an active ticket task")?;
+                if !active_exists {
+                    let key = identity.key();
+                    let now = now_millis()?;
+                    let inserted = transaction
+                        .execute(
+                        "INSERT OR IGNORE INTO tasks
+                         (identity_key, kind, repository, workflow, source_item, payload, state, created_at, updated_at)
+                         VALUES (?1, 'ticket', ?2, ?3, ?4, ?5, 'queued', ?6, ?6)",
+                        params![
+                            key,
+                            repository,
+                            workflow,
+                            observation.source_item,
+                            observation.payload,
+                            now
+                        ],
+                        )
+                        .context("failed to enqueue observed ticket")?
+                        == 1;
+                    let task = query_task_by_key(&transaction, &identity.key())?
+                        .context("observed ticket task disappeared")?;
+                    enqueued.push(EnqueuedTask {
+                        task,
+                        created: inserted,
+                    });
+                }
+            }
+            transaction
+                .execute(
+                    "INSERT INTO trigger_observations
+                     (repository, workflow, source_item, revision, eligible, payload, observed_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                     ON CONFLICT(repository, workflow, source_item) DO UPDATE SET
+                       revision = excluded.revision,
+                       eligible = excluded.eligible,
+                       payload = excluded.payload,
+                       observed_at = excluded.observed_at",
+                    params![
+                        repository,
+                        workflow,
+                        observation.source_item,
+                        observation.revision,
+                        observation.eligible,
+                        observation.payload,
+                        now_millis()?
+                    ],
+                )
+                .context("failed to persist ticket observation")?;
+        }
+        transaction
+            .commit()
+            .context("failed to commit ticket poll transaction")?;
+        Ok(enqueued)
     }
 
     pub fn task(&self, id: i64) -> Result<Option<Task>> {
@@ -479,9 +615,16 @@ fn migrate(connection: &Connection) -> Result<()> {
     if version > SCHEMA_VERSION {
         bail!("SQLite schema version {version} is newer than supported version {SCHEMA_VERSION}");
     }
-    if version == SCHEMA_VERSION {
-        return Ok(());
+    if version < 1 {
+        migrate_v1(connection)?;
     }
+    if version < 2 {
+        migrate_v2(connection)?;
+    }
+    Ok(())
+}
+
+fn migrate_v1(connection: &Connection) -> Result<()> {
     connection
         .execute_batch(
             "BEGIN IMMEDIATE;
@@ -527,6 +670,30 @@ fn migrate(connection: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v2(connection: &Connection) -> Result<()> {
+    connection
+        .execute_batch(
+            "BEGIN IMMEDIATE;
+             ALTER TABLE tasks ADD COLUMN payload TEXT;
+             CREATE TABLE trigger_observations (
+                 repository TEXT NOT NULL,
+                 workflow TEXT NOT NULL,
+                 source_item TEXT NOT NULL,
+                 revision TEXT NOT NULL,
+                 eligible INTEGER NOT NULL CHECK (eligible IN (0, 1)),
+                 payload TEXT NOT NULL,
+                 observed_at INTEGER NOT NULL,
+                 PRIMARY KEY(repository, workflow, source_item)
+             );
+             INSERT INTO schema_migrations(version, applied_at)
+                 VALUES (2, unixepoch('subsec') * 1000);
+             PRAGMA user_version = 2;
+             COMMIT;",
+        )
+        .context("failed to migrate SQLite ledger to version 2")?;
+    Ok(())
+}
+
 fn query_task(connection: &Connection, id: i64) -> Result<Option<Task>> {
     connection
         .query_row("SELECT * FROM tasks WHERE id = ?1", [id], row_to_task)
@@ -561,6 +728,7 @@ fn row_to_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<Task> {
         repository: row.get("repository")?,
         workflow: row.get("workflow")?,
         source_item: row.get("source_item")?,
+        payload: row.get("payload")?,
         state,
         created_at: row.get("created_at")?,
         updated_at: row.get("updated_at")?,

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -1,0 +1,409 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use assert_cmd::Command as AssertCommand;
+use factory::config::Config;
+use factory::github::{GitHubClient, TicketContext};
+use factory::storage::{Ledger, RunOutcome};
+use factory::workflow::WorkflowCatalog;
+use tokio_util::sync::CancellationToken;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    repositories: Vec<PathBuf>,
+    config_path: PathBuf,
+    ledger_path: PathBuf,
+    gh: PathBuf,
+}
+
+impl Fixture {
+    fn new(repository_count: usize) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let mut repositories = Vec::new();
+        for index in 0..repository_count {
+            let repository = temp.path().join(format!("repo-{index}"));
+            fs::create_dir_all(repository.join(".factory/workflows")).unwrap();
+            fs::write(
+                repository.join(".factory/workflows/implement-ready-ticket.md"),
+                "+++\nlabel = \"factory:ready\"\n+++\n\nImplement the ticket.\n",
+            )
+            .unwrap();
+            fs::write(
+                repository.join(".gh-name"),
+                format!("example/repo-{index}\n"),
+            )
+            .unwrap();
+            fs::write(repository.join(".issues.json"), "[[]]").unwrap();
+            repositories.push(repository);
+        }
+        let workspace = temp.path().join("worktrees");
+        fs::create_dir(&workspace).unwrap();
+        let config_path = temp.path().join("config.toml");
+        let repository_values = repositories
+            .iter()
+            .map(|path| format!("\"{}\"", path.display()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        fs::write(
+            &config_path,
+            format!(
+                "repositories = [{repository_values}]\npoll_every = \"20ms\"\ndefault_runtime = \"codex\"\ndefault_timeout = \"2h\"\nmaximum_timeout = \"8h\"\nmax_concurrent_runs = 2\nworkspace_root = \"{}\"\n",
+                workspace.display()
+            ),
+        )
+        .unwrap();
+        let gh = temp.path().join("gh");
+        fs::write(
+            &gh,
+            r#"#!/bin/sh
+if [ -f "$0.hang" ]; then echo $$ > "$0.hang.pid"; exec sleep 30; fi
+if [ "$1" = "--version" ]; then echo "gh version 2.80.0"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  if [ -f "$0.auth-fail" ]; then echo "not logged in" >&2; exit 1; fi
+  echo "logged in"; exit 0
+fi
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  if [ -f ".gh-fail" ]; then echo "repository denied" >&2; exit 1; fi
+  cat .gh-name; exit 0
+fi
+if [ "$1" = "api" ]; then
+  if [ -f ".api-fail" ]; then echo "API rate limit exceeded" >&2; exit 1; fi
+  endpoint="$4"
+  case "$endpoint" in
+    */comments*)
+      number=$(printf '%s' "$endpoint" | sed -E 's#^.*/issues/([0-9]+)/comments.*#\1#')
+      file=".comments-$number.json"
+      if [ -f "$file" ]; then cat "$file"; else printf '[[]]'; fi
+      ;;
+    *) cat .issues.json ;;
+  esac
+  exit 0
+fi
+echo "unexpected fake gh arguments: $*" >&2
+exit 64
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&gh).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&gh, permissions).unwrap();
+        let ledger_path = temp.path().join("factory.db");
+        Self {
+            _temp: temp,
+            repositories,
+            config_path,
+            ledger_path,
+            gh,
+        }
+    }
+
+    async fn poll(&self) -> anyhow::Result<(factory::github::PollReport, Ledger)> {
+        let config = Config::load(&self.config_path).unwrap();
+        let catalog = WorkflowCatalog::load(&config).unwrap();
+        let mut ledger = Ledger::open(&self.ledger_path).unwrap();
+        let report = GitHubClient::new(&self.gh)
+            .poll_once(&config, &catalog, &mut ledger)
+            .await?;
+        Ok((report, ledger))
+    }
+}
+
+fn issue(number: u64, revision: &str, labels: &[&str]) -> String {
+    let labels = labels
+        .iter()
+        .map(|label| format!(r#"{{"name":"{label}"}}"#))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        r#"{{"number":{number},"html_url":"https://github.com/example/repo/issues/{number}","title":"Ticket {number}","body":"Body {number}","labels":[{labels}],"updated_at":"{revision}"}}"#
+    )
+}
+
+fn write_issues(repository: &Path, pages: &[Vec<String>]) {
+    let contents = pages
+        .iter()
+        .map(|page| format!("[{}]", page.join(",")))
+        .collect::<Vec<_>>()
+        .join(",");
+    fs::write(repository.join(".issues.json"), format!("[{contents}]")).unwrap();
+}
+
+#[test]
+fn factory_run_once_persists_a_task_without_launching_codex() {
+    let fixture = Fixture::new(1);
+    write_issues(
+        &fixture.repositories[0],
+        &[vec![issue(9, "revision-1", &["factory:ready"])]],
+    );
+    let data = fixture._temp.path().join("data");
+    let codex_marker = fixture._temp.path().join("codex-launched");
+    let codex = fixture._temp.path().join("codex");
+    fs::write(
+        &codex,
+        format!("#!/bin/sh\ntouch '{}'\nexit 99\n", codex_marker.display()),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&codex).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(codex, permissions).unwrap();
+    let path = format!(
+        "{}:{}",
+        fixture._temp.path().display(),
+        std::env::var("PATH").unwrap()
+    );
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            data.to_str().unwrap(),
+        ])
+        .env("PATH", path)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("tasks_created=1"));
+
+    assert!(!codex_marker.exists());
+    let mut ledger = Ledger::open_in(&data).unwrap();
+    assert_eq!(
+        ledger.claim_next().unwrap().unwrap().source_item.as_deref(),
+        Some("9")
+    );
+}
+
+#[tokio::test]
+async fn no_matches_creates_no_tasks() {
+    let fixture = Fixture::new(1);
+    write_issues(
+        &fixture.repositories[0],
+        &[vec![issue(1, "revision-1", &["bug"])]],
+    );
+
+    let (report, mut ledger) = fixture.poll().await.unwrap();
+
+    assert_eq!(report.tasks_created(), 0);
+    assert_eq!(report.repositories[0].issues_seen, 1);
+    assert!(ledger.claim_next().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn pagination_and_comments_create_one_complete_durable_task() {
+    let fixture = Fixture::new(1);
+    write_issues(
+        &fixture.repositories[0],
+        &[
+            vec![issue(1, "revision-1", &["bug"])],
+            vec![issue(2, "revision-2", &["factory:ready", "enhancement"])],
+        ],
+    );
+    fs::write(
+        fixture.repositories[0].join(".comments-2.json"),
+        r#"[[{"id":10,"html_url":"https://example/comment/10","user":{"login":"alice"},"body":"First","created_at":"a","updated_at":"a"}],[{"id":11,"html_url":"https://example/comment/11","user":{"login":"bob"},"body":"Second","created_at":"b","updated_at":"c"}]]"#,
+    )
+    .unwrap();
+
+    let (report, mut ledger) = fixture.poll().await.unwrap();
+    let task = ledger.claim_next().unwrap().unwrap();
+    let context: TicketContext = serde_json::from_str(task.payload.as_deref().unwrap()).unwrap();
+
+    assert_eq!(report.tasks_created(), 1);
+    assert_eq!(report.repositories[0].issues_seen, 2);
+    assert_eq!(context.number, 2);
+    assert_eq!(context.labels, vec!["factory:ready", "enhancement"]);
+    assert_eq!(context.comments.len(), 2);
+    assert_eq!(context.comments[1].author, "bob");
+}
+
+#[tokio::test]
+async fn unchanged_and_changed_eligible_tickets_do_not_duplicate_until_relabelled() {
+    let fixture = Fixture::new(1);
+    let repository = &fixture.repositories[0];
+    write_issues(
+        repository,
+        &[vec![issue(4, "revision-1", &["factory:ready"])]],
+    );
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 1);
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 0);
+
+    write_issues(
+        repository,
+        &[vec![issue(4, "revision-2", &["factory:ready"])]],
+    );
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 0);
+    write_issues(
+        repository,
+        &[vec![issue(4, "revision-3", &["enhancement"])]],
+    );
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 0);
+    write_issues(
+        repository,
+        &[vec![issue(4, "revision-4", &["factory:ready"])]],
+    );
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 0);
+
+    let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    let task = ledger.claim_next().unwrap().unwrap();
+    let run = ledger.start_run(task.id, "codex").unwrap();
+    drop(ledger);
+    write_issues(
+        repository,
+        &[vec![issue(4, "revision-5", &["enhancement"])]],
+    );
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 0);
+    write_issues(
+        repository,
+        &[vec![issue(4, "revision-6", &["factory:ready"])]],
+    );
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 0);
+
+    let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    ledger
+        .finish_run_and_task(run.id, RunOutcome::Failed, None, Some("expected"), None)
+        .unwrap();
+    drop(ledger);
+    write_issues(
+        repository,
+        &[vec![issue(4, "revision-7", &["enhancement"])]],
+    );
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 0);
+    write_issues(
+        repository,
+        &[vec![issue(4, "revision-8", &["factory:ready"])]],
+    );
+    assert_eq!(fixture.poll().await.unwrap().0.tasks_created(), 1);
+}
+
+#[tokio::test]
+async fn authentication_failure_is_actionable_and_creates_nothing() {
+    let fixture = Fixture::new(1);
+    fs::write(format!("{}.auth-fail", fixture.gh.display()), "").unwrap();
+
+    let error = match fixture.poll().await {
+        Ok(_) => panic!("authentication failure unexpectedly succeeded"),
+        Err(error) => error,
+    };
+
+    assert!(format!("{error:#}").contains("run gh auth login"));
+    let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    assert!(ledger.claim_next().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn malformed_output_and_rate_limiting_are_isolated_from_healthy_repositories() {
+    let fixture = Fixture::new(2);
+    fs::write(fixture.repositories[0].join(".issues.json"), "not json").unwrap();
+    write_issues(
+        &fixture.repositories[1],
+        &[vec![issue(6, "revision-1", &["factory:ready"])]],
+    );
+
+    let (report, _) = fixture.poll().await.unwrap();
+
+    assert_eq!(report.failures(), 1);
+    assert!(
+        report.repositories[0]
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("malformed paginated JSON")
+    );
+    assert_eq!(report.repositories[1].tasks_created, 1);
+
+    fs::remove_file(fixture.repositories[0].join(".issues.json")).unwrap();
+    fs::write(fixture.repositories[0].join(".api-fail"), "").unwrap();
+    let (report, _) = fixture.poll().await.unwrap();
+    assert_eq!(report.failures(), 1);
+    assert!(
+        report.repositories[0]
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("rate limit")
+    );
+    assert_eq!(report.repositories[1].tasks_created, 0);
+}
+
+#[tokio::test]
+async fn polling_repeats_at_the_configured_interval_and_stops_on_cancellation() {
+    let fixture = Fixture::new(1);
+    let config = Config::load(&fixture.config_path).unwrap();
+    let catalog = WorkflowCatalog::load(&config).unwrap();
+    let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    let cancellation = CancellationToken::new();
+    let cancel_after_two = cancellation.clone();
+    let polls = AtomicUsize::new(0);
+    tokio::time::timeout(
+        Duration::from_secs(3),
+        GitHubClient::new(&fixture.gh).poll_until_cancelled(
+            &config,
+            &catalog,
+            &mut ledger,
+            cancellation,
+            |_| {
+                if polls.fetch_add(1, Ordering::Relaxed) == 1 {
+                    cancel_after_two.cancel();
+                }
+            },
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert!(polls.load(Ordering::Relaxed) >= 2);
+}
+
+#[tokio::test]
+async fn cancellation_terminates_a_hung_gh_process() {
+    let fixture = Fixture::new(1);
+    fs::write(format!("{}.hang", fixture.gh.display()), "").unwrap();
+    let pid_path = PathBuf::from(format!("{}.hang.pid", fixture.gh.display()));
+    let config = Config::load(&fixture.config_path).unwrap();
+    let catalog = WorkflowCatalog::load(&config).unwrap();
+    let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    let cancellation = CancellationToken::new();
+    let cancel = cancellation.clone();
+    let wait_for_pid = pid_path.clone();
+    tokio::spawn(async move {
+        for _ in 0..1000 {
+            if wait_for_pid.exists() {
+                cancel.cancel();
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        cancel.cancel();
+    });
+
+    GitHubClient::new(&fixture.gh)
+        .with_command_timeout(Duration::from_secs(15))
+        .poll_until_cancelled(&config, &catalog, &mut ledger, cancellation, |_| {})
+        .await
+        .unwrap();
+
+    let pid = fs::read_to_string(pid_path).expect("fake gh never reported its process ID");
+    let mut gone = false;
+    for _ in 0..100 {
+        if !Command::new("kill")
+            .args(["-0", pid.trim()])
+            .status()
+            .unwrap()
+            .success()
+        {
+            gone = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(gone, "hung gh process {pid:?} survived cancellation");
+}

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -171,6 +171,58 @@ fn rejects_a_database_from_a_newer_factory_version_without_changing_it() {
 }
 
 #[test]
+fn migrates_a_version_one_ledger_without_losing_tasks() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("version-one.db");
+    let connection = Connection::open(&path).unwrap();
+    connection
+        .execute_batch(
+            "CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);
+             CREATE TABLE tasks (
+                 id INTEGER PRIMARY KEY,
+                 identity_key TEXT NOT NULL UNIQUE,
+                 kind TEXT NOT NULL,
+                 repository TEXT NOT NULL,
+                 workflow TEXT NOT NULL,
+                 source_item TEXT,
+                 state TEXT NOT NULL,
+                 created_at INTEGER NOT NULL,
+                 updated_at INTEGER NOT NULL
+             );
+             CREATE TABLE runs (
+                 id INTEGER PRIMARY KEY,
+                 task_id INTEGER NOT NULL REFERENCES tasks(id),
+                 workflow TEXT NOT NULL,
+                 repository TEXT NOT NULL,
+                 source_item TEXT,
+                 runtime TEXT NOT NULL,
+                 started_at INTEGER NOT NULL,
+                 finished_at INTEGER,
+                 outcome TEXT NOT NULL,
+                 result TEXT,
+                 error TEXT,
+                 session_id TEXT
+             );
+             INSERT INTO schema_migrations VALUES (1, 1);
+             INSERT INTO tasks VALUES (7, 'legacy', 'ticket', 'example/repo', 'workflow', '4', 'queued', 1, 1);
+             PRAGMA user_version = 1;",
+        )
+        .unwrap();
+    drop(connection);
+
+    let ledger = Ledger::open(&path).unwrap();
+    let task = ledger.task(7).unwrap().unwrap();
+
+    assert_eq!(task.repository, "example/repo");
+    assert_eq!(task.payload, None);
+    let connection = Connection::open(path).unwrap();
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, 2);
+}
+
+#[test]
 fn failed_writes_do_not_damage_prior_state() {
     let temp = tempfile::tempdir().unwrap();
     let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();


### PR DESCRIPTION
Closes #4

## Summary
- validate subscription-independent `gh` installation, authentication, and repository access
- poll open GitHub issues and paginated discussion through supervised, cancellable CLI processes
- persist complete ticket context and label eligibility in the SQLite ledger
- create exactly one task per eligible label episode while suppressing queued/running duplicates
- add `factory run --once` and interval polling without launching an agent
- isolate repository failures and preserve healthy repository progress

## Acceptance proof
- fake-gh tests cover no match, one match, pagination, comments, repeated polls, changed tickets, relabels, queued/running suppression, auth failure, malformed JSON, rate limits, mixed healthy/failing repositories, hung process cancellation, and the CLI no-Codex boundary
- SQLite v1-to-v2 migration test preserves existing tasks
- real smoke: temporary issue #15 with `factory:ready` produced `tasks_created=1`, repeat poll produced `0`, SQLite contained one queued task, and no Codex process launched; the issue was then unlabelled and closed

## Checks
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## Review
A fresh agent found active-task duplication and unbounded gh execution. Both were fixed and re-reviewed with no remaining blockers.