### PR TITLE
feat(cli): inspect and cancel Factory runs (#7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "humantime",
  "nix",
  "predicates",
+ "regex",
  "rusqlite",
  "rustix",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ chrono-tz = "0.10"
 cron = "0.15"
 dirs = "6.0"
 humantime = "2.2"
+regex = "1.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rusqlite = { version = "0.37", features = ["bundled"] }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 use tokio::task::JoinSet;
@@ -14,6 +16,27 @@ use crate::storage::{Ledger, RunOutcome, Task};
 use crate::workflow::{WorkflowCatalog, WorkflowEntry};
 
 const HUMAN_MERGE_POLICY: &str = "Factory-created software pull requests must remain for human merge. Never merge or enable automatic merge.";
+static OWNER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct DaemonOwner {
+    id: String,
+    pid: u32,
+}
+
+impl DaemonOwner {
+    fn new() -> Result<Self> {
+        let pid = std::process::id();
+        let started = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system clock is before the Unix epoch")?
+            .as_nanos();
+        let sequence = OWNER_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        Ok(Self {
+            id: format!("{pid}-{started}-{sequence}"),
+            pid,
+        })
+    }
+}
 
 #[derive(Clone)]
 struct RepositoryTarget {
@@ -76,6 +99,23 @@ impl FactoryDaemon {
             Err(error) => return Err(error),
         };
         let mut ledger = Ledger::open(&self.ledger_path)?;
+        let owner = DaemonOwner::new()?;
+        ledger.register_daemon_owner(&owner.id, owner.pid)?;
+        let owner_heartbeat_shutdown = CancellationToken::new();
+        let owner_heartbeat_task = {
+            let ledger_path = self.ledger_path.clone();
+            let owner_id = owner.id.clone();
+            let shutdown = owner_heartbeat_shutdown.clone();
+            let daemon_cancellation = cancellation.clone();
+            tokio::spawn(async move {
+                let result = maintain_owner_lease(&ledger_path, &owner_id, shutdown).await;
+                if let Err(error) = &result {
+                    eprintln!("Factory daemon owner heartbeat failed: {error:#}");
+                    daemon_cancellation.cancel();
+                }
+                result
+            })
+        };
         let mut active = HashMap::<String, usize>::new();
         let mut runs = JoinSet::<(String, Result<()>)>::new();
         let mut poll_interval = tokio::time::interval_at(Instant::now(), self.config.poll_every);
@@ -93,6 +133,7 @@ impl FactoryDaemon {
                     &self.ledger_path,
                     &self.codex,
                     &cancellation,
+                    &owner,
                 )?;
 
                 tokio::select! {
@@ -146,7 +187,14 @@ impl FactoryDaemon {
                 }
             }
         }
+        owner_heartbeat_shutdown.cancel();
+        let heartbeat_result = owner_heartbeat_task
+            .await
+            .context("daemon owner heartbeat task panicked")?;
+        let cleanup_result = ledger.remove_daemon_owner(&owner.id);
         loop_result?;
+        heartbeat_result?;
+        cleanup_result?;
         if let Some(error) = drain_error {
             return Err(error);
         }
@@ -200,6 +248,22 @@ impl FactoryDaemon {
     }
 }
 
