### PR TITLE
feat(supervision): recover interrupted agent runs (#8)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,6 +10,27 @@ Factory requires the conventional `factory:ready` and
 does not create, remove, or otherwise mutate labels itself. The delegated
 workflow owns ticket and pull-request updates.
 
+Every active run records the Factory owner, Codex process group leader and
+process-start identity, Codex session ID as soon as it is observed, working
+directory, pull-request URL when safely recognized, start time, and latest
+structural runtime activity. Raw event text is not stored. A workflow timeout is
+the maximum deadline for one execution.
+There is no short fixed idle timeout, so an active agent can keep working until
+that configured deadline. Explicit cancellation and deadline expiry terminate
+the complete Codex process group.
+
+At startup and periodically while running, Factory checks every database run
+still marked `running`. It leaves a run alone when its owning daemon lease and
+process are live. Otherwise it verifies the recorded process-start identity,
+stops the matching orphan process group, closes the interrupted run, and queues
+one recovery attempt. Recovery first resumes the stored Codex session. If that
+session cannot be resumed, Factory starts one fresh fallback within the same
+execution deadline. The recovery prompt includes the current ticket,
+repository, Git worktree and branch inventory, pull-request URL when found, and
+bounded previous evidence, and tells Codex to inspect current reality before continuing.
+Factory permits at most two durable recovery attempts. Repeated failure leaves
+the task failed and inspectable. Terminal runs are never recovered.
+
 On Ctrl-C, Factory stops polling and claiming immediately, cancels active
 Codex process trees, waits for the workers to record `cancelled`, and exits.
 Queued tasks remain durable for the next start. Failed and cancelled runs keep

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,8 +10,9 @@ Factory requires the conventional `factory:ready` and
 does not create, remove, or otherwise mutate labels itself. The delegated
 workflow owns ticket and pull-request updates.
 
-Every active run records the Factory owner, Codex process group leader and
-process-start identity, Codex session ID as soon as it is observed, working
+Every active run records the Factory owner, a durable supervisor anchor that
+owns the Codex process group, the anchor's process-start identity, Codex session
+ID as soon as it is observed, working
 directory, pull-request URL when safely recognized, start time, and latest
 structural runtime activity. Raw event text is not stored. A workflow timeout is
 the maximum deadline for one execution.
@@ -21,9 +22,11 @@ the complete Codex process group.
 
 At startup and periodically while running, Factory checks every database run
 still marked `running`. It leaves a run alone when its owning daemon lease and
-process are live. Otherwise it verifies the recorded process-start identity,
-stops the matching orphan process group, closes the interrupted run, and queues
-one recovery attempt. Recovery first resumes the stored Codex session. If that
+process are live. The supervisor anchor remains the group leader if Codex exits
+while descendants are still running. Otherwise Factory verifies the anchor's
+recorded process-start identity, stops the matching orphan process group, closes
+the interrupted run, and queues one recovery attempt. Recovery first resumes
+the stored Codex session. If that
 session cannot be resumed, Factory starts one fresh fallback within the same
 execution deadline. The recovery prompt includes the current ticket,
 repository, Git worktree and branch inventory, pull-request URL when found, and

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -11,11 +11,15 @@ use tokio_util::sync::CancellationToken;
 
 use crate::config::Config;
 use crate::github::{GitHubClient, TicketContext};
-use crate::runtime::{CodexRuntime, ExecutionResult, RuntimeCancelled, Termination};
-use crate::storage::{Ledger, RunOutcome, Task};
+use crate::runtime::{
+    CodexRuntime, ExecutionResult, RuntimeCancelled, RuntimeObservation, Termination,
+    observation_channel,
+};
+use crate::storage::{Ledger, Run, RunOutcome, Task};
 use crate::workflow::{WorkflowCatalog, WorkflowEntry};
 
 const HUMAN_MERGE_POLICY: &str = "Factory-created software pull requests must remain for human merge. Never merge or enable automatic merge.";
+const RECOVERY_POLL_INTERVAL: Duration = Duration::from_secs(1);
 static OWNER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 struct DaemonOwner {
@@ -66,7 +70,7 @@ impl FactoryDaemon {
             catalog,
             ledger_path,
             GitHubClient::default(),
-            CodexRuntime::default(),
+            CodexRuntime::default().with_activity_streaming(false),
         )
     }
 
@@ -82,7 +86,7 @@ impl FactoryDaemon {
             catalog,
             ledger_path: ledger_path.into(),
             github,
-            codex,
+            codex: codex.with_activity_streaming(false),
         }
     }
 