+async fn maintain_owner_lease(
+    ledger_path: &Path,
+    owner_id: &str,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let mut ledger = Ledger::open(ledger_path)?;
+    let mut interval = tokio::time::interval(Duration::from_millis(250));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => return Ok(()),
+            _ = interval.tick() => ledger.heartbeat_daemon_owner(owner_id)?,
+        }
+    }
+}
+
 fn resolve_workflow_target(entry: &WorkflowEntry) -> Option<(String, WorkflowTarget)> {
     Some((
         entry.id.clone(),
@@ -222,6 +286,7 @@ fn dispatch_available(
     ledger_path: &Path,
     codex: &CodexRuntime,
     cancellation: &CancellationToken,
+    owner: &DaemonOwner,
 ) -> Result<()> {
     while runs.len() < global_limit && !cancellation.is_cancelled() {
         let available = targets
@@ -241,7 +306,12 @@ fn dispatch_available(
             })
             .collect::<HashMap<_, _>>();
         let mut worker_ledger = Ledger::open(ledger_path)?;
-        let Some(claimed) = ledger.claim_ticket_and_start_run(&available, &workflow_runtimes)?
+        let Some(claimed) = ledger.claim_ticket_and_start_run(
+            &available,
+            &workflow_runtimes,
+            &owner.id,
+            owner.pid,
+        )?
         else {
             break;
         };
@@ -321,10 +391,25 @@ async fn execute_task(
     prompt: String,
     cancellation: CancellationToken,
 ) -> Result<()> {
-    match codex
-        .run(&prompt, &repository.path, workflow.timeout, cancellation)
-        .await
-    {
+    let run_cancellation = cancellation.child_token();
+    let monitor_token = run_cancellation.clone();
+    let ledger_path = ledger.path().to_owned();
+    let cancellation_monitor = tokio::spawn(async move {
+        if let Err(error) = monitor_run_cancellation(&ledger_path, run_id, &monitor_token).await {
+            eprintln!("Factory cancellation monitor failed for run {run_id}: {error:#}");
+            monitor_token.cancel();
+        }
+    });
+    let execution = codex
+        .run(
+            &prompt,
+            &repository.path,
+            workflow.timeout,
+            run_cancellation,
+        )
+        .await;
+    cancellation_monitor.abort();
+    match execution {
         Ok(result) => record_execution(&mut ledger, run_id, &result),
         Err(error) => {
             ledger.finish_run_and_task(
@@ -335,6 +420,27 @@ async fn execute_task(
                 None,
             )?;
             Err(error)
+        }
+    }
+}
+
+async fn monitor_run_cancellation(
+    ledger_path: &Path,
+    run_id: i64,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    let ledger = Ledger::open(ledger_path)?;
+    let mut interval = tokio::time::interval(Duration::from_millis(50));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = cancellation.cancelled() => return Ok(()),
+            _ = interval.tick() => {
+                if ledger.cancellation_requested(run_id)? {
+                    cancellation.cancel();
+                    return Ok(());
+                }
+            }
         }
     }
 }

--- a/src/inspection.rs
+++ b/src/inspection.rs
@@ -233,6 +233,8 @@ fn sanitize(value: &str) -> String {
     static ASSIGNMENT: OnceLock<Regex> = OnceLock::new();
     static BEARER: OnceLock<Regex> = OnceLock::new();
     static TOKEN_PREFIX: OnceLock<Regex> = OnceLock::new();
+    static URI_USERINFO: OnceLock<Regex> = OnceLock::new();
+    static AWS_ACCESS_KEY: OnceLock<Regex> = OnceLock::new();
 
     let value = PRIVATE_KEY
         .get_or_init(|| {
@@ -256,6 +258,18 @@ fn sanitize(value: &str) -> String {
             .expect("credential-assignment redaction pattern is valid")
         })
         .replace_all(&value, "${1}[REDACTED]");
+    let value = URI_USERINFO
+        .get_or_init(|| {
+            Regex::new(r"(?i)\b([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^@/\s]+@")
+                .expect("credential-URI redaction pattern is valid")
+        })
+        .replace_all(&value, "${1}[REDACTED]@");
+    let value = AWS_ACCESS_KEY
+        .get_or_init(|| {
+            Regex::new(r"\b(?:AKIA|ASIA|AIDA|AROA|AIPA|ANPA|ANVA|ASCA)[A-Z0-9]{16}\b")
+                .expect("AWS access-key redaction pattern is valid")
+        })
+        .replace_all(&value, "[REDACTED]");
     TOKEN_PREFIX
         .get_or_init(|| {
             Regex::new(

--- a/src/inspection.rs
+++ b/src/inspection.rs
@@ -1,0 +1,268 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::Serialize;
+
+use crate::storage::{Run, Task, TaskState};
+
+const MAX_SUMMARY_BYTES: usize = 240;
+const MAX_DETAIL_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Serialize)]
+pub struct TaskView {
+    pub id: i64,
+    pub repository: String,
+    pub workflow: String,
+    pub source_item: Option<String>,
+    pub state: &'static str,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+impl From<&Task> for TaskView {
+    fn from(task: &Task) -> Self {
+        Self {
+            id: task.id,
+            repository: task.repository.clone(),
+            workflow: task.workflow.clone(),
+            source_item: task.source_item.clone(),
+            state: task_state(task.state),
+            created_at: task.created_at,
+            updated_at: task.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunView {
+    pub id: i64,
+    pub task_id: i64,
+    pub repository: String,
+    pub workflow: String,
+    pub source_item: Option<String>,
+    pub runtime: String,
+    pub outcome: String,
+    pub started_at: i64,
+    pub finished_at: Option<i64>,
+    pub duration_ms: Option<i64>,
+    pub summary: Option<String>,
+    pub cancellation_requested_at: Option<i64>,
+    pub owner_pid: Option<u32>,
+    pub owner_id: Option<String>,
+}
+
+impl From<&Run> for RunView {
+    fn from(run: &Run) -> Self {
+        let summary = run
+            .error
+            .as_deref()
+            .or(run.result.as_deref())
+            .map(sanitize)
+            .map(|value| truncate(&value, MAX_SUMMARY_BYTES).0);
+        Self {
+            id: run.id,
+            task_id: run.task_id,
+            repository: run.repository.clone(),
+            workflow: run.workflow.clone(),
+            source_item: run.source_item.clone(),
+            runtime: run.runtime.clone(),
+            outcome: run.outcome.clone(),
+            started_at: run.started_at,
+            finished_at: run.finished_at,
+            duration_ms: run
+                .finished_at
+                .map(|finished| finished.saturating_sub(run.started_at)),
+            summary,
+            cancellation_requested_at: run.cancellation_requested_at,
+            owner_pid: run.owner_pid,
+            owner_id: run.owner_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct BoundedText {
+    pub value: String,
+    pub truncated: bool,
+}
+
+impl BoundedText {
+    fn new(value: &str) -> Self {
+        let value = sanitize(value);
+        let (value, truncated) = truncate(&value, MAX_DETAIL_BYTES);
+        Self { value, truncated }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunInspection {
+    pub run: RunView,
+    pub task: TaskView,
+    pub session_id: Option<String>,
+    pub result: Option<BoundedText>,
+    pub error: Option<BoundedText>,
+}
+
+impl RunInspection {
+    pub fn new(run: &Run, task: &Task) -> Self {
+        Self {
+            run: RunView::from(run),
+            task: TaskView::from(task),
+            session_id: run.session_id.clone(),
+            result: run.result.as_deref().map(BoundedText::new),
+            error: run.error.as_deref().map(BoundedText::new),
+        }
+    }
+}
+
+pub fn print_tasks(tasks: &[Task]) {
+    println!("ID\tSTATE\tREPOSITORY\tWORKFLOW\tSOURCE\tCREATED\tUPDATED");
+    for task in tasks {
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            task.id,
+            task_state(task.state),
+            safe_column(&task.repository, 48),
+            safe_column(&task.workflow, 36),
+            safe_column(task.source_item.as_deref().unwrap_or("-"), 24),
+            task.created_at,
+            task.updated_at,
+        );
+    }
+}
+
+pub fn print_runs(runs: &[Run]) {
+    println!("ID\tOUTCOME\tRUNTIME\tWORKFLOW\tREPOSITORY\tSOURCE\tDURATION_MS\tSUMMARY");
+    for run in runs {
+        let view = RunView::from(run);
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            view.id,
+            safe_column(&view.outcome, 16),
+            safe_column(&view.runtime, 16),
+            safe_column(&view.workflow, 36),
+            safe_column(&view.repository, 48),
+            safe_column(view.source_item.as_deref().unwrap_or("-"), 24),
+            view.duration_ms
+                .map_or_else(|| "-".to_owned(), |value| value.to_string()),
+            safe_column(view.summary.as_deref().unwrap_or("-"), MAX_SUMMARY_BYTES),
+        );
+    }
+}
+
+pub fn print_inspection(inspection: &RunInspection) {
+    println!("Run: {}", inspection.run.id);
+    println!("Task: {}", inspection.task.id);
+    println!("Repository: {}", safe_text(&inspection.run.repository));
+    println!("Workflow: {}", safe_text(&inspection.run.workflow));
+    println!(
+        "Source: {}",
+        safe_text(inspection.run.source_item.as_deref().unwrap_or("-"))
+    );
+    println!("Runtime: {}", safe_text(&inspection.run.runtime));
+    println!("Outcome: {}", safe_text(&inspection.run.outcome));
+    println!("Started: {}", inspection.run.started_at);
+    println!(
+        "Finished: {}",
+        inspection
+            .run
+            .finished_at
+            .map_or_else(|| "-".to_owned(), |value| value.to_string())
+    );
+    println!(
+        "Duration ms: {}",
+        inspection
+            .run
+            .duration_ms
+            .map_or_else(|| "-".to_owned(), |value| value.to_string())
+    );
+    println!(
+        "Session: {}",
+        safe_text(inspection.session_id.as_deref().unwrap_or("-"))
+    );
+    print_detail("Result", inspection.result.as_ref());
+    print_detail("Error", inspection.error.as_ref());
+}
+
+fn print_detail(label: &str, detail: Option<&BoundedText>) {
+    match detail {
+        Some(detail) => {
+            let suffix = if detail.truncated { " [truncated]" } else { "" };
+            println!("{label}{suffix}: {}", safe_text(&detail.value));
+        }
+        None => println!("{label}: -"),
+    }
+}
+
+fn task_state(state: TaskState) -> &'static str {
+    match state {
+        TaskState::Queued => "queued",
+        TaskState::Running => "running",
+        TaskState::Succeeded => "succeeded",
+        TaskState::Failed => "failed",
+        TaskState::Cancelled => "cancelled",
+    }
+}
+
+fn safe_column(value: &str, maximum: usize) -> String {
+    let (value, truncated) = truncate(value, maximum);
+    let mut value = safe_text(&value);
+    if truncated {
+        value.push('…');
+    }
+    value
+}
+
+fn safe_text(value: &str) -> String {
+    value.chars().flat_map(char::escape_default).collect()
+}
+
+fn truncate(value: &str, maximum_bytes: usize) -> (String, bool) {
+    if value.len() <= maximum_bytes {
+        return (value.to_owned(), false);
+    }
+    let mut end = maximum_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    (value[..end].to_owned(), true)
+}
+
+fn sanitize(value: &str) -> String {
+    static PRIVATE_KEY: OnceLock<Regex> = OnceLock::new();
+    static ASSIGNMENT: OnceLock<Regex> = OnceLock::new();
+    static BEARER: OnceLock<Regex> = OnceLock::new();
+    static TOKEN_PREFIX: OnceLock<Regex> = OnceLock::new();
+
+    let value = PRIVATE_KEY
+        .get_or_init(|| {
+            Regex::new(
+                r"(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?(?:-----END [A-Z ]*PRIVATE KEY-----|\z)",
+            )
+            .expect("private-key redaction pattern is valid")
+        })
+        .replace_all(value, "[REDACTED PRIVATE KEY]");
+    let value = BEARER
+        .get_or_init(|| {
+            Regex::new(r"(?i)\bbearer\s+[A-Za-z0-9._~+/-]+=*")
+                .expect("bearer redaction pattern is valid")
+        })
+        .replace_all(&value, "Bearer [REDACTED]");
+    let value = ASSIGNMENT
+        .get_or_init(|| {
+            Regex::new(
+                r#"(?i)([\"']?(?:[A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|API_KEY|ACCESS_KEY|PRIVATE_KEY|CREDENTIAL|COOKIE)[A-Z0-9_]*|DATABASE_URL|AUTHORIZATION)[\"']?\s*[:=]\s*)(?:\"(?:\\.|[^\"\\])*(?:\"|\z)|'(?:\\.|[^'\\])*(?:'|\z)|[^\s,}]+)"#,
+            )
+            .expect("credential-assignment redaction pattern is valid")
+        })
+        .replace_all(&value, "${1}[REDACTED]");
+    TOKEN_PREFIX
+        .get_or_init(|| {
+            Regex::new(
+                r"\b(?:gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]+)\b",
+            )
+            .expect("token-prefix redaction pattern is valid")
+        })
+        .replace_all(&value, "[REDACTED]")
+        .into_owned()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod daemon;
 pub mod execution;
 pub mod github;
+pub mod inspection;
 pub mod runtime;
 pub mod storage;
 pub mod workflow;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
+use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
 use factory::config::{Config, default_config_path};
@@ -125,6 +126,16 @@ enum WorkflowCommand {
     },
 }
 
+#[derive(Serialize)]
+struct CancellationResponse {
+    run_id: i64,
+    status: &'static str,
+    owner_kind: &'static str,
+    owner_pid: Option<u32>,
+    outcome: String,
+    message: &'static str,
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     match run_cli().await {
@@ -229,34 +240,38 @@ async fn run_cli() -> Result<u8> {
         } => {
             let mut ledger = open_data_ledger(config, data_directory)?;
             let response = match ledger.request_run_cancellation(run_id)? {
-                CancellationRequest::Requested(run) => serde_json::json!({
-                    "run_id": run.id,
-                    "status": "requested",
-                    "owner": "factory-daemon",
-                    "outcome": run.outcome,
-                    "message": "cancellation requested; the owning Factory daemon will stop the active process tree"
-                }),
-                CancellationRequest::AlreadyRequested(run) => serde_json::json!({
-                    "run_id": run.id,
-                    "status": "already_requested",
-                    "owner": "factory-daemon",
-                    "outcome": run.outcome,
-                    "message": "cancellation was already requested from the owning Factory daemon"
-                }),
-                CancellationRequest::Terminal(run) => serde_json::json!({
-                    "run_id": run.id,
-                    "status": "already_terminal",
-                    "owner": null,
-                    "outcome": run.outcome,
-                    "message": "run is already terminal"
-                }),
-                CancellationRequest::OwnedElsewhere(run) => serde_json::json!({
-                    "run_id": run.id,
-                    "status": "owned_elsewhere",
-                    "owner": run.owner_pid,
-                    "outcome": run.outcome,
-                    "message": "run has no live local Factory daemon owner; inspect or recover it before retrying cancellation"
-                }),
+                CancellationRequest::Requested(run) => CancellationResponse {
+                    run_id: run.id,
+                    status: "requested",
+                    owner_kind: "factory-daemon",
+                    owner_pid: run.owner_pid,
+                    outcome: run.outcome,
+                    message: "cancellation requested; the owning Factory daemon will stop the active process tree",
+                },
+                CancellationRequest::AlreadyRequested(run) => CancellationResponse {
+                    run_id: run.id,
+                    status: "already_requested",
+                    owner_kind: "factory-daemon",
+                    owner_pid: run.owner_pid,
+                    outcome: run.outcome,
+                    message: "cancellation was already requested from the owning Factory daemon",
+                },
+                CancellationRequest::Terminal(run) => CancellationResponse {
+                    run_id: run.id,
+                    status: "already_terminal",
+                    owner_kind: "none",
+                    owner_pid: None,
+                    outcome: run.outcome,
+                    message: "run is already terminal",
+                },
+                CancellationRequest::OwnedElsewhere(run) => CancellationResponse {
+                    run_id: run.id,
+                    status: "owned_elsewhere",
+                    owner_kind: "stale-or-foreign",
+                    owner_pid: run.owner_pid,
+                    outcome: run.outcome,
+                    message: "run has no live local Factory daemon owner; inspect or recover it before retrying cancellation",
+                },
                 CancellationRequest::NotFound => bail!("run {run_id} does not exist"),
             };
             if json {
@@ -264,9 +279,7 @@ async fn run_cli() -> Result<u8> {
             } else {
                 println!(
                     "Run {}: {} ({})",
-                    response["run_id"],
-                    response["message"].as_str().unwrap_or("unknown status"),
-                    response["status"].as_str().unwrap_or("unknown")
+                    response.run_id, response.message, response.status
                 );
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
 use tokio_util::sync::CancellationToken;
 
@@ -9,10 +9,13 @@ use factory::config::{Config, default_config_path};
 use factory::daemon::FactoryDaemon;
 use factory::execution::ResolvedWorkflow;
 use factory::github::{GitHubClient, PollReport};
+use factory::inspection::{
+    RunInspection, RunView, TaskView, print_inspection, print_runs, print_tasks,
+};
 use factory::runtime::{
     CodexRuntime, RuntimeCancelled, Termination, write_stderr_best_effort, write_stdout_best_effort,
 };
-use factory::storage::Ledger;
+use factory::storage::{CancellationRequest, Ledger};
 use factory::workflow::WorkflowCatalog;
 
 #[derive(Debug, Parser)]
@@ -52,6 +55,58 @@ enum Command {
     Workflow {
         #[command(subcommand)]
         command: WorkflowCommand,
+    },
+    /// List durable tasks.
+    Tasks {
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        /// Path to the Factory configuration file used to locate the data directory.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Directory containing the durable Factory database.
+        #[arg(long)]
+        data_directory: Option<PathBuf>,
+    },
+    /// List run attempts, optionally filtered by workflow.
+    Runs {
+        /// Workflow ID to filter by.
+        workflow: Option<String>,
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        /// Path to the Factory configuration file used to locate the data directory.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Directory containing the durable Factory database.
+        #[arg(long)]
+        data_directory: Option<PathBuf>,
+    },
+    /// Inspect one run and its resolved task context.
+    Inspect {
+        run_id: i64,
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        /// Path to the Factory configuration file used to locate the data directory.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Directory containing the durable Factory database.
+        #[arg(long)]
+        data_directory: Option<PathBuf>,
+    },
+    /// Request cancellation of an active local run.
+    Cancel {
+        run_id: i64,
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        /// Path to the Factory configuration file used to locate the data directory.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Directory containing the durable Factory database.
+        #[arg(long)]
+        data_directory: Option<PathBuf>,
     },
 }
 
@@ -117,9 +172,129 @@ async fn run_cli() -> Result<u8> {
         } => {
             return run_workflow(&workflow_id, &repository, config).await;
         }
+        Command::Tasks {
+            json,
+            config,
+            data_directory,
+        } => {
+            let ledger = open_data_ledger(config, data_directory)?;
+            let tasks = ledger.tasks()?;
+            if json {
+                let views = tasks.iter().map(TaskView::from).collect::<Vec<_>>();
+                print_json(&views)?;
+            } else {
+                print_tasks(&tasks);
+            }
+        }
+        Command::Runs {
+            workflow,
+            json,
+            config,
+            data_directory,
+        } => {
+            let ledger = open_data_ledger(config, data_directory)?;
+            let runs = ledger.runs(workflow.as_deref())?;
+            if json {
+                let views = runs.iter().map(RunView::from).collect::<Vec<_>>();
+                print_json(&views)?;
+            } else {
+                print_runs(&runs);
+            }
+        }
+        Command::Inspect {
+            run_id,
+            json,
+            config,
+            data_directory,
+        } => {
+            let ledger = open_data_ledger(config, data_directory)?;
+            let run = ledger
+                .run(run_id)?
+                .with_context(|| format!("run {run_id} does not exist"))?;
+            let task = ledger
+                .task(run.task_id)?
+                .with_context(|| format!("task {} for run {run_id} does not exist", run.task_id))?;
+            let inspection = RunInspection::new(&run, &task);
+            if json {
+                print_json(&inspection)?;
+            } else {
+                print_inspection(&inspection);
+            }
+        }
+        Command::Cancel {
+            run_id,
+            json,
+            config,
+            data_directory,
+        } => {
+            let mut ledger = open_data_ledger(config, data_directory)?;
+            let response = match ledger.request_run_cancellation(run_id)? {
+                CancellationRequest::Requested(run) => serde_json::json!({
+                    "run_id": run.id,
+                    "status": "requested",
+                    "owner": "factory-daemon",
+                    "outcome": run.outcome,
+                    "message": "cancellation requested; the owning Factory daemon will stop the active process tree"
+                }),
+                CancellationRequest::AlreadyRequested(run) => serde_json::json!({
+                    "run_id": run.id,
+                    "status": "already_requested",
+                    "owner": "factory-daemon",
+                    "outcome": run.outcome,
+                    "message": "cancellation was already requested from the owning Factory daemon"
+                }),
+                CancellationRequest::Terminal(run) => serde_json::json!({
+                    "run_id": run.id,
+                    "status": "already_terminal",
+                    "owner": null,
+                    "outcome": run.outcome,
+                    "message": "run is already terminal"
+                }),
+                CancellationRequest::OwnedElsewhere(run) => serde_json::json!({
+                    "run_id": run.id,
+                    "status": "owned_elsewhere",
+                    "owner": run.owner_pid,
+                    "outcome": run.outcome,
+                    "message": "run has no live local Factory daemon owner; inspect or recover it before retrying cancellation"
+                }),
+                CancellationRequest::NotFound => bail!("run {run_id} does not exist"),
+            };
+            if json {
+                print_json(&response)?;
+            } else {
+                println!(
+                    "Run {}: {} ({})",
+                    response["run_id"],
+                    response["message"].as_str().unwrap_or("unknown status"),
+                    response["status"].as_str().unwrap_or("unknown")
+                );
+            }
+        }
     }
 
     Ok(0)
+}
+
+fn open_data_ledger(
+    config_path: Option<PathBuf>,
+    data_directory: Option<PathBuf>,
+) -> Result<Ledger> {
+    let config_path = config_path.unwrap_or_else(default_config_path);
+    let data_directory = data_directory.unwrap_or_else(|| {
+        config_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."))
+            .to_path_buf()
+    });
+    Ledger::open_in(&data_directory)
+}
+
+fn print_json(value: &impl serde::Serialize) -> Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(value).context("failed to encode JSON output")?
+    );
+    Ok(())
 }
 
 async fn run_poller(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,10 +8,11 @@ use anyhow::{Context, Result, bail};
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 
 const DATABASE_NAME: &str = "factory.sqlite3";
-const SCHEMA_VERSION: i64 = 2;
+const SCHEMA_VERSION: i64 = 3;
 pub const MAX_RESULT_BYTES: usize = 256 * 1024;
 pub const MAX_ERROR_BYTES: usize = 64 * 1024;
 pub const MAX_SESSION_ID_BYTES: usize = 1024;
+const DAEMON_OWNER_LEASE_MILLIS: i64 = 10_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskState {
@@ -248,6 +249,18 @@ pub struct Run {
     pub result: Option<String>,
     pub error: Option<String>,
     pub session_id: Option<String>,
+    pub cancellation_requested_at: Option<i64>,
+    pub owner_pid: Option<u32>,
+    pub owner_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CancellationRequest {
+    Requested(Run),
+    AlreadyRequested(Run),
+    Terminal(Run),
+    OwnedElsewhere(Run),
+    NotFound,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -479,6 +492,8 @@ impl Ledger {
         &mut self,
         available_repositories: &[String],
         workflow_runtimes: &HashMap<(String, String), String>,
+        owner_id: &str,
+        owner_pid: u32,
     ) -> Result<Option<ClaimedRun>> {
         if available_repositories.is_empty() {
             return Ok(None);
@@ -530,15 +545,17 @@ impl Ledger {
         transaction
             .execute(
                 "INSERT INTO runs
-                 (task_id, workflow, repository, source_item, runtime, started_at, outcome)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'running')",
+                 (task_id, workflow, repository, source_item, runtime, started_at, outcome, owner_pid, owner_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'running', ?7, ?8)",
                 params![
                     task.id,
                     task.workflow,
                     task.repository,
                     task.source_item,
                     runtime,
-                    now
+                    now,
+                    owner_pid,
+                    owner_id
                 ],
             )
             .context("failed to create run in task claim transaction")?;
@@ -668,21 +685,30 @@ impl Ledger {
             bail!("finish_run_and_task requires a terminal outcome");
         }
         let result = result.map(|value| truncate_utf8(value, MAX_RESULT_BYTES));
-        let error = error.map(|value| truncate_utf8(value, MAX_ERROR_BYTES));
+        let mut error = error.map(|value| truncate_utf8(value, MAX_ERROR_BYTES));
         let session_id = session_id.map(|value| truncate_utf8(value, MAX_SESSION_ID_BYTES));
         let transaction = self
             .connection
             .transaction()
             .context("failed to begin run completion transaction")?;
-        let task_id = transaction
+        let (task_id, cancellation_requested) = transaction
             .query_row(
-                "SELECT task_id FROM runs WHERE id = ?1 AND outcome = 'running'",
+                "SELECT task_id, cancellation_requested_at IS NOT NULL
+                 FROM runs WHERE id = ?1 AND outcome = 'running'",
                 [id],
-                |row| row.get::<_, i64>(0),
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, bool>(1)?)),
             )
             .optional()
             .context("failed to resolve active run task")?
             .with_context(|| format!("run {id} is missing or already terminal"))?;
+        let outcome = if cancellation_requested {
+            if error.is_none() {
+                error = Some("Cancellation requested by local operator".to_owned());
+            }
+            RunOutcome::Cancelled
+        } else {
+            outcome
+        };
         let changed = transaction
             .execute(
                 "UPDATE runs SET finished_at = ?1, outcome = ?2, result = ?3, error = ?4,
@@ -735,6 +761,137 @@ impl Ledger {
             .context("failed to read run history")?;
         Ok(runs)
     }
+
+    pub fn runs(&self, workflow: Option<&str>) -> Result<Vec<Run>> {
+        let mut statement = self
+            .connection
+            .prepare(
+                "SELECT * FROM runs
+                 WHERE (?1 IS NULL OR workflow = ?1)
+                 ORDER BY id",
+            )
+            .context("failed to prepare runs query")?;
+        statement
+            .query_map([workflow], row_to_run)
+            .context("failed to query runs")?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("failed to read runs")
+    }
+
+    pub fn run(&self, id: i64) -> Result<Option<Run>> {
+        query_run(&self.connection, id)
+    }
+
+    pub fn request_run_cancellation(&mut self, id: i64) -> Result<CancellationRequest> {
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .context("failed to begin cancellation request transaction")?;
+        let Some(run) = query_run(&transaction, id)? else {
+            transaction
+                .commit()
+                .context("failed to finish missing cancellation request")?;
+            return Ok(CancellationRequest::NotFound);
+        };
+        if run.outcome != "running" {
+            transaction
+                .commit()
+                .context("failed to finish terminal cancellation request")?;
+            return Ok(CancellationRequest::Terminal(run));
+        }
+        let owner_is_live = match (&run.owner_id, run.owner_pid) {
+            (Some(owner_id), Some(owner_pid)) => {
+                let lease_cutoff = now_millis()?.saturating_sub(DAEMON_OWNER_LEASE_MILLIS);
+                transaction
+                    .query_row(
+                        "SELECT EXISTS(
+                            SELECT 1 FROM daemon_owners
+                            WHERE owner_id = ?1 AND pid = ?2 AND heartbeat_at >= ?3
+                        )",
+                        params![owner_id, owner_pid, lease_cutoff],
+                        |row| row.get::<_, bool>(0),
+                    )
+                    .context("failed to validate run owner lease")?
+                    && process_is_alive(owner_pid)
+            }
+            _ => false,
+        };
+        if !owner_is_live {
+            transaction
+                .commit()
+                .context("failed to finish unowned cancellation request")?;
+            return Ok(CancellationRequest::OwnedElsewhere(run));
+        }
+        if run.cancellation_requested_at.is_some() {
+            transaction
+                .commit()
+                .context("failed to finish repeated cancellation request")?;
+            return Ok(CancellationRequest::AlreadyRequested(run));
+        }
+        transaction
+            .execute(
+                "UPDATE runs SET cancellation_requested_at = ?1
+                 WHERE id = ?2 AND outcome = 'running' AND cancellation_requested_at IS NULL",
+                params![now_millis()?, id],
+            )
+            .context("failed to persist cancellation request")?;
+        let run = query_run(&transaction, id)?.context("cancelled run disappeared")?;
+        transaction
+            .commit()
+            .context("failed to commit cancellation request")?;
+        Ok(CancellationRequest::Requested(run))
+    }
+
+    pub fn cancellation_requested(&self, id: i64) -> Result<bool> {
+        self.connection
+            .query_row(
+                "SELECT cancellation_requested_at IS NOT NULL
+                 FROM runs WHERE id = ?1 AND outcome = 'running'",
+                [id],
+                |row| row.get(0),
+            )
+            .optional()
+            .context("failed to query cancellation request")
+            .map(|requested| requested.unwrap_or(false))
+    }
+
+    pub fn register_daemon_owner(&mut self, owner_id: &str, pid: u32) -> Result<()> {
+        if owner_id.trim().is_empty() {
+            bail!("daemon owner ID must not be empty");
+        }
+        self.connection
+            .execute(
+                "INSERT INTO daemon_owners(owner_id, pid, heartbeat_at)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(owner_id) DO UPDATE SET
+                   pid = excluded.pid,
+                   heartbeat_at = excluded.heartbeat_at",
+                params![owner_id, pid, now_millis()?],
+            )
+            .context("failed to register daemon owner")?;
+        Ok(())
+    }
+
+    pub fn heartbeat_daemon_owner(&mut self, owner_id: &str) -> Result<()> {
+        let changed = self
+            .connection
+            .execute(
+                "UPDATE daemon_owners SET heartbeat_at = ?1 WHERE owner_id = ?2",
+                params![now_millis()?, owner_id],
+            )
+            .context("failed to update daemon owner heartbeat")?;
+        if changed != 1 {
+            bail!("daemon owner {owner_id:?} is not registered");
+        }
+        Ok(())
+    }
+
+    pub fn remove_daemon_owner(&mut self, owner_id: &str) -> Result<()> {
+        self.connection
+            .execute("DELETE FROM daemon_owners WHERE owner_id = ?1", [owner_id])
+            .context("failed to remove daemon owner")?;
+        Ok(())
+    }
 }
 
 fn migrate(connection: &Connection) -> Result<()> {
@@ -749,6 +906,9 @@ fn migrate(connection: &Connection) -> Result<()> {
     }
     if version < 2 {
         migrate_v2(connection)?;
+    }
+    if version < 3 {
+        migrate_v3(connection)?;
     }
     Ok(())
 }
@@ -823,6 +983,27 @@ fn migrate_v2(connection: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v3(connection: &Connection) -> Result<()> {
+    connection
+        .execute_batch(
+            "BEGIN IMMEDIATE;
+             ALTER TABLE runs ADD COLUMN cancellation_requested_at INTEGER;
+             ALTER TABLE runs ADD COLUMN owner_pid INTEGER;
+             ALTER TABLE runs ADD COLUMN owner_id TEXT;
+             CREATE TABLE daemon_owners (
+                 owner_id TEXT PRIMARY KEY,
+                 pid INTEGER NOT NULL,
+                 heartbeat_at INTEGER NOT NULL
+             );
+             INSERT INTO schema_migrations(version, applied_at)
+                 VALUES (3, unixepoch('subsec') * 1000);
+             PRAGMA user_version = 3;
+             COMMIT;",
+        )
+        .context("failed to migrate SQLite ledger to version 3")?;
+    Ok(())
+}
+
 fn query_task(connection: &Connection, id: i64) -> Result<Option<Task>> {
     connection
         .query_row("SELECT * FROM tasks WHERE id = ?1", [id], row_to_task)
@@ -885,7 +1066,26 @@ fn row_to_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<Run> {
         result: row.get("result")?,
         error: row.get("error")?,
         session_id: row.get("session_id")?,
+        cancellation_requested_at: row.get("cancellation_requested_at")?,
+        owner_pid: row.get("owner_pid")?,
+        owner_id: row.get("owner_id")?,
     })
+}
+
+#[cfg(unix)]
+fn process_is_alive(process_id: u32) -> bool {
+    let Ok(process_id) = i32::try_from(process_id) else {
+        return false;
+    };
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(process_id), None) {
+        Ok(()) | Err(nix::errno::Errno::EPERM) => true,
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn process_is_alive(_process_id: u32) -> bool {
+    false
 }
 
 fn now_millis() -> Result<i64> {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -689,7 +689,7 @@ impl Ledger {
         let session_id = session_id.map(|value| truncate_utf8(value, MAX_SESSION_ID_BYTES));
         let transaction = self
             .connection
-            .transaction()
+            .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("failed to begin run completion transaction")?;
         let (task_id, cancellation_requested) = transaction
             .query_row(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -799,6 +799,12 @@ impl Ledger {
                 .context("failed to finish terminal cancellation request")?;
             return Ok(CancellationRequest::Terminal(run));
         }
+        if run.cancellation_requested_at.is_some() {
+            transaction
+                .commit()
+                .context("failed to finish repeated cancellation request")?;
+            return Ok(CancellationRequest::AlreadyRequested(run));
+        }
         let owner_is_live = match (&run.owner_id, run.owner_pid) {
             (Some(owner_id), Some(owner_pid)) => {
                 let lease_cutoff = now_millis()?.saturating_sub(DAEMON_OWNER_LEASE_MILLIS);
@@ -821,12 +827,6 @@ impl Ledger {
                 .commit()
                 .context("failed to finish unowned cancellation request")?;
             return Ok(CancellationRequest::OwnedElsewhere(run));
-        }
-        if run.cancellation_requested_at.is_some() {
-            transaction
-                .commit()
-                .context("failed to finish repeated cancellation request")?;
-            return Ok(CancellationRequest::AlreadyRequested(run));
         }
         transaction
             .execute(

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -119,6 +119,8 @@ done
 slot=1
 while ! mkdir "{root}/slot-$slot" 2>/dev/null; do slot=$((slot + 1)); done
 echo $$ > "{root}/slot-$slot/pid"
+sleep 1000 &
+echo $! > "{root}/slot-$slot/child-pid"
 cat > "{root}/slot-$slot/prompt"
 touch "{root}/slot-$slot/started"
 while [ ! -f "{root}/gate" ]; do sleep 0.02; done
@@ -324,6 +326,7 @@ async fn shutdown_cancels_the_active_codex_process_and_records_it() {
     };
     wait_for(|| fixture.started_slots().len() == 1).await;
     let pid = fs::read_to_string(fixture.started_slots()[0].join("pid")).unwrap();
+    let child_pid = fs::read_to_string(fixture.started_slots()[0].join("child-pid")).unwrap();
     cancellation.cancel();
     running.await.unwrap().unwrap();
 
@@ -332,6 +335,13 @@ async fn shutdown_cancels_the_active_codex_process_and_records_it() {
     assert!(
         !Command::new("kill")
             .args(["-0", pid.trim()])
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        !Command::new("kill")
+            .args(["-0", child_pid.trim()])
             .status()
             .unwrap()
             .success()
@@ -350,6 +360,7 @@ async fn cli_cancellation_stops_the_owned_process_tree_and_records_cancelled() {
     };
     wait_for(|| fixture.started_slots().len() == 1).await;
     let pid = fs::read_to_string(fixture.started_slots()[0].join("pid")).unwrap();
+    let child_pid = fs::read_to_string(fixture.started_slots()[0].join("child-pid")).unwrap();
     let run_id = Ledger::open(&fixture.ledger_path)
         .unwrap()
         .runs(None)
@@ -402,6 +413,13 @@ async fn cli_cancellation_stops_the_owned_process_tree_and_records_cancelled() {
     assert!(
         !Command::new("kill")
             .args(["-0", pid.trim()])
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        !Command::new("kill")
+            .args(["-0", child_pid.trim()])
             .status()
             .unwrap()
             .success()

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
 
+use assert_cmd::Command as AssertCommand;
 use factory::config::Config;
 use factory::daemon::FactoryDaemon;
 use factory::github::GitHubClient;
@@ -129,7 +130,7 @@ exit 0
             ),
         );
         Self {
-            ledger_path: temp.path().join("factory.db"),
+            ledger_path: temp.path().join("data/factory.sqlite3"),
             _temp: temp,
             config,
             catalog,
@@ -335,6 +336,101 @@ async fn shutdown_cancels_the_active_codex_process_and_records_it() {
             .unwrap()
             .success()
     );
+}
+
+#[tokio::test]
+async fn cli_cancellation_stops_the_owned_process_tree_and_records_cancelled() {
+    let fixture = Fixture::new(&[vec![issue(12)]], 1, 1);
+    let shutdown = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+    wait_for(|| fixture.started_slots().len() == 1).await;
+    let pid = fs::read_to_string(fixture.started_slots()[0].join("pid")).unwrap();
+    let run_id = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap()[0]
+        .id;
+
+    let run_id_string = run_id.to_string();
+    for args in [
+        vec!["tasks", "--json"],
+        vec!["runs", "--json"],
+        vec!["inspect", run_id_string.as_str(), "--json"],
+    ] {
+        let output = AssertCommand::cargo_bin("factory")
+            .unwrap()
+            .args(args)
+            .args([
+                "--data-directory",
+                fixture.ledger_path.parent().unwrap().to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(value.is_array() || value.is_object());
+        assert!(
+            String::from_utf8(output.stdout)
+                .unwrap()
+                .contains("running")
+        );
+    }
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "cancel",
+            &run_id.to_string(),
+            "--data-directory",
+            fixture.ledger_path.parent().unwrap().to_str().unwrap(),
+            "--json",
+        ])
+        .assert()
+        .success();
+
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Cancelled)
+    })
+    .await;
+    assert!(
+        !Command::new("kill")
+            .args(["-0", pid.trim()])
+            .status()
+            .unwrap()
+            .success()
+    );
+    shutdown.cancel();
+    running.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn losing_the_durable_owner_lease_is_a_daemon_error() {
+    let fixture = Fixture::new(&[vec![issue(13)]], 1, 1);
+    let cancellation = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let cancellation = cancellation.clone();
+        tokio::spawn(async move { daemon.run(cancellation).await })
+    };
+    wait_for(|| fixture.started_slots().len() == 1).await;
+    let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    let owner_id = ledger.runs(None).unwrap()[0].owner_id.clone().unwrap();
+    ledger.remove_daemon_owner(&owner_id).unwrap();
+    drop(ledger);
+
+    let error = running.await.unwrap().unwrap_err();
+
+    assert!(format!("{error:#}").contains("is not registered"));
+    let ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    assert_eq!(ledger.tasks().unwrap()[0].state, TaskState::Cancelled);
 }
 
 #[tokio::test]

--- a/tests/inspection_cli.rs
+++ b/tests/inspection_cli.rs
@@ -29,7 +29,7 @@ impl Fixture {
             .finish_run_and_task(
                 failed_run.id,
                 RunOutcome::Failed,
-                Some("partial result\nGITHUB_TOKEN=ghp_supersecret\nAWS_ACCESS_KEY_ID=AKIAEXAMPLE\nAuthorization: Bearer abc123"),
+                Some("partial result\nGITHUB_TOKEN=ghp_supersecret\nAWS_ACCESS_KEY_ID=AKIAEXAMPLE\nAuthorization: Bearer abc123\npostgres://standalone:password@host/db\nAKIAIOSFODNN7EXAMPLE"),
                 Some(
                     "failure \u{1b}[31m detail DATABASE_URL=postgres://user:pass@host/db\nPASSWORD=\"correct horse battery staple\"\n{\"PASSWORD\":\"abc\\\"remaining secret\"}\n-----BEGIN PRIVATE KEY-----\ntruncated-key-material",
                 ),
@@ -206,7 +206,8 @@ fn inspect_resolves_task_context_bounds_detail_and_escapes_terminal_controls() {
         .stdout(predicate::str::contains("thread-failed"))
         .stdout(predicate::str::contains("\\u{1b}"))
         .stdout(predicate::str::contains("\u{1b}").not())
-        .stdout(predicate::str::contains("postgres://").not())
+        .stdout(predicate::str::contains("user:pass").not())
+        .stdout(predicate::str::contains("standalone:password").not())
         .stdout(predicate::str::contains("ghp_supersecret").not())
         .stdout(predicate::str::contains("SECRET=").not());
 
@@ -219,9 +220,11 @@ fn inspect_resolves_task_context_bounds_detail_and_escapes_terminal_controls() {
     let failed_json: serde_json::Value = serde_json::from_slice(&failed_output.stdout).unwrap();
     let encoded = serde_json::to_string(&failed_json).unwrap();
     assert!(!encoded.contains("ghp_supersecret"));
-    assert!(!encoded.contains("postgres://"));
+    assert!(!encoded.contains("user:pass"));
     assert!(!encoded.contains("abc123"));
     assert!(!encoded.contains("AKIAEXAMPLE"));
+    assert!(!encoded.contains("standalone:password"));
+    assert!(!encoded.contains("AKIAIOSFODNN7EXAMPLE"));
     assert!(!encoded.contains("horse battery"));
     assert!(!encoded.contains("remaining secret"));
     assert!(!encoded.contains("truncated-key-material"));
@@ -259,7 +262,10 @@ fn cancel_reports_unowned_terminal_and_missing_runs() {
     .assert()
     .success()
     .stdout(predicate::str::contains("\"status\": \"owned_elsewhere\""))
-    .stdout(predicate::str::contains("\"owner\": null"));
+    .stdout(predicate::str::contains(
+        "\"owner_kind\": \"stale-or-foreign\"",
+    ))
+    .stdout(predicate::str::contains("\"owner_pid\": null"));
     command(
         &fixture,
         &["cancel", &fixture.cancelled_run_id.to_string(), "--json"],

--- a/tests/inspection_cli.rs
+++ b/tests/inspection_cli.rs
@@ -1,0 +1,297 @@
+use assert_cmd::Command;
+use factory::storage::{Ledger, RunOutcome, TaskIdentity};
+use predicates::prelude::*;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    data: std::path::PathBuf,
+    queued_id: i64,
+    running_run_id: i64,
+    failed_run_id: i64,
+    cancelled_run_id: i64,
+    succeeded_run_id: i64,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let data = temp.path().join("data");
+        let mut ledger = Ledger::open_in(&data).unwrap();
+
+        let running_task = enqueue(&mut ledger, "running", "implement-ready-ticket");
+        claim(&mut ledger, running_task);
+        let running_run_id = ledger.start_run(running_task, "codex").unwrap().id;
+
+        let failed_task = enqueue(&mut ledger, "failed", "implement-ready-ticket");
+        claim(&mut ledger, failed_task);
+        let failed_run = ledger.start_run(failed_task, "codex").unwrap();
+        let failed_run_id = ledger
+            .finish_run_and_task(
+                failed_run.id,
+                RunOutcome::Failed,
+                Some("partial result\nGITHUB_TOKEN=ghp_supersecret\nAWS_ACCESS_KEY_ID=AKIAEXAMPLE\nAuthorization: Bearer abc123"),
+                Some(
+                    "failure \u{1b}[31m detail DATABASE_URL=postgres://user:pass@host/db\nPASSWORD=\"correct horse battery staple\"\n{\"PASSWORD\":\"abc\\\"remaining secret\"}\n-----BEGIN PRIVATE KEY-----\ntruncated-key-material",
+                ),
+                Some("thread-failed"),
+            )
+            .unwrap()
+            .id;
+
+        let cancelled_task = enqueue(&mut ledger, "cancelled", "implement-ready-ticket");
+        claim(&mut ledger, cancelled_task);
+        let cancelled_run = ledger.start_run(cancelled_task, "codex").unwrap();
+        let cancelled_run_id = ledger
+            .finish_run_and_task(
+                cancelled_run.id,
+                RunOutcome::Cancelled,
+                None,
+                Some("cancelled"),
+                None,
+            )
+            .unwrap()
+            .id;
+
+        let succeeded_task = enqueue(&mut ledger, "succeeded", "find-bugs");
+        claim(&mut ledger, succeeded_task);
+        let succeeded_run = ledger.start_run(succeeded_task, "codex").unwrap();
+        let succeeded_run_id = ledger
+            .finish_run_and_task(
+                succeeded_run.id,
+                RunOutcome::Succeeded,
+                Some(&"x".repeat(20_000)),
+                None,
+                Some("thread-succeeded"),
+            )
+            .unwrap()
+            .id;
+        let queued_id = enqueue(&mut ledger, "queued", "implement-ready-ticket");
+
+        Self {
+            _temp: temp,
+            data,
+            queued_id,
+            running_run_id,
+            failed_run_id,
+            cancelled_run_id,
+            succeeded_run_id,
+        }
+    }
+}
+
+fn enqueue(ledger: &mut Ledger, revision: &str, workflow: &str) -> i64 {
+    ledger
+        .enqueue_with_payload(
+            &TaskIdentity::ticket("example/repo", workflow, revision, revision).unwrap(),
+            Some("unbounded ticket body is not printed\nSECRET=not-for-output"),
+        )
+        .unwrap()
+        .task
+        .id
+}
+
+fn claim(ledger: &mut Ledger, expected: i64) {
+    assert_eq!(ledger.claim_next().unwrap().unwrap().id, expected);
+}
+
+fn command(fixture: &Fixture, args: &[&str]) -> Command {
+    let mut command = Command::cargo_bin("factory").unwrap();
+    command
+        .env("HOME", fixture._temp.path().join("home"))
+        .args(args)
+        .args(["--data-directory", fixture.data.to_str().unwrap()]);
+    command
+}
+
+#[test]
+fn tasks_lists_all_states_and_json_is_parseable_without_payloads() {
+    let fixture = Fixture::new();
+
+    command(&fixture, &["tasks"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("queued"))
+        .stdout(predicate::str::contains("running"))
+        .stdout(predicate::str::contains("succeeded"))
+        .stdout(predicate::str::contains("failed"))
+        .stdout(predicate::str::contains("cancelled"))
+        .stdout(predicate::str::contains("SECRET=").not());
+
+    let output = command(&fixture, &["tasks", "--json"]).output().unwrap();
+    assert!(output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let tasks = value.as_array().unwrap();
+    assert_eq!(tasks.len(), 5);
+    assert!(tasks.iter().any(|task| task["id"] == fixture.queued_id));
+    assert!(tasks.iter().all(|task| task.get("payload").is_none()));
+    let keys = tasks[0]
+        .as_object()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        keys,
+        [
+            "created_at",
+            "id",
+            "repository",
+            "source_item",
+            "state",
+            "updated_at",
+            "workflow",
+        ]
+    );
+}
+
+#[test]
+fn runs_filters_by_workflow_and_includes_bounded_summaries() {
+    let fixture = Fixture::new();
+
+    let output = command(&fixture, &["runs", "implement-ready-ticket", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let runs = value.as_array().unwrap();
+    assert_eq!(runs.len(), 3);
+    assert!(
+        runs.iter()
+            .all(|run| run["workflow"] == "implement-ready-ticket")
+    );
+    assert!(runs.iter().any(|run| run["outcome"] == "running"));
+    assert!(runs.iter().any(|run| run["outcome"] == "failed"));
+    assert!(runs.iter().any(|run| run["outcome"] == "cancelled"));
+    assert!(runs.iter().all(|run| {
+        !run["summary"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("postgres://")
+    }));
+    let keys = runs[0]
+        .as_object()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        keys,
+        [
+            "cancellation_requested_at",
+            "duration_ms",
+            "finished_at",
+            "id",
+            "outcome",
+            "owner_id",
+            "owner_pid",
+            "repository",
+            "runtime",
+            "source_item",
+            "started_at",
+            "summary",
+            "task_id",
+            "workflow",
+        ]
+    );
+}
+
+#[test]
+fn inspect_resolves_task_context_bounds_detail_and_escapes_terminal_controls() {
+    let fixture = Fixture::new();
+
+    command(&fixture, &["inspect", &fixture.failed_run_id.to_string()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Repository: example/repo"))
+        .stdout(predicate::str::contains("thread-failed"))
+        .stdout(predicate::str::contains("\\u{1b}"))
+        .stdout(predicate::str::contains("\u{1b}").not())
+        .stdout(predicate::str::contains("postgres://").not())
+        .stdout(predicate::str::contains("ghp_supersecret").not())
+        .stdout(predicate::str::contains("SECRET=").not());
+
+    let failed_output = command(
+        &fixture,
+        &["inspect", &fixture.failed_run_id.to_string(), "--json"],
+    )
+    .output()
+    .unwrap();
+    let failed_json: serde_json::Value = serde_json::from_slice(&failed_output.stdout).unwrap();
+    let encoded = serde_json::to_string(&failed_json).unwrap();
+    assert!(!encoded.contains("ghp_supersecret"));
+    assert!(!encoded.contains("postgres://"));
+    assert!(!encoded.contains("abc123"));
+    assert!(!encoded.contains("AKIAEXAMPLE"));
+    assert!(!encoded.contains("horse battery"));
+    assert!(!encoded.contains("remaining secret"));
+    assert!(!encoded.contains("truncated-key-material"));
+    assert!(encoded.contains("[REDACTED]"));
+
+    let output = command(
+        &fixture,
+        &["inspect", &fixture.succeeded_run_id.to_string(), "--json"],
+    )
+    .output()
+    .unwrap();
+    assert!(output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["run"]["id"], fixture.succeeded_run_id);
+    assert_eq!(value["session_id"], "thread-succeeded");
+    assert_eq!(value["result"]["truncated"], true);
+    assert!(value["result"]["value"].as_str().unwrap().len() <= 16 * 1024);
+    let keys = value
+        .as_object()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(keys, ["error", "result", "run", "session_id", "task"]);
+}
+
+#[test]
+fn cancel_reports_unowned_terminal_and_missing_runs() {
+    let fixture = Fixture::new();
+
+    command(
+        &fixture,
+        &["cancel", &fixture.running_run_id.to_string(), "--json"],
+    )
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("\"status\": \"owned_elsewhere\""))
+    .stdout(predicate::str::contains("\"owner\": null"));
+    command(
+        &fixture,
+        &["cancel", &fixture.cancelled_run_id.to_string(), "--json"],
+    )
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("already_terminal"));
+    command(&fixture, &["cancel", "99999"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("run 99999 does not exist"));
+}
+
+#[test]
+fn empty_ledgers_have_stable_empty_outputs() {
+    let temp = tempfile::tempdir().unwrap();
+    let data = temp.path().join("empty");
+
+    for subcommand in ["tasks", "runs"] {
+        Command::cargo_bin("factory")
+            .unwrap()
+            .args([subcommand, "--json", "--data-directory"])
+            .arg(&data)
+            .assert()
+            .success()
+            .stdout("[]\n");
+    }
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["tasks", "--data-directory"])
+        .arg(&data)
+        .assert()
+        .success()
+        .stdout("ID\tSTATE\tREPOSITORY\tWORKFLOW\tSOURCE\tCREATED\tUPDATED\n");
+}

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -259,6 +259,7 @@ fn cancellation_requests_are_durable_idempotent_and_force_cancelled_outcome() {
 
     let mut reopened = Ledger::open(&path).unwrap();
     assert!(reopened.cancellation_requested(run.id).unwrap());
+    reopened.remove_daemon_owner("storage-test-owner").unwrap();
     assert!(matches!(
         reopened.request_run_cancellation(run.id).unwrap(),
         CancellationRequest::AlreadyRequested(_)

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -344,6 +344,74 @@ fn cancellation_rejects_a_reused_live_pid_when_the_owner_lease_is_stale() {
 }
 
 #[test]
+fn concurrent_completion_and_cancellation_always_leave_a_terminal_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let runtimes = HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "implement-ready-ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    let mut setup = Ledger::open(&path).unwrap();
+    setup
+        .register_daemon_owner("race-owner", std::process::id())
+        .unwrap();
+
+    for index in 0..25 {
+        setup.heartbeat_daemon_owner("race-owner").unwrap();
+        let task = setup
+            .enqueue(&ticket(&format!("race-revision-{index}")))
+            .unwrap()
+            .task;
+        let run = setup
+            .claim_ticket_and_start_run(
+                &["owainlewis/factory".to_owned()],
+                &runtimes,
+                "race-owner",
+                std::process::id(),
+            )
+            .unwrap()
+            .unwrap()
+            .run;
+        let run_id = run.id;
+        let barrier = Arc::new(Barrier::new(3));
+        let finish = {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let mut ledger = Ledger::open(&path).unwrap();
+                barrier.wait();
+                ledger.finish_run_and_task(
+                    run_id,
+                    RunOutcome::Succeeded,
+                    Some("complete"),
+                    None,
+                    None,
+                )
+            })
+        };
+        let cancel = {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let mut ledger = Ledger::open(&path).unwrap();
+                barrier.wait();
+                ledger.request_run_cancellation(run_id)
+            })
+        };
+        barrier.wait();
+
+        finish.join().unwrap().unwrap();
+        cancel.join().unwrap().unwrap();
+        let completed = setup.run(run_id).unwrap().unwrap();
+        assert_ne!(completed.outcome, "running");
+        assert!(setup.task(task.id).unwrap().unwrap().state.is_terminal());
+    }
+}
+
+#[test]
 fn failed_writes_do_not_damage_prior_state() {
     let temp = tempfile::tempdir().unwrap();
     let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Barrier};
 use std::thread;
 
 use factory::storage::{
-    Ledger, MAX_ERROR_BYTES, MAX_RESULT_BYTES, RunOutcome, TaskIdentity, TaskState,
+    CancellationRequest, Ledger, MAX_ERROR_BYTES, MAX_RESULT_BYTES, RunOutcome, TaskIdentity,
+    TaskState,
 };
 use rusqlite::Connection;
 
@@ -219,7 +221,126 @@ fn migrates_a_version_one_ledger_without_losing_tasks() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 2);
+    assert_eq!(version, 3);
+}
+
+#[test]
+fn cancellation_requests_are_durable_idempotent_and_force_cancelled_outcome() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    let task = ledger.enqueue(&ticket("cancel-revision")).unwrap().task;
+    let runtimes = HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "implement-ready-ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    ledger
+        .register_daemon_owner("storage-test-owner", std::process::id())
+        .unwrap();
+    let run = ledger
+        .claim_ticket_and_start_run(
+            &["owainlewis/factory".to_owned()],
+            &runtimes,
+            "storage-test-owner",
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap()
+        .run;
+
+    assert!(matches!(
+        ledger.request_run_cancellation(run.id).unwrap(),
+        CancellationRequest::Requested(_)
+    ));
+    drop(ledger);
+
+    let mut reopened = Ledger::open(&path).unwrap();
+    assert!(reopened.cancellation_requested(run.id).unwrap());
+    assert!(matches!(
+        reopened.request_run_cancellation(run.id).unwrap(),
+        CancellationRequest::AlreadyRequested(_)
+    ));
+    let completed = reopened
+        .finish_run_and_task(
+            run.id,
+            RunOutcome::Succeeded,
+            Some("runtime exited during cancellation"),
+            None,
+            Some("thread-cancel"),
+        )
+        .unwrap();
+
+    assert_eq!(completed.outcome, "cancelled");
+    assert_eq!(
+        reopened.task(task.id).unwrap().unwrap().state,
+        TaskState::Cancelled
+    );
+    assert!(matches!(
+        reopened.request_run_cancellation(run.id).unwrap(),
+        CancellationRequest::Terminal(_)
+    ));
+    assert!(matches!(
+        reopened.request_run_cancellation(99_999).unwrap(),
+        CancellationRequest::NotFound
+    ));
+}
+
+#[test]
+fn cancellation_rejects_a_running_row_without_a_live_daemon_owner() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    let task = ledger.enqueue(&ticket("unowned-revision")).unwrap().task;
+    ledger.claim_next().unwrap().unwrap();
+    let run = ledger.start_run(task.id, "codex").unwrap();
+
+    let status = ledger.request_run_cancellation(run.id).unwrap();
+
+    assert!(matches!(status, CancellationRequest::OwnedElsewhere(_)));
+    assert!(!ledger.cancellation_requested(run.id).unwrap());
+}
+
+#[test]
+fn cancellation_rejects_a_reused_live_pid_when_the_owner_lease_is_stale() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    ledger
+        .register_daemon_owner("stale-owner", std::process::id())
+        .unwrap();
+    ledger.enqueue(&ticket("stale-owner-revision")).unwrap();
+    let runtimes = HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "implement-ready-ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    let run = ledger
+        .claim_ticket_and_start_run(
+            &["owainlewis/factory".to_owned()],
+            &runtimes,
+            "stale-owner",
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap()
+        .run;
+    drop(ledger);
+    let connection = Connection::open(&path).unwrap();
+    connection
+        .execute("UPDATE daemon_owners SET heartbeat_at = 0", [])
+        .unwrap();
+    drop(connection);
+    let mut ledger = Ledger::open(&path).unwrap();
+
+    assert!(matches!(
+        ledger.request_run_cancellation(run.id).unwrap(),
+        CancellationRequest::OwnedElsewhere(_)
+    ));
+    assert!(!ledger.cancellation_requested(run.id).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Closes #7

## Summary

- add human-readable and stable JSON views for `factory tasks`, `runs`, and `inspect`
- add durable, idempotent cancellation requests routed to the owning live daemon and Codex process group
- add daemon instance leases so stale or foreign runs are reported without false cancellation claims
- bound and redact stored runtime output before displaying it

## Acceptance proof

- seeded CLI tests cover empty, queued, running, failed, cancelled, and succeeded states
- JSON schemas are parsed and asserted; task payloads are excluded
- concurrent daemon inspection and CLI cancellation stop the owned process tree and record `cancelled`
- stale leases, unowned runs, lease failure, terminal runs, repeated requests, and missing runs are covered
- fresh-agent review findings on ownership, credential leakage, lease failure, and escaped secrets were fixed and re-reviewed with no remaining blockers

## Checks

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (78 tests)
- repeated `cargo test --test daemon`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CLI commands to list tasks, view runs, inspect run details, and request cancellation.
  - Added human-readable tables and formatted JSON output for automation.
  - Added workflow filtering for run listings.
- **Bug Fixes**
  - Active runs now respond to cancellation requests and record a cancelled outcome.
  - Improved run ownership and liveness handling to prevent invalid cancellations.
  - Inspection output now truncates and redacts sensitive information.
- **Tests**
  - Added coverage for CLI inspection, cancellation workflows, persistence, and empty data sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