@@ -101,6 +105,7 @@ impl FactoryDaemon {
         let mut ledger = Ledger::open(&self.ledger_path)?;
         let owner = DaemonOwner::new()?;
         ledger.register_daemon_owner(&owner.id, owner.pid)?;
+        report_recovery(ledger.recover_orphaned_runs()?);
         let owner_heartbeat_shutdown = CancellationToken::new();
         let owner_heartbeat_task = {
             let ledger_path = self.ledger_path.clone();
@@ -120,6 +125,11 @@ impl FactoryDaemon {
         let mut runs = JoinSet::<(String, Result<()>)>::new();
         let mut poll_interval = tokio::time::interval_at(Instant::now(), self.config.poll_every);
         poll_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut recovery_interval = tokio::time::interval_at(
+            Instant::now() + RECOVERY_POLL_INTERVAL,
+            RECOVERY_POLL_INTERVAL,
+        );
+        recovery_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         let loop_result: Result<()> = async {
             loop {
@@ -138,6 +148,9 @@ impl FactoryDaemon {
 
                 tokio::select! {
                     _ = cancellation.cancelled() => return Ok(()),
+                    _ = recovery_interval.tick() => {
+                        report_recovery(ledger.recover_orphaned_runs()?);
+                    }
                     _ = poll_interval.tick() => {
                         let report = self.github
                             .poll_once_with_cancellation(
@@ -248,6 +261,17 @@ impl FactoryDaemon {
     }
 }
 
+fn report_recovery(report: crate::storage::RecoveryReport) {
+    for run_id in report.recovered_run_ids {
+        eprintln!("Factory queued one bounded recovery for interrupted run {run_id}");
+    }
+    for run_id in report.exhausted_run_ids {
+        eprintln!(
+            "Factory left interrupted run {run_id} failed after exhausting recovery attempts"
+        );
+    }
+}
+
 async fn maintain_owner_lease(
     ledger_path: &Path,
     owner_id: &str,
@@ -305,18 +329,24 @@ fn dispatch_available(
                 })
             })
             .collect::<HashMap<_, _>>();
+        let working_directories = targets
+            .iter()
+            .map(|(repository, target)| (repository.clone(), target.path.display().to_string()))
+            .collect::<HashMap<_, _>>();
         let mut worker_ledger = Ledger::open(ledger_path)?;
-        let Some(claimed) = ledger.claim_ticket_and_start_run(
+        let Some(claimed) = ledger.claim_ticket_and_start_run_with_workdirs(
             &available,
             &workflow_runtimes,
             &owner.id,
             owner.pid,
+            &working_directories,
         )?
         else {
             break;
         };
         let task = claimed.task;
-        let run_id = claimed.run.id;
+        let run = claimed.run;
+        let run_id = run.id;
         let repository = task.repository.clone();
         let target = targets
             .get(&repository)
@@ -332,21 +362,38 @@ fn dispatch_available(
             &task.workflow,
             task.source_item.as_deref(),
         )?;
-        let prompt =
-            match execution_prompt(&task, run_id, &target, &workflow, prior_session.as_deref()) {
-                Ok(prompt) => prompt,
-                Err(error) => {
-                    worker_ledger.finish_run_and_task(
-                        run_id,
-                        RunOutcome::Failed,
-                        None,
-                        Some(&format!("{error:#}")),
-                        None,
-                    )?;
-                    eprintln!("Factory rejected claimed task {}: {error:#}", task.id);
-                    continue;
-                }
-            };
+        let mut recovery_source = run
+            .recovery_of
+            .map(|id| worker_ledger.run(id))
+            .transpose()?
+            .flatten();
+        if let Some(previous) = recovery_source.as_mut()
+            && previous.pull_request.is_none()
+        {
+            previous.pull_request = worker_ledger.latest_pull_request_for_task(task.id)?;
+        }
+        let prompt_result =
+            execution_prompt(&task, run_id, &target, &workflow, prior_session.as_deref()).map(
+                |prompt| {
+                    recovery_source.as_ref().map_or(prompt.clone(), |previous| {
+                        recovery_prompt(&prompt, previous, &target)
+                    })
+                },
+            );
+        let prompt = match prompt_result {
+            Ok(prompt) => prompt,
+            Err(error) => {
+                worker_ledger.finish_run_and_task(
+                    run_id,
+                    RunOutcome::Failed,
+                    None,
+                    Some(&format!("{error:#}")),
+                    None,
+                )?;
+                eprintln!("Factory rejected claimed task {}: {error:#}", task.id);
+                continue;
+            }
+        };
         if workflow.runtime != "codex" {
             let error = format!(
                 "unsupported runtime {:?}; Factory v1 supports codex",
@@ -374,6 +421,7 @@ fn dispatch_available(
                 run_id,
                 prompt,
                 cancellation,
+                recovery_source.and_then(|previous| previous.session_id),
             )
             .await;
             (repository, result)
@@ -382,6 +430,7 @@ fn dispatch_available(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn execute_task(
     mut ledger: Ledger,
     repository: &RepositoryTarget,
@@ -390,24 +439,94 @@ async fn execute_task(
     run_id: i64,
     prompt: String,
     cancellation: CancellationToken,
+    recovery_session: Option<String>,
 ) -> Result<()> {
     let run_cancellation = cancellation.child_token();
+    let execution_deadline = Instant::now() + workflow.timeout;
     let monitor_token = run_cancellation.clone();
     let ledger_path = ledger.path().to_owned();
+    let (observations, mut observation_receiver) = observation_channel();
     let cancellation_monitor = tokio::spawn(async move {
-        if let Err(error) = monitor_run_cancellation(&ledger_path, run_id, &monitor_token).await {
+        if let Err(error) = monitor_run(
+            &ledger_path,
+            run_id,
+            &monitor_token,
+            &mut observation_receiver,
+        )
+        .await
+        {
             eprintln!("Factory cancellation monitor failed for run {run_id}: {error:#}");
             monitor_token.cancel();
         }
     });
-    let execution = codex
-        .run(
-            &prompt,
-            &repository.path,
-            workflow.timeout,
-            run_cancellation,
-        )
-        .await;
+    let execution = if let Some(session_id) = recovery_session.as_deref() {
+        let resumed = codex
+            .run_with_session(
+                &prompt,
+                &repository.path,
+                workflow.timeout,
+                run_cancellation.clone(),
+                Some(session_id),
+                observations.clone(),
+            )
+            .await;
+        let needs_fallback = match &resumed {
+            Ok(result) => result.termination == Termination::Exited && !result.status.success(),
+            Err(_) => true,
+        };
+        if needs_fallback && !run_cancellation.is_cancelled() {
+            let detail = resumed
+                .as_ref()
+                .map(|result| format!("Codex session resume exited with {}", result.status))
+                .unwrap_or_else(|error| format!("Codex session resume failed: {error:#}"));
+            ledger.observe_run(run_id, None, None, None, None, Some(&detail))?;
+            let fallback_prompt = format!(
+                "{prompt}\n\n# Session fallback\n\n\
+                 The stored Codex session could not be resumed: {}.\n\
+                 Start one bounded recovery run. Inspect current Git, GitHub, pull-request, and CI reality before continuing. Do not replay assumed steps.",
+                crate::inspection::sanitize_for_storage(&detail),
+            );
+            let remaining = execution_deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                resumed
+            } else {
+                codex
+                    .run_with_session(
+                        &fallback_prompt,
+                        &repository.path,
+                        remaining,
+                        run_cancellation.clone(),
+                        None,
+                        observations.clone(),
+                    )
+                    .await
+            }
+        } else {
+            resumed
+        }
+    } else {
+        codex
+            .run_with_session(
+                &prompt,
+                &repository.path,
+                workflow.timeout,
+                run_cancellation.clone(),
+                None,
+                observations.clone(),
+            )
+            .await
+    };
+    let observation = observations.borrow().clone();
+    if observation.sequence > 0 {
+        ledger.observe_run(
+            run_id,
+            observation.process_id,
+            observation.process_identity.as_deref(),
+            observation.session_id.as_deref(),
+            observation.pull_request.as_deref(),
+            observation.activity.as_deref(),
+        )?;
+    }
     cancellation_monitor.abort();
     match execution {
         Ok(result) => record_execution(&mut ledger, run_id, &result),
@@ -424,17 +543,32 @@ async fn execute_task(
     }
 }
 
-async fn monitor_run_cancellation(
+async fn monitor_run(
     ledger_path: &Path,
     run_id: i64,
     cancellation: &CancellationToken,
+    observations: &mut tokio::sync::watch::Receiver<RuntimeObservation>,
 ) -> Result<()> {
-    let ledger = Ledger::open(ledger_path)?;
+    let mut ledger = Ledger::open(ledger_path)?;
     let mut interval = tokio::time::interval(Duration::from_millis(50));
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
     loop {
         tokio::select! {
             _ = cancellation.cancelled() => return Ok(()),
+            changed = observations.changed() => {
+                if changed.is_err() {
+                    return Ok(());
+                }
+                let observation = observations.borrow_and_update().clone();
+                ledger.observe_run(
+                    run_id,
+                    observation.process_id,
+                    observation.process_identity.as_deref(),
+                    observation.session_id.as_deref(),
+                    observation.pull_request.as_deref(),
+                    observation.activity.as_deref(),
+                )?;
+            }
             _ = interval.tick() => {
                 if ledger.cancellation_requested(run_id)? {
                     cancellation.cancel();
@@ -443,6 +577,103 @@ async fn monitor_run_cancellation(
             }
         }
     }
+}
+
+fn recovery_prompt(base: &str, previous: &Run, repository: &RepositoryTarget) -> String {
+    let branch = current_branch(&repository.path).unwrap_or_else(|| "unknown".to_owned());
+    let pull_request = previous
+        .pull_request
+        .clone()
+        .or_else(|| {
+            [
+                previous.result.as_deref(),
+                previous.activity.as_deref(),
+                previous.error.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .find_map(find_pull_request_url)
+        })
+        .unwrap_or_else(|| "unknown; inspect GitHub".to_owned());
+    let worktrees = git_worktree_context(&repository.path)
+        .unwrap_or_else(|| "unavailable; inspect Git before continuing".to_owned());
+    let previous_output = serde_json::json!({
+        "activity": previous.activity.as_deref().filter(|value| !value.trim().is_empty()),
+        "result": previous.result.as_deref().filter(|value| !value.trim().is_empty()),
+        "error": previous.error.as_deref().filter(|value| !value.trim().is_empty()),
+    });
+    let previous_output = bounded_context(&previous_output.to_string(), 32 * 1024);
+    format!(
+        "{base}\n\n# Interrupted-run recovery\n\n\
+         Factory detected that run {} lost its owned process. This is recovery attempt {} of {}.\n\
+         Working directory: {}\n\
+         Current branch: {}\n\
+         Current Git worktrees and branches:\n{}\n\
+         Pull-request context: {}\n\
+         Stored Codex session: {}\n\n\
+         Previous bounded output (JSON):\n{}\n\n\
+         Inspect current repository, ticket, GitHub, pull-request, and CI reality. Continue safely from what exists now. Do not replay a deterministic checklist or assume an earlier operation did or did not complete.",
+        previous.id,
+        previous.recovery_attempt.saturating_add(1),
+        crate::storage::MAX_RECOVERY_ATTEMPTS,
+        repository.path.display(),
+        crate::inspection::sanitize_for_storage(&branch),
+        worktrees,
+        crate::inspection::sanitize_for_storage(&pull_request),
+        previous.session_id.as_deref().unwrap_or("none"),
+        previous_output,
+    )
+}
+
+fn git_worktree_context(repository: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repository)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| bounded_context(&String::from_utf8_lossy(&output.stdout), 16 * 1024))
+        .filter(|context| !context.trim().is_empty())
+}
+
+fn bounded_context(value: &str, maximum: usize) -> String {
+    let value = crate::inspection::sanitize_for_storage(value);
+    if value.len() <= maximum {
+        return value;
+    }
+    let mut start = value.len() - maximum;
+    while !value.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("[truncated]\n{}", &value[start..])
+}
+
+fn current_branch(repository: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(repository)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|branch| !branch.is_empty())
+}
+
+fn find_pull_request_url(value: &str) -> Option<String> {
+    value.split_whitespace().find_map(|word| {
+        let candidate = word.trim_matches(|character: char| {
+            matches!(
+                character,
+                '(' | ')' | '[' | ']' | ',' | '.' | ';' | '\'' | '"'
+            )
+        });
+        (candidate.starts_with("https://github.com/") && candidate.contains("/pull/"))
+            .then(|| candidate.to_owned())
+    })
 }
 
 fn execution_prompt(
@@ -518,5 +749,101 @@ fn decrement_active(active: &mut HashMap<String, usize>, repository: &str) {
         if *count == 0 {
             active.remove(repository);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_prompt_includes_discovered_worktrees_pr_and_all_nonempty_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repository");
+        let worktree = temp.path().join("ticket-worktree");
+        std::fs::create_dir(&repository).unwrap();
+        for args in [
+            vec!["init", "-b", "main"],
+            vec!["config", "user.email", "factory@example.test"],
+            vec!["config", "user.name", "Factory Test"],
+        ] {
+            assert!(
+                std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(&repository)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        }
+        std::fs::write(repository.join("README.md"), "test").unwrap();
+        assert!(
+            std::process::Command::new("git")
+                .args(["add", "README.md"])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            std::process::Command::new("git")
+                .args(["commit", "-m", "test"])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            std::process::Command::new("git")
+                .args([
+                    "worktree",
+                    "add",
+                    "-b",
+                    "codex/recovery",
+                    worktree.to_str().unwrap(),
+                ])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let target = RepositoryTarget {
+            path: repository.clone(),
+            workflows: HashMap::new(),
+        };
+        let previous = Run {
+            id: 7,
+            task_id: 3,
+            workflow: "implement-ready-ticket".to_owned(),
+            repository: "owainlewis/factory".to_owned(),
+            source_item: Some("8".to_owned()),
+            runtime: "codex".to_owned(),
+            started_at: 1,
+            finished_at: Some(2),
+            outcome: "failed".to_owned(),
+            result: Some(String::new()),
+            error: Some("runtime interrupted".to_owned()),
+            session_id: Some("thread-7".to_owned()),
+            cancellation_requested_at: None,
+            owner_pid: None,
+            owner_id: None,
+            process_id: None,
+            process_identity: None,
+            pull_request: Some("https://github.com/owainlewis/factory/pull/99".to_owned()),
+            last_activity_at: 2,
+            activity: Some("Codex event: item.completed".to_owned()),
+            working_directory: Some(repository.display().to_string()),
+            recovery_of: None,
+            recovery_attempt: 0,
+        };
+
+        let prompt = recovery_prompt("base", &previous, &target);
+
+        assert!(prompt.contains(repository.to_str().unwrap()));
+        assert!(prompt.contains(worktree.to_str().unwrap()));
+        assert!(prompt.contains("codex/recovery"));
+        assert!(prompt.contains("https://github.com/owainlewis/factory/pull/99"));
+        assert!(prompt.contains("Codex event: item.completed"));
+        assert!(prompt.contains("runtime interrupted"));
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -454,13 +454,14 @@ async fn execute_task(
     );
     let execution = if let Some(session_id) = recovery_session.as_deref() {
         let resumed = codex
-            .run_with_session(
+            .run_with_session_supervised(
                 &prompt,
                 &repository.path,
                 workflow.timeout,
                 run_cancellation.clone(),
                 Some(session_id),
                 observations.clone(),
+                |observation| persist_run_anchor(&ledger_path, run_id, observation),
             )
             .await;
         let needs_fallback = match &resumed {
@@ -496,13 +497,14 @@ async fn execute_task(
                 );
                 let remaining = execution_deadline.saturating_duration_since(Instant::now());
                 codex
-                    .run_with_session(
+                    .run_with_session_supervised(
                         &fallback_prompt,
                         &repository.path,
                         remaining,
                         run_cancellation.clone(),
                         None,
                         observations.clone(),
+                        |observation| persist_run_anchor(&ledger_path, run_id, observation),
                     )
                     .await
             }
@@ -511,13 +513,14 @@ async fn execute_task(
         }
     } else {
         codex
-            .run_with_session(
+            .run_with_session_supervised(
                 &prompt,
                 &repository.path,
                 workflow.timeout,
                 run_cancellation.clone(),
                 None,
                 observations.clone(),
+                |observation| persist_run_anchor(&ledger_path, run_id, observation),
             )
             .await
     };
@@ -547,6 +550,22 @@ async fn execute_task(
             Err(error)
         }
     }
+}
+
+fn persist_run_anchor(
+    ledger_path: &Path,
+    run_id: i64,
+    observation: &RuntimeObservation,
+) -> Result<()> {
+    let mut ledger = Ledger::open(ledger_path)?;
+    ledger.observe_run(
+        run_id,
+        observation.process_id,
+        observation.process_identity.as_deref(),
+        None,
+        None,
+        None,
+    )
 }
 
 fn spawn_run_monitor(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -445,20 +445,13 @@ async fn execute_task(
     let execution_deadline = Instant::now() + workflow.timeout;
     let monitor_token = run_cancellation.clone();
     let ledger_path = ledger.path().to_owned();
-    let (observations, mut observation_receiver) = observation_channel();
-    let cancellation_monitor = tokio::spawn(async move {
-        if let Err(error) = monitor_run(
-            &ledger_path,
-            run_id,
-            &monitor_token,
-            &mut observation_receiver,
-        )
-        .await
-        {
-            eprintln!("Factory cancellation monitor failed for run {run_id}: {error:#}");
-            monitor_token.cancel();
-        }
-    });
+    let (mut observations, observation_receiver) = observation_channel();
+    let mut cancellation_monitor = spawn_run_monitor(
+        ledger_path.clone(),
+        run_id,
+        monitor_token.clone(),
+        observation_receiver,
+    );
     let execution = if let Some(session_id) = recovery_session.as_deref() {
         let resumed = codex
             .run_with_session(
@@ -490,6 +483,18 @@ async fn execute_task(
             if remaining.is_zero() {
                 resumed
             } else {
+                cancellation_monitor.abort();
+                let _ = (&mut cancellation_monitor).await;
+                ledger.reset_run_runtime_observation(run_id)?;
+                let (fallback_observations, fallback_receiver) = observation_channel();
+                observations = fallback_observations;
+                cancellation_monitor = spawn_run_monitor(
+                    ledger_path.clone(),
+                    run_id,
+                    monitor_token.clone(),
+                    fallback_receiver,
+                );
+                let remaining = execution_deadline.saturating_duration_since(Instant::now());
                 codex
                     .run_with_session(
                         &fallback_prompt,
@@ -516,6 +521,8 @@ async fn execute_task(
             )
             .await
     };
+    cancellation_monitor.abort();
+    let _ = cancellation_monitor.await;
     let observation = observations.borrow().clone();
     if observation.sequence > 0 {
         ledger.observe_run(
@@ -527,7 +534,6 @@ async fn execute_task(
             observation.activity.as_deref(),
         )?;
     }
-    cancellation_monitor.abort();
     match execution {
         Ok(result) => record_execution(&mut ledger, run_id, &result),
         Err(error) => {
@@ -541,6 +547,22 @@ async fn execute_task(
             Err(error)
         }
     }
+}
+
+fn spawn_run_monitor(
+    ledger_path: PathBuf,
+    run_id: i64,
+    cancellation: CancellationToken,
+    mut observations: tokio::sync::watch::Receiver<RuntimeObservation>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(error) =
+            monitor_run(&ledger_path, run_id, &cancellation, &mut observations).await
+        {
+            eprintln!("Factory cancellation monitor failed for run {run_id}: {error:#}");
+            cancellation.cancel();
+        }
+    })
 }
 
 async fn monitor_run(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -486,7 +486,18 @@ async fn execute_task(
             } else {
                 cancellation_monitor.abort();
                 let _ = (&mut cancellation_monitor).await;
-                ledger.reset_run_runtime_observation(run_id)?;
+                if let Err(error) = ledger.reset_run_runtime_observation(run_id) {
+                    ledger.finish_run_and_task(
+                        run_id,
+                        RunOutcome::Failed,
+                        None,
+                        Some(&format!(
+                            "failed to prepare a fresh recovery fallback: {error:#}"
+                        )),
+                        None,
+                    )?;
+                    return Err(error.context("failed to prepare a fresh recovery fallback"));
+                }
                 let (fallback_observations, fallback_receiver) = observation_channel();
                 observations = fallback_observations;
                 cancellation_monitor = spawn_run_monitor(
@@ -774,7 +785,13 @@ fn record_execution(ledger: &mut Ledger, run_id: i64, result: &ExecutionResult) 
             )),
         ),
     };
-    ledger.finish_run_and_task(
+    let finish = if result.termination == Termination::TimedOut {
+        Ledger::finish_run_and_task_terminal
+    } else {
+        Ledger::finish_run_and_task
+    };
+    finish(
+        ledger,
         run_id,
         outcome,
         Some(&result.final_response),

--- a/src/inspection.rs
+++ b/src/inspection.rs
@@ -49,6 +49,13 @@ pub struct RunView {
     pub cancellation_requested_at: Option<i64>,
     pub owner_pid: Option<u32>,
     pub owner_id: Option<String>,
+    pub process_id: Option<u32>,
+    pub process_identity: Option<String>,
+    pub pull_request: Option<String>,
+    pub last_activity_at: i64,
+    pub working_directory: Option<String>,
+    pub recovery_of: Option<i64>,
+    pub recovery_attempt: u32,
 }
 
 impl From<&Run> for RunView {
@@ -76,6 +83,13 @@ impl From<&Run> for RunView {
             cancellation_requested_at: run.cancellation_requested_at,
             owner_pid: run.owner_pid,
             owner_id: run.owner_id.clone(),
+            process_id: run.process_id,
+            process_identity: run.process_identity.clone(),
+            pull_request: run.pull_request.clone(),
+            last_activity_at: run.last_activity_at,
+            working_directory: run.working_directory.clone(),
+            recovery_of: run.recovery_of,
+            recovery_attempt: run.recovery_attempt,
         }
     }
 }
@@ -101,6 +115,7 @@ pub struct RunInspection {
     pub session_id: Option<String>,
     pub result: Option<BoundedText>,
     pub error: Option<BoundedText>,
+    pub activity: Option<BoundedText>,
 }
 
 impl RunInspection {
@@ -111,6 +126,7 @@ impl RunInspection {
             session_id: run.session_id.clone(),
             result: run.result.as_deref().map(BoundedText::new),
             error: run.error.as_deref().map(BoundedText::new),
+            activity: run.activity.as_deref().map(BoundedText::new),
         }
     }
 }
@@ -162,6 +178,34 @@ pub fn print_inspection(inspection: &RunInspection) {
     println!("Runtime: {}", safe_text(&inspection.run.runtime));
     println!("Outcome: {}", safe_text(&inspection.run.outcome));
     println!("Started: {}", inspection.run.started_at);
+    println!("Last activity: {}", inspection.run.last_activity_at);
+    println!(
+        "Process: {}",
+        inspection
+            .run
+            .process_id
+            .map_or_else(|| "-".to_owned(), |value| value.to_string())
+    );
+    println!(
+        "Process identity: {}",
+        safe_text(inspection.run.process_identity.as_deref().unwrap_or("-"))
+    );
+    println!(
+        "Working directory: {}",
+        safe_text(inspection.run.working_directory.as_deref().unwrap_or("-"))
+    );
+    println!(
+        "Pull request: {}",
+        safe_text(inspection.run.pull_request.as_deref().unwrap_or("-"))
+    );
+    println!(
+        "Recovery: {} (attempt {})",
+        inspection
+            .run
+            .recovery_of
+            .map_or_else(|| "-".to_owned(), |value| value.to_string()),
+        inspection.run.recovery_attempt,
+    );
     println!(
         "Finished: {}",
         inspection
@@ -182,6 +226,7 @@ pub fn print_inspection(inspection: &RunInspection) {
     );
     print_detail("Result", inspection.result.as_ref());
     print_detail("Error", inspection.error.as_ref());
+    print_detail("Activity", inspection.activity.as_ref());
 }
 
 fn print_detail(label: &str, detail: Option<&BoundedText>) {
@@ -228,7 +273,7 @@ fn truncate(value: &str, maximum_bytes: usize) -> (String, bool) {
     (value[..end].to_owned(), true)
 }
 
-fn sanitize(value: &str) -> String {
+pub(crate) fn sanitize_for_storage(value: &str) -> String {
     static PRIVATE_KEY: OnceLock<Regex> = OnceLock::new();
     static ASSIGNMENT: OnceLock<Regex> = OnceLock::new();
     static BEARER: OnceLock<Regex> = OnceLock::new();
@@ -279,4 +324,8 @@ fn sanitize(value: &str) -> String {
         })
         .replace_all(&value, "[REDACTED]")
         .into_owned()
+}
+
+fn sanitize(value: &str) -> String {
+    sanitize_for_storage(value)
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -605,8 +605,10 @@ pub(crate) fn process_identity(process_id: u32) -> Option<String> {
 #[cfg(target_os = "linux")]
 pub(crate) fn process_identity(process_id: u32) -> Option<String> {
     let stat = std::fs::read_to_string(format!("/proc/{process_id}/stat")).ok()?;
-    let fields = stat.get(stat.rfind(')')? + 1..)?.split_whitespace();
-    let start_ticks = fields.skip(19).next()?;
+    let start_ticks = stat
+        .get(stat.rfind(')')? + 1..)?
+        .split_whitespace()
+        .nth(19)?;
     Some(format!("linux:{start_ticks}"))
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result, bail};
 use serde_json::Value;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::{Instant as TokioInstant, sleep_until, timeout};
 use tokio_util::sync::CancellationToken;
@@ -22,6 +23,7 @@ const MAX_ACTIVITY_LINE_BYTES: usize = 256 * 1024;
 const MAX_THREAD_ID_BYTES: usize = 256;
 const MAX_FINAL_RESPONSE_BYTES: usize = 256 * 1024;
 const MAX_STDERR_BYTES: usize = 64 * 1024;
+const MAX_OBSERVED_ACTIVITY_BYTES: usize = 64 * 1024;
 const MAX_HEALTH_OUTPUT_BYTES: usize = 64 * 1024;
 const OUTPUT_CHANNEL_CAPACITY: usize = 16;
 const OUTPUT_ACK_TIMEOUT: Duration = Duration::from_millis(250);
@@ -50,6 +52,23 @@ pub struct ExecutionResult {
     pub activity_lines: usize,
     pub activity_error: Option<String>,
     pub stderr_tail: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeObservation {
+    pub process_id: Option<u32>,
+    pub process_identity: Option<String>,
+    pub session_id: Option<String>,
+    pub pull_request: Option<String>,
+    pub activity: Option<String>,
+    pub sequence: u64,
+}
+
+pub fn observation_channel() -> (
+    watch::Sender<RuntimeObservation>,
+    watch::Receiver<RuntimeObservation>,
+) {
+    watch::channel(RuntimeObservation::default())
 }
 
 #[derive(Debug)]
@@ -143,18 +162,50 @@ impl CodexRuntime {
         run_timeout: Duration,
         cancellation: CancellationToken,
     ) -> Result<ExecutionResult> {
+        let (observations, _receiver) = observation_channel();
+        self.run_with_session(
+            prompt,
+            working_directory,
+            run_timeout,
+            cancellation,
+            None,
+            observations,
+        )
+        .await
+    }
+
+    pub async fn run_with_session(
+        &self,
+        prompt: &str,
+        working_directory: &Path,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+        resume_session: Option<&str>,
+        observations: watch::Sender<RuntimeObservation>,
+    ) -> Result<ExecutionResult> {
         let output_path = tempfile::NamedTempFile::new()
             .context("failed to create Codex final-response file")?
             .into_temp_path();
         let mut command = Command::new(&self.executable);
+        command.arg("exec");
+        if let Some(session_id) = resume_session {
+            command.arg("resume");
+            command
+                .arg("--json")
+                .arg("--output-last-message")
+                .arg(&output_path)
+                .arg(session_id)
+                .arg("-");
+        } else {
+            command
+                .arg("--json")
+                .arg("--color")
+                .arg("never")
+                .arg("--output-last-message")
+                .arg(&output_path)
+                .arg("-");
+        }
         command
-            .arg("exec")
-            .arg("--json")
-            .arg("--color")
-            .arg("never")
-            .arg("--output-last-message")
-            .arg(&output_path)
-            .arg("-")
             .current_dir(working_directory)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -168,6 +219,8 @@ impl CodexRuntime {
             format!("failed to start Codex CLI at {}", self.executable.display())
         })?;
         let process_id = child.id();
+        let identity = process_id.and_then(process_identity);
+        update_observation(&observations, process_id, identity, None, None);
         let mut stdin = child
             .stdin
             .take()
@@ -181,8 +234,9 @@ impl CodexRuntime {
             .take()
             .context("Codex process did not expose stderr")?;
         let stdout_stream = self.stream_activity.then_some(OutputStream::Stdout);
-        let stdout_task = tokio::spawn(read_stdout(stdout, stdout_stream));
-        let stderr_task = tokio::spawn(read_stderr(stderr, Some(OutputStream::Stderr)));
+        let stderr_stream = self.stream_activity.then_some(OutputStream::Stderr);
+        let stdout_task = tokio::spawn(read_stdout(stdout, stdout_stream, observations.clone()));
+        let stderr_task = tokio::spawn(read_stderr(stderr, stderr_stream, observations.clone()));
 
         let deliver_prompt = async {
             stdin
@@ -344,6 +398,7 @@ struct ActivityCapture {
 async fn read_stdout(
     mut stdout: tokio::process::ChildStdout,
     activity_stream: Option<OutputStream>,
+    observations: watch::Sender<RuntimeObservation>,
 ) -> Result<ActivityCapture> {
     let mut capture = ActivityCapture::default();
     let mut chunk = [0_u8; 8192];
@@ -364,7 +419,7 @@ async fn read_stdout(
             if *byte == b'\n' {
                 capture.lines += 1;
                 if !discarding {
-                    capture_activity_line(&line, &mut capture);
+                    capture_activity_line(&line, &mut capture, &observations);
                 }
                 line.clear();
                 discarding = false;
@@ -380,21 +435,49 @@ async fn read_stdout(
     if !line.is_empty() || discarding {
         capture.lines += 1;
         if !discarding {
-            capture_activity_line(&line, &mut capture);
+            capture_activity_line(&line, &mut capture, &observations);
         }
     }
     Ok(capture)
 }
 
-fn capture_activity_line(line: &[u8], capture: &mut ActivityCapture) {
+fn capture_activity_line(
+    line: &[u8],
+    capture: &mut ActivityCapture,
+    observations: &watch::Sender<RuntimeObservation>,
+) {
     let line = line.strip_suffix(b"\r").unwrap_or(line);
     match serde_json::from_slice::<Value>(line) {
         Ok(event) => {
+            let event_type = event
+                .get("type")
+                .and_then(Value::as_str)
+                .filter(|value| {
+                    value.len() <= 80
+                        && value.bytes().all(|byte| {
+                            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+                        })
+                })
+                .unwrap_or("unknown");
+            update_observation(
+                observations,
+                None,
+                None,
+                None,
+                Some(format!("Codex event: {event_type}\n")),
+            );
+            if let Some(pull_request) = find_pull_request_url(&event) {
+                observations.send_modify(|observation| {
+                    observation.pull_request = Some(pull_request);
+                    observation.sequence = observation.sequence.saturating_add(1);
+                });
+            }
             if capture.thread_id.is_none()
                 && let Some(thread_id) = event.get("thread_id").and_then(Value::as_str)
             {
                 if thread_id.len() <= MAX_THREAD_ID_BYTES {
                     capture.thread_id = Some(thread_id.to_owned());
+                    update_observation(observations, None, None, Some(thread_id.to_owned()), None);
                 } else if capture.malformed_line.is_none() {
                     capture.malformed_line =
                         Some(format!("thread ID exceeds {MAX_THREAD_ID_BYTES} bytes"));
@@ -408,9 +491,36 @@ fn capture_activity_line(line: &[u8], capture: &mut ActivityCapture) {
     }
 }
 
+fn find_pull_request_url(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => value.split_whitespace().find_map(|word| {
+            let candidate = word.trim_matches(|character: char| {
+                matches!(
+                    character,
+                    '(' | ')' | '[' | ']' | ',' | '.' | ';' | '\'' | '"'
+                )
+            });
+            let mut parts = candidate.strip_prefix("https://github.com/")?.split('/');
+            let owner = parts.next()?;
+            let repository = parts.next()?;
+            let pull = parts.next()?;
+            let number = parts.next()?;
+            (!owner.is_empty()
+                && !repository.is_empty()
+                && pull == "pull"
+                && number.bytes().all(|byte| byte.is_ascii_digit()))
+            .then(|| candidate.to_owned())
+        }),
+        Value::Array(values) => values.iter().find_map(find_pull_request_url),
+        Value::Object(values) => values.values().find_map(find_pull_request_url),
+        _ => None,
+    }
+}
+
 async fn read_stderr(
     mut stderr: tokio::process::ChildStderr,
     activity_stream: Option<OutputStream>,
+    observations: watch::Sender<RuntimeObservation>,
 ) -> Result<String> {
     let mut tail = Vec::new();
     let mut chunk = [0_u8; 8192];
@@ -425,9 +535,84 @@ async fn read_stderr(
         if let Some(stream) = activity_stream {
             stream_output(stream, &chunk[..read]);
         }
+        update_observation(
+            &observations,
+            None,
+            None,
+            None,
+            Some(format!("Codex stderr activity: {read} bytes\n")),
+        );
         append_bounded(&mut tail, &chunk[..read], MAX_STDERR_BYTES);
     }
     Ok(String::from_utf8_lossy(&tail).into_owned())
+}
+
+fn update_observation(
+    observations: &watch::Sender<RuntimeObservation>,
+    process_id: Option<u32>,
+    process_identity: Option<String>,
+    session_id: Option<String>,
+    activity: Option<String>,
+) {
+    observations.send_modify(|observation| {
+        if let Some(process_id) = process_id {
+            observation.process_id = Some(process_id);
+        }
+        if let Some(process_identity) = process_identity {
+            observation.process_identity = Some(process_identity);
+        }
+        if let Some(session_id) = session_id {
+            observation.session_id = Some(session_id);
+        }
+        if let Some(activity) = activity {
+            let observed = observation.activity.get_or_insert_with(String::new);
+            observed.push_str(&crate::inspection::sanitize_for_storage(&activity));
+            if observed.len() > MAX_OBSERVED_ACTIVITY_BYTES {
+                let mut start = observed.len() - MAX_OBSERVED_ACTIVITY_BYTES;
+                while !observed.is_char_boundary(start) {
+                    start += 1;
+                }
+                observed.drain(..start);
+            }
+        }
+        observation.sequence = observation.sequence.saturating_add(1);
+    });
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn process_identity(process_id: u32) -> Option<String> {
+    let process_id = i32::try_from(process_id).ok()?;
+    // SAFETY: proc_pidinfo initializes proc_bsdinfo when it returns the full
+    // structure size. The buffer points to valid writable storage.
+    let information = unsafe {
+        let mut information = std::mem::zeroed::<nix::libc::proc_bsdinfo>();
+        let expected = i32::try_from(std::mem::size_of_val(&information)).ok()?;
+        let written = nix::libc::proc_pidinfo(
+            process_id,
+            nix::libc::PROC_PIDTBSDINFO,
+            0,
+            (&raw mut information).cast(),
+            expected,
+        );
+        (written == expected).then_some(information)?
+    };
+    Some(format!(
+        "macos:{}:{}",
+        information.pbi_start_tvsec, information.pbi_start_tvusec
+    ))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn process_identity(process_id: u32) -> Option<String> {
+    let stat = std::fs::read_to_string(format!("/proc/{process_id}/stat")).ok()?;
+    let fields = stat.get(stat.rfind(')')? + 1..)?.split_whitespace();
+    let start_ticks = fields.skip(19).next()?;
+    Some(format!("linux:{start_ticks}"))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub(crate) fn process_identity(_process_id: u32) -> Option<String> {
+    None
 }
 
 async fn read_pipe_bounded<R>(mut reader: R, maximum: usize) -> Result<Vec<u8>>

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -65,6 +65,8 @@ pub struct RuntimeObservation {
     pub sequence: u64,
 }
 
+type BeforeCodexSpawn<'a> = Box<dyn FnOnce(&RuntimeObservation) -> Result<()> + Send + 'a>;
+
 pub fn observation_channel() -> (
     watch::Sender<RuntimeObservation>,
     watch::Receiver<RuntimeObservation>,
@@ -282,6 +284,55 @@ impl CodexRuntime {
         resume_session: Option<&str>,
         observations: watch::Sender<RuntimeObservation>,
     ) -> Result<ExecutionResult> {
+        self.run_with_session_inner(
+            prompt,
+            working_directory,
+            run_timeout,
+            cancellation,
+            resume_session,
+            observations,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn run_with_session_supervised<F>(
+        &self,
+        prompt: &str,
+        working_directory: &Path,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+        resume_session: Option<&str>,
+        observations: watch::Sender<RuntimeObservation>,
+        before_spawn: F,
+    ) -> Result<ExecutionResult>
+    where
+        F: FnOnce(&RuntimeObservation) -> Result<()> + Send,
+    {
+        self.run_with_session_inner(
+            prompt,
+            working_directory,
+            run_timeout,
+            cancellation,
+            resume_session,
+            observations,
+            Some(Box::new(before_spawn)),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_with_session_inner(
+        &self,
+        prompt: &str,
+        working_directory: &Path,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+        resume_session: Option<&str>,
+        observations: watch::Sender<RuntimeObservation>,
+        before_spawn: Option<BeforeCodexSpawn<'_>>,
+    ) -> Result<ExecutionResult> {
         let output_path = tempfile::NamedTempFile::new()
             .context("failed to create Codex final-response file")?
             .into_temp_path();
@@ -312,6 +363,16 @@ impl CodexRuntime {
             .kill_on_drop(true);
         let mut process_group = RunProcessGroup::start().await?;
         process_group.configure(&mut command)?;
+        let anchor_observation = RuntimeObservation {
+            process_id: process_group.process_id,
+            process_identity: process_group.process_identity.clone(),
+            sequence: 1,
+            ..RuntimeObservation::default()
+        };
+        if let Some(before_spawn) = before_spawn {
+            before_spawn(&anchor_observation)?;
+        }
+        observations.send_replace(anchor_observation);
 
         let started = Instant::now();
         let deadline = TokioInstant::now() + run_timeout;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -4,8 +4,9 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 use serde_json::Value;
@@ -93,6 +94,104 @@ pub struct CodexRuntime {
     executable: PathBuf,
     health_timeout: Duration,
     stream_activity: bool,
+}
+
+struct RunProcessGroup {
+    #[cfg(unix)]
+    anchor: Child,
+    process_id: Option<u32>,
+    process_identity: Option<String>,
+}
+
+impl RunProcessGroup {
+    async fn start() -> Result<Self> {
+        #[cfg(unix)]
+        {
+            let anchor_token = process_group_anchor_token();
+            let mut command = Command::new("/bin/sh");
+            command
+                .args([
+                    "-c",
+                    "trap '' TERM; while :; do sleep 3600; done",
+                    &anchor_token,
+                ])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .kill_on_drop(true);
+            configure_process_group(&mut command);
+            let mut anchor = spawn_with_retry(&mut command)
+                .await
+                .context("failed to start Codex process-group anchor")?;
+            let process_id = anchor
+                .id()
+                .filter(|process_id| *process_id > 0)
+                .context("Codex process-group anchor has no positive process ID")?;
+            let Some(process_identity) = process_identity(process_id) else {
+                let _ = stop_process_group_anchor(&mut anchor, process_id).await;
+                bail!("could not establish Codex process-group anchor identity");
+            };
+            Ok(Self {
+                anchor,
+                process_id: Some(process_id),
+                process_identity: Some(process_identity),
+            })
+        }
+        #[cfg(not(unix))]
+        {
+            Ok(Self {
+                process_id: None,
+                process_identity: None,
+            })
+        }
+    }
+
+    fn configure(&self, command: &mut Command) -> Result<()> {
+        #[cfg(unix)]
+        {
+            let process_id = self
+                .process_id
+                .context("Codex process-group anchor has no process ID")?;
+            let process_id = i32::try_from(process_id)
+                .context("Codex process-group anchor ID exceeds platform range")?;
+            command.process_group(process_id);
+        }
+        #[cfg(not(unix))]
+        let _ = command;
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<()> {
+        #[cfg(unix)]
+        if let Some(process_id) = self.process_id {
+            stop_process_group_anchor(&mut self.anchor, process_id).await?;
+            self.process_id = None;
+            self.process_identity = None;
+        }
+        Ok(())
+    }
+
+    async fn reap(&mut self) -> Result<()> {
+        #[cfg(unix)]
+        {
+            self.anchor
+                .wait()
+                .await
+                .context("failed to reap Codex process-group anchor")?;
+            self.process_id = None;
+            self.process_identity = None;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RunProcessGroup {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(process_id) = self.process_id {
+            let _ = signal_process_group(Some(process_id), true);
+        }
+    }
 }
 
 impl Default for CodexRuntime {
@@ -211,16 +310,33 @@ impl CodexRuntime {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
-        configure_process_group(&mut command);
+        let mut process_group = RunProcessGroup::start().await?;
+        process_group.configure(&mut command)?;
 
         let started = Instant::now();
         let deadline = TokioInstant::now() + run_timeout;
-        let mut child = spawn_with_retry(&mut command).await.with_context(|| {
-            format!("failed to start Codex CLI at {}", self.executable.display())
-        })?;
+        let mut child = match spawn_with_retry(&mut command).await {
+            Ok(child) => child,
+            Err(error) => {
+                let _ = process_group.stop().await;
+                return Err(error).with_context(|| {
+                    format!("failed to start Codex CLI at {}", self.executable.display())
+                });
+            }
+        };
         let process_id = child.id();
-        let identity = process_id.and_then(process_identity);
-        update_observation(&observations, process_id, identity, None, None);
+        let observed_process_id = process_group.process_id.or(process_id);
+        let observed_process_identity = process_group
+            .process_identity
+            .clone()
+            .or_else(|| process_id.and_then(process_identity));
+        update_observation(
+            &observations,
+            observed_process_id,
+            observed_process_identity,
+            None,
+            None,
+        );
         let mut stdin = child
             .stdin
             .take()
@@ -262,6 +378,8 @@ impl CodexRuntime {
                     cleanup_failed_delivery(
                         &mut child,
                         process_id,
+                        process_group.process_id.or(process_id),
+                        &mut process_group,
                         stdout_task,
                         stderr_task,
                     )
@@ -273,21 +391,30 @@ impl CodexRuntime {
         };
 
         let (status, termination) = if let Some(termination) = early_termination {
-            (terminate(&mut child, process_id).await?, termination)
+            (
+                terminate(
+                    &mut child,
+                    process_id,
+                    process_group.process_id.or(process_id),
+                )
+                .await?,
+                termination,
+            )
         } else {
             tokio::select! {
                 biased;
                 () = cancellation.cancelled() => {
-                    (terminate(&mut child, process_id).await?, Termination::Cancelled)
+                    (terminate(&mut child, process_id, process_group.process_id.or(process_id)).await?, Termination::Cancelled)
                 }
                 () = sleep_until(deadline) => {
-                    (terminate(&mut child, process_id).await?, Termination::TimedOut)
+                    (terminate(&mut child, process_id, process_group.process_id.or(process_id)).await?, Termination::TimedOut)
                 }
-                status = wait_for_clean_exit(&mut child, process_id) => {
+                status = wait_for_clean_exit(&mut child, process_id, process_group.process_id.or(process_id)) => {
                     (status.context("failed while waiting for Codex")?, Termination::Exited)
                 }
             }
         };
+        process_group.reap().await?;
 
         let capture = join_reader(stdout_task, "stdout").await?;
         let stderr_tail = join_reader(stderr_task, "stderr").await?;
@@ -346,13 +473,13 @@ impl CodexRuntime {
         let status = tokio::select! {
             biased;
             () = cancellation.cancelled() => {
-                terminate(&mut child, process_id).await?;
+                terminate(&mut child, process_id, process_id).await?;
                 join_reader(stdout_task, "health-check stdout").await?;
                 join_reader(stderr_task, "health-check stderr").await?;
                 return Err(RuntimeCancelled.into());
             }
             () = sleep_until(deadline) => {
-                terminate(&mut child, process_id).await?;
+                terminate(&mut child, process_id, process_id).await?;
                 join_reader(stdout_task, "health-check stdout").await?;
                 join_reader(stderr_task, "health-check stderr").await?;
                 bail!(
@@ -360,7 +487,7 @@ impl CodexRuntime {
                     humantime::format_duration(self.health_timeout)
                 );
             }
-            status = wait_for_clean_exit(&mut child, process_id) => {
+            status = wait_for_clean_exit(&mut child, process_id, process_id) => {
                 status.context("failed while waiting for Codex health check")?
             }
         };
@@ -579,6 +706,20 @@ fn update_observation(
     });
 }
 
+#[cfg(unix)]
+fn process_group_anchor_token() -> String {
+    static NEXT_TOKEN: AtomicU64 = AtomicU64::new(1);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!(
+        "factory-anchor-{}-{timestamp}-{}",
+        std::process::id(),
+        NEXT_TOKEN.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
 #[cfg(target_os = "macos")]
 pub(crate) fn process_identity(process_id: u32) -> Option<String> {
     let process_id = i32::try_from(process_id).ok()?;
@@ -612,7 +753,31 @@ pub(crate) fn process_identity(process_id: u32) -> Option<String> {
     Some(format!("linux:{start_ticks}"))
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "linux"))))]
+pub(crate) fn process_identity(process_id: u32) -> Option<String> {
+    let process_id = i32::try_from(process_id).ok().filter(|value| *value > 0)?;
+    let output = std::process::Command::new("ps")
+        .env("LC_ALL", "C")
+        .args([
+            "-ww",
+            "-o",
+            "lstart=",
+            "-o",
+            "command=",
+            "-p",
+            &process_id.to_string(),
+        ])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("unix:{value}"))
+}
+
+#[cfg(not(unix))]
 pub(crate) fn process_identity(_process_id: u32) -> Option<String> {
     None
 }
@@ -742,10 +907,13 @@ pub fn write_stderr_best_effort(bytes: &[u8]) {
 async fn cleanup_failed_delivery(
     child: &mut Child,
     process_id: Option<u32>,
+    process_group_id: Option<u32>,
+    process_group: &mut RunProcessGroup,
     stdout_task: JoinHandle<Result<ActivityCapture>>,
     stderr_task: JoinHandle<Result<String>>,
 ) {
-    let _ = terminate(child, process_id).await;
+    let _ = terminate(child, process_id, process_group_id).await;
+    let _ = process_group.stop().await;
     let _ = join_reader(stdout_task, "stdout").await;
     let _ = join_reader(stderr_task, "stderr").await;
 }
@@ -791,10 +959,14 @@ fn text_file_busy(_error: &std::io::Error) -> bool {
 }
 
 #[cfg(unix)]
-async fn wait_for_clean_exit(child: &mut Child, process_id: Option<u32>) -> Result<ExitStatus> {
+async fn wait_for_clean_exit(
+    child: &mut Child,
+    process_id: Option<u32>,
+    process_group_id: Option<u32>,
+) -> Result<ExitStatus> {
     let process_id = process_id.context("Codex process has no process ID")?;
     observe_exit(process_id).await?;
-    cleanup_descendants(Some(process_id))?;
+    cleanup_descendants(process_group_id)?;
     child
         .wait()
         .await
@@ -835,7 +1007,11 @@ fn wait_without_reaping(process_id: u32) -> Result<()> {
 }
 
 #[cfg(not(unix))]
-async fn wait_for_clean_exit(child: &mut Child, _process_id: Option<u32>) -> Result<ExitStatus> {
+async fn wait_for_clean_exit(
+    child: &mut Child,
+    _process_id: Option<u32>,
+    _process_group_id: Option<u32>,
+) -> Result<ExitStatus> {
     child
         .wait()
         .await
@@ -843,17 +1019,21 @@ async fn wait_for_clean_exit(child: &mut Child, _process_id: Option<u32>) -> Res
 }
 
 #[cfg(unix)]
-async fn terminate(child: &mut Child, process_id: Option<u32>) -> Result<ExitStatus> {
+async fn terminate(
+    child: &mut Child,
+    process_id: Option<u32>,
+    process_group_id: Option<u32>,
+) -> Result<ExitStatus> {
     let process_id = process_id.context("Codex process has no process ID")?;
-    signal_process_group(Some(process_id), false)?;
+    signal_process_group(process_group_id, false)?;
     match timeout(TERMINATION_GRACE, observe_exit(process_id)).await {
         Ok(observed) => observed?,
         Err(_) => {
-            signal_process_group(Some(process_id), true)?;
+            signal_process_group(process_group_id, true)?;
             observe_exit(process_id).await?;
         }
     }
-    cleanup_descendants(Some(process_id))?;
+    cleanup_descendants(process_group_id)?;
     child
         .wait()
         .await
@@ -861,7 +1041,11 @@ async fn terminate(child: &mut Child, process_id: Option<u32>) -> Result<ExitSta
 }
 
 #[cfg(not(unix))]
-async fn terminate(child: &mut Child, _process_id: Option<u32>) -> Result<ExitStatus> {
+async fn terminate(
+    child: &mut Child,
+    _process_id: Option<u32>,
+    _process_group_id: Option<u32>,
+) -> Result<ExitStatus> {
     child
         .start_kill()
         .context("failed to cancel Codex process")?;
@@ -906,13 +1090,28 @@ fn signal_process_group(process_id: Option<u32>, force: bool) -> Result<()> {
     let Some(process_id) = process_id else {
         return Ok(());
     };
+    if process_id == 0 {
+        bail!("refusing to signal process group zero");
+    }
+    let process_id =
+        i32::try_from(process_id).context("process group ID exceeds platform range")?;
     let signal = if force {
         Signal::SIGKILL
     } else {
         Signal::SIGTERM
     };
-    match killpg(Pid::from_raw(process_id as i32), signal) {
+    match killpg(Pid::from_raw(process_id), signal) {
         Ok(()) | Err(Errno::ESRCH) => Ok(()),
         Err(error) => Err(error).context("failed to signal Codex process group"),
     }
+}
+
+#[cfg(unix)]
+async fn stop_process_group_anchor(anchor: &mut Child, process_id: u32) -> Result<()> {
+    signal_process_group(Some(process_id), true)?;
+    anchor
+        .wait()
+        .await
+        .context("failed to reap Codex process-group anchor")?;
+    Ok(())
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -91,6 +91,36 @@ impl ExecutionResult {
     }
 }
 
+fn preparation_termination(
+    cancellation: &CancellationToken,
+    deadline: TokioInstant,
+) -> Option<Termination> {
+    if cancellation.is_cancelled() {
+        Some(Termination::Cancelled)
+    } else if TokioInstant::now() >= deadline {
+        Some(Termination::TimedOut)
+    } else {
+        None
+    }
+}
+
+#[cfg(unix)]
+fn preparation_result(termination: Termination, started: Instant) -> ExecutionResult {
+    use std::os::unix::process::ExitStatusExt;
+
+    ExecutionResult {
+        status: ExitStatus::from_raw(1 << 8),
+        termination,
+        final_response: String::new(),
+        final_response_truncated: false,
+        thread_id: None,
+        duration: started.elapsed(),
+        activity_lines: 0,
+        activity_error: None,
+        stderr_tail: String::new(),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CodexRuntime {
     executable: PathBuf,
@@ -333,6 +363,11 @@ impl CodexRuntime {
         observations: watch::Sender<RuntimeObservation>,
         before_spawn: Option<BeforeCodexSpawn<'_>>,
     ) -> Result<ExecutionResult> {
+        let started = Instant::now();
+        let deadline = TokioInstant::now() + run_timeout;
+        if let Some(termination) = preparation_termination(&cancellation, deadline) {
+            return Ok(preparation_result(termination, started));
+        }
         let output_path = tempfile::NamedTempFile::new()
             .context("failed to create Codex final-response file")?
             .into_temp_path();
@@ -363,22 +398,44 @@ impl CodexRuntime {
             .kill_on_drop(true);
         let mut process_group = RunProcessGroup::start().await?;
         process_group.configure(&mut command)?;
+        if let Some(termination) = preparation_termination(&cancellation, deadline) {
+            process_group.stop().await?;
+            return Ok(preparation_result(termination, started));
+        }
         let anchor_observation = RuntimeObservation {
             process_id: process_group.process_id,
             process_identity: process_group.process_identity.clone(),
             sequence: 1,
             ..RuntimeObservation::default()
         };
-        if let Some(before_spawn) = before_spawn {
-            before_spawn(&anchor_observation)?;
+        if let Some(before_spawn) = before_spawn
+            && let Err(error) = before_spawn(&anchor_observation)
+        {
+            process_group
+                .stop()
+                .await
+                .context("failed to stop Codex process group after persistence failure")?;
+            return Err(error);
         }
         observations.send_replace(anchor_observation);
+        if let Some(termination) = preparation_termination(&cancellation, deadline) {
+            process_group.stop().await?;
+            return Ok(preparation_result(termination, started));
+        }
 
-        let started = Instant::now();
-        let deadline = TokioInstant::now() + run_timeout;
-        let mut child = match spawn_with_retry(&mut command).await {
-            Ok(child) => child,
-            Err(error) => {
+        let spawned = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => Err(Termination::Cancelled),
+            () = sleep_until(deadline) => Err(Termination::TimedOut),
+            result = spawn_with_retry(&mut command) => Ok(result),
+        };
+        let mut child = match spawned {
+            Err(termination) => {
+                process_group.stop().await?;
+                return Ok(preparation_result(termination, started));
+            }
+            Ok(Ok(child)) => child,
+            Ok(Err(error)) => {
                 let _ = process_group.stop().await;
                 return Err(error).with_context(|| {
                     format!("failed to start Codex CLI at {}", self.executable.display())

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -969,6 +969,9 @@ impl Ledger {
         pull_request: Option<&str>,
         activity: Option<&str>,
     ) -> Result<()> {
+        if process_id == Some(0) {
+            bail!("run process ID must be positive");
+        }
         let session_id = session_id.map(|value| truncate_utf8(value, MAX_SESSION_ID_BYTES));
         let pull_request = pull_request.map(|value| truncate_utf8(value, 2048));
         let activity = activity.map(|value| {
@@ -1059,6 +1062,7 @@ impl Ledger {
             }
             if let (Some(process_id), Some(recorded_identity)) =
                 (run.process_id, run.process_identity.as_deref())
+                && process_id > 0
                 && crate::runtime::process_identity(process_id).as_deref()
                     == Some(recorded_identity)
             {
@@ -1371,6 +1375,9 @@ fn process_is_alive(process_id: u32) -> bool {
 #[cfg(unix)]
 fn terminate_orphaned_process_group(process_id: u32) -> Result<()> {
     use nix::sys::signal::{Signal, killpg};
+    if process_id == 0 {
+        bail!("refusing to signal process group zero");
+    }
     let process_id = i32::try_from(process_id).context("process ID exceeds platform range")?;
     match killpg(nix::unistd::Pid::from_raw(process_id), Signal::SIGKILL) {
         Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,10 +8,12 @@ use anyhow::{Context, Result, bail};
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 
 const DATABASE_NAME: &str = "factory.sqlite3";
-const SCHEMA_VERSION: i64 = 3;
+const SCHEMA_VERSION: i64 = 4;
 pub const MAX_RESULT_BYTES: usize = 256 * 1024;
 pub const MAX_ERROR_BYTES: usize = 64 * 1024;
 pub const MAX_SESSION_ID_BYTES: usize = 1024;
+pub const MAX_ACTIVITY_BYTES: usize = 64 * 1024;
+pub const MAX_RECOVERY_ATTEMPTS: u32 = 2;
 const DAEMON_OWNER_LEASE_MILLIS: i64 = 10_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -200,6 +202,7 @@ pub struct Task {
     pub state: TaskState,
     pub created_at: i64,
     pub updated_at: i64,
+    pub recovery_source_run_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -252,6 +255,14 @@ pub struct Run {
     pub cancellation_requested_at: Option<i64>,
     pub owner_pid: Option<u32>,
     pub owner_id: Option<String>,
+    pub process_id: Option<u32>,
+    pub process_identity: Option<String>,
+    pub pull_request: Option<String>,
+    pub last_activity_at: i64,
+    pub activity: Option<String>,
+    pub working_directory: Option<String>,
+    pub recovery_of: Option<i64>,
+    pub recovery_attempt: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -267,6 +278,12 @@ pub enum CancellationRequest {
 pub struct ClaimedRun {
     pub task: Task,
     pub run: Run,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveryReport {
+    pub recovered_run_ids: Vec<i64>,
+    pub exhausted_run_ids: Vec<i64>,
 }
 
 pub struct Ledger {
@@ -495,6 +512,27 @@ impl Ledger {
         owner_id: &str,
         owner_pid: u32,
     ) -> Result<Option<ClaimedRun>> {
+        let working_directories = available_repositories
+            .iter()
+            .map(|repository| (repository.clone(), repository.clone()))
+            .collect();
+        self.claim_ticket_and_start_run_with_workdirs(
+            available_repositories,
+            workflow_runtimes,
+            owner_id,
+            owner_pid,
+            &working_directories,
+        )
+    }
+
+    pub fn claim_ticket_and_start_run_with_workdirs(
+        &mut self,
+        available_repositories: &[String],
+        workflow_runtimes: &HashMap<(String, String), String>,
+        owner_id: &str,
+        owner_pid: u32,
+        working_directories: &HashMap<String, String>,
+    ) -> Result<Option<ClaimedRun>> {
         if available_repositories.is_empty() {
             return Ok(None);
         }
@@ -542,11 +580,27 @@ impl Ledger {
         if changed != 1 {
             bail!("queued task {} could not be claimed atomically", task.id);
         }
+        let recovery_source = task.recovery_source_run_id;
+        let recovery_attempt = recovery_source
+            .map(|run_id| {
+                transaction.query_row(
+                    "SELECT recovery_attempt + 1 FROM runs WHERE id = ?1",
+                    [run_id],
+                    |row| row.get::<_, u32>(0),
+                )
+            })
+            .transpose()
+            .context("failed to resolve recovery attempt")?
+            .unwrap_or(0);
+        let working_directory = working_directories
+            .get(&task.repository)
+            .context("claimed repository working directory disappeared")?;
         transaction
             .execute(
                 "INSERT INTO runs
-                 (task_id, workflow, repository, source_item, runtime, started_at, outcome, owner_pid, owner_id)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'running', ?7, ?8)",
+                 (task_id, workflow, repository, source_item, runtime, started_at, outcome,
+                  owner_pid, owner_id, last_activity_at, working_directory, recovery_of, recovery_attempt)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'running', ?7, ?8, ?6, ?9, ?10, ?11)",
                 params![
                     task.id,
                     task.workflow,
@@ -555,13 +609,22 @@ impl Ledger {
                     runtime,
                     now,
                     owner_pid,
-                    owner_id
+                    owner_id,
+                    working_directory,
+                    recovery_source,
+                    recovery_attempt,
                 ],
             )
             .context("failed to create run in task claim transaction")?;
         let run_id = transaction.last_insert_rowid();
         let task = query_task(&transaction, task.id)?.context("claimed task disappeared")?;
         let run = query_run(&transaction, run_id)?.context("claimed run disappeared")?;
+        transaction
+            .execute(
+                "UPDATE tasks SET recovery_source_run_id = NULL WHERE id = ?1",
+                [task.id],
+            )
+            .context("failed to clear claimed recovery source")?;
         transaction
             .commit()
             .context("failed to commit atomic task and run claim")?;
@@ -627,6 +690,19 @@ impl Ledger {
             .context("failed to query prior agent session")
     }
 
+    pub fn latest_pull_request_for_task(&self, task_id: i64) -> Result<Option<String>> {
+        self.connection
+            .query_row(
+                "SELECT pull_request FROM runs
+                 WHERE task_id = ?1 AND pull_request IS NOT NULL
+                 ORDER BY id DESC LIMIT 1",
+                [task_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .context("failed to query recovery pull-request context")
+    }
+
     pub fn tasks(&self) -> Result<Vec<Task>> {
         let mut statement = self
             .connection
@@ -655,8 +731,8 @@ impl Ledger {
         transaction
             .execute(
                 "INSERT INTO runs
-                 (task_id, workflow, repository, source_item, runtime, started_at, outcome)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'running')",
+                 (task_id, workflow, repository, source_item, runtime, started_at, outcome, last_activity_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'running', ?6)",
                 params![
                     task_id,
                     task.workflow,
@@ -684,19 +760,37 @@ impl Ledger {
         if outcome == RunOutcome::Running {
             bail!("finish_run_and_task requires a terminal outcome");
         }
-        let result = result.map(|value| truncate_utf8(value, MAX_RESULT_BYTES));
-        let mut error = error.map(|value| truncate_utf8(value, MAX_ERROR_BYTES));
+        let result = result.map(|value| {
+            truncate_utf8(
+                &crate::inspection::sanitize_for_storage(value),
+                MAX_RESULT_BYTES,
+            )
+        });
+        let mut error = error.map(|value| {
+            truncate_utf8(
+                &crate::inspection::sanitize_for_storage(value),
+                MAX_ERROR_BYTES,
+            )
+        });
         let session_id = session_id.map(|value| truncate_utf8(value, MAX_SESSION_ID_BYTES));
         let transaction = self
             .connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("failed to begin run completion transaction")?;
-        let (task_id, cancellation_requested) = transaction
+        let (task_id, cancellation_requested, recovery_attempt, process_started) = transaction
             .query_row(
-                "SELECT task_id, cancellation_requested_at IS NOT NULL
+                "SELECT task_id, cancellation_requested_at IS NOT NULL, recovery_attempt,
+                        process_id IS NOT NULL
                  FROM runs WHERE id = ?1 AND outcome = 'running'",
                 [id],
-                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, bool>(1)?)),
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, bool>(1)?,
+                        row.get::<_, u32>(2)?,
+                        row.get::<_, bool>(3)?,
+                    ))
+                },
             )
             .optional()
             .context("failed to resolve active run task")?
@@ -712,7 +806,7 @@ impl Ledger {
         let changed = transaction
             .execute(
                 "UPDATE runs SET finished_at = ?1, outcome = ?2, result = ?3, error = ?4,
-                 session_id = ?5 WHERE id = ?6 AND outcome = 'running'",
+                 session_id = COALESCE(?5, session_id) WHERE id = ?6 AND outcome = 'running'",
                 params![
                     now_millis()?,
                     outcome.as_str(),
@@ -726,19 +820,30 @@ impl Ledger {
         if changed != 1 {
             bail!("run {id} is missing or already terminal");
         }
+        let retry_recovery = outcome == RunOutcome::Failed
+            && process_started
+            && recovery_attempt < MAX_RECOVERY_ATTEMPTS
+            && !cancellation_requested;
         let task_state = match outcome {
             RunOutcome::Succeeded => TaskState::Succeeded,
             RunOutcome::Failed => TaskState::Failed,
             RunOutcome::Cancelled => TaskState::Cancelled,
             RunOutcome::Running => unreachable!(),
         };
-        let changed = transaction
-            .execute(
+        let changed = if retry_recovery {
+            transaction.execute(
+                "UPDATE tasks SET state = 'queued', updated_at = ?1, recovery_source_run_id = ?2
+                 WHERE id = ?3 AND state = 'running'",
+                params![now_millis()?, id, task_id],
+            )
+        } else {
+            transaction.execute(
                 "UPDATE tasks SET state = ?1, updated_at = ?2
                  WHERE id = ?3 AND state = 'running'",
                 params![task_state.as_str(), now_millis()?, task_id],
             )
-            .context("failed to record terminal task state")?;
+        }
+        .context("failed to record terminal task state")?;
         if changed != 1 {
             bail!("task {task_id} is not running; run completion was not recorded");
         }
@@ -855,6 +960,135 @@ impl Ledger {
             .map(|requested| requested.unwrap_or(false))
     }
 
+    pub fn observe_run(
+        &mut self,
+        id: i64,
+        process_id: Option<u32>,
+        process_identity: Option<&str>,
+        session_id: Option<&str>,
+        pull_request: Option<&str>,
+        activity: Option<&str>,
+    ) -> Result<()> {
+        let session_id = session_id.map(|value| truncate_utf8(value, MAX_SESSION_ID_BYTES));
+        let pull_request = pull_request.map(|value| truncate_utf8(value, 2048));
+        let activity = activity.map(|value| {
+            truncate_tail_utf8(
+                &crate::inspection::sanitize_for_storage(value),
+                MAX_ACTIVITY_BYTES,
+            )
+        });
+        let changed = self
+            .connection
+            .execute(
+                "UPDATE runs SET
+               process_id = COALESCE(?1, process_id),
+               process_identity = COALESCE(?2, process_identity),
+               session_id = COALESCE(?3, session_id),
+               pull_request = COALESCE(?4, pull_request),
+               activity = COALESCE(?5, activity),
+               last_activity_at = ?6
+             WHERE id = ?7 AND outcome = 'running'",
+                params![
+                    process_id,
+                    process_identity,
+                    session_id,
+                    pull_request,
+                    activity,
+                    now_millis()?,
+                    id
+                ],
+            )
+            .context("failed to persist runtime activity")?;
+        if changed != 1 {
+            bail!("run {id} is missing or already terminal");
+        }
+        Ok(())
+    }
+
+    pub fn recover_orphaned_runs(&mut self) -> Result<RecoveryReport> {
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .context("failed to begin orphan recovery transaction")?;
+        let active = {
+            let mut statement = transaction
+                .prepare("SELECT * FROM runs WHERE outcome = 'running' ORDER BY id")
+                .context("failed to prepare active run recovery query")?;
+            statement
+                .query_map([], row_to_run)
+                .context("failed to query active runs for recovery")?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .context("failed to read active runs for recovery")?
+        };
+        let mut recovered_run_ids = Vec::new();
+        let mut exhausted_run_ids = Vec::new();
+        let lease_cutoff = now_millis()?.saturating_sub(DAEMON_OWNER_LEASE_MILLIS);
+        for run in active {
+            let owner_is_live = match (&run.owner_id, run.owner_pid) {
+                (Some(owner_id), Some(owner_pid)) => {
+                    transaction
+                        .query_row(
+                            "SELECT EXISTS(SELECT 1 FROM daemon_owners
+                     WHERE owner_id = ?1 AND pid = ?2 AND heartbeat_at >= ?3)",
+                            params![owner_id, owner_pid, lease_cutoff],
+                            |row| row.get::<_, bool>(0),
+                        )
+                        .context("failed to validate orphan owner lease")?
+                        && process_is_alive(owner_pid)
+                }
+                _ => false,
+            };
+            if owner_is_live {
+                continue;
+            }
+            if let (Some(process_id), Some(recorded_identity)) =
+                (run.process_id, run.process_identity.as_deref())
+                && crate::runtime::process_identity(process_id).as_deref()
+                    == Some(recorded_identity)
+            {
+                terminate_orphaned_process_group(process_id).with_context(|| {
+                    format!("failed to stop orphaned process tree for run {}", run.id)
+                })?;
+            }
+            let now = now_millis()?;
+            transaction
+                .execute(
+                    "UPDATE runs SET outcome = 'failed', finished_at = ?1,
+                 error = ?2 WHERE id = ?3 AND outcome = 'running'",
+                    params![
+                        now,
+                        "Factory detected an interrupted run without a live owned process",
+                        run.id
+                    ],
+                )
+                .context("failed to close orphaned run")?;
+            if run.recovery_attempt < MAX_RECOVERY_ATTEMPTS {
+                transaction.execute(
+                    "UPDATE tasks SET state = 'queued', updated_at = ?1, recovery_source_run_id = ?2
+                     WHERE id = ?3 AND state = 'running'",
+                    params![now, run.id, run.task_id],
+                ).context("failed to queue orphan recovery")?;
+                recovered_run_ids.push(run.id);
+            } else {
+                transaction
+                    .execute(
+                        "UPDATE tasks SET state = 'failed', updated_at = ?1
+                     WHERE id = ?2 AND state = 'running'",
+                        params![now, run.task_id],
+                    )
+                    .context("failed to exhaust orphan recovery")?;
+                exhausted_run_ids.push(run.id);
+            }
+        }
+        transaction
+            .commit()
+            .context("failed to commit orphan recovery")?;
+        Ok(RecoveryReport {
+            recovered_run_ids,
+            exhausted_run_ids,
+        })
+    }
+
     pub fn register_daemon_owner(&mut self, owner_id: &str, pid: u32) -> Result<()> {
         if owner_id.trim().is_empty() {
             bail!("daemon owner ID must not be empty");
@@ -909,6 +1143,9 @@ fn migrate(connection: &Connection) -> Result<()> {
     }
     if version < 3 {
         migrate_v3(connection)?;
+    }
+    if version < 4 {
+        migrate_v4(connection)?;
     }
     Ok(())
 }
@@ -1004,6 +1241,29 @@ fn migrate_v3(connection: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v4(connection: &Connection) -> Result<()> {
+    connection
+        .execute_batch(
+            "BEGIN IMMEDIATE;
+         ALTER TABLE tasks ADD COLUMN recovery_source_run_id INTEGER REFERENCES runs(id);
+         ALTER TABLE runs ADD COLUMN process_id INTEGER;
+         ALTER TABLE runs ADD COLUMN process_identity TEXT;
+         ALTER TABLE runs ADD COLUMN pull_request TEXT;
+         ALTER TABLE runs ADD COLUMN last_activity_at INTEGER;
+         ALTER TABLE runs ADD COLUMN activity TEXT;
+         ALTER TABLE runs ADD COLUMN working_directory TEXT;
+         ALTER TABLE runs ADD COLUMN recovery_of INTEGER REFERENCES runs(id);
+         ALTER TABLE runs ADD COLUMN recovery_attempt INTEGER NOT NULL DEFAULT 0;
+         UPDATE runs SET last_activity_at = started_at WHERE last_activity_at IS NULL;
+         INSERT INTO schema_migrations(version, applied_at)
+             VALUES (4, unixepoch('subsec') * 1000);
+         PRAGMA user_version = 4;
+         COMMIT;",
+        )
+        .context("failed to migrate SQLite ledger to version 4")?;
+    Ok(())
+}
+
 fn query_task(connection: &Connection, id: i64) -> Result<Option<Task>> {
     connection
         .query_row("SELECT * FROM tasks WHERE id = ?1", [id], row_to_task)
@@ -1042,6 +1302,7 @@ fn row_to_task(row: &rusqlite::Row<'_>) -> rusqlite::Result<Task> {
         state,
         created_at: row.get("created_at")?,
         updated_at: row.get("updated_at")?,
+        recovery_source_run_id: row.get("recovery_source_run_id")?,
     })
 }
 
@@ -1069,6 +1330,14 @@ fn row_to_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<Run> {
         cancellation_requested_at: row.get("cancellation_requested_at")?,
         owner_pid: row.get("owner_pid")?,
         owner_id: row.get("owner_id")?,
+        process_id: row.get("process_id")?,
+        process_identity: row.get("process_identity")?,
+        pull_request: row.get("pull_request")?,
+        last_activity_at: row.get("last_activity_at")?,
+        activity: row.get("activity")?,
+        working_directory: row.get("working_directory")?,
+        recovery_of: row.get("recovery_of")?,
+        recovery_attempt: row.get("recovery_attempt")?,
     })
 }
 
@@ -1083,9 +1352,24 @@ fn process_is_alive(process_id: u32) -> bool {
     }
 }
 
+#[cfg(unix)]
+fn terminate_orphaned_process_group(process_id: u32) -> Result<()> {
+    use nix::sys::signal::{Signal, killpg};
+    let process_id = i32::try_from(process_id).context("process ID exceeds platform range")?;
+    match killpg(nix::unistd::Pid::from_raw(process_id), Signal::SIGKILL) {
+        Ok(()) | Err(nix::errno::Errno::ESRCH) => Ok(()),
+        Err(error) => Err(error).context("failed to signal orphaned process group"),
+    }
+}
+
 #[cfg(not(unix))]
 fn process_is_alive(_process_id: u32) -> bool {
     false
+}
+
+#[cfg(not(unix))]
+fn terminate_orphaned_process_group(_process_id: u32) -> Result<()> {
+    Ok(())
 }
 
 fn now_millis() -> Result<i64> {
@@ -1105,4 +1389,15 @@ fn truncate_utf8(value: &str, maximum_bytes: usize) -> String {
         end -= 1;
     }
     value[..end].to_owned()
+}
+
+fn truncate_tail_utf8(value: &str, maximum_bytes: usize) -> String {
+    if value.len() <= maximum_bytes {
+        return value.to_owned();
+    }
+    let mut start = value.len() - maximum_bytes;
+    while !value.is_char_boundary(start) {
+        start += 1;
+    }
+    value[start..].to_owned()
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -757,6 +757,29 @@ impl Ledger {
         error: Option<&str>,
         session_id: Option<&str>,
     ) -> Result<Run> {
+        self.finish_run_and_task_with_recovery(id, outcome, result, error, session_id, true)
+    }
+
+    pub fn finish_run_and_task_terminal(
+        &mut self,
+        id: i64,
+        outcome: RunOutcome,
+        result: Option<&str>,
+        error: Option<&str>,
+        session_id: Option<&str>,
+    ) -> Result<Run> {
+        self.finish_run_and_task_with_recovery(id, outcome, result, error, session_id, false)
+    }
+
+    fn finish_run_and_task_with_recovery(
+        &mut self,
+        id: i64,
+        outcome: RunOutcome,
+        result: Option<&str>,
+        error: Option<&str>,
+        session_id: Option<&str>,
+        allow_recovery: bool,
+    ) -> Result<Run> {
         if outcome == RunOutcome::Running {
             bail!("finish_run_and_task requires a terminal outcome");
         }
@@ -820,7 +843,8 @@ impl Ledger {
         if changed != 1 {
             bail!("run {id} is missing or already terminal");
         }
-        let retry_recovery = outcome == RunOutcome::Failed
+        let retry_recovery = allow_recovery
+            && outcome == RunOutcome::Failed
             && process_started
             && recovery_attempt < MAX_RECOVERY_ATTEMPTS
             && !cancellation_requested;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1005,6 +1005,22 @@ impl Ledger {
         Ok(())
     }
 
+    pub fn reset_run_runtime_observation(&mut self, id: i64) -> Result<()> {
+        let changed = self
+            .connection
+            .execute(
+                "UPDATE runs SET process_id = NULL, process_identity = NULL,
+                 session_id = NULL, activity = NULL, last_activity_at = ?1
+                 WHERE id = ?2 AND outcome = 'running'",
+                params![now_millis()?, id],
+            )
+            .context("failed to reset failed session-resume observation")?;
+        if changed != 1 {
+            bail!("run {id} is missing or already terminal");
+        }
+        Ok(())
+    }
+
     pub fn recover_orphaned_runs(&mut self) -> Result<RecoveryReport> {
         let transaction = self
             .connection

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1071,17 +1071,34 @@ impl Ledger {
                 })?;
             }
             let now = now_millis()?;
+            let cancellation_requested = run.cancellation_requested_at.is_some();
+            let outcome = if cancellation_requested {
+                "cancelled"
+            } else {
+                "failed"
+            };
+            let error = if cancellation_requested {
+                "Factory completed a durable cancellation after its owning daemon stopped"
+            } else {
+                "Factory detected an interrupted run without a live owned process"
+            };
             transaction
                 .execute(
-                    "UPDATE runs SET outcome = 'failed', finished_at = ?1,
-                 error = ?2 WHERE id = ?3 AND outcome = 'running'",
-                    params![
-                        now,
-                        "Factory detected an interrupted run without a live owned process",
-                        run.id
-                    ],
+                    "UPDATE runs SET outcome = ?1, finished_at = ?2,
+                 error = ?3 WHERE id = ?4 AND outcome = 'running'",
+                    params![outcome, now, error, run.id],
                 )
                 .context("failed to close orphaned run")?;
+            if cancellation_requested {
+                transaction
+                    .execute(
+                        "UPDATE tasks SET state = 'cancelled', updated_at = ?1
+                     WHERE id = ?2 AND state = 'running'",
+                        params![now, run.task_id],
+                    )
+                    .context("failed to complete orphaned run cancellation")?;
+                continue;
+            }
             if run.recovery_attempt < MAX_RECOVERY_ATTEMPTS {
                 transaction.execute(
                     "UPDATE tasks SET state = 'queued', updated_at = ?1, recovery_source_run_id = ?2

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -111,6 +111,8 @@ exit 64
                 r#"#!/bin/sh
 if [ "$1" = "--version" ]; then echo "codex-cli 1.2.3"; exit 0; fi
 if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Logged in using ChatGPT"; exit 0; fi
+mode=initial
+if [ "$1" = "exec" ] && [ "$2" = "resume" ]; then mode=resume; fi
 output=""
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "--output-last-message" ]; then shift; output="$1"; fi
@@ -119,12 +121,30 @@ done
 slot=1
 while ! mkdir "{root}/slot-$slot" 2>/dev/null; do slot=$((slot + 1)); done
 echo $$ > "{root}/slot-$slot/pid"
+echo "$mode" > "{root}/slot-$slot/mode"
 sleep 1000 &
 echo $! > "{root}/slot-$slot/child-pid"
 cat > "{root}/slot-$slot/prompt"
 touch "{root}/slot-$slot/started"
-while [ ! -f "{root}/gate" ]; do sleep 0.02; done
 echo "{{\"type\":\"thread.started\",\"thread_id\":\"thread-$slot\"}}"
+echo "{{\"type\":\"item.completed\",\"item\":{{\"text\":\"active SECRET=hunter2\"}}}}"
+if [ -f "{root}/emit-pr-first" ] && [ "$slot" = "1" ]; then
+  echo "{{\"type\":\"item.completed\",\"item\":{{\"text\":\"https://github.com/example/repo-0/pull/77\"}}}}"
+fi
+if [ -f "{root}/malformed-once" ]; then
+  rm "{root}/malformed-once"
+  echo "not-json"
+  exit 0
+fi
+if [ "$mode" = "resume" ] && [ -f "{root}/fail-resume" ]; then
+  echo "stored session is missing" >&2
+  exit 44
+fi
+if [ -f "{root}/fail-all" ]; then
+  echo "agent process exited unexpectedly" >&2
+  exit 55
+fi
+while [ ! -f "{root}/gate" ]; do sleep 0.02; done
 printf 'Draft PR: https://example.test/pr/%s' "$slot" > "$output"
 exit 0
 "#,
@@ -449,6 +469,285 @@ async fn losing_the_durable_owner_lease_is_a_daemon_error() {
     assert!(format!("{error:#}").contains("is not registered"));
     let ledger = Ledger::open(&fixture.ledger_path).unwrap();
     assert_eq!(ledger.tasks().unwrap()[0].state, TaskState::Cancelled);
+}
+
+#[tokio::test]
+async fn restart_recovers_one_orphan_by_resuming_its_live_observed_session() {
+    let fixture = Fixture::new(&[vec![issue(21)]], 1, 1);
+    let first_daemon = Arc::new(fixture.daemon());
+    let first_shutdown = CancellationToken::new();
+    let first = {
+        let daemon = Arc::clone(&first_daemon);
+        let shutdown = first_shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+    wait_for(|| fixture.started_slots().len() == 1).await;
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.runs(None))
+            .is_ok_and(|runs| {
+                runs.len() == 1
+                    && runs[0].process_id.is_some()
+                    && runs[0].session_id.as_deref() == Some("thread-1")
+                    && runs[0].last_activity_at >= runs[0].started_at
+                    && runs[0]
+                        .activity
+                        .as_deref()
+                        .is_some_and(|activity| !activity.contains("hunter2"))
+            })
+    })
+    .await;
+    let owner_id = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap()[0]
+        .owner_id
+        .clone()
+        .unwrap();
+    first.abort();
+    let _ = first.await;
+    Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .remove_daemon_owner(&owner_id)
+        .unwrap();
+
+    let second_daemon = Arc::new(fixture.daemon());
+    let second_shutdown = CancellationToken::new();
+    let second = {
+        let daemon = Arc::clone(&second_daemon);
+        let shutdown = second_shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+    wait_for(|| fixture.started_slots().len() == 2).await;
+    let slots = fixture.started_slots();
+    assert_eq!(
+        fs::read_to_string(slots[1].join("mode")).unwrap().trim(),
+        "resume"
+    );
+    let prompt = fs::read_to_string(slots[1].join("prompt")).unwrap();
+    assert!(prompt.contains("Interrupted-run recovery"));
+    assert!(prompt.contains("Inspect current repository, ticket, GitHub"));
+    assert!(prompt.contains("thread-1"));
+    fixture.open_gate();
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
+    })
+    .await;
+    let runs = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap();
+    assert_eq!(runs.len(), 2);
+    assert_eq!(runs[0].outcome, "failed");
+    assert_eq!(runs[1].recovery_of, Some(runs[0].id));
+    assert_eq!(runs[1].recovery_attempt, 1);
+    second_shutdown.cancel();
+    second.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn live_second_daemon_recovers_when_the_first_owner_disappears_later() {
+    let fixture = Fixture::new(&[vec![issue(24)]], 1, 1);
+    let first_daemon = Arc::new(fixture.daemon());
+    let first = {
+        let daemon = Arc::clone(&first_daemon);
+        tokio::spawn(async move { daemon.run(CancellationToken::new()).await })
+    };
+    wait_for(|| fixture.started_slots().len() == 1).await;
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.runs(None))
+            .is_ok_and(|runs| runs[0].session_id.as_deref() == Some("thread-1"))
+    })
+    .await;
+    let first_owner = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap()[0]
+        .owner_id
+        .clone()
+        .unwrap();
+
+    let second_shutdown = CancellationToken::new();
+    let second_daemon = Arc::new(fixture.daemon());
+    let second = {
+        let daemon = Arc::clone(&second_daemon);
+        let shutdown = second_shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(fixture.started_slots().len(), 1);
+
+    first.abort();
+    let _ = first.await;
+    Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .remove_daemon_owner(&first_owner)
+        .unwrap();
+    wait_for(|| fixture.started_slots().len() == 2).await;
+    let slots = fixture.started_slots();
+    assert_eq!(
+        fs::read_to_string(slots[1].join("mode")).unwrap().trim(),
+        "resume"
+    );
+    fixture.open_gate();
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
+    })
+    .await;
+    second_shutdown.cancel();
+    second.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn missing_stored_session_gets_one_fresh_recovery_fallback() {
+    let fixture = Fixture::new(&[vec![issue(22)]], 1, 1);
+    let first_daemon = Arc::new(fixture.daemon());
+    let first = {
+        let daemon = Arc::clone(&first_daemon);
+        tokio::spawn(async move { daemon.run(CancellationToken::new()).await })
+    };
+    wait_for(|| fixture.started_slots().len() == 1).await;
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.runs(None))
+            .is_ok_and(|runs| runs[0].session_id.as_deref() == Some("thread-1"))
+    })
+    .await;
+    let owner_id = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap()[0]
+        .owner_id
+        .clone()
+        .unwrap();
+    first.abort();
+    let _ = first.await;
+    Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .remove_daemon_owner(&owner_id)
+        .unwrap();
+    fs::write(fixture.runtime_dir.join("fail-resume"), "yes").unwrap();
+
+    let shutdown = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let restarted = {
+        let daemon = Arc::clone(&daemon);
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+    wait_for(|| fixture.started_slots().len() == 3).await;
+    let slots = fixture.started_slots();
+    assert_eq!(
+        fs::read_to_string(slots[1].join("mode")).unwrap().trim(),
+        "resume"
+    );
+    assert_eq!(
+        fs::read_to_string(slots[2].join("mode")).unwrap().trim(),
+        "initial"
+    );
+    let fallback_prompt = fs::read_to_string(slots[2].join("prompt")).unwrap();
+    assert!(fallback_prompt.contains("Session fallback"));
+    assert!(fallback_prompt.contains("Do not replay assumed steps"));
+    fixture.open_gate();
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
+    })
+    .await;
+    assert_eq!(
+        Ledger::open(&fixture.ledger_path)
+            .unwrap()
+            .runs(None)
+            .unwrap()
+            .len(),
+        2,
+        "resume fallback stays within one durable recovery attempt"
+    );
+    shutdown.cancel();
+    restarted.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn repeated_agent_exit_uses_two_recoveries_then_leaves_failed_task() {
+    let fixture = Fixture::new(&[vec![issue(23)]], 1, 1);
+    fs::write(fixture.runtime_dir.join("fail-all"), "yes").unwrap();
+    fs::write(fixture.runtime_dir.join("emit-pr-first"), "yes").unwrap();
+    let shutdown = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| {
+                tasks
+                    .first()
+                    .is_some_and(|task| task.state == TaskState::Failed)
+            })
+    })
+    .await;
+    let runs = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap();
+    assert_eq!(runs.len(), 3);
+    assert_eq!(
+        runs.iter()
+            .map(|run| run.recovery_attempt)
+            .collect::<Vec<_>>(),
+        [0, 1, 2]
+    );
+    assert!(runs.iter().all(|run| run.outcome == "failed"));
+    assert_eq!(fixture.started_slots().len(), 5);
+    let final_recovery_prompt =
+        fs::read_to_string(fixture.started_slots()[3].join("prompt")).unwrap();
+    assert!(final_recovery_prompt.contains("https://github.com/example/repo-0/pull/77"));
+    shutdown.cancel();
+    running.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn observed_session_survives_later_malformed_activity_and_is_resumed() {
+    let fixture = Fixture::new(&[vec![issue(25)]], 1, 1);
+    fs::write(fixture.runtime_dir.join("malformed-once"), "yes").unwrap();
+    let shutdown = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+
+    wait_for(|| fixture.started_slots().len() == 2).await;
+    let slots = fixture.started_slots();
+    assert_eq!(
+        fs::read_to_string(slots[1].join("mode")).unwrap().trim(),
+        "resume"
+    );
+    let runs = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap();
+    assert_eq!(runs[0].session_id.as_deref(), Some("thread-1"));
+    fixture.open_gate();
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
+    })
+    .await;
+    shutdown.cancel();
+    running.await.unwrap().unwrap();
 }
 
 #[tokio::test]

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -141,6 +141,9 @@ if [ -f "{root}/malformed-once" ]; then
   exit 0
 fi
 if [ "$mode" = "resume" ] && [ -f "{root}/fail-resume" ]; then
+  if [ -f "{root}/pause-resume-before-fail" ]; then
+    while [ ! -f "{root}/release-resume" ]; do sleep 0.02; done
+  fi
   echo "stored session is missing" >&2
   exit 44
 fi
@@ -278,6 +281,45 @@ async fn discovers_claims_and_records_a_complete_codex_run() {
     ] {
         assert!(prompt.contains(expected), "missing {expected:?} in prompt");
     }
+}
+
+#[tokio::test]
+async fn workflow_deadline_is_terminal_and_does_not_queue_recovery() {
+    let mut fixture = Fixture::new(&[vec![issue(28)]], 1, 1);
+    fs::write(
+        fixture.config.repositories[0].join(".factory/workflows/implement-ready-ticket.md"),
+        "+++\nlabel = \"factory:ready\"\nruntime = \"codex\"\ntimeout = \"100ms\"\n+++\n\nTIME-BOUNDED WORKFLOW\n",
+    )
+    .unwrap();
+    fixture.catalog = WorkflowCatalog::load(&fixture.config).unwrap();
+    let shutdown = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| {
+                tasks
+                    .first()
+                    .is_some_and(|task| task.state == TaskState::Failed)
+            })
+    })
+    .await;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    shutdown.cancel();
+    running.await.unwrap().unwrap();
+
+    let ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    let runs = ledger.runs(None).unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].outcome, "failed");
+    assert_eq!(runs[0].error.as_deref(), Some("Codex execution timed out"));
+    assert_eq!(fixture.started_slots().len(), 1);
 }
 
 #[tokio::test]
@@ -917,6 +959,58 @@ async fn failed_fallback_before_thread_cannot_restore_stale_resume_observation()
     }
     shutdown.cancel();
     running.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn failed_fallback_reset_records_an_outcome_instead_of_stranding_the_run() {
+    let fixture = Fixture::new(&[vec![issue(27)]], 1, 1);
+    fs::write(fixture.runtime_dir.join("malformed-once"), "yes").unwrap();
+    fs::write(fixture.runtime_dir.join("fail-resume"), "yes").unwrap();
+    fs::write(fixture.runtime_dir.join("pause-resume-before-fail"), "yes").unwrap();
+    let shutdown = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+
+    wait_for(|| fixture.started_slots().len() == 2).await;
+    rusqlite::Connection::open(&fixture.ledger_path)
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER reject_fallback_reset
+             BEFORE UPDATE OF process_id ON runs
+             WHEN OLD.outcome = 'running'
+              AND OLD.process_id IS NOT NULL
+              AND NEW.process_id IS NULL
+             BEGIN
+               SELECT RAISE(ABORT, 'injected fallback reset failure');
+             END;",
+        )
+        .unwrap();
+    fs::write(fixture.runtime_dir.join("release-resume"), "go").unwrap();
+
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Failed)
+    })
+    .await;
+    shutdown.cancel();
+    running.await.unwrap().unwrap();
+
+    let runs = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap();
+    assert_eq!(runs.len(), 3);
+    assert!(runs.iter().all(|run| run.outcome != "running"));
+    assert!(runs[1..].iter().all(|run| {
+        run.error
+            .as_deref()
+            .is_some_and(|error| error.contains("failed to prepare a fresh recovery fallback"))
+    }));
 }
 
 #[tokio::test]

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -126,6 +126,9 @@ sleep 1000 &
 echo $! > "{root}/slot-$slot/child-pid"
 cat > "{root}/slot-$slot/prompt"
 touch "{root}/slot-$slot/started"
+if [ "$mode" = "initial" ] && [ "$slot" != "1" ] && [ -f "{root}/fail-fallback-before-thread" ]; then
+  exit 66
+fi
 echo "{{\"type\":\"thread.started\",\"thread_id\":\"thread-$slot\"}}"
 echo "{{\"type\":\"item.completed\",\"item\":{{\"text\":\"active SECRET=hunter2\"}}}}"
 if [ -f "{root}/emit-pr-first" ] && [ "$slot" = "1" ]; then
@@ -660,15 +663,22 @@ async fn missing_stored_session_gets_one_fresh_recovery_fallback() {
             .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
     })
     .await;
+    let runs = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap();
     assert_eq!(
-        Ledger::open(&fixture.ledger_path)
-            .unwrap()
-            .runs(None)
-            .unwrap()
-            .len(),
+        runs.len(),
         2,
         "resume fallback stays within one durable recovery attempt"
     );
+    let fallback_pid: u32 = fs::read_to_string(slots[2].join("pid"))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(runs[1].process_id, Some(fallback_pid));
+    assert_eq!(runs[1].session_id.as_deref(), Some("thread-3"));
     shutdown.cancel();
     restarted.await.unwrap().unwrap();
 }
@@ -746,6 +756,48 @@ async fn observed_session_survives_later_malformed_activity_and_is_resumed() {
             .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
     })
     .await;
+    shutdown.cancel();
+    running.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn failed_fallback_before_thread_cannot_restore_stale_resume_observation() {
+    let fixture = Fixture::new(&[vec![issue(26)]], 1, 1);
+    fs::write(fixture.runtime_dir.join("malformed-once"), "yes").unwrap();
+    fs::write(fixture.runtime_dir.join("fail-resume"), "yes").unwrap();
+    fs::write(
+        fixture.runtime_dir.join("fail-fallback-before-thread"),
+        "yes",
+    )
+    .unwrap();
+    let shutdown = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let shutdown = shutdown.clone();
+        tokio::spawn(async move { daemon.run(shutdown).await })
+    };
+
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| {
+                tasks
+                    .first()
+                    .is_some_and(|task| task.state == TaskState::Failed)
+            })
+    })
+    .await;
+    let runs = Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .runs(None)
+        .unwrap();
+    assert_eq!(runs.len(), 3);
+    assert_eq!(fixture.started_slots().len(), 4);
+    for recovery in &runs[1..] {
+        assert_eq!(recovery.session_id, None);
+        assert_eq!(recovery.activity, None);
+    }
     shutdown.cancel();
     running.await.unwrap().unwrap();
 }

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -20,6 +20,7 @@ struct Fixture {
     _temp: tempfile::TempDir,
     config: Config,
     catalog: WorkflowCatalog,
+    config_path: PathBuf,
     ledger_path: PathBuf,
     gh: PathBuf,
     codex: PathBuf,
@@ -155,6 +156,7 @@ exit 0
             ),
         );
         Self {
+            config_path,
             ledger_path: temp.path().join("data/factory.sqlite3"),
             _temp: temp,
             config,
@@ -226,6 +228,16 @@ where
     })
     .await
     .unwrap();
+}
+
+fn process_is_alive(process_id: u32) -> bool {
+    matches!(
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(process_id).unwrap()),
+            None,
+        ),
+        Ok(()) | Err(nix::errno::Errno::EPERM)
+    )
 }
 
 #[tokio::test]
@@ -551,6 +563,110 @@ async fn restart_recovers_one_orphan_by_resuming_its_live_observed_session() {
 }
 
 #[tokio::test]
+async fn subprocess_restart_kills_the_surviving_anchored_process_tree() {
+    let fixture = Fixture::new(&[vec![issue(25)]], 1, 1);
+    let search_path = std::env::join_paths(
+        std::iter::once(fixture.gh.parent().unwrap().to_path_buf()).chain(
+            std::env::var_os("PATH")
+                .as_deref()
+                .map(std::env::split_paths)
+                .into_iter()
+                .flatten(),
+        ),
+    )
+    .unwrap();
+    let mut first = Command::new(env!("CARGO_BIN_EXE_factory"));
+    first
+        .args([
+            "run",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            fixture.ledger_path.parent().unwrap().to_str().unwrap(),
+        ])
+        .env("PATH", &search_path);
+    let mut first = first.spawn().unwrap();
+    wait_for(|| fixture.started_slots().len() == 1).await;
+    let first_run = tokio::time::timeout(Duration::from_secs(8), async {
+        loop {
+            if let Ok(runs) =
+                Ledger::open(&fixture.ledger_path).and_then(|ledger| ledger.runs(None))
+                && let Some(run) = runs.first()
+                && run.process_id.is_some()
+                && run.process_identity.is_some()
+                && run.session_id.is_some()
+            {
+                break run.clone();
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .unwrap();
+    let slot = &fixture.started_slots()[0];
+    let codex_pid: u32 = fs::read_to_string(slot.join("pid"))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    let child_pid: u32 = fs::read_to_string(slot.join("child-pid"))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    let anchor_pid = first_run.process_id.unwrap();
+
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(i32::try_from(first.id()).unwrap()),
+        nix::sys::signal::Signal::SIGKILL,
+    )
+    .unwrap();
+    first.wait().unwrap();
+    assert!(process_is_alive(anchor_pid));
+    assert!(process_is_alive(codex_pid));
+    assert!(process_is_alive(child_pid));
+
+    let mut second = Command::new(env!("CARGO_BIN_EXE_factory"));
+    second
+        .args([
+            "run",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            fixture.ledger_path.parent().unwrap().to_str().unwrap(),
+        ])
+        .env("PATH", &search_path);
+    let mut second = second.spawn().unwrap();
+    wait_for(|| fixture.started_slots().len() == 2).await;
+    wait_for(|| {
+        !process_is_alive(anchor_pid)
+            && !process_is_alive(codex_pid)
+            && !process_is_alive(child_pid)
+    })
+    .await;
+    assert_eq!(
+        fs::read_to_string(fixture.started_slots()[1].join("mode"))
+            .unwrap()
+            .trim(),
+        "resume"
+    );
+
+    fixture.open_gate();
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
+    })
+    .await;
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(i32::try_from(second.id()).unwrap()),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .unwrap();
+    assert!(second.wait().unwrap().success());
+}
+
+#[tokio::test]
 async fn live_second_daemon_recovers_when_the_first_owner_disappears_later() {
     let fixture = Fixture::new(&[vec![issue(24)]], 1, 1);
     let first_daemon = Arc::new(fixture.daemon());
@@ -677,7 +793,8 @@ async fn missing_stored_session_gets_one_fresh_recovery_fallback() {
         .trim()
         .parse()
         .unwrap();
-    assert_eq!(runs[1].process_id, Some(fallback_pid));
+    assert_ne!(runs[1].process_id, Some(fallback_pid));
+    assert!(runs[1].process_identity.is_some());
     assert_eq!(runs[1].session_id.as_deref(), Some("thread-3"));
     shutdown.cancel();
     restarted.await.unwrap().unwrap();

--- a/tests/inspection_cli.rs
+++ b/tests/inspection_cli.rs
@@ -181,9 +181,15 @@ fn runs_filters_by_workflow_and_includes_bounded_summaries() {
             "duration_ms",
             "finished_at",
             "id",
+            "last_activity_at",
             "outcome",
             "owner_id",
             "owner_pid",
+            "process_id",
+            "process_identity",
+            "pull_request",
+            "recovery_attempt",
+            "recovery_of",
             "repository",
             "runtime",
             "source_item",
@@ -191,6 +197,7 @@ fn runs_filters_by_workflow_and_includes_bounded_summaries() {
             "summary",
             "task_id",
             "workflow",
+            "working_directory",
         ]
     );
 }
@@ -248,7 +255,10 @@ fn inspect_resolves_task_context_bounds_detail_and_escapes_terminal_controls() {
         .keys()
         .cloned()
         .collect::<Vec<_>>();
-    assert_eq!(keys, ["error", "result", "run", "session_id", "task"]);
+    assert_eq!(
+        keys,
+        ["activity", "error", "result", "run", "session_id", "task"]
+    );
 }
 
 #[test]

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -483,6 +483,128 @@ async fn failed_anchor_persistence_prevents_spawn_and_reaps_the_group() {
 }
 
 #[tokio::test]
+async fn pre_cancelled_run_never_spawns_codex() {
+    let temp = tempfile::tempdir().unwrap();
+    let started_path = temp.path().join("pre-cancelled-started");
+    let executable = fake_codex(
+        temp.path(),
+        &format!("touch \"{}\"", started_path.display()),
+    );
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+
+    let result = CodexRuntime::new(executable)
+        .run(
+            "Already cancelled.",
+            temp.path(),
+            Duration::from_secs(5),
+            cancellation,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::Cancelled);
+    assert!(!started_path.exists());
+}
+
+#[tokio::test]
+async fn zero_timeout_run_never_spawns_codex() {
+    let temp = tempfile::tempdir().unwrap();
+    let started_path = temp.path().join("zero-timeout-started");
+    let executable = fake_codex(
+        temp.path(),
+        &format!("touch \"{}\"", started_path.display()),
+    );
+
+    let result = CodexRuntime::new(executable)
+        .run(
+            "Already timed out.",
+            temp.path(),
+            Duration::ZERO,
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::TimedOut);
+    assert!(!started_path.exists());
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[tokio::test]
+async fn cancellation_after_anchor_persistence_prevents_spawn_and_reaps() {
+    let temp = tempfile::tempdir().unwrap();
+    let started_path = temp.path().join("post-persistence-cancel-started");
+    let executable = fake_codex(
+        temp.path(),
+        &format!("touch \"{}\"", started_path.display()),
+    );
+    let cancellation = CancellationToken::new();
+    let cancel_from_callback = cancellation.clone();
+    let captured_anchor = Arc::new(Mutex::new(None));
+    let captured_for_callback = Arc::clone(&captured_anchor);
+    let (observations, _receiver) = observation_channel();
+
+    let result = CodexRuntime::new(executable)
+        .run_with_session_supervised(
+            "Cancel after persistence.",
+            temp.path(),
+            Duration::from_secs(5),
+            cancellation,
+            None,
+            observations,
+            move |observation| {
+                *captured_for_callback.lock().unwrap() = observation.process_id;
+                cancel_from_callback.cancel();
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::Cancelled);
+    assert!(!started_path.exists());
+    let anchor_pid = captured_anchor.lock().unwrap().unwrap();
+    assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[tokio::test]
+async fn deadline_after_anchor_persistence_prevents_spawn_and_reaps() {
+    let temp = tempfile::tempdir().unwrap();
+    let started_path = temp.path().join("post-persistence-timeout-started");
+    let executable = fake_codex(
+        temp.path(),
+        &format!("touch \"{}\"", started_path.display()),
+    );
+    let captured_anchor = Arc::new(Mutex::new(None));
+    let captured_for_callback = Arc::clone(&captured_anchor);
+    let (observations, _receiver) = observation_channel();
+
+    let result = CodexRuntime::new(executable)
+        .run_with_session_supervised(
+            "Expire after persistence.",
+            temp.path(),
+            Duration::from_millis(500),
+            CancellationToken::new(),
+            None,
+            observations,
+            move |observation| {
+                *captured_for_callback.lock().unwrap() = observation.process_id;
+                std::thread::sleep(Duration::from_millis(700));
+                Ok(())
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::TimedOut);
+    assert!(!started_path.exists());
+    let anchor_pid = captured_anchor.lock().unwrap().unwrap();
+    assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
+}
+
+#[tokio::test]
 async fn authentication_failure_is_actionable() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("codex");

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -5,7 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use factory::runtime::{CodexRuntime, RuntimeCancelled, Termination};
+use factory::runtime::{CodexRuntime, RuntimeCancelled, Termination, observation_channel};
 use tokio_util::sync::CancellationToken;
 
 fn fake_codex(directory: &Path, execution: &str) -> PathBuf {
@@ -167,20 +167,101 @@ exit 0"#,
 #[tokio::test]
 async fn timeout_stops_the_run() {
     let temp = tempfile::tempdir().unwrap();
-    let executable = fake_codex(temp.path(), "cat >/dev/null\nsleep 30");
+    let descendant = temp.path().join("deadline-descendant.pid");
+    let executable = fake_codex(
+        temp.path(),
+        &format!(
+            "sleep 30 &\necho $! > \"{}\"\ncat >/dev/null\nwait",
+            descendant.display()
+        ),
+    );
     let runtime = CodexRuntime::new(executable);
 
     let result = runtime
         .run(
             "Time out.",
             temp.path(),
-            Duration::from_secs(2),
+            Duration::from_secs(5),
             CancellationToken::new(),
         )
         .await
         .unwrap();
 
     assert_eq!(result.termination, Termination::TimedOut);
+    let pid: i32 = fs::read_to_string(descendant)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_process_gone(pid).await;
+}
+
+#[tokio::test]
+async fn active_long_running_agent_is_allowed_to_finish_before_its_deadline() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"cat >/dev/null
+echo '{"type":"thread.started","thread_id":"active-thread"}'
+echo '{"type":"item.completed","sequence":1}'
+sleep 1
+echo '{"type":"item.completed","sequence":2}'
+printf 'active work completed' > "$output"
+exit 0"#,
+    );
+
+    let result = CodexRuntime::new(executable)
+        .run(
+            "Keep working while active.",
+            temp.path(),
+            Duration::from_secs(10),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+    assert!(result.succeeded());
+    assert_eq!(result.activity_lines, 3);
+    assert_eq!(result.final_response, "active work completed");
+}
+
+#[tokio::test]
+async fn persisted_activity_is_structural_and_never_contains_raw_secret_output() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"cat >/dev/null
+printf '{"type":"item.completed","text":"TOKEN='
+awk 'BEGIN { for (i = 0; i < 70000; i++) printf "s" }'
+echo '","url":"https://github.com/owainlewis/factory/pull/123"}'
+printf 'done' > "$output"
+exit 0"#,
+    );
+    let (observations, receiver) = observation_channel();
+
+    let result = CodexRuntime::new(executable)
+        .with_activity_streaming(false)
+        .run_with_session(
+            "Observe safely.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+            None,
+            observations,
+        )
+        .await
+        .unwrap();
+    let observation = receiver.borrow().clone();
+
+    assert!(result.succeeded());
+    assert_eq!(
+        observation.pull_request.as_deref(),
+        Some("https://github.com/owainlewis/factory/pull/123")
+    );
+    let activity = observation.activity.unwrap();
+    assert_eq!(activity, "Codex event: item.completed\n");
+    assert!(!activity.contains("TOKEN"));
+    assert!(!activity.contains('s'));
 }
 
 #[tokio::test]

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -308,6 +308,113 @@ async fn cancellation_stops_the_run() {
     assert_process_gone(pid).await;
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[tokio::test]
+async fn durable_runs_use_a_verified_process_group_anchor() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_pid_path = temp.path().join("codex.pid");
+    let executable = fake_codex(
+        temp.path(),
+        &format!(
+            "echo $$ > \"{}\"\ncat >/dev/null\nsleep 30",
+            codex_pid_path.display()
+        ),
+    );
+    let cancellation = CancellationToken::new();
+    let (observations, receiver) = observation_channel();
+    let runtime_cancellation = cancellation.clone();
+    let working_directory = temp.path().to_owned();
+    let run = tokio::spawn(async move {
+        CodexRuntime::new(executable)
+            .run_with_session(
+                "Stay anchored.",
+                &working_directory,
+                Duration::from_secs(5),
+                runtime_cancellation,
+                None,
+                observations,
+            )
+            .await
+    });
+
+    for _ in 0..500 {
+        if receiver.borrow().process_id.is_some() && codex_pid_path.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let observation = receiver.borrow().clone();
+    let anchor_pid = observation.process_id.unwrap();
+    let codex_pid: u32 = fs::read_to_string(&codex_pid_path)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_ne!(anchor_pid, codex_pid);
+    assert!(observation.process_identity.is_some());
+    assert!(matches!(
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(anchor_pid).unwrap()),
+            None,
+        ),
+        Ok(()) | Err(nix::errno::Errno::EPERM)
+    ));
+
+    cancellation.cancel();
+    assert_eq!(
+        run.await.unwrap().unwrap().termination,
+        Termination::Cancelled
+    );
+    assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
+    assert_process_gone(i32::try_from(codex_pid).unwrap()).await;
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[tokio::test]
+async fn aborting_a_run_reaps_its_process_group_anchor() {
+    let temp = tempfile::tempdir().unwrap();
+    let codex_pid_path = temp.path().join("aborted-codex.pid");
+    let executable = fake_codex(
+        temp.path(),
+        &format!(
+            "echo $$ > \"{}\"\ncat >/dev/null\nsleep 30",
+            codex_pid_path.display()
+        ),
+    );
+    let (observations, receiver) = observation_channel();
+    let working_directory = temp.path().to_owned();
+    let run = tokio::spawn(async move {
+        CodexRuntime::new(executable)
+            .run_with_session(
+                "Abort safely.",
+                &working_directory,
+                Duration::from_secs(30),
+                CancellationToken::new(),
+                None,
+                observations,
+            )
+            .await
+    });
+
+    for _ in 0..500 {
+        if receiver.borrow().process_id.is_some() && codex_pid_path.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    let anchor_pid = receiver.borrow().process_id.unwrap();
+    let codex_pid: u32 = fs::read_to_string(&codex_pid_path)
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+
+    run.abort();
+    let _ = run.await;
+    assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
+    assert_process_gone(i32::try_from(codex_pid).unwrap()).await;
+}
+
 #[tokio::test]
 async fn authentication_failure_is_actionable() {
     let temp = tempfile::tempdir().unwrap();

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use factory::runtime::{CodexRuntime, RuntimeCancelled, Termination, observation_channel};
@@ -413,6 +414,72 @@ async fn aborting_a_run_reaps_its_process_group_anchor() {
     let _ = run.await;
     assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
     assert_process_gone(i32::try_from(codex_pid).unwrap()).await;
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[tokio::test]
+async fn supervisor_persists_the_anchor_before_codex_spawn() {
+    let temp = tempfile::tempdir().unwrap();
+    let persisted = Arc::new(Mutex::new(None));
+    let persisted_for_callback = Arc::clone(&persisted);
+    let (observations, _receiver) = observation_channel();
+
+    let error = CodexRuntime::new(temp.path().join("missing-codex"))
+        .run_with_session_supervised(
+            "Persist first.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+            None,
+            observations,
+            move |observation| {
+                *persisted_for_callback.lock().unwrap() = Some(observation.clone());
+                Ok(())
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(format!("{error:#}").contains("failed to start Codex CLI"));
+    let observation = persisted.lock().unwrap().clone().unwrap();
+    let anchor_pid = observation.process_id.unwrap();
+    assert!(observation.process_identity.is_some());
+    assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[tokio::test]
+async fn failed_anchor_persistence_prevents_spawn_and_reaps_the_group() {
+    let temp = tempfile::tempdir().unwrap();
+    let started_path = temp.path().join("codex-started");
+    let executable = fake_codex(
+        temp.path(),
+        &format!("touch \"{}\"", started_path.display()),
+    );
+    let captured_anchor = Arc::new(Mutex::new(None));
+    let captured_for_callback = Arc::clone(&captured_anchor);
+    let (observations, _receiver) = observation_channel();
+
+    let error = CodexRuntime::new(executable)
+        .run_with_session_supervised(
+            "Fail persistence.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+            None,
+            observations,
+            move |observation| {
+                *captured_for_callback.lock().unwrap() = observation.process_id;
+                anyhow::bail!("simulated durable persistence failure")
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(format!("{error:#}").contains("simulated durable persistence failure"));
+    assert!(!started_path.exists());
+    let anchor_pid = captured_anchor.lock().unwrap().unwrap();
+    assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
 }
 
 #[tokio::test]

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -275,13 +275,9 @@ fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
     let report = ledger.recover_orphaned_runs().unwrap();
     assert_eq!(report.recovered_run_ids, [interrupted.id]);
     assert!(report.exhausted_run_ids.is_empty());
-    assert!(
-        ledger
-            .recover_orphaned_runs()
-            .unwrap()
-            .recovered_run_ids
-            .is_empty()
-    );
+    let report = ledger.recover_orphaned_runs().unwrap();
+    assert!(report.recovered_run_ids.is_empty());
+    assert!(report.exhausted_run_ids.is_empty());
     let closed = ledger.run(interrupted.id).unwrap().unwrap();
     assert_eq!(closed.outcome, "failed");
     assert_eq!(closed.process_id, None);
@@ -313,29 +309,20 @@ fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
         Some("/worktrees/factory-3")
     );
     ledger
-        .observe_run(
-            first_recovery.id,
-            Some(std::process::id()),
-            None,
-            None,
-            None,
-            None,
-        )
+        .observe_run(first_recovery.id, None, None, None, None, None)
         .unwrap();
-    ledger
-        .finish_run_and_task(
-            first_recovery.id,
-            RunOutcome::Failed,
-            None,
-            Some("first recovery failed"),
-            None,
-        )
-        .unwrap();
+    ledger.remove_daemon_owner("recovery-owner").unwrap();
+    let report = ledger.recover_orphaned_runs().unwrap();
+    assert_eq!(report.recovered_run_ids, [first_recovery.id]);
+    assert!(report.exhausted_run_ids.is_empty());
     assert_eq!(
         ledger.task(task.id).unwrap().unwrap().state,
         TaskState::Queued
     );
 
+    ledger
+        .register_daemon_owner("recovery-owner", std::process::id())
+        .unwrap();
     let final_recovery = ledger
         .claim_ticket_and_start_run_with_workdirs(
             &["owainlewis/factory".to_owned()],
@@ -350,43 +337,27 @@ fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
     assert_eq!(final_recovery.recovery_of, Some(first_recovery.id));
     assert_eq!(final_recovery.recovery_attempt, 2);
     ledger
-        .observe_run(
-            final_recovery.id,
-            Some(std::process::id()),
-            None,
-            None,
-            None,
-            None,
-        )
+        .observe_run(final_recovery.id, None, None, None, None, None)
         .unwrap();
-    ledger
-        .finish_run_and_task(
-            final_recovery.id,
-            RunOutcome::Failed,
-            None,
-            Some("second recovery failed TOKEN=secret"),
-            None,
-        )
-        .unwrap();
+    ledger.remove_daemon_owner("recovery-owner").unwrap();
+    let report = ledger.recover_orphaned_runs().unwrap();
+    assert!(report.recovered_run_ids.is_empty());
+    assert_eq!(report.exhausted_run_ids, [final_recovery.id]);
     assert_eq!(
         ledger.task(task.id).unwrap().unwrap().state,
         TaskState::Failed
     );
-    assert!(
+    let report = ledger.recover_orphaned_runs().unwrap();
+    assert!(report.recovered_run_ids.is_empty());
+    assert!(report.exhausted_run_ids.is_empty());
+    assert_eq!(
         ledger
-            .recover_orphaned_runs()
-            .unwrap()
-            .recovered_run_ids
-            .is_empty()
-    );
-    assert!(
-        !ledger
             .run(final_recovery.id)
             .unwrap()
             .unwrap()
             .error
-            .unwrap()
-            .contains("secret")
+            .as_deref(),
+        Some("Factory detected an interrupted run without a live owned process")
     );
 }
 

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -2,6 +2,11 @@ use std::collections::HashMap;
 use std::sync::{Arc, Barrier};
 use std::thread;
 
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+#[cfg(unix)]
+use std::process::Command;
+
 use factory::storage::{
     CancellationRequest, Ledger, MAX_ERROR_BYTES, MAX_RESULT_BYTES, RunOutcome, TaskIdentity,
     TaskState,
@@ -221,7 +226,226 @@ fn migrates_a_version_one_ledger_without_losing_tasks() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 3);
+    assert_eq!(version, 4);
+}
+
+#[test]
+fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    ledger
+        .register_daemon_owner("interrupted-owner", std::process::id())
+        .unwrap();
+    let task = ledger.enqueue(&ticket("recovery-revision")).unwrap().task;
+    let runtimes = HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "implement-ready-ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    let workdirs = HashMap::from([(
+        "owainlewis/factory".to_owned(),
+        "/worktrees/factory-3".to_owned(),
+    )]);
+    let interrupted = ledger
+        .claim_ticket_and_start_run_with_workdirs(
+            &["owainlewis/factory".to_owned()],
+            &runtimes,
+            "interrupted-owner",
+            std::process::id(),
+            &workdirs,
+        )
+        .unwrap()
+        .unwrap()
+        .run;
+    ledger
+        .observe_run(
+            interrupted.id,
+            None,
+            None,
+            Some("thread-recover"),
+            Some("https://github.com/owainlewis/factory/pull/99"),
+            Some("PR https://github.com/owainlewis/factory/pull/99 SECRET=hunter2"),
+        )
+        .unwrap();
+    ledger.remove_daemon_owner("interrupted-owner").unwrap();
+
+    let report = ledger.recover_orphaned_runs().unwrap();
+    assert_eq!(report.recovered_run_ids, [interrupted.id]);
+    assert!(report.exhausted_run_ids.is_empty());
+    assert!(
+        ledger
+            .recover_orphaned_runs()
+            .unwrap()
+            .recovered_run_ids
+            .is_empty()
+    );
+    let closed = ledger.run(interrupted.id).unwrap().unwrap();
+    assert_eq!(closed.outcome, "failed");
+    assert_eq!(closed.process_id, None);
+    assert_eq!(closed.session_id.as_deref(), Some("thread-recover"));
+    assert!(!closed.activity.unwrap().contains("hunter2"));
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Queued
+    );
+
+    ledger
+        .register_daemon_owner("recovery-owner", std::process::id())
+        .unwrap();
+    let first_recovery = ledger
+        .claim_ticket_and_start_run_with_workdirs(
+            &["owainlewis/factory".to_owned()],
+            &runtimes,
+            "recovery-owner",
+            std::process::id(),
+            &workdirs,
+        )
+        .unwrap()
+        .unwrap()
+        .run;
+    assert_eq!(first_recovery.recovery_of, Some(interrupted.id));
+    assert_eq!(first_recovery.recovery_attempt, 1);
+    assert_eq!(
+        first_recovery.working_directory.as_deref(),
+        Some("/worktrees/factory-3")
+    );
+    ledger
+        .observe_run(
+            first_recovery.id,
+            Some(std::process::id()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    ledger
+        .finish_run_and_task(
+            first_recovery.id,
+            RunOutcome::Failed,
+            None,
+            Some("first recovery failed"),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Queued
+    );
+
+    let final_recovery = ledger
+        .claim_ticket_and_start_run_with_workdirs(
+            &["owainlewis/factory".to_owned()],
+            &runtimes,
+            "recovery-owner",
+            std::process::id(),
+            &workdirs,
+        )
+        .unwrap()
+        .unwrap()
+        .run;
+    assert_eq!(final_recovery.recovery_of, Some(first_recovery.id));
+    assert_eq!(final_recovery.recovery_attempt, 2);
+    ledger
+        .observe_run(
+            final_recovery.id,
+            Some(std::process::id()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    ledger
+        .finish_run_and_task(
+            final_recovery.id,
+            RunOutcome::Failed,
+            None,
+            Some("second recovery failed TOKEN=secret"),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Failed
+    );
+    assert!(
+        ledger
+            .recover_orphaned_runs()
+            .unwrap()
+            .recovered_run_ids
+            .is_empty()
+    );
+    assert!(
+        !ledger
+            .run(final_recovery.id)
+            .unwrap()
+            .unwrap()
+            .error
+            .unwrap()
+            .contains("secret")
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn orphan_recovery_does_not_signal_a_reused_process_group() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    ledger
+        .register_daemon_owner("gone-owner", std::process::id())
+        .unwrap();
+    ledger.enqueue(&ticket("pid-reuse-revision")).unwrap();
+    let runtimes = HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "implement-ready-ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    let run = ledger
+        .claim_ticket_and_start_run(
+            &["owainlewis/factory".to_owned()],
+            &runtimes,
+            "gone-owner",
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap()
+        .run;
+    let mut unrelated = Command::new("sleep")
+        .arg("30")
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let unrelated_pid = unrelated.id();
+    ledger
+        .observe_run(
+            run.id,
+            Some(unrelated_pid),
+            Some("different-process-start-identity"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    ledger.remove_daemon_owner("gone-owner").unwrap();
+
+    ledger.recover_orphaned_runs().unwrap();
+
+    assert!(matches!(
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(unrelated_pid).unwrap()),
+            None,
+        ),
+        Ok(()) | Err(nix::errno::Errno::EPERM)
+    ));
+    unrelated.kill().unwrap();
+    unrelated.wait().unwrap();
 }
 
 #[test]

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -547,6 +547,55 @@ fn cancellation_rejects_a_reused_live_pid_when_the_owner_lease_is_stale() {
 }
 
 #[test]
+fn orphan_recovery_completes_a_pending_cancellation_without_retrying() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    let task = ledger
+        .enqueue(&ticket("orphan-cancel-revision"))
+        .unwrap()
+        .task;
+    let runtimes = HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "implement-ready-ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    ledger
+        .register_daemon_owner("cancelled-owner", std::process::id())
+        .unwrap();
+    let run = ledger
+        .claim_ticket_and_start_run(
+            &["owainlewis/factory".to_owned()],
+            &runtimes,
+            "cancelled-owner",
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap()
+        .run;
+    assert!(matches!(
+        ledger.request_run_cancellation(run.id).unwrap(),
+        CancellationRequest::Requested(_)
+    ));
+    ledger.remove_daemon_owner("cancelled-owner").unwrap();
+
+    let report = ledger.recover_orphaned_runs().unwrap();
+
+    assert!(report.recovered_run_ids.is_empty());
+    assert!(report.exhausted_run_ids.is_empty());
+    assert_eq!(ledger.run(run.id).unwrap().unwrap().outcome, "cancelled");
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Cancelled
+    );
+    let second = ledger.recover_orphaned_runs().unwrap();
+    assert!(second.recovered_run_ids.is_empty());
+    assert!(second.exhausted_run_ids.is_empty());
+}
+
+#[test]
 fn concurrent_completion_and_cancellation_always_leave_a_terminal_run() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("ledger.db");

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -130,6 +130,41 @@ fn records_bounded_run_history_and_terminal_tasks_cannot_be_reclaimed() {
 }
 
 #[test]
+fn terminal_failure_does_not_requeue_a_started_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    let task = ledger.enqueue(&ticket("deadline-revision")).unwrap().task;
+    ledger.claim_next().unwrap().unwrap();
+    let run = ledger.start_run(task.id, "codex").unwrap();
+    ledger
+        .observe_run(
+            run.id,
+            Some(std::process::id()),
+            Some("started-process"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+    ledger
+        .finish_run_and_task_terminal(
+            run.id,
+            RunOutcome::Failed,
+            None,
+            Some("execution deadline elapsed"),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Failed
+    );
+    assert!(ledger.claim_next().unwrap().is_none());
+}
+
+#[test]
 fn only_one_active_run_can_start_for_a_claimed_task() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("ledger.db");

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -388,6 +388,13 @@ fn orphan_recovery_does_not_signal_a_reused_process_group() {
         .unwrap()
         .unwrap()
         .run;
+    assert!(
+        ledger
+            .observe_run(run.id, Some(0), Some("invalid"), None, None, None)
+            .unwrap_err()
+            .to_string()
+            .contains("must be positive")
+    );
     let mut unrelated = Command::new("sleep")
         .arg("30")
         .process_group(0)


### PR DESCRIPTION
Closes #8

## Summary

- record live Codex process identity, session, deadline context, structural activity, and recognized pull-request context
- enforce process-tree deadlines and secret-safe daemon logging without a short idle timeout
- detect orphaned runs at startup and periodically, safely terminate only matching process identities, and deduplicate recovery
- resume stored Codex sessions with one deadline-bounded fallback and context from the ticket, repository, Git worktrees, branches, PR, and prior evidence
- cap durable recovery at two attempts and leave repeated failures terminal and inspectable

## Acceptance proof

- restart tests kill a fake worker and prove exactly one session-resuming recovery
- two-daemon coverage proves an owner that disappears after startup is recovered
- missing and malformed sessions prove fresh fallback and observed-session preservation
- repeated agent exits stop after recovery attempts 1 and 2
- PID-reuse mismatch, terminal exclusion, deadline, cancellation, active output, worktree/branch, PR lineage, and secret-boundary regressions pass
- fresh subagent reviews found and verified fixes for orphan signaling, periodic reconciliation, activity leakage, context inheritance, raw logs, and session preservation

## Checks

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (102 tests)
- `git diff --check`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated orphan-run recovery with session resumption, bounded recovery attempts, and intelligent prompt context for prior evidence.
  * Run views and inspections now include activity, working directory, pull request, process metadata, and recovery linkage/attempt counts.
  * Added runtime observation tracking (process/session/pull request/activity) with structured, size-bounded activity persistence.
* **Bug Fixes**
  * Improved recovery and runtime monitoring to avoid terminating reused/unrelated process groups; ensures proper shutdown on cancellation and deadline expiry.
* **Documentation**
  * Documented stored run metadata, recovery workflow (including fallback rules and exclusions), and timeout/cancellation termination semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


