### PR TITLE
feat: run scheduled workflows through durable queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +233,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cron"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,10 +253,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -296,6 +334,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -369,6 +408,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -796,6 +845,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1046,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -281,6 +283,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "chrono-tz",
  "clap",
  "cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ humantime = "2.2"
 regex = "1.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 rusqlite = { version = "0.37", features = ["bundled"] }
 tempfile = "3.20"
 tokio = { version = "1.47", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "A local-first supervisor for agent workflows"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
+chrono = "0.4"
 chrono-tz = "0.10"
 cron = "0.15"
 dirs = "6.0"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,7 +1,8 @@
 # Factory operation
 
-`factory run` validates `gh` and Codex subscription authentication, polls all
-configured repositories, and dispatches durable ready-ticket tasks. Global and
+`factory run` validates `gh` and Codex subscription authentication, evaluates
+scheduled workflows, polls all configured repositories, and dispatches durable
+scheduled and ready-ticket tasks. Global and
 per-repository concurrency are controlled by `max_concurrent_runs` and
 `max_concurrent_runs_per_repository`. The per-repository value defaults to 1.
 
@@ -9,6 +10,18 @@ Factory requires the conventional `factory:ready` and
 `factory:needs-review` labels to be created by repository maintainers. Factory
 does not create, remove, or otherwise mutate labels itself. The delegated
 workflow owns ticket and pull-request updates.
+
+Five-field cron schedules are evaluated in the IANA timezone declared by the
+workflow. Factory stores the next occurrence and atomically advances that
+cursor when it creates the durable task, so repeated ticks, restarts, and
+multiple daemon loops cannot duplicate one UTC scheduled instant. Startup moves
+an overdue cursor to the next future occurrence instead of replaying work missed
+while Factory was offline. Disabled workflows are not evaluated. Invalid or
+failing scheduled workflows are reported and isolated from ready-ticket
+polling. A scheduled prompt receives its UTC occurrence, repository path,
+inspected commit, and previous successful run time when available. The agent may
+use its authenticated `gh` CLI to create or update tickets; Factory does not
+hard-code those effects.
 
 Every active run records the Factory owner, a durable supervisor anchor that
 owns the Codex process group, the anchor's process-start identity, Codex session

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -350,8 +350,12 @@ fn dispatch_available(
             .iter()
             .flat_map(|(repository, target)| {
                 target.workflows.iter().map(|(workflow, target)| {
+                    let task_kind = match target.trigger {
+                        Trigger::Schedule { .. } => "scheduled",
+                        Trigger::Label(_) => "ticket",
+                    };
                     (
-                        (repository.clone(), workflow.clone()),
+                        (repository.clone(), workflow.clone(), task_kind.to_owned()),
                         target.runtime.clone(),
                     )
                 })

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, SecondsFormat, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
+use sha2::{Digest, Sha256};
 use tokio::task::JoinSet;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
@@ -878,7 +879,7 @@ fn initialize_schedules(
                 let schedule = Schedule::from_str(&format!("0 {expression}"))
                     .context("validated cron schedule could not be parsed")?;
                 let calculated = next_occurrence(&schedule, *timezone, startup_at)?;
-                let fingerprint = format!("{expression}|{}", timezone.name());
+                let fingerprint = schedule_fingerprint(expression, *timezone, target)?;
                 let cursor = ledger.initialize_schedule_cursor(
                     repository,
                     workflow,
@@ -907,6 +908,23 @@ fn initialize_schedules(
         }
     }
     schedules
+}
+
+fn schedule_fingerprint(
+    expression: &str,
+    timezone: Tz,
+    workflow: &WorkflowTarget,
+) -> Result<String> {
+    let definition = serde_json::to_vec(&(
+        expression,
+        timezone.name(),
+        &workflow.runtime,
+        workflow.timeout.as_secs(),
+        workflow.timeout.subsec_nanos(),
+        &workflow.prompt,
+    ))
+    .context("failed to encode scheduled workflow definition")?;
+    Ok(format!("v2:{:x}", Sha256::digest(definition)))
 }
 
 fn evaluate_schedules(
@@ -1180,6 +1198,58 @@ mod tests {
         assert_eq!(schedules.len(), 1);
         evaluate_schedules(&mut new, &mut schedules, utc("2026-07-18T12:02:00Z"));
         assert_eq!(new.tasks().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn workflow_definition_changes_block_overlapping_daemons() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("ledger.db");
+        let old_targets = scheduled_targets(temp.path(), "* * * * *", chrono_tz::UTC);
+        let mut new_targets = old_targets.clone();
+        new_targets
+            .get_mut("example/repo")
+            .unwrap()
+            .workflows
+            .get_mut("scheduled-review")
+            .unwrap()
+            .prompt = "Use the new workflow definition.".to_owned();
+        let mut old = Ledger::open(&path).unwrap();
+        old.register_daemon_owner("old-definition-owner", std::process::id())
+            .unwrap();
+        assert_eq!(
+            initialize_schedules(
+                &mut old,
+                &old_targets,
+                utc("2026-07-18T12:00:10Z"),
+                "old-definition-owner",
+            )
+            .len(),
+            1
+        );
+
+        let mut new = Ledger::open(&path).unwrap();
+        new.register_daemon_owner("new-definition-owner", std::process::id())
+            .unwrap();
+        assert!(
+            initialize_schedules(
+                &mut new,
+                &new_targets,
+                utc("2026-07-18T12:00:20Z"),
+                "new-definition-owner",
+            )
+            .is_empty()
+        );
+        old.remove_daemon_owner("old-definition-owner").unwrap();
+        assert_eq!(
+            initialize_schedules(
+                &mut new,
+                &new_targets,
+                utc("2026-07-18T12:00:30Z"),
+                "new-definition-owner",
+            )
+            .len(),
+            1
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -237,33 +237,14 @@ impl FactoryDaemon {
     }
 
     async fn validate(&self, cancellation: &CancellationToken) -> Result<()> {
-        let invalid_entries = self
-            .catalog
-            .entries
-            .iter()
-            .filter(|entry| !entry.errors.is_empty())
-            .collect::<Vec<_>>();
-        for entry in invalid_entries
-            .iter()
-            .filter(|entry| entry.is_schedule_workflow)
-        {
+        for entry in self.catalog.invalid_scheduled_entries() {
             eprintln!(
                 "Factory skipped invalid scheduled workflow {}: {}",
                 entry.path.display(),
                 entry.errors.join("; ")
             );
         }
-        let invalid_non_schedules = invalid_entries
-            .iter()
-            .filter(|entry| !entry.is_schedule_workflow)
-            .map(|entry| format!("{}: {}", entry.path.display(), entry.errors.join("; ")))
-            .collect::<Vec<_>>();
-        if !invalid_non_schedules.is_empty() {
-            bail!(
-                "Factory cannot start with invalid ticket workflows:\n{}",
-                invalid_non_schedules.join("\n")
-            );
-        }
+        self.catalog.validate_ticket_workflows()?;
         self.github.validate_global(cancellation).await?;
         match self
             .codex

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -25,6 +25,7 @@ use crate::workflow::{Trigger, WorkflowCatalog, WorkflowEntry};
 
 const HUMAN_MERGE_POLICY: &str = "Factory-created software pull requests must remain for human merge. Never merge or enable automatic merge.";
 const RECOVERY_POLL_INTERVAL: Duration = Duration::from_secs(1);
+const SCHEDULE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 static OWNER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 struct DaemonOwner {
@@ -139,8 +140,30 @@ impl FactoryDaemon {
         };
         let mut active = HashMap::<String, usize>::new();
         let mut runs = JoinSet::<(String, Result<()>)>::new();
-        let mut poll_interval = tokio::time::interval_at(Instant::now(), self.config.poll_every);
-        poll_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut github_polls = JoinSet::<Result<()>>::new();
+        {
+            let config = self.config.clone();
+            let catalog = self.catalog.clone();
+            let ledger_path = self.ledger_path.clone();
+            let github = self.github.clone();
+            let poll_cancellation = cancellation.clone();
+            github_polls.spawn(async move {
+                let mut poll_ledger = Ledger::open(&ledger_path)?;
+                github
+                    .poll_until_cancelled(
+                        &config,
+                        &catalog,
+                        &mut poll_ledger,
+                        poll_cancellation,
+                        |_| {},
+                    )
+                    .await
+                    .context("GitHub polling failed")
+            });
+        }
+        let mut schedule_interval =
+            tokio::time::interval_at(Instant::now(), SCHEDULE_POLL_INTERVAL);
+        schedule_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
         let mut recovery_interval = tokio::time::interval_at(
             Instant::now() + RECOVERY_POLL_INTERVAL,
             RECOVERY_POLL_INTERVAL,
@@ -167,7 +190,7 @@ impl FactoryDaemon {
                     _ = recovery_interval.tick() => {
                         report_recovery(ledger.recover_orphaned_runs()?);
                     }
-                    _ = poll_interval.tick() => {
+                    _ = schedule_interval.tick() => {
                         schedules = initialize_schedules(
                             &mut ledger,
                             &targets,
@@ -175,20 +198,11 @@ impl FactoryDaemon {
                             &owner.id,
                         );
                         evaluate_schedules(&mut ledger, &mut schedules, Utc::now());
-                        let report = self.github
-                            .poll_once_with_cancellation(
-                                &self.config,
-                                &self.catalog,
-                                &mut ledger,
-                                cancellation.clone(),
-                            )
-                            .await;
-                        if let Err(error) = report {
-                            if cancellation.is_cancelled() {
-                                return Ok(());
-                            }
-                            return Err(error).context("GitHub polling failed");
-                        }
+                    }
+                    completed = github_polls.join_next(), if !github_polls.is_empty() => {
+                        return completed
+                            .context("GitHub polling task disappeared")?
+                            .context("GitHub polling task panicked")?;
                     }
                     completed = runs.join_next(), if !runs.is_empty() => {
                         let (repository, result) = completed
@@ -219,6 +233,20 @@ impl FactoryDaemon {
                 Err(error) => {
                     drain_error.get_or_insert_with(|| {
                         anyhow::anyhow!(error).context("worker task panicked during shutdown")
+                    });
+                }
+            }
+        }
+        while let Some(completed) = github_polls.join_next().await {
+            match completed {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    drain_error.get_or_insert(error);
+                }
+                Err(error) => {
+                    drain_error.get_or_insert_with(|| {
+                        anyhow::anyhow!(error)
+                            .context("GitHub polling task panicked during shutdown")
                     });
                 }
             }
@@ -405,8 +433,12 @@ fn dispatch_available(
         {
             previous.pull_request = worker_ledger.latest_pull_request_for_task(task.id)?;
         }
-        let prior_successful_run_at =
-            worker_ledger.latest_successful_run_finished_at(&task.repository, &task.workflow)?;
+        let prior_successful_run_at = if task.kind == "scheduled" {
+            worker_ledger
+                .latest_successful_scheduled_run_finished_at(&task.repository, &task.workflow)?
+        } else {
+            None
+        };
         let prompt_result = execution_prompt(
             &task,
             run_id,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -119,10 +119,9 @@ impl FactoryDaemon {
             Err(error) => return Err(error),
         };
         let mut ledger = Ledger::open(&self.ledger_path)?;
+        report_recovery(ledger.recover_orphaned_runs()?);
         let owner = DaemonOwner::new()?;
         ledger.register_daemon_owner(&owner.id, owner.pid)?;
-        report_recovery(ledger.recover_orphaned_runs()?);
-        let mut schedules = initialize_schedules(&mut ledger, &targets, Utc::now(), &owner.id);
         let owner_heartbeat_shutdown = CancellationToken::new();
         let owner_heartbeat_task = {
             let ledger_path = self.ledger_path.clone();
@@ -138,6 +137,7 @@ impl FactoryDaemon {
                 result
             })
         };
+        let mut schedules = initialize_schedules(&mut ledger, &targets, Utc::now(), &owner.id);
         let mut active = HashMap::<String, usize>::new();
         let mut runs = JoinSet::<(String, Result<()>)>::new();
         let mut github_polls = JoinSet::<Result<()>>::new();

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,7 +9,6 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, SecondsFormat, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
-use sha2::{Digest, Sha256};
 use tokio::task::JoinSet;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
@@ -21,7 +20,7 @@ use crate::runtime::{
     observation_channel,
 };
 use crate::storage::{Ledger, Run, RunOutcome, Task, TaskIdentity};
-use crate::workflow::{Trigger, WorkflowCatalog, WorkflowEntry};
+use crate::workflow::{Trigger, WorkflowCatalog, WorkflowEntry, scheduled_workflow_fingerprint};
 
 const HUMAN_MERGE_POLICY: &str = "Factory-created software pull requests must remain for human merge. Never merge or enable automatic merge.";
 const RECOVERY_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -911,7 +910,13 @@ fn initialize_schedules(
                 let schedule = Schedule::from_str(&format!("0 {expression}"))
                     .context("validated cron schedule could not be parsed")?;
                 let calculated = next_occurrence(&schedule, *timezone, startup_at)?;
-                let fingerprint = schedule_fingerprint(expression, *timezone, target)?;
+                let fingerprint = scheduled_workflow_fingerprint(
+                    expression,
+                    *timezone,
+                    &target.runtime,
+                    target.timeout,
+                    &target.prompt,
+                )?;
                 let cursor = ledger.initialize_schedule_cursor(
                     repository,
                     workflow,
@@ -940,23 +945,6 @@ fn initialize_schedules(
         }
     }
     schedules
-}
-
-fn schedule_fingerprint(
-    expression: &str,
-    timezone: Tz,
-    workflow: &WorkflowTarget,
-) -> Result<String> {
-    let definition = serde_json::to_vec(&(
-        expression,
-        timezone.name(),
-        &workflow.runtime,
-        workflow.timeout.as_secs(),
-        workflow.timeout.subsec_nanos(),
-        &workflow.prompt,
-    ))
-    .context("failed to encode scheduled workflow definition")?;
-    Ok(format!("v2:{:x}", Sha256::digest(definition)))
 }
 
 fn evaluate_schedules(
@@ -1156,10 +1144,12 @@ mod tests {
         let tasks = ledger.tasks().unwrap();
         assert_eq!(tasks.len(), 3);
         assert!(tasks.iter().all(|task| task.kind == "scheduled"));
-        assert_eq!(
-            tasks[2].payload.as_deref(),
-            Some(r#"{"scheduled_at":"2026-07-18T15:01:00Z"}"#)
-        );
+        let payload = serde_json::from_str::<serde_json::Value>(
+            tasks[2].payload.as_deref().expect("scheduled payload"),
+        )
+        .unwrap();
+        assert_eq!(payload["scheduled_at"], "2026-07-18T15:01:00Z");
+        assert_eq!(payload["schedule_fingerprint"], schedules[0].fingerprint);
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -237,16 +237,31 @@ impl FactoryDaemon {
     }
 
     async fn validate(&self, cancellation: &CancellationToken) -> Result<()> {
-        for entry in self
+        let invalid_entries = self
             .catalog
             .entries
             .iter()
             .filter(|entry| !entry.errors.is_empty())
+            .collect::<Vec<_>>();
+        for entry in invalid_entries
+            .iter()
+            .filter(|entry| entry.is_schedule_workflow)
         {
             eprintln!(
-                "Factory skipped invalid workflow {}: {}",
+                "Factory skipped invalid scheduled workflow {}: {}",
                 entry.path.display(),
                 entry.errors.join("; ")
+            );
+        }
+        let invalid_non_schedules = invalid_entries
+            .iter()
+            .filter(|entry| !entry.is_schedule_workflow)
+            .map(|entry| format!("{}: {}", entry.path.display(), entry.errors.join("; ")))
+            .collect::<Vec<_>>();
+        if !invalid_non_schedules.is_empty() {
+            bail!(
+                "Factory cannot start with invalid ticket workflows:\n{}",
+                invalid_non_schedules.join("\n")
             );
         }
         self.github.validate_global(cancellation).await?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,10 +1,14 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
+use chrono::{DateTime, SecondsFormat, Utc};
+use chrono_tz::Tz;
+use cron::Schedule;
 use tokio::task::JoinSet;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
@@ -15,8 +19,8 @@ use crate::runtime::{
     CodexRuntime, ExecutionResult, RuntimeCancelled, RuntimeObservation, Termination,
     observation_channel,
 };
-use crate::storage::{Ledger, Run, RunOutcome, Task};
-use crate::workflow::{WorkflowCatalog, WorkflowEntry};
+use crate::storage::{Ledger, Run, RunOutcome, Task, TaskIdentity};
+use crate::workflow::{Trigger, WorkflowCatalog, WorkflowEntry};
 
 const HUMAN_MERGE_POLICY: &str = "Factory-created software pull requests must remain for human merge. Never merge or enable automatic merge.";
 const RECOVERY_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -53,6 +57,16 @@ struct WorkflowTarget {
     prompt: String,
     runtime: String,
     timeout: Duration,
+    trigger: Trigger,
+}
+
+struct ScheduledTarget {
+    repository: String,
+    workflow: String,
+    schedule: Schedule,
+    timezone: Tz,
+    fingerprint: String,
+    next_due: DateTime<Utc>,
 }
 
 pub struct FactoryDaemon {
@@ -106,6 +120,7 @@ impl FactoryDaemon {
         let owner = DaemonOwner::new()?;
         ledger.register_daemon_owner(&owner.id, owner.pid)?;
         report_recovery(ledger.recover_orphaned_runs()?);
+        let mut schedules = initialize_schedules(&mut ledger, &targets, Utc::now(), &owner.id);
         let owner_heartbeat_shutdown = CancellationToken::new();
         let owner_heartbeat_task = {
             let ledger_path = self.ledger_path.clone();
@@ -152,6 +167,13 @@ impl FactoryDaemon {
                         report_recovery(ledger.recover_orphaned_runs()?);
                     }
                     _ = poll_interval.tick() => {
+                        schedules = initialize_schedules(
+                            &mut ledger,
+                            &targets,
+                            Utc::now(),
+                            &owner.id,
+                        );
+                        evaluate_schedules(&mut ledger, &mut schedules, Utc::now());
                         let report = self.github
                             .poll_once_with_cancellation(
                                 &self.config,
@@ -215,8 +237,17 @@ impl FactoryDaemon {
     }
 
     async fn validate(&self, cancellation: &CancellationToken) -> Result<()> {
-        if self.catalog.invalid_count() > 0 {
-            bail!("workflow catalog contains invalid workflows");
+        for entry in self
+            .catalog
+            .entries
+            .iter()
+            .filter(|entry| !entry.errors.is_empty())
+        {
+            eprintln!(
+                "Factory skipped invalid workflow {}: {}",
+                entry.path.display(),
+                entry.errors.join("; ")
+            );
         }
         self.github.validate_global(cancellation).await?;
         match self
@@ -295,6 +326,7 @@ fn resolve_workflow_target(entry: &WorkflowEntry) -> Option<(String, WorkflowTar
             prompt: entry.prompt.clone()?,
             runtime: entry.runtime.clone()?,
             timeout: entry.timeout?,
+            trigger: entry.trigger.clone()?,
         },
     ))
 }
@@ -334,7 +366,7 @@ fn dispatch_available(
             .map(|(repository, target)| (repository.clone(), target.path.display().to_string()))
             .collect::<HashMap<_, _>>();
         let mut worker_ledger = Ledger::open(ledger_path)?;
-        let Some(claimed) = ledger.claim_ticket_and_start_run_with_workdirs(
+        let Some(claimed) = ledger.claim_and_start_run_with_workdirs(
             &available,
             &workflow_runtimes,
             &owner.id,
@@ -372,14 +404,21 @@ fn dispatch_available(
         {
             previous.pull_request = worker_ledger.latest_pull_request_for_task(task.id)?;
         }
-        let prompt_result =
-            execution_prompt(&task, run_id, &target, &workflow, prior_session.as_deref()).map(
-                |prompt| {
-                    recovery_source.as_ref().map_or(prompt.clone(), |previous| {
-                        recovery_prompt(&prompt, previous, &target)
-                    })
-                },
-            );
+        let prior_successful_run_at =
+            worker_ledger.latest_successful_run_finished_at(&task.repository, &task.workflow)?;
+        let prompt_result = execution_prompt(
+            &task,
+            run_id,
+            &target,
+            &workflow,
+            prior_session.as_deref(),
+            prior_successful_run_at,
+        )
+        .map(|prompt| {
+            recovery_source.as_ref().map_or(prompt.clone(), |previous| {
+                recovery_prompt(&prompt, previous, &target)
+            })
+        });
         let prompt = match prompt_result {
             Ok(prompt) => prompt,
             Err(error) => {
@@ -734,7 +773,47 @@ fn execution_prompt(
     repository: &RepositoryTarget,
     workflow: &WorkflowTarget,
     prior_session: Option<&str>,
+    prior_successful_run_at: Option<i64>,
 ) -> Result<String> {
+    if task.kind == "scheduled" {
+        let payload = task
+            .payload
+            .as_deref()
+            .context("scheduled task has no occurrence context")?;
+        let context: serde_json::Value = serde_json::from_str(payload)
+            .context("scheduled task contains invalid occurrence context")?;
+        let scheduled_at = context
+            .get("scheduled_at")
+            .and_then(serde_json::Value::as_str)
+            .context("scheduled task occurrence context has no scheduled_at")?;
+        let prior_success = prior_successful_run_at
+            .and_then(DateTime::<Utc>::from_timestamp_millis)
+            .map(|value| value.to_rfc3339_opts(SecondsFormat::Millis, true))
+            .unwrap_or_else(|| "none".to_owned());
+        let inspected_commit = current_commit(&repository.path)
+            .unwrap_or_else(|| "unavailable; inspect Git before making changes".to_owned());
+        return Ok(format!(
+            "# Factory execution policy\n\n\
+             {HUMAN_MERGE_POLICY}\n\
+             Factory owns durable scheduling, claims, concurrency, timeout, cancellation, and run history.\n\
+             You own the adaptive repository inspection and GitHub effects requested by the workflow. You may use the authenticated gh CLI; Factory does not create tickets for you.\n\n\
+             Run ID: {run_id}\n\
+             Repository: {}\n\
+             Repository path: {}\n\
+             Scheduled occurrence: {scheduled_at}\n\
+             Previous successful run: {prior_success}\n\
+             Inspected repository commit: {}\n\
+             Timeout: {}\n\
+             Prior Codex session: {}\n\n\
+             # Validated workflow\n\n{}",
+            task.repository,
+            repository.path.display(),
+            crate::inspection::sanitize_for_storage(&inspected_commit),
+            humantime::format_duration(workflow.timeout),
+            prior_session.unwrap_or("none"),
+            workflow.prompt
+        ));
+    }
     let payload = task
         .payload
         .as_deref()
@@ -764,6 +843,135 @@ fn execution_prompt(
         prior_session.unwrap_or("none"),
         workflow.prompt
     ))
+}
+
+fn current_commit(repository: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repository)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|commit| !commit.is_empty())
+}
+
+fn initialize_schedules(
+    ledger: &mut Ledger,
+    targets: &HashMap<String, RepositoryTarget>,
+    startup_at: DateTime<Utc>,
+    owner_id: &str,
+) -> Vec<ScheduledTarget> {
+    let mut schedules = Vec::new();
+    for (repository, target) in targets {
+        for (workflow, target) in &target.workflows {
+            let Trigger::Schedule {
+                expression,
+                timezone,
+            } = &target.trigger
+            else {
+                continue;
+            };
+            let initialized = (|| -> Result<ScheduledTarget> {
+                let schedule = Schedule::from_str(&format!("0 {expression}"))
+                    .context("validated cron schedule could not be parsed")?;
+                let calculated = next_occurrence(&schedule, *timezone, startup_at)?;
+                let fingerprint = format!("{expression}|{}", timezone.name());
+                let cursor = ledger.initialize_schedule_cursor(
+                    repository,
+                    workflow,
+                    &fingerprint,
+                    calculated.timestamp_millis(),
+                    startup_at.timestamp_millis(),
+                    owner_id,
+                )?;
+                let next_due = DateTime::<Utc>::from_timestamp_millis(cursor.next_due_at)
+                    .context("stored schedule cursor is outside the supported time range")?;
+                Ok(ScheduledTarget {
+                    repository: repository.clone(),
+                    workflow: workflow.clone(),
+                    schedule,
+                    timezone: *timezone,
+                    fingerprint,
+                    next_due,
+                })
+            })();
+            match initialized {
+                Ok(schedule) => schedules.push(schedule),
+                Err(error) => {
+                    eprintln!("Factory skipped schedule {repository}/{workflow}: {error:#}")
+                }
+            }
+        }
+    }
+    schedules
+}
+
+fn evaluate_schedules(
+    ledger: &mut Ledger,
+    schedules: &mut [ScheduledTarget],
+    through: DateTime<Utc>,
+) {
+    for target in schedules {
+        while target.next_due <= through {
+            let due = target.next_due;
+            let result = (|| -> Result<DateTime<Utc>> {
+                let next = next_occurrence(&target.schedule, target.timezone, due)?;
+                let scheduled_at = due.to_rfc3339_opts(SecondsFormat::Secs, true);
+                let identity =
+                    TaskIdentity::scheduled(&target.repository, &target.workflow, &scheduled_at)?;
+                let payload = serde_json::json!({ "scheduled_at": scheduled_at }).to_string();
+                ledger.enqueue_scheduled_occurrence(
+                    &identity,
+                    &payload,
+                    &target.fingerprint,
+                    due.timestamp_millis(),
+                    next.timestamp_millis(),
+                )?;
+                Ok(next)
+            })();
+            match result {
+                Ok(next) => target.next_due = next,
+                Err(error) => {
+                    eprintln!(
+                        "Factory schedule tick failed for {}/{}: {error:#}",
+                        target.repository, target.workflow
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn next_occurrence(
+    schedule: &Schedule,
+    timezone: Tz,
+    after: DateTime<Utc>,
+) -> Result<DateTime<Utc>> {
+    let candidate = schedule
+        .after(&after.with_timezone(&timezone))
+        .next()
+        .map(|occurrence| occurrence.with_timezone(&Utc))
+        .context("schedule has no future occurrence")?;
+    let scan_until = candidate.min(after + chrono::Duration::hours(3));
+    let next_minute = after
+        .timestamp()
+        .div_euclid(60)
+        .checked_add(1)
+        .and_then(|minute| minute.checked_mul(60))
+        .context("schedule cursor exceeds the supported time range")?;
+    let mut probe = DateTime::<Utc>::from_timestamp(next_minute, 0)
+        .context("schedule cursor exceeds the supported time range")?;
+    while probe <= scan_until {
+        if schedule.includes(probe.with_timezone(&timezone)) {
+            return Ok(probe);
+        }
+        probe += chrono::Duration::minutes(1);
+    }
+    Ok(candidate)
 }
 
 fn record_execution(ledger: &mut Ledger, run_id: i64, result: &ExecutionResult) -> Result<()> {
@@ -813,6 +1021,184 @@ fn decrement_active(active: &mut HashMap<String, usize>, repository: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn utc(value: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(value)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    fn scheduled_targets(
+        repository: &Path,
+        expression: &str,
+        timezone: Tz,
+    ) -> HashMap<String, RepositoryTarget> {
+        HashMap::from([(
+            "example/repo".to_owned(),
+            RepositoryTarget {
+                path: repository.to_owned(),
+                workflows: HashMap::from([(
+                    "scheduled-review".to_owned(),
+                    WorkflowTarget {
+                        prompt: "Review the repository.".to_owned(),
+                        runtime: "codex".to_owned(),
+                        timeout: Duration::from_secs(60),
+                        trigger: Trigger::Schedule {
+                            expression: expression.to_owned(),
+                            timezone,
+                        },
+                    },
+                )]),
+            },
+        )])
+    }
+
+    #[test]
+    fn schedule_ticks_deduplicate_restart_and_skip_offline_backlog() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("ledger.db");
+        let targets = scheduled_targets(temp.path(), "* * * * *", chrono_tz::UTC);
+        let mut ledger = Ledger::open(&path).unwrap();
+        ledger
+            .register_daemon_owner("schedule-owner-1", std::process::id())
+            .unwrap();
+        let mut schedules = initialize_schedules(
+            &mut ledger,
+            &targets,
+            utc("2026-07-18T12:00:30Z"),
+            "schedule-owner-1",
+        );
+
+        evaluate_schedules(&mut ledger, &mut schedules, utc("2026-07-18T12:01:30Z"));
+        evaluate_schedules(&mut ledger, &mut schedules, utc("2026-07-18T12:01:30Z"));
+        assert_eq!(ledger.tasks().unwrap().len(), 1);
+        ledger.remove_daemon_owner("schedule-owner-1").unwrap();
+        drop(ledger);
+
+        let mut ledger = Ledger::open(&path).unwrap();
+        ledger
+            .register_daemon_owner("schedule-owner-2", std::process::id())
+            .unwrap();
+        let mut schedules = initialize_schedules(
+            &mut ledger,
+            &targets,
+            utc("2026-07-18T12:01:40Z"),
+            "schedule-owner-2",
+        );
+        evaluate_schedules(&mut ledger, &mut schedules, utc("2026-07-18T12:02:00Z"));
+        assert_eq!(ledger.tasks().unwrap().len(), 2);
+        ledger.remove_daemon_owner("schedule-owner-2").unwrap();
+        drop(ledger);
+
+        let mut ledger = Ledger::open(&path).unwrap();
+        ledger
+            .register_daemon_owner("schedule-owner-3", std::process::id())
+            .unwrap();
+        let mut schedules = initialize_schedules(
+            &mut ledger,
+            &targets,
+            utc("2026-07-18T15:00:30Z"),
+            "schedule-owner-3",
+        );
+        evaluate_schedules(&mut ledger, &mut schedules, utc("2026-07-18T15:00:30Z"));
+        assert_eq!(ledger.tasks().unwrap().len(), 2);
+        evaluate_schedules(&mut ledger, &mut schedules, utc("2026-07-18T15:01:00Z"));
+        let tasks = ledger.tasks().unwrap();
+        assert_eq!(tasks.len(), 3);
+        assert!(tasks.iter().all(|task| task.kind == "scheduled"));
+        assert_eq!(
+            tasks[2].payload.as_deref(),
+            Some(r#"{"scheduled_at":"2026-07-18T15:01:00Z"}"#)
+        );
+    }
+
+    #[test]
+    fn disabled_schedule_is_not_initialized_or_replayed() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+        ledger
+            .register_daemon_owner("disabled-owner", std::process::id())
+            .unwrap();
+        let targets = HashMap::from([(
+            "example/repo".to_owned(),
+            RepositoryTarget {
+                path: temp.path().to_owned(),
+                workflows: HashMap::new(),
+            },
+        )]);
+        let mut schedules = initialize_schedules(
+            &mut ledger,
+            &targets,
+            utc("2026-07-18T12:00:00Z"),
+            "disabled-owner",
+        );
+        evaluate_schedules(&mut ledger, &mut schedules, utc("2026-07-19T12:00:00Z"));
+        assert!(schedules.is_empty());
+        assert!(ledger.tasks().unwrap().is_empty());
+    }
+
+    #[test]
+    fn conflicting_schedule_initialization_retries_after_owner_exits() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("ledger.db");
+        let old_targets = scheduled_targets(temp.path(), "* * * * *", chrono_tz::UTC);
+        let new_targets = scheduled_targets(temp.path(), "*/2 * * * *", chrono_tz::UTC);
+        let mut old = Ledger::open(&path).unwrap();
+        old.register_daemon_owner("old-schedule-owner", std::process::id())
+            .unwrap();
+        assert_eq!(
+            initialize_schedules(
+                &mut old,
+                &old_targets,
+                utc("2026-07-18T12:00:10Z"),
+                "old-schedule-owner",
+            )
+            .len(),
+            1
+        );
+
+        let mut new = Ledger::open(&path).unwrap();
+        new.register_daemon_owner("new-schedule-owner", std::process::id())
+            .unwrap();
+        assert!(
+            initialize_schedules(
+                &mut new,
+                &new_targets,
+                utc("2026-07-18T12:00:20Z"),
+                "new-schedule-owner",
+            )
+            .is_empty()
+        );
+        old.remove_daemon_owner("old-schedule-owner").unwrap();
+
+        let mut schedules = initialize_schedules(
+            &mut new,
+            &new_targets,
+            utc("2026-07-18T12:00:30Z"),
+            "new-schedule-owner",
+        );
+        assert_eq!(schedules.len(), 1);
+        evaluate_schedules(&mut new, &mut schedules, utc("2026-07-18T12:02:00Z"));
+        assert_eq!(new.tasks().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn timezone_and_dst_gaps_and_repeats_produce_real_utc_instants() {
+        let london = chrono_tz::Europe::London;
+        let schedule = Schedule::from_str("0 30 1 * * *").unwrap();
+
+        let gap = next_occurrence(&schedule, london, utc("2026-03-29T00:00:00Z")).unwrap();
+        assert_eq!(gap, utc("2026-03-30T00:30:00Z"));
+
+        let first_repeat = next_occurrence(&schedule, london, utc("2026-10-24T23:59:59Z")).unwrap();
+        let second_repeat = next_occurrence(&schedule, london, first_repeat).unwrap();
+        assert_eq!(first_repeat, utc("2026-10-25T00:30:00Z"));
+        assert_eq!(second_repeat, utc("2026-10-25T01:30:00Z"));
+        assert_ne!(
+            first_repeat.to_rfc3339_opts(SecondsFormat::Secs, true),
+            second_repeat.to_rfc3339_opts(SecondsFormat::Secs, true)
+        );
+    }
 
     #[test]
     fn recovery_prompt_includes_discovered_worktrees_pr_and_all_nonempty_evidence() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,10 +318,6 @@ async fn run_poller(
     let path = config_path.unwrap_or_else(default_config_path);
     let config = Config::load(&path)?;
     let catalog = WorkflowCatalog::load(&config)?;
-    let invalid = catalog.invalid_count();
-    if invalid > 0 {
-        bail!("workflow catalog contains {invalid} invalid workflow(s)");
-    }
     let data_directory = data_directory.unwrap_or_else(|| {
         path.parent()
             .unwrap_or_else(|| std::path::Path::new("."))
@@ -330,6 +326,17 @@ async fn run_poller(
     let mut ledger = Ledger::open_in(&data_directory)?;
     let github = GitHubClient::default();
     if once {
+        for entry in catalog
+            .entries
+            .iter()
+            .filter(|entry| !entry.errors.is_empty())
+        {
+            eprintln!(
+                "Factory skipped invalid workflow {}: {}",
+                entry.path.display(),
+                entry.errors.join("; ")
+            );
+        }
         let report = github.poll_once(&config, &catalog, &mut ledger).await?;
         print_poll_report(&report);
         return Ok(u8::from(report.failures() > 0));

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,17 @@ async fn run_poller(
     let path = config_path.unwrap_or_else(default_config_path);
     let config = Config::load(&path)?;
     let catalog = WorkflowCatalog::load(&config)?;
+    let ticket_validation = catalog.validate_ticket_workflows();
+    if once || ticket_validation.is_err() {
+        for entry in catalog.invalid_scheduled_entries() {
+            eprintln!(
+                "Factory skipped invalid scheduled workflow {}: {}",
+                entry.path.display(),
+                entry.errors.join("; ")
+            );
+        }
+    }
+    ticket_validation?;
     let data_directory = data_directory.unwrap_or_else(|| {
         path.parent()
             .unwrap_or_else(|| std::path::Path::new("."))
@@ -326,14 +337,6 @@ async fn run_poller(
     let mut ledger = Ledger::open_in(&data_directory)?;
     let github = GitHubClient::default();
     if once {
-        for entry in catalog.invalid_scheduled_entries() {
-            eprintln!(
-                "Factory skipped invalid scheduled workflow {}: {}",
-                entry.path.display(),
-                entry.errors.join("; ")
-            );
-        }
-        catalog.validate_ticket_workflows()?;
         let report = github.poll_once(&config, &catalog, &mut ledger).await?;
         print_poll_report(&report);
         return Ok(u8::from(report.failures() > 0));

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,17 +326,14 @@ async fn run_poller(
     let mut ledger = Ledger::open_in(&data_directory)?;
     let github = GitHubClient::default();
     if once {
-        for entry in catalog
-            .entries
-            .iter()
-            .filter(|entry| !entry.errors.is_empty())
-        {
+        for entry in catalog.invalid_scheduled_entries() {
             eprintln!(
-                "Factory skipped invalid workflow {}: {}",
+                "Factory skipped invalid scheduled workflow {}: {}",
                 entry.path.display(),
                 entry.errors.join("; ")
             );
         }
+        catalog.validate_ticket_workflows()?;
         let report = github.poll_once(&config, &catalog, &mut ledger).await?;
         print_poll_report(&report);
         return Ok(u8::from(report.failures() > 0));

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -924,17 +924,19 @@ impl Ledger {
             .context("failed to query prior agent session")
     }
 
-    pub fn latest_successful_run_finished_at(
+    pub fn latest_successful_scheduled_run_finished_at(
         &self,
         repository: &str,
         workflow: &str,
     ) -> Result<Option<i64>> {
         self.connection
             .query_row(
-                "SELECT finished_at FROM runs
-                 WHERE repository = ?1 AND workflow = ?2
-                   AND outcome = 'succeeded' AND finished_at IS NOT NULL
-                 ORDER BY finished_at DESC, id DESC LIMIT 1",
+                "SELECT runs.finished_at FROM runs
+                 JOIN tasks ON tasks.id = runs.task_id
+                 WHERE runs.repository = ?1 AND runs.workflow = ?2
+                   AND tasks.kind = 'scheduled'
+                   AND runs.outcome = 'succeeded' AND runs.finished_at IS NOT NULL
+                 ORDER BY runs.finished_at DESC, runs.id DESC LIMIT 1",
                 params![repository, workflow],
                 |row| row.get(0),
             )

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -543,6 +543,7 @@ impl Ledger {
             )
             .optional()
             .context("failed to query schedule cursor")?;
+        let lease_cutoff = now_millis()? - DAEMON_OWNER_LEASE_MILLIS;
         let live_owner_fingerprints = {
             let mut statement = transaction
                 .prepare(
@@ -555,12 +556,7 @@ impl Ledger {
                 .context("failed to prepare live schedule owner query")?;
             statement
                 .query_map(
-                    params![
-                        repository,
-                        workflow,
-                        owner_id,
-                        now_millis()? - DAEMON_OWNER_LEASE_MILLIS
-                    ],
+                    params![repository, workflow, owner_id, lease_cutoff],
                     |row| row.get::<_, String>(0),
                 )
                 .context("failed to query live schedule owners")?
@@ -573,11 +569,13 @@ impl Ledger {
         let current_owner_matches = transaction
             .query_row(
                 "SELECT EXISTS(
-                    SELECT 1 FROM schedule_owners
-                    WHERE repository = ?1 AND workflow = ?2
-                      AND owner_id = ?3 AND fingerprint = ?4
+                    SELECT 1 FROM schedule_owners schedules
+                    JOIN daemon_owners owners ON owners.owner_id = schedules.owner_id
+                    WHERE schedules.repository = ?1 AND schedules.workflow = ?2
+                      AND schedules.owner_id = ?3 AND schedules.fingerprint = ?4
+                      AND owners.heartbeat_at >= ?5
                  )",
-                params![repository, workflow, owner_id, fingerprint],
+                params![repository, workflow, owner_id, fingerprint, lease_cutoff],
                 |row| row.get::<_, bool>(0),
             )
             .context("failed to query current schedule ownership")?;
@@ -1405,15 +1403,17 @@ impl Ledger {
     }
 
     pub fn heartbeat_daemon_owner(&mut self, owner_id: &str) -> Result<()> {
+        let now = now_millis()?;
         let changed = self
             .connection
             .execute(
-                "UPDATE daemon_owners SET heartbeat_at = ?1 WHERE owner_id = ?2",
-                params![now_millis()?, owner_id],
+                "UPDATE daemon_owners SET heartbeat_at = ?1
+                 WHERE owner_id = ?2 AND heartbeat_at >= ?3",
+                params![now, owner_id, now - DAEMON_OWNER_LEASE_MILLIS],
             )
             .context("failed to update daemon owner heartbeat")?;
         if changed != 1 {
-            bail!("daemon owner {owner_id:?} is not registered");
+            bail!("daemon owner {owner_id:?} is not registered or its lease expired");
         }
         Ok(())
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -719,7 +719,7 @@ impl Ledger {
     pub fn claim_and_start_run(
         &mut self,
         available_repositories: &[String],
-        workflow_runtimes: &HashMap<(String, String), String>,
+        workflow_runtimes: &HashMap<(String, String, String), String>,
         owner_id: &str,
         owner_pid: u32,
     ) -> Result<Option<ClaimedRun>> {
@@ -739,7 +739,7 @@ impl Ledger {
     pub fn claim_and_start_run_with_workdirs(
         &mut self,
         available_repositories: &[String],
-        workflow_runtimes: &HashMap<(String, String), String>,
+        workflow_runtimes: &HashMap<(String, String, String), String>,
         owner_id: &str,
         owner_pid: u32,
         working_directories: &HashMap<String, String>,
@@ -771,7 +771,11 @@ impl Ledger {
         };
         let Some(task) = candidates.into_iter().find(|task| {
             available.contains(&task.repository)
-                && workflow_runtimes.contains_key(&(task.repository.clone(), task.workflow.clone()))
+                && workflow_runtimes.contains_key(&(
+                    task.repository.clone(),
+                    task.workflow.clone(),
+                    task.kind.clone(),
+                ))
         }) else {
             transaction
                 .commit()
@@ -779,7 +783,11 @@ impl Ledger {
             return Ok(None);
         };
         let runtime = workflow_runtimes
-            .get(&(task.repository.clone(), task.workflow.clone()))
+            .get(&(
+                task.repository.clone(),
+                task.workflow.clone(),
+                task.kind.clone(),
+            ))
             .context("claimed workflow runtime disappeared")?;
         let changed = transaction
             .execute(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, bail};
 use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 
 const DATABASE_NAME: &str = "factory.sqlite3";
-const SCHEMA_VERSION: i64 = 4;
+const SCHEMA_VERSION: i64 = 5;
 pub const MAX_RESULT_BYTES: usize = 256 * 1024;
 pub const MAX_ERROR_BYTES: usize = 64 * 1024;
 pub const MAX_SESSION_ID_BYTES: usize = 1024;
@@ -209,6 +209,11 @@ pub struct Task {
 pub struct EnqueuedTask {
     pub task: Task,
     pub created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduleCursor {
+    pub next_due_at: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -505,7 +510,212 @@ impl Ledger {
         self.claim_next_matching(Some(&repositories))
     }
 
-    pub fn claim_ticket_and_start_run(
+    pub fn initialize_schedule_cursor(
+        &mut self,
+        repository: &str,
+        workflow: &str,
+        fingerprint: &str,
+        next_due_at: i64,
+        startup_at: i64,
+        owner_id: &str,
+    ) -> Result<ScheduleCursor> {
+        if repository.trim().is_empty()
+            || workflow.trim().is_empty()
+            || fingerprint.trim().is_empty()
+            || owner_id.trim().is_empty()
+        {
+            bail!("schedule repository, workflow, fingerprint, and owner must not be empty");
+        }
+        if next_due_at <= startup_at {
+            bail!("initialized schedule occurrence must be after startup");
+        }
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .context("failed to begin schedule initialization transaction")?;
+        let prior = transaction
+            .query_row(
+                "SELECT fingerprint, next_due_at FROM schedule_cursors
+                 WHERE repository = ?1 AND workflow = ?2",
+                params![repository, workflow],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()
+            .context("failed to query schedule cursor")?;
+        let live_owner_fingerprints = {
+            let mut statement = transaction
+                .prepare(
+                    "SELECT DISTINCT schedules.fingerprint
+                     FROM schedule_owners schedules
+                     JOIN daemon_owners owners ON owners.owner_id = schedules.owner_id
+                     WHERE schedules.repository = ?1 AND schedules.workflow = ?2
+                       AND owners.owner_id != ?3 AND owners.heartbeat_at >= ?4",
+                )
+                .context("failed to prepare live schedule owner query")?;
+            statement
+                .query_map(
+                    params![
+                        repository,
+                        workflow,
+                        owner_id,
+                        now_millis()? - DAEMON_OWNER_LEASE_MILLIS
+                    ],
+                    |row| row.get::<_, String>(0),
+                )
+                .context("failed to query live schedule owners")?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .context("failed to read live schedule owners")?
+        };
+        let other_matching_owner = live_owner_fingerprints
+            .iter()
+            .any(|owner_fingerprint| owner_fingerprint == fingerprint);
+        let current_owner_matches = transaction
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM schedule_owners
+                    WHERE repository = ?1 AND workflow = ?2
+                      AND owner_id = ?3 AND fingerprint = ?4
+                 )",
+                params![repository, workflow, owner_id, fingerprint],
+                |row| row.get::<_, bool>(0),
+            )
+            .context("failed to query current schedule ownership")?;
+        if let Some((prior_fingerprint, _)) = &prior
+            && prior_fingerprint != fingerprint
+            && live_owner_fingerprints
+                .iter()
+                .any(|owner_fingerprint| owner_fingerprint == prior_fingerprint)
+        {
+            bail!(
+                "schedule {repository}/{workflow} has live owner using different fingerprint {prior_fingerprint:?}"
+            );
+        }
+        let resolved = match prior {
+            Some((prior_fingerprint, prior_due))
+                if prior_fingerprint == fingerprint
+                    && (prior_due > startup_at
+                        || other_matching_owner
+                        || current_owner_matches) =>
+            {
+                prior_due
+            }
+            _ => {
+                transaction
+                    .execute(
+                        "INSERT INTO schedule_cursors
+                         (repository, workflow, fingerprint, next_due_at, updated_at)
+                         VALUES (?1, ?2, ?3, ?4, ?5)
+                         ON CONFLICT(repository, workflow) DO UPDATE SET
+                           fingerprint = excluded.fingerprint,
+                           next_due_at = excluded.next_due_at,
+                           updated_at = excluded.updated_at",
+                        params![
+                            repository,
+                            workflow,
+                            fingerprint,
+                            next_due_at,
+                            now_millis()?
+                        ],
+                    )
+                    .context("failed to initialize schedule cursor")?;
+                next_due_at
+            }
+        };
+        transaction
+            .execute(
+                "INSERT OR REPLACE INTO schedule_owners
+                 (repository, workflow, owner_id, fingerprint)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![repository, workflow, owner_id, fingerprint],
+            )
+            .context("failed to register schedule owner")?;
+        transaction
+            .commit()
+            .context("failed to commit schedule initialization")?;
+        Ok(ScheduleCursor {
+            next_due_at: resolved,
+        })
+    }
+
+    pub fn enqueue_scheduled_occurrence(
+        &mut self,
+        identity: &TaskIdentity,
+        payload: &str,
+        expected_fingerprint: &str,
+        expected_due_at: i64,
+        next_due_at: i64,
+    ) -> Result<Option<EnqueuedTask>> {
+        let TaskIdentity::Scheduled {
+            repository,
+            workflow,
+            ..
+        } = identity
+        else {
+            bail!("scheduled occurrence requires a scheduled task identity");
+        };
+        identity.validate()?;
+        if next_due_at <= expected_due_at {
+            bail!("next scheduled occurrence must follow the due occurrence");
+        }
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .context("failed to begin scheduled occurrence transaction")?;
+        let cursor = transaction
+            .query_row(
+                "SELECT fingerprint, next_due_at FROM schedule_cursors
+                 WHERE repository = ?1 AND workflow = ?2",
+                params![repository, workflow],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()
+            .context("failed to read due schedule cursor")?;
+        if cursor != Some((expected_fingerprint.to_owned(), expected_due_at)) {
+            transaction
+                .commit()
+                .context("failed to finish superseded schedule occurrence")?;
+            return Ok(None);
+        }
+        let now = now_millis()?;
+        let inserted = transaction
+            .execute(
+                "INSERT OR IGNORE INTO tasks
+                 (identity_key, kind, repository, workflow, source_item, payload, state, created_at, updated_at)
+                 VALUES (?1, 'scheduled', ?2, ?3, NULL, ?4, 'queued', ?5, ?5)",
+                params![identity.key(), repository, workflow, payload, now],
+            )
+            .context("failed to enqueue scheduled occurrence")?
+            == 1;
+        let task = query_task_by_key(&transaction, &identity.key())?
+            .context("scheduled occurrence task disappeared")?;
+        let changed = transaction
+            .execute(
+                "UPDATE schedule_cursors SET next_due_at = ?1, updated_at = ?2
+                 WHERE repository = ?3 AND workflow = ?4
+                   AND fingerprint = ?5 AND next_due_at = ?6",
+                params![
+                    next_due_at,
+                    now,
+                    repository,
+                    workflow,
+                    expected_fingerprint,
+                    expected_due_at
+                ],
+            )
+            .context("failed to advance schedule cursor")?;
+        if changed != 1 {
+            bail!("scheduled occurrence cursor changed during enqueue");
+        }
+        transaction
+            .commit()
+            .context("failed to commit scheduled occurrence")?;
+        Ok(Some(EnqueuedTask {
+            task,
+            created: inserted,
+        }))
+    }
+
+    pub fn claim_and_start_run(
         &mut self,
         available_repositories: &[String],
         workflow_runtimes: &HashMap<(String, String), String>,
@@ -516,7 +726,7 @@ impl Ledger {
             .iter()
             .map(|repository| (repository.clone(), repository.clone()))
             .collect();
-        self.claim_ticket_and_start_run_with_workdirs(
+        self.claim_and_start_run_with_workdirs(
             available_repositories,
             workflow_runtimes,
             owner_id,
@@ -525,7 +735,7 @@ impl Ledger {
         )
     }
 
-    pub fn claim_ticket_and_start_run_with_workdirs(
+    pub fn claim_and_start_run_with_workdirs(
         &mut self,
         available_repositories: &[String],
         workflow_runtimes: &HashMap<(String, String), String>,
@@ -548,15 +758,15 @@ impl Ledger {
             let mut statement = transaction
                 .prepare(
                     "SELECT * FROM tasks
-                     WHERE state = 'queued' AND kind = 'ticket'
+                     WHERE state = 'queued'
                      ORDER BY created_at, id",
                 )
-                .context("failed to prepare ticket claim query")?;
+                .context("failed to prepare task claim query")?;
             statement
                 .query_map([], row_to_task)
-                .context("failed to query queued ticket tasks")?
+                .context("failed to query queued tasks")?
                 .collect::<rusqlite::Result<Vec<_>>>()
-                .context("failed to read queued ticket tasks")?
+                .context("failed to read queued tasks")?
         };
         let Some(task) = candidates.into_iter().find(|task| {
             available.contains(&task.repository)
@@ -564,7 +774,7 @@ impl Ledger {
         }) else {
             transaction
                 .commit()
-                .context("failed to finish empty ticket claim")?;
+                .context("failed to finish empty task claim")?;
             return Ok(None);
         };
         let runtime = workflow_runtimes
@@ -688,6 +898,24 @@ impl Ledger {
             )
             .optional()
             .context("failed to query prior agent session")
+    }
+
+    pub fn latest_successful_run_finished_at(
+        &self,
+        repository: &str,
+        workflow: &str,
+    ) -> Result<Option<i64>> {
+        self.connection
+            .query_row(
+                "SELECT finished_at FROM runs
+                 WHERE repository = ?1 AND workflow = ?2
+                   AND outcome = 'succeeded' AND finished_at IS NOT NULL
+                 ORDER BY finished_at DESC, id DESC LIMIT 1",
+                params![repository, workflow],
+                |row| row.get(0),
+            )
+            .optional()
+            .context("failed to query previous successful workflow run")
     }
 
     pub fn latest_pull_request_for_task(&self, task_id: i64) -> Result<Option<String>> {
@@ -1208,6 +1436,9 @@ fn migrate(connection: &Connection) -> Result<()> {
     if version < 4 {
         migrate_v4(connection)?;
     }
+    if version < 5 {
+        migrate_v5(connection)?;
+    }
     Ok(())
 }
 
@@ -1322,6 +1553,34 @@ fn migrate_v4(connection: &Connection) -> Result<()> {
          COMMIT;",
         )
         .context("failed to migrate SQLite ledger to version 4")?;
+    Ok(())
+}
+
+fn migrate_v5(connection: &Connection) -> Result<()> {
+    connection
+        .execute_batch(
+            "BEGIN IMMEDIATE;
+             CREATE TABLE schedule_cursors (
+                 repository TEXT NOT NULL,
+                 workflow TEXT NOT NULL,
+                 fingerprint TEXT NOT NULL,
+                 next_due_at INTEGER NOT NULL,
+                 updated_at INTEGER NOT NULL,
+                 PRIMARY KEY(repository, workflow)
+             );
+             CREATE TABLE schedule_owners (
+                 repository TEXT NOT NULL,
+                 workflow TEXT NOT NULL,
+                 owner_id TEXT NOT NULL REFERENCES daemon_owners(owner_id) ON DELETE CASCADE,
+                 fingerprint TEXT NOT NULL,
+                 PRIMARY KEY(repository, workflow, owner_id)
+             );
+             INSERT INTO schema_migrations(version, applied_at)
+                 VALUES (5, unixepoch('subsec') * 1000);
+             PRAGMA user_version = 5;
+             COMMIT;",
+        )
+        .context("failed to migrate SQLite ledger to version 5")?;
     Ok(())
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -748,11 +748,28 @@ impl Ledger {
         let available = available_repositories
             .iter()
             .collect::<std::collections::HashSet<_>>();
-        let now = now_millis()?;
         let transaction = self
             .connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("failed to begin atomic task and run claim")?;
+        let now = now_millis()?;
+        let owner_is_live = transaction
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM daemon_owners
+                    WHERE owner_id = ?1 AND pid = ?2 AND heartbeat_at >= ?3
+                 )",
+                params![
+                    owner_id,
+                    owner_pid,
+                    now.saturating_sub(DAEMON_OWNER_LEASE_MILLIS)
+                ],
+                |row| row.get::<_, bool>(0),
+            )
+            .context("failed to validate task claim owner lease")?;
+        if !owner_is_live {
+            bail!("daemon owner {owner_id:?} has no live lease for task claims");
+        }
         let candidates = {
             let mut statement = transaction
                 .prepare(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -547,7 +547,7 @@ impl Ledger {
         let live_owner_fingerprints = {
             let mut statement = transaction
                 .prepare(
-                    "SELECT DISTINCT schedules.fingerprint
+                    "SELECT DISTINCT schedules.fingerprint, owners.pid
                      FROM schedule_owners schedules
                      JOIN daemon_owners owners ON owners.owner_id = schedules.owner_id
                      WHERE schedules.repository = ?1 AND schedules.workflow = ?2
@@ -557,11 +557,14 @@ impl Ledger {
             statement
                 .query_map(
                     params![repository, workflow, owner_id, lease_cutoff],
-                    |row| row.get::<_, String>(0),
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?)),
                 )
                 .context("failed to query live schedule owners")?
                 .collect::<rusqlite::Result<Vec<_>>>()
                 .context("failed to read live schedule owners")?
+                .into_iter()
+                .filter_map(|(fingerprint, pid)| process_is_alive(pid).then_some(fingerprint))
+                .collect::<Vec<_>>()
         };
         let other_matching_owner = live_owner_fingerprints
             .iter()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -316,11 +316,12 @@ impl Ledger {
         let connection = Connection::open(path)
             .with_context(|| format!("failed to open SQLite database {}", path.display()))?;
         connection
+            .execute_batch("PRAGMA foreign_keys = ON;")
+            .context("failed to enable SQLite foreign keys")?;
+        configure_wal(&connection)?;
+        connection
             .busy_timeout(std::time::Duration::from_secs(5))
             .context("failed to configure SQLite busy timeout")?;
-        connection
-            .execute_batch("PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL;")
-            .context("failed to configure SQLite database")?;
         migrate(&connection)?;
         Ok(Self {
             connection,
@@ -1417,36 +1418,86 @@ impl Ledger {
     }
 }
 
+fn configure_wal(connection: &Connection) -> Result<()> {
+    connection
+        .busy_timeout(std::time::Duration::from_millis(10))
+        .context("failed to configure SQLite WAL setup timeout")?;
+    let mut last_error = None;
+    for _ in 0..100 {
+        match connection.query_row("PRAGMA journal_mode = WAL", [], |row| {
+            row.get::<_, String>(0)
+        }) {
+            Ok(mode) if mode.eq_ignore_ascii_case("wal") => return Ok(()),
+            Ok(mode) => bail!("SQLite refused WAL journal mode and selected {mode:?}"),
+            Err(error) if sqlite_is_busy(&error) => {
+                last_error = Some(error);
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            Err(error) => return Err(error).context("failed to configure SQLite WAL mode"),
+        }
+    }
+    Err(anyhow::Error::new(
+        last_error.expect("WAL retry loop records each lock failure"),
+    ))
+    .context("failed to configure SQLite WAL mode after lock retries")
+}
+
+fn sqlite_is_busy(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(code, _)
+            if matches!(
+                code.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            )
+    )
+}
+
 fn migrate(connection: &Connection) -> Result<()> {
-    let version: i64 = connection
-        .pragma_query_value(None, "user_version", |row| row.get(0))
-        .context("failed to read SQLite schema version")?;
-    if version > SCHEMA_VERSION {
-        bail!("SQLite schema version {version} is newer than supported version {SCHEMA_VERSION}");
+    connection
+        .execute_batch("BEGIN IMMEDIATE;")
+        .context("failed to lock SQLite schema for migration")?;
+    let result = (|| -> Result<()> {
+        let version: i64 = connection
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .context("failed to read SQLite schema version")?;
+        if version > SCHEMA_VERSION {
+            bail!(
+                "SQLite schema version {version} is newer than supported version {SCHEMA_VERSION}"
+            );
+        }
+        if version < 1 {
+            migrate_v1(connection)?;
+        }
+        if version < 2 {
+            migrate_v2(connection)?;
+        }
+        if version < 3 {
+            migrate_v3(connection)?;
+        }
+        if version < 4 {
+            migrate_v4(connection)?;
+        }
+        if version < 5 {
+            migrate_v5(connection)?;
+        }
+        Ok(())
+    })();
+    match result {
+        Ok(()) => connection
+            .execute_batch("COMMIT;")
+            .context("failed to commit SQLite schema migration"),
+        Err(error) => {
+            let _ = connection.execute_batch("ROLLBACK;");
+            Err(error)
+        }
     }
-    if version < 1 {
-        migrate_v1(connection)?;
-    }
-    if version < 2 {
-        migrate_v2(connection)?;
-    }
-    if version < 3 {
-        migrate_v3(connection)?;
-    }
-    if version < 4 {
-        migrate_v4(connection)?;
-    }
-    if version < 5 {
-        migrate_v5(connection)?;
-    }
-    Ok(())
 }
 
 fn migrate_v1(connection: &Connection) -> Result<()> {
     connection
         .execute_batch(
-            "BEGIN IMMEDIATE;
-             CREATE TABLE IF NOT EXISTS schema_migrations (
+            "CREATE TABLE IF NOT EXISTS schema_migrations (
                  version INTEGER PRIMARY KEY,
                  applied_at INTEGER NOT NULL
              );
@@ -1481,8 +1532,7 @@ fn migrate_v1(connection: &Connection) -> Result<()> {
                  ON runs(task_id) WHERE outcome = 'running';
              INSERT OR IGNORE INTO schema_migrations(version, applied_at)
                  VALUES (1, unixepoch('subsec') * 1000);
-             PRAGMA user_version = 1;
-             COMMIT;",
+             PRAGMA user_version = 1;",
         )
         .context("failed to initialize or migrate SQLite ledger")?;
     Ok(())
@@ -1491,8 +1541,7 @@ fn migrate_v1(connection: &Connection) -> Result<()> {
 fn migrate_v2(connection: &Connection) -> Result<()> {
     connection
         .execute_batch(
-            "BEGIN IMMEDIATE;
-             ALTER TABLE tasks ADD COLUMN payload TEXT;
+            "ALTER TABLE tasks ADD COLUMN payload TEXT;
              CREATE TABLE trigger_observations (
                  repository TEXT NOT NULL,
                  workflow TEXT NOT NULL,
@@ -1505,8 +1554,7 @@ fn migrate_v2(connection: &Connection) -> Result<()> {
              );
              INSERT INTO schema_migrations(version, applied_at)
                  VALUES (2, unixepoch('subsec') * 1000);
-             PRAGMA user_version = 2;
-             COMMIT;",
+             PRAGMA user_version = 2;",
         )
         .context("failed to migrate SQLite ledger to version 2")?;
     Ok(())
@@ -1515,8 +1563,7 @@ fn migrate_v2(connection: &Connection) -> Result<()> {
 fn migrate_v3(connection: &Connection) -> Result<()> {
     connection
         .execute_batch(
-            "BEGIN IMMEDIATE;
-             ALTER TABLE runs ADD COLUMN cancellation_requested_at INTEGER;
+            "ALTER TABLE runs ADD COLUMN cancellation_requested_at INTEGER;
              ALTER TABLE runs ADD COLUMN owner_pid INTEGER;
              ALTER TABLE runs ADD COLUMN owner_id TEXT;
              CREATE TABLE daemon_owners (
@@ -1526,8 +1573,7 @@ fn migrate_v3(connection: &Connection) -> Result<()> {
              );
              INSERT INTO schema_migrations(version, applied_at)
                  VALUES (3, unixepoch('subsec') * 1000);
-             PRAGMA user_version = 3;
-             COMMIT;",
+             PRAGMA user_version = 3;",
         )
         .context("failed to migrate SQLite ledger to version 3")?;
     Ok(())
@@ -1536,8 +1582,7 @@ fn migrate_v3(connection: &Connection) -> Result<()> {
 fn migrate_v4(connection: &Connection) -> Result<()> {
     connection
         .execute_batch(
-            "BEGIN IMMEDIATE;
-         ALTER TABLE tasks ADD COLUMN recovery_source_run_id INTEGER REFERENCES runs(id);
+            "ALTER TABLE tasks ADD COLUMN recovery_source_run_id INTEGER REFERENCES runs(id);
          ALTER TABLE runs ADD COLUMN process_id INTEGER;
          ALTER TABLE runs ADD COLUMN process_identity TEXT;
          ALTER TABLE runs ADD COLUMN pull_request TEXT;
@@ -1549,8 +1594,7 @@ fn migrate_v4(connection: &Connection) -> Result<()> {
          UPDATE runs SET last_activity_at = started_at WHERE last_activity_at IS NULL;
          INSERT INTO schema_migrations(version, applied_at)
              VALUES (4, unixepoch('subsec') * 1000);
-         PRAGMA user_version = 4;
-         COMMIT;",
+         PRAGMA user_version = 4;",
         )
         .context("failed to migrate SQLite ledger to version 4")?;
     Ok(())
@@ -1559,8 +1603,7 @@ fn migrate_v4(connection: &Connection) -> Result<()> {
 fn migrate_v5(connection: &Connection) -> Result<()> {
     connection
         .execute_batch(
-            "BEGIN IMMEDIATE;
-             CREATE TABLE schedule_cursors (
+            "CREATE TABLE schedule_cursors (
                  repository TEXT NOT NULL,
                  workflow TEXT NOT NULL,
                  fingerprint TEXT NOT NULL,
@@ -1577,8 +1620,7 @@ fn migrate_v5(connection: &Connection) -> Result<()> {
              );
              INSERT INTO schema_migrations(version, applied_at)
                  VALUES (5, unixepoch('subsec') * 1000);
-             PRAGMA user_version = 5;
-             COMMIT;",
+             PRAGMA user_version = 5;",
         )
         .context("failed to migrate SQLite ledger to version 5")?;
     Ok(())

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -659,6 +659,17 @@ impl Ledger {
         if next_due_at <= expected_due_at {
             bail!("next scheduled occurrence must follow the due occurrence");
         }
+        let mut payload = serde_json::from_str::<serde_json::Value>(payload)
+            .context("scheduled occurrence payload is not valid JSON")?;
+        let payload = payload
+            .as_object_mut()
+            .context("scheduled occurrence payload must be a JSON object")?;
+        payload.insert(
+            "schedule_fingerprint".to_owned(),
+            serde_json::Value::String(expected_fingerprint.to_owned()),
+        );
+        let payload = serde_json::to_string(payload)
+            .context("failed to encode scheduled occurrence payload")?;
         let transaction = self
             .connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -773,6 +784,26 @@ impl Ledger {
         if !owner_is_live {
             bail!("daemon owner {owner_id:?} has no live lease for task claims");
         }
+        let schedule_ownership = {
+            let mut statement = transaction
+                .prepare(
+                    "SELECT owners.repository, owners.workflow, owners.fingerprint
+                     FROM schedule_owners owners
+                     JOIN schedule_cursors cursors
+                       ON cursors.repository = owners.repository
+                      AND cursors.workflow = owners.workflow
+                      AND cursors.fingerprint = owners.fingerprint
+                     WHERE owners.owner_id = ?1",
+                )
+                .context("failed to prepare schedule ownership query")?;
+            statement
+                .query_map([owner_id], |row| {
+                    Ok(((row.get(0)?, row.get(1)?), row.get(2)?))
+                })
+                .context("failed to query schedule ownership")?
+                .collect::<rusqlite::Result<HashMap<_, _>>>()
+                .context("failed to read schedule ownership")?
+        };
         let candidates = {
             let mut statement = transaction
                 .prepare(
@@ -788,12 +819,38 @@ impl Ledger {
                 .context("failed to read queued tasks")?
         };
         let Some(task) = candidates.into_iter().find(|task| {
-            available.contains(&task.repository)
-                && workflow_runtimes.contains_key(&(
+            if !available.contains(&task.repository)
+                || !workflow_runtimes.contains_key(&(
                     task.repository.clone(),
                     task.workflow.clone(),
                     task.kind.clone(),
                 ))
+            {
+                return false;
+            }
+            if task.kind != "scheduled" {
+                return true;
+            }
+            let task_fingerprint = task
+                .payload
+                .as_deref()
+                .and_then(|payload| serde_json::from_str::<serde_json::Value>(payload).ok())
+                .and_then(|payload| {
+                    payload
+                        .get("schedule_fingerprint")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned)
+                });
+            matches!(
+                (
+                    task_fingerprint.as_deref(),
+                    schedule_ownership
+                        .get(&(task.repository.clone(), task.workflow.clone()))
+                        .map(String::as_str),
+                ),
+                (Some(task_fingerprint), Some(owner_fingerprint))
+                    if task_fingerprint == owner_fingerprint
+            )
         }) else {
             transaction
                 .commit()

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -521,11 +521,15 @@ fn declares_only_schedule(frontmatter: &str) -> bool {
 fn line_declares_key(line: &str, expected: &str) -> bool {
     let bytes = line.as_bytes();
     let mut index = 0;
+    let mut brace_depth = 0_u32;
+    let mut bracket_depth = 0_u32;
+    let mut expecting_value = false;
     while index < bytes.len() {
         if bytes[index] == b'#' {
             return false;
         }
         if matches!(bytes[index], b'\'' | b'"') {
+            let quoted_key_start = index;
             let quote = bytes[index];
             let start = index + 1;
             index = start;
@@ -542,7 +546,12 @@ fn line_declares_key(line: &str, expected: &str) -> bool {
                 escaped = false;
                 index += 1;
             }
-            if index < bytes.len()
+            if expecting_value {
+                expecting_value = false;
+            } else if index < bytes.len()
+                && brace_depth == 0
+                && bracket_depth == 0
+                && previous_non_whitespace(bytes, quoted_key_start) != Some(b'.')
                 && &line[start..index] == expected
                 && bytes[index + 1..]
                     .iter()
@@ -563,7 +572,12 @@ fn line_declares_key(line: &str, expected: &str) -> bool {
             {
                 index += 1;
             }
-            if &line[start..index] == expected
+            if expecting_value {
+                expecting_value = false;
+            } else if brace_depth == 0
+                && bracket_depth == 0
+                && previous_non_whitespace(bytes, start) != Some(b'.')
+                && &line[start..index] == expected
                 && bytes[index..]
                     .iter()
                     .copied()
@@ -574,9 +588,31 @@ fn line_declares_key(line: &str, expected: &str) -> bool {
             }
             continue;
         }
+        match bytes[index] {
+            b'=' if brace_depth == 0 && bracket_depth == 0 => expecting_value = true,
+            b'{' => {
+                brace_depth = brace_depth.saturating_add(1);
+                expecting_value = false;
+            }
+            b'}' => brace_depth = brace_depth.saturating_sub(1),
+            b'[' => {
+                bracket_depth = bracket_depth.saturating_add(1);
+                expecting_value = false;
+            }
+            b']' => bracket_depth = bracket_depth.saturating_sub(1),
+            _ => {}
+        }
         index += 1;
     }
     false
+}
+
+fn previous_non_whitespace(bytes: &[u8], before: usize) -> Option<u8> {
+    bytes[..before]
+        .iter()
+        .rev()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
 }
 
 fn contains_multiline_closing(value: &str, delimiter: &str) -> bool {
@@ -883,6 +919,23 @@ schedule = "not-a-key"#
         ));
         assert!(declares_only_schedule(
             "schedule = \"0 9 * * 1\"\ndescription = \"label = factory:ready\""
+        ));
+        assert!(declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\nmetadata = { label = \"triage\" }\nbroken = ???"
+        ));
+        assert!(declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\nmetadata.label = \"triage\"\nbroken = ???"
+        ));
+        assert!(declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\n\"metadata\".\"label\" = \"triage\"\nbroken = ???"
+        ));
+        assert!(!declares_only_schedule("description = \"schedule\" = ???"));
+        assert!(!declares_only_schedule("description = schedule = ???"));
+        assert!(declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\ndescription = \"label\" = ???"
+        ));
+        assert!(declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\ndescription = label = ???"
         ));
         assert!(missing_frontmatter_declares_only_schedule(
             "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nImplement maintenance.\n"

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -354,11 +354,14 @@ fn load_file(repository: &Path, path: &Path, config: &Config) -> WorkflowEntry {
         entry.prompt = Some(prompt);
     }
 
-    if let Ok(value) = toml::from_str::<toml::Value>(&frontmatter)
-        && let Some(table) = value.as_table()
-    {
-        entry.is_schedule_workflow = table.contains_key("schedule") && !table.contains_key("label");
-    }
+    entry.is_schedule_workflow = toml::from_str::<toml::Value>(&frontmatter)
+        .ok()
+        .and_then(|value| {
+            value
+                .as_table()
+                .map(|table| table.contains_key("schedule") && !table.contains_key("label"))
+        })
+        .unwrap_or_else(|| declares_only_schedule(&frontmatter));
     let raw: Frontmatter = match toml::from_str(&frontmatter) {
         Ok(raw) => raw,
         Err(error) => {
@@ -412,6 +415,26 @@ fn split_frontmatter(contents: &str) -> std::result::Result<(String, String), St
         after_opening[..closing].to_owned(),
         after_opening[prompt_start..].to_owned(),
     ))
+}
+
+fn declares_only_schedule(frontmatter: &str) -> bool {
+    let mut first_key = None;
+    let mut label = false;
+    for line in frontmatter.lines() {
+        let line = line.trim_start();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, _)) = line.split_once('=') else {
+            return false;
+        };
+        let key = key.trim();
+        first_key.get_or_insert(key);
+        if matches!(key, "label" | "\"label\"" | "'label'") {
+            label = true;
+        }
+    }
+    first_key == Some("schedule") && !label
 }
 
 fn resolve_runtime(
@@ -628,6 +651,28 @@ mod tests {
         assert!(valid_cron("0 9 * * 1"));
         assert!(!valid_cron("0 0 9 * * 1"));
         assert!(!valid_cron("eventually"));
+    }
+
+    #[test]
+    fn malformed_frontmatter_schedule_detection_is_conservative() {
+        assert!(declares_only_schedule(
+            "schedule = \"unterminated\ntimezone = \"UTC\""
+        ));
+        assert!(!declares_only_schedule(
+            "description = \"\"\"\nschedule = \"not-a-key"
+        ));
+        assert!(!declares_only_schedule(
+            "[metadata]\nschedule = \"unterminated"
+        ));
+        assert!(!declares_only_schedule(
+            "\"schedule=not-trigger\" = \"unterminated"
+        ));
+        assert!(!declares_only_schedule(
+            "schedule = \"unterminated\nlabel = \"factory:ready\""
+        ));
+        assert!(!declares_only_schedule(
+            "schedule = \"unterminated\n\"label\" = \"factory:ready\""
+        ));
     }
 
     #[test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -495,16 +495,11 @@ fn declares_only_schedule(frontmatter: &str) -> bool {
         if line.starts_with('[') {
             return false;
         }
-        let Some((key, value)) = line.split_once('=') else {
+        schedule |= line_declares_key(line, "schedule");
+        label |= line_declares_key(line, "label");
+        let Some((_, value)) = line.split_once('=') else {
             return false;
         };
-        let key = key.trim();
-        if matches!(key, "schedule" | "\"schedule\"" | "'schedule'") {
-            schedule = true;
-        }
-        if matches!(key, "label" | "\"label\"" | "'label'") {
-            label = true;
-        }
         let value = value.trim_start();
         if matches!(value.as_bytes().first(), Some(b'{') | Some(b'['))
             && !inline_container_closes(value)
@@ -521,6 +516,67 @@ fn declares_only_schedule(frontmatter: &str) -> bool {
         }
     }
     schedule && !label && multiline_delimiter.is_none()
+}
+
+fn line_declares_key(line: &str, expected: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'#' {
+            return false;
+        }
+        if matches!(bytes[index], b'\'' | b'"') {
+            let quote = bytes[index];
+            let start = index + 1;
+            index = start;
+            let mut escaped = false;
+            while index < bytes.len() {
+                if quote == b'"' && bytes[index] == b'\\' && !escaped {
+                    escaped = true;
+                    index += 1;
+                    continue;
+                }
+                if bytes[index] == quote && !escaped {
+                    break;
+                }
+                escaped = false;
+                index += 1;
+            }
+            if index < bytes.len()
+                && &line[start..index] == expected
+                && bytes[index + 1..]
+                    .iter()
+                    .copied()
+                    .find(|byte| !byte.is_ascii_whitespace())
+                    == Some(b'=')
+            {
+                return true;
+            }
+            index = index.saturating_add(1);
+            continue;
+        }
+        if bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'_' | b'-') {
+            let start = index;
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'_' | b'-'))
+            {
+                index += 1;
+            }
+            if &line[start..index] == expected
+                && bytes[index..]
+                    .iter()
+                    .copied()
+                    .find(|byte| !byte.is_ascii_whitespace())
+                    == Some(b'=')
+            {
+                return true;
+            }
+            continue;
+        }
+        index += 1;
+    }
+    false
 }
 
 fn contains_multiline_closing(value: &str, delimiter: &str) -> bool {
@@ -821,6 +877,12 @@ schedule = "not-a-key"#
         ));
         assert!(!declares_only_schedule(
             "schedule = \"unterminated\n\"label\" = \"factory:ready\""
+        ));
+        assert!(!declares_only_schedule(
+            "schedule = \"0 9 * * 1\" label = \"factory:ready\""
+        ));
+        assert!(declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\ndescription = \"label = factory:ready\""
         ));
         assert!(missing_frontmatter_declares_only_schedule(
             "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nImplement maintenance.\n"

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -444,23 +444,92 @@ fn missing_frontmatter_declares_only_schedule(contents: &str) -> bool {
 }
 
 fn declares_only_schedule(frontmatter: &str) -> bool {
-    let mut first_key = None;
+    let mut schedule = false;
     let mut label = false;
+    let mut multiline_delimiter = None;
     for line in frontmatter.lines() {
         let line = line.trim_start();
+        if let Some(delimiter) = multiline_delimiter {
+            if contains_multiline_closing(line, delimiter) {
+                multiline_delimiter = None;
+            }
+            continue;
+        }
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
-        let Some((key, _)) = line.split_once('=') else {
+        if line.starts_with('[') {
+            return false;
+        }
+        let Some((key, value)) = line.split_once('=') else {
             return false;
         };
         let key = key.trim();
-        first_key.get_or_insert(key);
+        if matches!(key, "schedule" | "\"schedule\"" | "'schedule'") {
+            schedule = true;
+        }
         if matches!(key, "label" | "\"label\"" | "'label'") {
             label = true;
         }
+        let value = value.trim_start();
+        if matches!(value.as_bytes().first(), Some(b'{') | Some(b'['))
+            && !inline_container_closes(value)
+        {
+            return false;
+        }
+        for delimiter in ["\"\"\"", "'''"] {
+            if let Some(remainder) = value.strip_prefix(delimiter)
+                && !contains_multiline_closing(remainder, delimiter)
+            {
+                multiline_delimiter = Some(delimiter);
+                break;
+            }
+        }
     }
-    first_key == Some("schedule") && !label
+    schedule && !label && multiline_delimiter.is_none()
+}
+
+fn contains_multiline_closing(value: &str, delimiter: &str) -> bool {
+    value.match_indices(delimiter).any(|(index, _)| {
+        delimiter == "'''"
+            || value.as_bytes()[..index]
+                .iter()
+                .rev()
+                .take_while(|byte| **byte == b'\\')
+                .count()
+                .is_multiple_of(2)
+    })
+}
+
+fn inline_container_closes(value: &str) -> bool {
+    let mut stack = Vec::new();
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, character) in value.char_indices() {
+        if let Some(active_quote) = quote {
+            if active_quote == '"' && character == '\\' && !escaped {
+                escaped = true;
+                continue;
+            }
+            if character == active_quote && !escaped {
+                quote = None;
+            }
+            escaped = false;
+            continue;
+        }
+        match character {
+            '"' | '\'' => quote = Some(character),
+            '{' => stack.push('}'),
+            '[' => stack.push(']'),
+            '}' | ']' if stack.pop() != Some(character) => return false,
+            '}' | ']' if stack.is_empty() => {
+                let trailing = value[index + character.len_utf8()..].trim_start();
+                return trailing.is_empty() || trailing.starts_with('#');
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 fn resolve_runtime(
@@ -687,11 +756,31 @@ mod tests {
         assert!(declares_only_schedule(
             "schedule = \"unterminated\ntimezone = \"UTC\""
         ));
+        assert!(declares_only_schedule(
+            "timezone = \"UTC\"\nruntime = \"codex\"\nschedule = \"unterminated"
+        ));
+        assert!(declares_only_schedule(
+            "timezone = \"UTC\"\n\"schedule\" = \"unterminated"
+        ));
         assert!(!declares_only_schedule(
             "description = \"\"\"\nschedule = \"not-a-key"
         ));
+        assert!(declares_only_schedule(
+            "description = \"\"\"\nescaped triple: \\\n+\"\"\"\nschedule = \"not-a-key"
+        ));
+        assert!(!declares_only_schedule(
+            r#"description = """
+escaped triple: \"""
+schedule = "not-a-key"#
+        ));
         assert!(!declares_only_schedule(
             "[metadata]\nschedule = \"unterminated"
+        ));
+        assert!(!declares_only_schedule(
+            "metadata = {\nschedule = \"unterminated"
+        ));
+        assert!(!declares_only_schedule(
+            "metadata = [\nschedule = \"unterminated"
         ));
         assert!(!declares_only_schedule(
             "\"schedule=not-trigger\" = \"unterminated"

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -10,10 +10,29 @@ use anyhow::Result;
 use chrono_tz::Tz;
 use cron::Schedule;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 use crate::config::Config;
 
 const WORKFLOW_DIRECTORY: &str = ".factory/workflows";
+
+pub fn scheduled_workflow_fingerprint(
+    expression: &str,
+    timezone: Tz,
+    runtime: &str,
+    timeout: Duration,
+    prompt: &str,
+) -> Result<String> {
+    let definition = serde_json::to_vec(&(
+        expression,
+        timezone.name(),
+        runtime,
+        timeout.as_secs(),
+        timeout.subsec_nanos(),
+        prompt,
+    ))?;
+    Ok(format!("v2:{:x}", Sha256::digest(definition)))
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkflowCatalog {
@@ -764,9 +783,6 @@ mod tests {
         ));
         assert!(!declares_only_schedule(
             "description = \"\"\"\nschedule = \"not-a-key"
-        ));
-        assert!(declares_only_schedule(
-            "description = \"\"\"\nescaped triple: \\\n+\"\"\"\nschedule = \"not-a-key"
         ));
         assert!(!declares_only_schedule(
             r#"description = """

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -612,6 +612,9 @@ fn open_workflow_file(path: &Path) -> std::io::Result<File> {
 fn mark_duplicate_ids(entries: &mut [WorkflowEntry]) {
     let mut groups: HashMap<(PathBuf, String), Vec<usize>> = HashMap::new();
     for (index, entry) in entries.iter().enumerate() {
+        if entry.is_schedule_workflow && !entry.errors.is_empty() {
+            continue;
+        }
         groups
             .entry((entry.repository.clone(), entry.id.clone()))
             .or_default()
@@ -691,6 +694,40 @@ mod tests {
                 .iter()
                 .any(|error| error.contains("duplicate workflow ID"))
         }));
+    }
+
+    #[test]
+    fn invalid_schedule_does_not_poison_ticket_with_the_same_id() {
+        let repository = PathBuf::from("/repo");
+        let mut skipped_schedule = invalid_entry(
+            &repository,
+            Path::new("SAME.md"),
+            "same",
+            "invalid schedule",
+        );
+        skipped_schedule.is_schedule_workflow = true;
+        let ticket = WorkflowEntry {
+            repository: repository.clone(),
+            path: PathBuf::from("same.md"),
+            id: "same".to_owned(),
+            trigger: Some(Trigger::Label("factory:ready".to_owned())),
+            runtime: Some("codex".to_owned()),
+            timeout: Some(Duration::from_secs(60)),
+            prompt: Some("implement".to_owned()),
+            errors: Vec::new(),
+            is_schedule_workflow: false,
+        };
+        let mut entries = vec![skipped_schedule, ticket];
+
+        mark_duplicate_ids(&mut entries);
+
+        assert!(entries[1].errors.is_empty());
+        assert!(
+            !entries[0]
+                .errors
+                .iter()
+                .any(|error| error.contains("duplicate workflow ID"))
+        );
     }
 
     #[cfg(unix)]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -342,6 +342,7 @@ fn load_file(repository: &Path, path: &Path, config: &Config) -> WorkflowEntry {
     let (frontmatter, prompt) = match split_frontmatter(&contents) {
         Ok(parts) => parts,
         Err(error) => {
+            entry.is_schedule_workflow = missing_frontmatter_declares_only_schedule(&contents);
             entry.errors.push(error);
             return entry;
         }
@@ -415,6 +416,31 @@ fn split_frontmatter(contents: &str) -> std::result::Result<(String, String), St
         after_opening[..closing].to_owned(),
         after_opening[prompt_start..].to_owned(),
     ))
+}
+
+fn missing_frontmatter_declares_only_schedule(contents: &str) -> bool {
+    let contents = contents.replace("\r\n", "\n");
+    let Some(after_opening) = contents.strip_prefix("+++\n") else {
+        return false;
+    };
+    let mut frontmatter_prefix = String::new();
+    for line in after_opening.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.contains('=') {
+            frontmatter_prefix.push_str(line);
+            frontmatter_prefix.push('\n');
+        } else {
+            break;
+        }
+    }
+    toml::from_str::<toml::Value>(&frontmatter_prefix)
+        .ok()
+        .and_then(|value| {
+            value
+                .as_table()
+                .map(|table| table.contains_key("schedule") && !table.contains_key("label"))
+        })
+        .unwrap_or(false)
 }
 
 fn declares_only_schedule(frontmatter: &str) -> bool {
@@ -675,6 +701,18 @@ mod tests {
         ));
         assert!(!declares_only_schedule(
             "schedule = \"unterminated\n\"label\" = \"factory:ready\""
+        ));
+        assert!(missing_frontmatter_declares_only_schedule(
+            "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nImplement maintenance.\n"
+        ));
+        assert!(!missing_frontmatter_declares_only_schedule(
+            "+++\nschedule = \"0 9 * * 1\"\nlabel = \"factory:ready\"\nImplement it.\n"
+        ));
+        assert!(!missing_frontmatter_declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\n"
+        ));
+        assert!(!missing_frontmatter_declares_only_schedule(
+            "+++\nschedule = \"0 9 * * 1\"\nruntime = \"\"\"\ncodex\n\"\"\"\nlabel = \"factory:ready\"\nPrompt.\n"
         ));
     }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -30,6 +30,7 @@ pub struct WorkflowEntry {
     pub timeout: Option<Duration>,
     pub prompt: Option<String>,
     pub errors: Vec<String>,
+    pub(crate) is_schedule_workflow: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -244,6 +245,7 @@ fn load_file(repository: &Path, path: &Path, config: &Config) -> WorkflowEntry {
         timeout: None,
         prompt: None,
         errors: Vec::new(),
+        is_schedule_workflow: false,
     };
 
     if !valid_workflow_id(&entry.id) {
@@ -330,6 +332,11 @@ fn load_file(repository: &Path, path: &Path, config: &Config) -> WorkflowEntry {
         entry.prompt = Some(prompt);
     }
 
+    if let Ok(value) = toml::from_str::<toml::Value>(&frontmatter)
+        && let Some(table) = value.as_table()
+    {
+        entry.is_schedule_workflow = table.contains_key("schedule") && !table.contains_key("label");
+    }
     let raw: Frontmatter = match toml::from_str(&frontmatter) {
         Ok(raw) => raw,
         Err(error) => {
@@ -586,6 +593,7 @@ fn invalid_entry(repository: &Path, path: &Path, id: &str, error: &str) -> Workf
         timeout: None,
         prompt: None,
         errors: vec![error.to_owned()],
+        is_schedule_workflow: false,
     }
 }
 

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -524,6 +524,8 @@ fn line_declares_key(line: &str, expected: &str) -> bool {
     let mut brace_depth = 0_u32;
     let mut bracket_depth = 0_u32;
     let mut expecting_value = false;
+    let mut can_start_key = true;
+    let mut container_is_value = false;
     while index < bytes.len() {
         if bytes[index] == b'#' {
             return false;
@@ -548,18 +550,22 @@ fn line_declares_key(line: &str, expected: &str) -> bool {
             }
             if expecting_value {
                 expecting_value = false;
-            } else if index < bytes.len()
-                && brace_depth == 0
-                && bracket_depth == 0
-                && previous_non_whitespace(bytes, quoted_key_start) != Some(b'.')
-                && &line[start..index] == expected
-                && bytes[index + 1..]
+                can_start_key = true;
+            } else if can_start_key && index < bytes.len() {
+                let followed_by_equal = bytes[index + 1..]
                     .iter()
                     .copied()
                     .find(|byte| !byte.is_ascii_whitespace())
-                    == Some(b'=')
-            {
-                return true;
+                    == Some(b'=');
+                let is_top_level_key = brace_depth == 0
+                    && bracket_depth == 0
+                    && previous_non_whitespace(bytes, quoted_key_start) != Some(b'.');
+                if is_top_level_key && &line[start..index] == expected && followed_by_equal {
+                    return true;
+                }
+                if is_top_level_key && !followed_by_equal {
+                    can_start_key = false;
+                }
             }
             index = index.saturating_add(1);
             continue;
@@ -574,32 +580,60 @@ fn line_declares_key(line: &str, expected: &str) -> bool {
             }
             if expecting_value {
                 expecting_value = false;
-            } else if brace_depth == 0
-                && bracket_depth == 0
-                && previous_non_whitespace(bytes, start) != Some(b'.')
-                && &line[start..index] == expected
-                && bytes[index..]
+                can_start_key = false;
+            } else if can_start_key {
+                let followed_by_equal = bytes[index..]
                     .iter()
                     .copied()
                     .find(|byte| !byte.is_ascii_whitespace())
-                    == Some(b'=')
-            {
-                return true;
+                    == Some(b'=');
+                let is_top_level_key = brace_depth == 0
+                    && bracket_depth == 0
+                    && previous_non_whitespace(bytes, start) != Some(b'.');
+                if is_top_level_key && &line[start..index] == expected && followed_by_equal {
+                    return true;
+                }
+                if is_top_level_key && !followed_by_equal {
+                    can_start_key = false;
+                }
             }
             continue;
         }
         match bytes[index] {
-            b'=' if brace_depth == 0 && bracket_depth == 0 => expecting_value = true,
+            b'=' if brace_depth == 0 && bracket_depth == 0 => {
+                expecting_value = true;
+                can_start_key = false;
+            }
             b'{' => {
+                if brace_depth == 0 && bracket_depth == 0 {
+                    container_is_value = expecting_value;
+                }
                 brace_depth = brace_depth.saturating_add(1);
                 expecting_value = false;
+                can_start_key = false;
             }
-            b'}' => brace_depth = brace_depth.saturating_sub(1),
+            b'}' => {
+                brace_depth = brace_depth.saturating_sub(1);
+                if brace_depth == 0 && bracket_depth == 0 && container_is_value {
+                    can_start_key = true;
+                    container_is_value = false;
+                }
+            }
             b'[' => {
+                if brace_depth == 0 && bracket_depth == 0 {
+                    container_is_value = expecting_value;
+                }
                 bracket_depth = bracket_depth.saturating_add(1);
                 expecting_value = false;
+                can_start_key = false;
             }
-            b']' => bracket_depth = bracket_depth.saturating_sub(1),
+            b']' => {
+                bracket_depth = bracket_depth.saturating_sub(1);
+                if brace_depth == 0 && bracket_depth == 0 && container_is_value {
+                    can_start_key = true;
+                    container_is_value = false;
+                }
+            }
             _ => {}
         }
         index += 1;
@@ -936,6 +970,31 @@ schedule = "not-a-key"#
         ));
         assert!(declares_only_schedule(
             "schedule = \"0 9 * * 1\"\ndescription = label = ???"
+        ));
+        assert!(!declares_only_schedule("description = run schedule = ???"));
+        assert!(declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\ndescription = run label = ???"
+        ));
+        for scalar_tail in ["run {}", "run []", "run }"] {
+            assert!(!declares_only_schedule(&format!(
+                "description = {scalar_tail} schedule = ???"
+            )));
+            assert!(declares_only_schedule(&format!(
+                "schedule = \"0 9 * * 1\"\ndescription = {scalar_tail} label = ???"
+            )));
+        }
+        for completed_value in ["\"done\"", "{}", "[]"] {
+            assert!(!line_declares_key(
+                &format!("description = {completed_value} run schedule = ???"),
+                "schedule",
+            ));
+            assert!(!line_declares_key(
+                &format!("description = {completed_value} run label = ???"),
+                "label",
+            ));
+        }
+        assert!(declares_only_schedule(
+            "schedule = \"0 9 * * 1\"\ndescription = \"done\" run label = ???"
         ));
         assert!(missing_frontmatter_declares_only_schedule(
             "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nImplement maintenance.\n"

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -443,23 +443,38 @@ fn missing_frontmatter_declares_only_schedule(contents: &str) -> bool {
         return false;
     };
     let mut frontmatter_prefix = String::new();
+    let mut multiline_delimiter = None;
     for line in after_opening.lines() {
         let trimmed = line.trim_start();
-        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.contains('=') {
+        if let Some(delimiter) = multiline_delimiter {
             frontmatter_prefix.push_str(line);
             frontmatter_prefix.push('\n');
-        } else {
+            if contains_multiline_closing(trimmed, delimiter) {
+                multiline_delimiter = None;
+            }
+            continue;
+        }
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            frontmatter_prefix.push_str(line);
+            frontmatter_prefix.push('\n');
+            continue;
+        }
+        let Some((_, value)) = trimmed.split_once('=') else {
             break;
+        };
+        frontmatter_prefix.push_str(line);
+        frontmatter_prefix.push('\n');
+        let value = value.trim_start();
+        for delimiter in ["\"\"\"", "'''"] {
+            if let Some(remainder) = value.strip_prefix(delimiter)
+                && !contains_multiline_closing(remainder, delimiter)
+            {
+                multiline_delimiter = Some(delimiter);
+                break;
+            }
         }
     }
-    toml::from_str::<toml::Value>(&frontmatter_prefix)
-        .ok()
-        .and_then(|value| {
-            value
-                .as_table()
-                .map(|table| table.contains_key("schedule") && !table.contains_key("label"))
-        })
-        .unwrap_or(false)
+    declares_only_schedule(&frontmatter_prefix)
 }
 
 fn declares_only_schedule(frontmatter: &str) -> bool {
@@ -809,6 +824,18 @@ schedule = "not-a-key"#
         ));
         assert!(missing_frontmatter_declares_only_schedule(
             "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nImplement maintenance.\n"
+        ));
+        assert!(missing_frontmatter_declares_only_schedule(
+            "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nCheck x = y before editing.\n"
+        ));
+        assert!(missing_frontmatter_declares_only_schedule(
+            "+++\nschedule = \"0 9 * * 1\"\ntimeout = O(n) before pruning.\n"
+        ));
+        assert!(missing_frontmatter_declares_only_schedule(
+            "+++\nschedule = \"0 9 * * 1\"\nruntime = \"\"\"\ncodex\n\"\"\"\nPrompt.\n"
+        ));
+        assert!(!missing_frontmatter_declares_only_schedule(
+            "+++\nschedule = \"0 9 * * 1\"\nsurprise = true\nlabel = \"factory:ready\"\nPrompt.\n"
         ));
         assert!(!missing_frontmatter_declares_only_schedule(
             "+++\nschedule = \"0 9 * * 1\"\nlabel = \"factory:ready\"\nImplement it.\n"

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -72,6 +72,28 @@ impl WorkflowCatalog {
             .filter(|entry| !entry.errors.is_empty())
             .count()
     }
+
+    pub fn invalid_scheduled_entries(&self) -> impl Iterator<Item = &WorkflowEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| !entry.errors.is_empty() && entry.is_schedule_workflow)
+    }
+
+    pub fn validate_ticket_workflows(&self) -> Result<()> {
+        let errors = self
+            .entries
+            .iter()
+            .filter(|entry| !entry.errors.is_empty() && !entry.is_schedule_workflow)
+            .map(|entry| format!("{}: {}", entry.path.display(), entry.errors.join("; ")))
+            .collect::<Vec<_>>();
+        if !errors.is_empty() {
+            anyhow::bail!(
+                "Factory cannot start with invalid ticket workflows:\n{}",
+                errors.join("\n")
+            );
+        }
+        Ok(())
+    }
 }
 
 impl fmt::Display for WorkflowCatalog {

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -1245,6 +1245,11 @@ fn invalid_label_workflow_fails_daemon_startup() {
         "+++\nlabel = \"factory:ready\"\ntimeout = \"0s\"\n+++\n\nINVALID TICKET WORKFLOW\n",
     )
     .unwrap();
+    fs::write(
+        fixture.config.repositories[0].join(".factory/workflows/invalid-schedule.md"),
+        "+++\nschedule = \"eventually\"\ntimezone = \"UTC\"\n+++\n\nINVALID SCHEDULE\n",
+    )
+    .unwrap();
     let search_path = std::env::join_paths(
         std::iter::once(fixture.gh.parent().unwrap().to_path_buf()).chain(
             std::env::var_os("PATH")
@@ -1269,11 +1274,15 @@ fn invalid_label_workflow_fails_daemon_startup() {
         .assert()
         .failure()
         .stderr(predicates::str::contains(
+            "Factory skipped invalid scheduled workflow",
+        ))
+        .stderr(predicates::str::contains(
             "Factory cannot start with invalid ticket workflows",
         ))
         .stderr(predicates::str::contains(
             "timeout must be greater than zero",
         ));
+    assert!(!fixture.ledger_path.exists());
 }
 
 #[test]

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -1168,11 +1168,17 @@ async fn invalid_scheduled_workflow_does_not_block_valid_ticket_workflow() {
         "+++\nschedule = \"eventually\"\ntimezone = \"UTC\"\n+++\n\nINVALID SCHEDULE\n",
     )
     .unwrap();
+    fs::write(
+        fixture.config.repositories[0]
+            .join(".factory/workflows/invalid-schedule-frontmatter.md"),
+        "+++\nschedule = \"* * * * *\"\ntimezone = \"UTC\"\nunknown = true\n+++\n\nINVALID SCHEDULE FRONTMATTER\n",
+    )
+    .unwrap();
     assert_eq!(
         WorkflowCatalog::load(&fixture.config)
             .unwrap()
             .invalid_count(),
-        1
+        2
     );
     fixture.open_gate();
     let search_path = std::env::join_paths(
@@ -1213,6 +1219,84 @@ async fn invalid_scheduled_workflow_does_not_block_valid_ticket_workflow() {
     )
     .unwrap();
     assert!(daemon.wait().unwrap().success());
+}
+
+#[test]
+fn invalid_label_workflow_fails_daemon_startup() {
+    let fixture = Fixture::new(&[vec![issue(32)]], 1, 1);
+    fs::write(
+        fixture.config.repositories[0].join(".factory/workflows/implement-ready-ticket.md"),
+        "+++\nlabel = \"factory:ready\"\ntimeout = \"0s\"\n+++\n\nINVALID TICKET WORKFLOW\n",
+    )
+    .unwrap();
+    let search_path = std::env::join_paths(
+        std::iter::once(fixture.gh.parent().unwrap().to_path_buf()).chain(
+            std::env::var_os("PATH")
+                .as_deref()
+                .map(std::env::split_paths)
+                .into_iter()
+                .flatten(),
+        ),
+    )
+    .unwrap();
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            fixture.ledger_path.parent().unwrap().to_str().unwrap(),
+        ])
+        .env("PATH", search_path)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "Factory cannot start with invalid ticket workflows",
+        ))
+        .stderr(predicates::str::contains(
+            "timeout must be greater than zero",
+        ));
+}
+
+#[test]
+fn ambiguous_schedule_and_label_workflow_fails_daemon_startup() {
+    let fixture = Fixture::new(&[vec![issue(33)]], 1, 1);
+    fs::write(
+        fixture.config.repositories[0].join(".factory/workflows/ambiguous.md"),
+        "+++\nschedule = \"* * * * *\"\ntimezone = \"UTC\"\nlabel = \"factory:ready\"\n+++\n\nAMBIGUOUS WORKFLOW\n",
+    )
+    .unwrap();
+    let search_path = std::env::join_paths(
+        std::iter::once(fixture.gh.parent().unwrap().to_path_buf()).chain(
+            std::env::var_os("PATH")
+                .as_deref()
+                .map(std::env::split_paths)
+                .into_iter()
+                .flatten(),
+        ),
+    )
+    .unwrap();
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            fixture.ledger_path.parent().unwrap().to_str().unwrap(),
+        ])
+        .env("PATH", search_path)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "Factory cannot start with invalid ticket workflows",
+        ))
+        .stderr(predicates::str::contains(
+            "workflow must declare exactly one trigger",
+        ));
 }
 
 #[tokio::test]

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -14,6 +14,7 @@ use factory::github::GitHubClient;
 use factory::runtime::CodexRuntime;
 use factory::storage::{Ledger, TaskIdentity, TaskState};
 use factory::workflow::WorkflowCatalog;
+use rusqlite::Connection;
 use tokio_util::sync::CancellationToken;
 
 struct Fixture {
@@ -92,6 +93,11 @@ if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
 fi
 if [ "$1" = "repo" ]; then cat .gh-name; exit 0; fi
 if [ "$1" = "api" ]; then
+  if ! mkdir "$0.api-active" 2>/dev/null; then touch "$0.api-concurrent"; fi
+  touch "$0.api-started"
+  if [ -f "$0.api-block" ]; then
+    while [ ! -f "$0.api-release" ]; do sleep 0.02; done
+  fi
   endpoint="$4"
   case "$endpoint" in
     */comments*)
@@ -100,6 +106,7 @@ if [ "$1" = "api" ]; then
       ;;
     *) cat .issues.json ;;
   esac
+  rmdir "$0.api-active" 2>/dev/null || true
   exit 0
 fi
 exit 64
@@ -1381,6 +1388,50 @@ async fn later_schedule_prompt_includes_previous_successful_run() {
     let prompt = fs::read_to_string(fixture.started_slots()[1].join("prompt")).unwrap();
     assert!(prompt.contains("Previous successful run: 20"));
     assert!(!prompt.contains("Previous successful run: none"));
+}
+
+#[tokio::test]
+async fn blocked_github_poll_does_not_delay_schedule_ticks_or_start_another_poll() {
+    let mut fixture = Fixture::new(&[vec![]], 1, 1);
+    fixture.add_scheduled_workflow();
+    fixture.open_gate();
+    let api_block = PathBuf::from(format!("{}.api-block", fixture.gh.display()));
+    let api_started = PathBuf::from(format!("{}.api-started", fixture.gh.display()));
+    let api_release = PathBuf::from(format!("{}.api-release", fixture.gh.display()));
+    let api_concurrent = PathBuf::from(format!("{}.api-concurrent", fixture.gh.display()));
+    fs::write(&api_block, "block").unwrap();
+    let cancellation = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let cancellation = cancellation.clone();
+        tokio::spawn(async move { daemon.run(cancellation).await })
+    };
+    wait_for(|| api_started.exists()).await;
+    Connection::open(&fixture.ledger_path)
+        .unwrap()
+        .execute(
+            "UPDATE schedule_cursors
+             SET next_due_at = (CAST(strftime('%s', 'now') AS INTEGER) * 1000) - 100",
+            [],
+        )
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while fixture.started_slots().is_empty() {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("scheduled task did not start while GitHub polling was blocked");
+    assert!(api_block.exists());
+    assert!(!api_release.exists());
+    assert!(!api_concurrent.exists());
+
+    fs::write(api_release, "release").unwrap();
+    cancellation.cancel();
+    running.await.unwrap().unwrap();
+    assert_eq!(fixture.started_slots().len(), 1);
 }
 
 #[tokio::test]

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -184,6 +184,15 @@ exit 0
         fs::write(self.runtime_dir.join("gate"), "go").unwrap();
     }
 
+    fn add_scheduled_workflow(&mut self) {
+        fs::write(
+            self.config.repositories[0].join(".factory/workflows/scheduled-maintenance.md"),
+            "+++\nschedule = \"0 0 1 1 *\"\ntimezone = \"UTC\"\nruntime = \"codex\"\ntimeout = \"10s\"\n+++\n\nSCHEDULED MAINTENANCE WORKFLOW\n",
+        )
+        .unwrap();
+        self.catalog = WorkflowCatalog::load(&self.config).unwrap();
+    }
+
     fn started_slots(&self) -> Vec<PathBuf> {
         let Ok(entries) = fs::read_dir(&self.runtime_dir) else {
             return Vec::new();
@@ -1048,7 +1057,8 @@ async fn polling_error_cancels_and_drains_an_active_run() {
 
 #[tokio::test]
 async fn scheduled_tasks_use_the_same_worker_and_run_history() {
-    let fixture = Fixture::new(&[vec![]], 1, 1);
+    let mut fixture = Fixture::new(&[vec![]], 1, 1);
+    fixture.add_scheduled_workflow();
     let repository = &fixture.config.repositories[0];
     for args in [
         vec!["init", "-b", "main"],
@@ -1082,7 +1092,7 @@ async fn scheduled_tasks_use_the_same_worker_and_run_history() {
         .enqueue_with_payload(
             &TaskIdentity::scheduled(
                 "example/repo-0",
-                "implement-ready-ticket",
+                "scheduled-maintenance",
                 "2026-07-18T12:00:00Z",
             )
             .unwrap(),
@@ -1121,13 +1131,14 @@ async fn scheduled_tasks_use_the_same_worker_and_run_history() {
 
 #[tokio::test]
 async fn failing_scheduled_task_does_not_block_ticket_polling() {
-    let fixture = Fixture::new(&[vec![issue(29)]], 1, 1);
+    let mut fixture = Fixture::new(&[vec![issue(29)]], 1, 1);
+    fixture.add_scheduled_workflow();
     Ledger::open(&fixture.ledger_path)
         .unwrap()
         .enqueue(
             &TaskIdentity::scheduled(
                 "example/repo-0",
-                "implement-ready-ticket",
+                "scheduled-maintenance",
                 "2026-07-18T12:00:00Z",
             )
             .unwrap(),
@@ -1174,11 +1185,16 @@ async fn invalid_scheduled_workflow_does_not_block_valid_ticket_workflow() {
         "+++\nschedule = \"* * * * *\"\ntimezone = \"UTC\"\nunknown = true\n+++\n\nINVALID SCHEDULE FRONTMATTER\n",
     )
     .unwrap();
+    fs::write(
+        fixture.config.repositories[0].join(".factory/workflows/malformed-schedule.md"),
+        "+++\nschedule = \"unterminated\ntimezone = \"UTC\"\n+++\n\nMALFORMED SCHEDULE\n",
+    )
+    .unwrap();
     assert_eq!(
         WorkflowCatalog::load(&fixture.config)
             .unwrap()
             .invalid_count(),
-        2
+        3
     );
     fixture.open_gate();
     let search_path = std::env::join_paths(
@@ -1301,13 +1317,14 @@ fn ambiguous_schedule_and_label_workflow_fails_daemon_startup() {
 
 #[tokio::test]
 async fn later_schedule_prompt_includes_previous_successful_run() {
-    let fixture = Fixture::new(&[vec![]], 1, 1);
+    let mut fixture = Fixture::new(&[vec![]], 1, 1);
+    fixture.add_scheduled_workflow();
     let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
     ledger
         .enqueue_with_payload(
             &TaskIdentity::scheduled(
                 "example/repo-0",
-                "implement-ready-ticket",
+                "scheduled-maintenance",
                 "2026-07-18T12:00:00Z",
             )
             .unwrap(),
@@ -1335,7 +1352,7 @@ async fn later_schedule_prompt_includes_previous_successful_run() {
         .enqueue_with_payload(
             &TaskIdentity::scheduled(
                 "example/repo-0",
-                "implement-ready-ticket",
+                "scheduled-maintenance",
                 "2026-07-18T12:01:00Z",
             )
             .unwrap(),
@@ -1359,13 +1376,14 @@ async fn later_schedule_prompt_includes_previous_successful_run() {
 
 #[tokio::test]
 async fn scheduled_and_ticket_tasks_share_concurrency_capacity() {
-    let fixture = Fixture::new(&[vec![issue(30)]], 2, 2);
+    let mut fixture = Fixture::new(&[vec![issue(30)]], 2, 2);
+    fixture.add_scheduled_workflow();
     Ledger::open(&fixture.ledger_path)
         .unwrap()
         .enqueue_with_payload(
             &TaskIdentity::scheduled(
                 "example/repo-0",
-                "implement-ready-ticket",
+                "scheduled-maintenance",
                 "2026-07-18T12:00:00Z",
             )
             .unwrap(),

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -13,7 +13,7 @@ use factory::daemon::FactoryDaemon;
 use factory::github::GitHubClient;
 use factory::runtime::CodexRuntime;
 use factory::storage::{Ledger, TaskIdentity, TaskState};
-use factory::workflow::WorkflowCatalog;
+use factory::workflow::{Trigger, WorkflowCatalog, scheduled_workflow_fingerprint};
 use rusqlite::Connection;
 use tokio_util::sync::CancellationToken;
 
@@ -198,6 +198,38 @@ exit 0
         )
         .unwrap();
         self.catalog = WorkflowCatalog::load(&self.config).unwrap();
+    }
+
+    fn scheduled_fingerprint(&self) -> String {
+        let workflow = self
+            .catalog
+            .entries
+            .iter()
+            .find(|entry| entry.id == "scheduled-maintenance")
+            .unwrap();
+        let Trigger::Schedule {
+            expression,
+            timezone,
+        } = workflow.trigger.as_ref().unwrap()
+        else {
+            panic!("scheduled maintenance workflow has the wrong trigger");
+        };
+        scheduled_workflow_fingerprint(
+            expression,
+            *timezone,
+            workflow.runtime.as_deref().unwrap(),
+            workflow.timeout.unwrap(),
+            workflow.prompt.as_deref().unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn scheduled_payload(&self, scheduled_at: &str) -> String {
+        serde_json::json!({
+            "scheduled_at": scheduled_at,
+            "schedule_fingerprint": self.scheduled_fingerprint(),
+        })
+        .to_string()
     }
 
     fn started_slots(&self) -> Vec<PathBuf> {
@@ -1103,7 +1135,7 @@ async fn scheduled_tasks_use_the_same_worker_and_run_history() {
                 "2026-07-18T12:00:00Z",
             )
             .unwrap(),
-            Some(r#"{"scheduled_at":"2026-07-18T12:00:00Z"}"#),
+            Some(&fixture.scheduled_payload("2026-07-18T12:00:00Z")),
         )
         .unwrap();
     drop(ledger);
@@ -1142,13 +1174,19 @@ async fn failing_scheduled_task_does_not_block_ticket_polling() {
     fixture.add_scheduled_workflow();
     Ledger::open(&fixture.ledger_path)
         .unwrap()
-        .enqueue(
+        .enqueue_with_payload(
             &TaskIdentity::scheduled(
                 "example/repo-0",
                 "scheduled-maintenance",
                 "2026-07-18T12:00:00Z",
             )
             .unwrap(),
+            Some(
+                &serde_json::json!({
+                    "schedule_fingerprint": fixture.scheduled_fingerprint(),
+                })
+                .to_string(),
+            ),
         )
         .unwrap();
     fixture.open_gate();
@@ -1344,7 +1382,7 @@ async fn later_schedule_prompt_includes_previous_successful_run() {
                 "2026-07-18T12:00:00Z",
             )
             .unwrap(),
-            Some(r#"{"scheduled_at":"2026-07-18T12:00:00Z"}"#),
+            Some(&fixture.scheduled_payload("2026-07-18T12:00:00Z")),
         )
         .unwrap();
     drop(ledger);
@@ -1372,7 +1410,7 @@ async fn later_schedule_prompt_includes_previous_successful_run() {
                 "2026-07-18T12:01:00Z",
             )
             .unwrap(),
-            Some(r#"{"scheduled_at":"2026-07-18T12:01:00Z"}"#),
+            Some(&fixture.scheduled_payload("2026-07-18T12:01:00Z")),
         )
         .unwrap();
     wait_for(|| fixture.started_slots().len() == 2).await;
@@ -1447,7 +1485,7 @@ async fn scheduled_and_ticket_tasks_share_concurrency_capacity() {
                 "2026-07-18T12:00:00Z",
             )
             .unwrap(),
-            Some(r#"{"scheduled_at":"2026-07-18T12:00:00Z"}"#),
+            Some(&fixture.scheduled_payload("2026-07-18T12:00:00Z")),
         )
         .unwrap();
     let cancellation = CancellationToken::new();

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -1047,10 +1047,83 @@ async fn polling_error_cancels_and_drains_an_active_run() {
 }
 
 #[tokio::test]
-async fn scheduled_tasks_are_not_claimed_by_ticket_workers() {
+async fn scheduled_tasks_use_the_same_worker_and_run_history() {
     let fixture = Fixture::new(&[vec![]], 1, 1);
+    let repository = &fixture.config.repositories[0];
+    for args in [
+        vec!["init", "-b", "main"],
+        vec!["config", "user.email", "factory@example.test"],
+        vec!["config", "user.name", "Factory Test"],
+        vec!["add", "."],
+        vec!["commit", "-m", "scheduled fixture"],
+    ] {
+        assert!(
+            Command::new("git")
+                .args(args)
+                .current_dir(repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+    let inspected_commit = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repository)
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_owned();
     let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
     ledger
+        .enqueue_with_payload(
+            &TaskIdentity::scheduled(
+                "example/repo-0",
+                "implement-ready-ticket",
+                "2026-07-18T12:00:00Z",
+            )
+            .unwrap(),
+            Some(r#"{"scheduled_at":"2026-07-18T12:00:00Z"}"#),
+        )
+        .unwrap();
+    drop(ledger);
+    fixture.open_gate();
+    let cancellation = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let token = cancellation.clone();
+        tokio::spawn(async move { daemon.run(token).await })
+    };
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
+    })
+    .await;
+    cancellation.cancel();
+    running.await.unwrap().unwrap();
+
+    let ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    let tasks = ledger.tasks().unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].state, TaskState::Succeeded);
+    assert_eq!(ledger.runs_for_task(tasks[0].id).unwrap().len(), 1);
+    let prompt = fs::read_to_string(fixture.started_slots()[0].join("prompt")).unwrap();
+    assert!(prompt.contains("Scheduled occurrence: 2026-07-18T12:00:00Z"));
+    assert!(prompt.contains("You may use the authenticated gh CLI"));
+    assert!(prompt.contains("Factory does not create tickets for you"));
+    assert!(prompt.contains(&format!("Inspected repository commit: {inspected_commit}")));
+}
+
+#[tokio::test]
+async fn failing_scheduled_task_does_not_block_ticket_polling() {
+    let fixture = Fixture::new(&[vec![issue(29)]], 1, 1);
+    Ledger::open(&fixture.ledger_path)
+        .unwrap()
         .enqueue(
             &TaskIdentity::scheduled(
                 "example/repo-0",
@@ -1060,20 +1133,192 @@ async fn scheduled_tasks_are_not_claimed_by_ticket_workers() {
             .unwrap(),
         )
         .unwrap();
-    drop(ledger);
+    fixture.open_gate();
     let cancellation = CancellationToken::new();
     let daemon = Arc::new(fixture.daemon());
     let running = {
         let daemon = Arc::clone(&daemon);
-        let token = cancellation.clone();
-        tokio::spawn(async move { daemon.run(token).await })
+        let cancellation = cancellation.clone();
+        tokio::spawn(async move { daemon.run(cancellation).await })
     };
-    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| {
+                tasks.len() == 2
+                    && tasks
+                        .iter()
+                        .any(|task| task.kind == "scheduled" && task.state == TaskState::Failed)
+                    && tasks
+                        .iter()
+                        .any(|task| task.kind == "ticket" && task.state == TaskState::Succeeded)
+            })
+    })
+    .await;
+    cancellation.cancel();
+    running.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn invalid_scheduled_workflow_does_not_block_valid_ticket_workflow() {
+    let fixture = Fixture::new(&[vec![issue(31)]], 1, 1);
+    fs::write(
+        fixture.config.repositories[0].join(".factory/workflows/invalid-schedule.md"),
+        "+++\nschedule = \"eventually\"\ntimezone = \"UTC\"\n+++\n\nINVALID SCHEDULE\n",
+    )
+    .unwrap();
+    assert_eq!(
+        WorkflowCatalog::load(&fixture.config)
+            .unwrap()
+            .invalid_count(),
+        1
+    );
+    fixture.open_gate();
+    let search_path = std::env::join_paths(
+        std::iter::once(fixture.gh.parent().unwrap().to_path_buf()).chain(
+            std::env::var_os("PATH")
+                .as_deref()
+                .map(std::env::split_paths)
+                .into_iter()
+                .flatten(),
+        ),
+    )
+    .unwrap();
+    let mut daemon = Command::new(env!("CARGO_BIN_EXE_factory"));
+    daemon
+        .args([
+            "run",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            fixture.ledger_path.parent().unwrap().to_str().unwrap(),
+        ])
+        .env("PATH", search_path);
+    let mut daemon = daemon.spawn().unwrap();
+
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| {
+                tasks.len() == 1
+                    && tasks[0].kind == "ticket"
+                    && tasks[0].state == TaskState::Succeeded
+            })
+    })
+    .await;
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(i32::try_from(daemon.id()).unwrap()),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .unwrap();
+    assert!(daemon.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn later_schedule_prompt_includes_previous_successful_run() {
+    let fixture = Fixture::new(&[vec![]], 1, 1);
+    let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
+    ledger
+        .enqueue_with_payload(
+            &TaskIdentity::scheduled(
+                "example/repo-0",
+                "implement-ready-ticket",
+                "2026-07-18T12:00:00Z",
+            )
+            .unwrap(),
+            Some(r#"{"scheduled_at":"2026-07-18T12:00:00Z"}"#),
+        )
+        .unwrap();
+    drop(ledger);
+    fixture.open_gate();
+    let cancellation = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let cancellation = cancellation.clone();
+        tokio::spawn(async move { daemon.run(cancellation).await })
+    };
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks[0].state == TaskState::Succeeded)
+    })
+    .await;
+
+    Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .enqueue_with_payload(
+            &TaskIdentity::scheduled(
+                "example/repo-0",
+                "implement-ready-ticket",
+                "2026-07-18T12:01:00Z",
+            )
+            .unwrap(),
+            Some(r#"{"scheduled_at":"2026-07-18T12:01:00Z"}"#),
+        )
+        .unwrap();
+    wait_for(|| fixture.started_slots().len() == 2).await;
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks.len() == 2 && tasks[1].state == TaskState::Succeeded)
+    })
+    .await;
     cancellation.cancel();
     running.await.unwrap().unwrap();
 
-    let tasks = Ledger::open(&fixture.ledger_path).unwrap().tasks().unwrap();
-    assert_eq!(tasks.len(), 1);
-    assert_eq!(tasks[0].state, TaskState::Queued);
-    assert!(fixture.started_slots().is_empty());
+    let prompt = fs::read_to_string(fixture.started_slots()[1].join("prompt")).unwrap();
+    assert!(prompt.contains("Previous successful run: 20"));
+    assert!(!prompt.contains("Previous successful run: none"));
+}
+
+#[tokio::test]
+async fn scheduled_and_ticket_tasks_share_concurrency_capacity() {
+    let fixture = Fixture::new(&[vec![issue(30)]], 2, 2);
+    Ledger::open(&fixture.ledger_path)
+        .unwrap()
+        .enqueue_with_payload(
+            &TaskIdentity::scheduled(
+                "example/repo-0",
+                "implement-ready-ticket",
+                "2026-07-18T12:00:00Z",
+            )
+            .unwrap(),
+            Some(r#"{"scheduled_at":"2026-07-18T12:00:00Z"}"#),
+        )
+        .unwrap();
+    let cancellation = CancellationToken::new();
+    let daemon = Arc::new(fixture.daemon());
+    let running = {
+        let daemon = Arc::clone(&daemon);
+        let cancellation = cancellation.clone();
+        tokio::spawn(async move { daemon.run(cancellation).await })
+    };
+
+    wait_for(|| fixture.started_slots().len() == 2).await;
+    let prompts = fixture
+        .started_slots()
+        .iter()
+        .map(|slot| fs::read_to_string(slot.join("prompt")).unwrap())
+        .collect::<Vec<_>>();
+    assert!(
+        prompts
+            .iter()
+            .any(|prompt| prompt.contains("Scheduled occurrence"))
+    );
+    assert!(
+        prompts
+            .iter()
+            .any(|prompt| prompt.contains("Current ticket and discussion"))
+    );
+    fixture.open_gate();
+    wait_for(|| {
+        Ledger::open(&fixture.ledger_path)
+            .and_then(|ledger| ledger.tasks())
+            .is_ok_and(|tasks| tasks.iter().all(|task| task.state == TaskState::Succeeded))
+    })
+    .await;
+    cancellation.cancel();
+    running.await.unwrap().unwrap();
 }

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -222,7 +222,7 @@ fn factory_run_once_skips_invalid_schedule_and_polls_tickets() {
     let fixture = Fixture::new(1);
     fs::write(
         fixture.repositories[0].join(".factory/workflows/invalid-schedule.md"),
-        "+++\nschedule = \"eventually\"\ntimezone = \"UTC\"\n+++\n\nINVALID SCHEDULE\n",
+        "+++\nschedule = \"unterminated\ntimezone = \"UTC\"\n+++\n\nINVALID SCHEDULE\n",
     )
     .unwrap();
     write_issues(

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -215,6 +215,7 @@ fn factory_run_once_fails_for_invalid_ticket_workflow() {
         .stderr(predicates::str::contains(
             "timeout must be greater than zero",
         ));
+    assert!(!data.exists());
 }
 
 #[test]

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -181,6 +181,80 @@ fn factory_run_once_persists_a_task_without_launching_codex() {
     );
 }
 
+#[test]
+fn factory_run_once_fails_for_invalid_ticket_workflow() {
+    let fixture = Fixture::new(1);
+    fs::write(
+        fixture.repositories[0].join(".factory/workflows/implement-ready-ticket.md"),
+        "+++\nlabel = \"factory:ready\"\ntimeout = \"0s\"\n+++\n\nINVALID TICKET WORKFLOW\n",
+    )
+    .unwrap();
+    let data = fixture._temp.path().join("data");
+    let path = format!(
+        "{}:{}",
+        fixture._temp.path().display(),
+        std::env::var("PATH").unwrap()
+    );
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            data.to_str().unwrap(),
+        ])
+        .env("PATH", path)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "Factory cannot start with invalid ticket workflows",
+        ))
+        .stderr(predicates::str::contains(
+            "timeout must be greater than zero",
+        ));
+}
+
+#[test]
+fn factory_run_once_skips_invalid_schedule_and_polls_tickets() {
+    let fixture = Fixture::new(1);
+    fs::write(
+        fixture.repositories[0].join(".factory/workflows/invalid-schedule.md"),
+        "+++\nschedule = \"eventually\"\ntimezone = \"UTC\"\n+++\n\nINVALID SCHEDULE\n",
+    )
+    .unwrap();
+    write_issues(
+        &fixture.repositories[0],
+        &[vec![issue(10, "revision-1", &["factory:ready"])]],
+    );
+    let data = fixture._temp.path().join("data");
+    let path = format!(
+        "{}:{}",
+        fixture._temp.path().display(),
+        std::env::var("PATH").unwrap()
+    );
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            data.to_str().unwrap(),
+        ])
+        .env("PATH", path)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("tasks_created=1"))
+        .stderr(predicates::str::contains(
+            "Factory skipped invalid scheduled workflow",
+        ));
+}
+
 #[tokio::test]
 async fn no_matches_creates_no_tasks() {
     let fixture = Fixture::new(1);

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -114,7 +114,8 @@ fn ticket_and_schedule_identities_deduplicate_exact_triggers() {
 #[test]
 fn schedule_cursor_atomically_enqueues_advances_and_skips_downtime() {
     let temp = tempfile::tempdir().unwrap();
-    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
     ledger
         .register_daemon_owner("schedule-storage-owner", std::process::id())
         .unwrap();
@@ -164,6 +165,31 @@ fn schedule_cursor_atomically_enqueues_advances_and_skips_downtime() {
         )
         .unwrap();
     assert_eq!(restart.next_due_at, 120_000);
+    Connection::open(&path)
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+            ["schedule-storage-owner"],
+        )
+        .unwrap();
+    assert!(
+        ledger
+            .heartbeat_daemon_owner("schedule-storage-owner")
+            .unwrap_err()
+            .to_string()
+            .contains("lease expired")
+    );
+    let after_sleep = ledger
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "* * * * *|UTC",
+            660_000,
+            630_000,
+            "schedule-storage-owner",
+        )
+        .unwrap();
+    assert_eq!(after_sleep.next_due_at, 660_000);
     ledger
         .remove_daemon_owner("schedule-storage-owner")
         .unwrap();

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -42,6 +42,42 @@ fn initializes_in_data_directory_and_persists_across_reopen() {
 }
 
 #[test]
+fn concurrent_first_open_converges_on_one_complete_schema() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let barrier = Arc::new(Barrier::new(9));
+    let handles = (0..8)
+        .map(|_| {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                Ledger::open(&path)
+            })
+        })
+        .collect::<Vec<_>>();
+    barrier.wait();
+    for handle in handles {
+        handle.join().unwrap().unwrap();
+    }
+
+    let connection = rusqlite::Connection::open(path).unwrap();
+    let version: i64 = connection
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .unwrap();
+    assert_eq!(version, 5);
+    let schedule_tables: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_schema
+             WHERE type = 'table' AND name IN ('schedule_cursors', 'schedule_owners')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(schedule_tables, 2);
+}
+
+#[test]
 fn ticket_and_schedule_identities_deduplicate_exact_triggers() {
     let temp = tempfile::tempdir().unwrap();
     let mut ledger = Ledger::open(temp.path().join("ledger.db").as_path()).unwrap();

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -113,6 +113,61 @@ fn ticket_and_schedule_identities_deduplicate_exact_triggers() {
 }
 
 #[test]
+fn previous_schedule_success_excludes_ticket_runs_for_the_same_workflow() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    let scheduled = ledger
+        .enqueue(
+            &TaskIdentity::scheduled(
+                "owainlewis/factory",
+                "shared-workflow",
+                "2026-07-20T09:00:00Z",
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .task;
+    ledger.claim_next().unwrap();
+    let scheduled_run = ledger.start_run(scheduled.id, "codex").unwrap();
+    ledger
+        .finish_run_and_task(scheduled_run.id, RunOutcome::Succeeded, None, None, None)
+        .unwrap();
+    let ticket = ledger
+        .enqueue(
+            &TaskIdentity::ticket("owainlewis/factory", "shared-workflow", "7", "revision-1")
+                .unwrap(),
+        )
+        .unwrap()
+        .task;
+    ledger.claim_next().unwrap();
+    let ticket_run = ledger.start_run(ticket.id, "codex").unwrap();
+    ledger
+        .finish_run_and_task(ticket_run.id, RunOutcome::Succeeded, None, None, None)
+        .unwrap();
+    let connection = Connection::open(&path).unwrap();
+    connection
+        .execute(
+            "UPDATE runs SET finished_at = 100 WHERE id = ?1",
+            [scheduled_run.id],
+        )
+        .unwrap();
+    connection
+        .execute(
+            "UPDATE runs SET finished_at = 200 WHERE id = ?1",
+            [ticket_run.id],
+        )
+        .unwrap();
+
+    assert_eq!(
+        ledger
+            .latest_successful_scheduled_run_finished_at("owainlewis/factory", "shared-workflow",)
+            .unwrap(),
+        Some(100)
+    );
+}
+
+#[test]
 fn schedule_cursor_atomically_enqueues_advances_and_skips_downtime() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("ledger.db");

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -369,6 +369,47 @@ fn live_schedule_owner_preserves_due_work_and_fingerprint_blocks_stale_daemon() 
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn crashed_schedule_owner_does_not_preserve_offline_due_work() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut crashed_process = Command::new("sh").args(["-c", "exit 0"]).spawn().unwrap();
+    let crashed_pid = crashed_process.id();
+    assert!(crashed_process.wait().unwrap().success());
+    let mut crashed = Ledger::open(&path).unwrap();
+    crashed
+        .register_daemon_owner("crashed-schedule-owner", crashed_pid)
+        .unwrap();
+    crashed
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "same|UTC",
+            60_000,
+            30_000,
+            "crashed-schedule-owner",
+        )
+        .unwrap();
+
+    let mut restarted = Ledger::open(&path).unwrap();
+    restarted
+        .register_daemon_owner("restarted-schedule-owner", std::process::id())
+        .unwrap();
+    let cursor = restarted
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "same|UTC",
+            120_000,
+            90_000,
+            "restarted-schedule-owner",
+        )
+        .unwrap();
+
+    assert_eq!(cursor.next_due_at, 120_000);
+}
+
 #[test]
 fn concurrent_claim_has_exactly_one_winner() {
     let temp = tempfile::tempdir().unwrap();

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -23,6 +23,17 @@ fn ticket(revision: &str) -> TaskIdentity {
     .unwrap()
 }
 
+fn ticket_runtimes() -> HashMap<(String, String, String), String> {
+    HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "implement-ready-ticket".to_owned(),
+            "ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )])
+}
+
 #[test]
 fn initializes_in_data_directory_and_persists_across_reopen() {
     let temp = tempfile::tempdir().unwrap();
@@ -305,6 +316,62 @@ fn concurrent_claim_has_exactly_one_winner() {
 }
 
 #[test]
+fn claim_requires_task_kind_to_match_the_current_workflow_trigger() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    let task = ledger
+        .enqueue(
+            &TaskIdentity::scheduled(
+                "owainlewis/factory",
+                "implement-ready-ticket",
+                "2026-07-20T09:00:00Z",
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .task;
+    ledger
+        .register_daemon_owner("kind-owner", std::process::id())
+        .unwrap();
+
+    assert!(
+        ledger
+            .claim_and_start_run(
+                &["owainlewis/factory".to_owned()],
+                &ticket_runtimes(),
+                "kind-owner",
+                std::process::id(),
+            )
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Queued
+    );
+
+    let scheduled_runtimes = HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "implement-ready-ticket".to_owned(),
+            "scheduled".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    let claimed = ledger
+        .claim_and_start_run(
+            &["owainlewis/factory".to_owned()],
+            &scheduled_runtimes,
+            "kind-owner",
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.task.id, task.id);
+    assert_eq!(claimed.task.kind, "scheduled");
+}
+
+#[test]
 fn records_bounded_run_history_and_terminal_tasks_cannot_be_reclaimed() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("ledger.db");
@@ -485,13 +552,7 @@ fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
         .register_daemon_owner("interrupted-owner", std::process::id())
         .unwrap();
     let task = ledger.enqueue(&ticket("recovery-revision")).unwrap().task;
-    let runtimes = HashMap::from([(
-        (
-            "owainlewis/factory".to_owned(),
-            "implement-ready-ticket".to_owned(),
-        ),
-        "codex".to_owned(),
-    )]);
+    let runtimes = ticket_runtimes();
     let workdirs = HashMap::from([(
         "owainlewis/factory".to_owned(),
         "/worktrees/factory-3".to_owned(),
@@ -618,13 +679,7 @@ fn orphan_recovery_does_not_signal_a_reused_process_group() {
         .register_daemon_owner("gone-owner", std::process::id())
         .unwrap();
     ledger.enqueue(&ticket("pid-reuse-revision")).unwrap();
-    let runtimes = HashMap::from([(
-        (
-            "owainlewis/factory".to_owned(),
-            "implement-ready-ticket".to_owned(),
-        ),
-        "codex".to_owned(),
-    )]);
+    let runtimes = ticket_runtimes();
     let run = ledger
         .claim_and_start_run(
             &["owainlewis/factory".to_owned()],
@@ -679,13 +734,7 @@ fn cancellation_requests_are_durable_idempotent_and_force_cancelled_outcome() {
     let path = temp.path().join("ledger.db");
     let mut ledger = Ledger::open(&path).unwrap();
     let task = ledger.enqueue(&ticket("cancel-revision")).unwrap().task;
-    let runtimes = HashMap::from([(
-        (
-            "owainlewis/factory".to_owned(),
-            "implement-ready-ticket".to_owned(),
-        ),
-        "codex".to_owned(),
-    )]);
+    let runtimes = ticket_runtimes();
     ledger
         .register_daemon_owner("storage-test-owner", std::process::id())
         .unwrap();
@@ -761,13 +810,7 @@ fn cancellation_rejects_a_reused_live_pid_when_the_owner_lease_is_stale() {
         .register_daemon_owner("stale-owner", std::process::id())
         .unwrap();
     ledger.enqueue(&ticket("stale-owner-revision")).unwrap();
-    let runtimes = HashMap::from([(
-        (
-            "owainlewis/factory".to_owned(),
-            "implement-ready-ticket".to_owned(),
-        ),
-        "codex".to_owned(),
-    )]);
+    let runtimes = ticket_runtimes();
     let run = ledger
         .claim_and_start_run(
             &["owainlewis/factory".to_owned()],
@@ -802,13 +845,7 @@ fn orphan_recovery_completes_a_pending_cancellation_without_retrying() {
         .enqueue(&ticket("orphan-cancel-revision"))
         .unwrap()
         .task;
-    let runtimes = HashMap::from([(
-        (
-            "owainlewis/factory".to_owned(),
-            "implement-ready-ticket".to_owned(),
-        ),
-        "codex".to_owned(),
-    )]);
+    let runtimes = ticket_runtimes();
     ledger
         .register_daemon_owner("cancelled-owner", std::process::id())
         .unwrap();
@@ -846,13 +883,7 @@ fn orphan_recovery_completes_a_pending_cancellation_without_retrying() {
 fn concurrent_completion_and_cancellation_always_leave_a_terminal_run() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("ledger.db");
-    let runtimes = HashMap::from([(
-        (
-            "owainlewis/factory".to_owned(),
-            "implement-ready-ticket".to_owned(),
-        ),
-        "codex".to_owned(),
-    )]);
+    let runtimes = ticket_runtimes();
     let mut setup = Ledger::open(&path).unwrap();
     setup
         .register_daemon_owner("race-owner", std::process::id())

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -299,6 +299,18 @@ fn live_schedule_owner_preserves_due_work_and_fingerprint_blocks_stale_daemon() 
         )
         .unwrap();
     assert_eq!(preserved.next_due_at, 60_000);
+    let queued_under_old_definition =
+        TaskIdentity::scheduled("owainlewis/factory", "find-bugs", "1970-01-01T00:01:00Z").unwrap();
+    first
+        .enqueue_scheduled_occurrence(
+            &queued_under_old_definition,
+            r#"{"scheduled_at":"1970-01-01T00:01:00Z"}"#,
+            "old|UTC",
+            60_000,
+            120_000,
+        )
+        .unwrap()
+        .unwrap();
 
     let conflict = second.initialize_schedule_cursor(
         "owainlewis/factory",
@@ -311,7 +323,13 @@ fn live_schedule_owner_preserves_due_work_and_fingerprint_blocks_stale_daemon() 
     assert!(
         format!("{:#}", conflict.unwrap_err()).contains("live owner using different fingerprint")
     );
-    first.remove_daemon_owner("schedule-owner-a").unwrap();
+    Connection::open(temp.path().join("ledger.db"))
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+            ["schedule-owner-a"],
+        )
+        .unwrap();
     let changed = second
         .initialize_schedule_cursor(
             "owainlewis/factory",
@@ -323,6 +341,39 @@ fn live_schedule_owner_preserves_due_work_and_fingerprint_blocks_stale_daemon() 
         )
         .unwrap();
     assert_eq!(changed.next_due_at, 90_000);
+    let resumed_at = i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap();
+    Connection::open(temp.path().join("ledger.db"))
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = ?1 WHERE owner_id = ?2",
+            rusqlite::params![resumed_at, "schedule-owner-a"],
+        )
+        .unwrap();
+    let scheduled_runtimes = HashMap::from([(
+        (
+            "owainlewis/factory".to_owned(),
+            "find-bugs".to_owned(),
+            "scheduled".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    assert!(
+        first
+            .claim_and_start_run(
+                &["owainlewis/factory".to_owned()],
+                &scheduled_runtimes,
+                "schedule-owner-a",
+                std::process::id(),
+            )
+            .unwrap()
+            .is_none()
+    );
     let mut stale_daemon = Ledger::open(&temp.path().join("ledger.db")).unwrap();
     stale_daemon
         .register_daemon_owner("schedule-owner-c", std::process::id())
@@ -340,12 +391,12 @@ fn live_schedule_owner_preserves_due_work_and_fingerprint_blocks_stale_daemon() 
             .is_err()
     );
     let stale =
-        TaskIdentity::scheduled("owainlewis/factory", "find-bugs", "1970-01-01T00:01:00Z").unwrap();
+        TaskIdentity::scheduled("owainlewis/factory", "find-bugs", "1970-01-01T00:00:30Z").unwrap();
     assert!(
         first
             .enqueue_scheduled_occurrence(
                 &stale,
-                r#"{"scheduled_at":"1970-01-01T00:01:00Z"}"#,
+                r#"{"scheduled_at":"1970-01-01T00:00:30Z"}"#,
                 "old|UTC",
                 60_000,
                 120_000,
@@ -367,6 +418,34 @@ fn live_schedule_owner_preserves_due_work_and_fingerprint_blocks_stale_daemon() 
             .unwrap()
             .is_some()
     );
+    let claimed = second
+        .claim_and_start_run(
+            &["owainlewis/factory".to_owned()],
+            &scheduled_runtimes,
+            "schedule-owner-b",
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap();
+    assert!(
+        claimed
+            .task
+            .payload
+            .as_deref()
+            .unwrap()
+            .contains("1970-01-01T00:01:30Z")
+    );
+    let stale_task = second
+        .tasks()
+        .unwrap()
+        .into_iter()
+        .find(|task| {
+            task.payload
+                .as_deref()
+                .is_some_and(|payload| payload.contains("1970-01-01T00:01:00Z"))
+        })
+        .unwrap();
+    assert_eq!(stale_task.state, TaskState::Queued);
 }
 
 #[cfg(unix)]
@@ -481,17 +560,21 @@ fn claim_requires_task_kind_to_match_the_current_workflow_trigger() {
         ),
         "codex".to_owned(),
     )]);
-    let claimed = ledger
-        .claim_and_start_run(
-            &["owainlewis/factory".to_owned()],
-            &scheduled_runtimes,
-            "kind-owner",
-            std::process::id(),
-        )
-        .unwrap()
-        .unwrap();
-    assert_eq!(claimed.task.id, task.id);
-    assert_eq!(claimed.task.kind, "scheduled");
+    assert!(
+        ledger
+            .claim_and_start_run(
+                &["owainlewis/factory".to_owned()],
+                &scheduled_runtimes,
+                "kind-owner",
+                std::process::id(),
+            )
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Queued
+    );
 }
 
 #[test]

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Barrier};
 use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
@@ -395,6 +396,94 @@ fn claim_requires_task_kind_to_match_the_current_workflow_trigger() {
         .unwrap();
     assert_eq!(claimed.task.id, task.id);
     assert_eq!(claimed.task.kind, "scheduled");
+}
+
+#[test]
+fn expired_daemon_owner_cannot_claim_or_start_work() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    let task = ledger.enqueue(&ticket("expired-claim-owner")).unwrap().task;
+    ledger
+        .register_daemon_owner("expired-claim-owner", std::process::id())
+        .unwrap();
+    Connection::open(&path)
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+            ["expired-claim-owner"],
+        )
+        .unwrap();
+
+    let error = ledger
+        .claim_and_start_run(
+            &["owainlewis/factory".to_owned()],
+            &ticket_runtimes(),
+            "expired-claim-owner",
+            std::process::id(),
+        )
+        .unwrap_err();
+    assert!(format!("{error:#}").contains("no live lease for task claims"));
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Queued
+    );
+    assert!(ledger.runs(None).unwrap().is_empty());
+}
+
+#[test]
+fn owner_lease_is_checked_after_waiting_for_the_claim_lock() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut setup = Ledger::open(&path).unwrap();
+    let task = setup.enqueue(&ticket("claim-lock-wait")).unwrap().task;
+    setup
+        .register_daemon_owner("claim-lock-owner", std::process::id())
+        .unwrap();
+    let now = i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap();
+    Connection::open(&path)
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = ?1 WHERE owner_id = ?2",
+            rusqlite::params![now - 9_500, "claim-lock-owner"],
+        )
+        .unwrap();
+    drop(setup);
+
+    let mut claimant = Ledger::open(&path).unwrap();
+    let blocker = Connection::open(&path).unwrap();
+    blocker.execute_batch("BEGIN IMMEDIATE;").unwrap();
+    let barrier = Arc::new(Barrier::new(2));
+    let waiting = {
+        let barrier = Arc::clone(&barrier);
+        thread::spawn(move || {
+            barrier.wait();
+            claimant.claim_and_start_run(
+                &["owainlewis/factory".to_owned()],
+                &ticket_runtimes(),
+                "claim-lock-owner",
+                std::process::id(),
+            )
+        })
+    };
+    barrier.wait();
+    thread::sleep(Duration::from_millis(700));
+    blocker.execute_batch("COMMIT;").unwrap();
+
+    let error = waiting.join().unwrap().unwrap_err();
+    assert!(format!("{error:#}").contains("no live lease for task claims"));
+    let ledger = Ledger::open(&path).unwrap();
+    assert_eq!(
+        ledger.task(task.id).unwrap().unwrap().state,
+        TaskState::Queued
+    );
+    assert!(ledger.runs(None).unwrap().is_empty());
 }
 
 #[test]

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -65,6 +65,182 @@ fn ticket_and_schedule_identities_deduplicate_exact_triggers() {
 }
 
 #[test]
+fn schedule_cursor_atomically_enqueues_advances_and_skips_downtime() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    ledger
+        .register_daemon_owner("schedule-storage-owner", std::process::id())
+        .unwrap();
+    let cursor = ledger
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "* * * * *|UTC",
+            60_000,
+            30_000,
+            "schedule-storage-owner",
+        )
+        .unwrap();
+    assert_eq!(cursor.next_due_at, 60_000);
+    let identity =
+        TaskIdentity::scheduled("owainlewis/factory", "find-bugs", "1970-01-01T00:01:00Z").unwrap();
+    let first = ledger
+        .enqueue_scheduled_occurrence(
+            &identity,
+            r#"{"scheduled_at":"1970-01-01T00:01:00Z"}"#,
+            "* * * * *|UTC",
+            60_000,
+            120_000,
+        )
+        .unwrap();
+    let repeated = ledger
+        .enqueue_scheduled_occurrence(
+            &identity,
+            r#"{"scheduled_at":"1970-01-01T00:01:00Z"}"#,
+            "* * * * *|UTC",
+            60_000,
+            120_000,
+        )
+        .unwrap();
+    assert!(first.is_some_and(|task| task.created));
+    assert!(repeated.is_none());
+    assert_eq!(ledger.tasks().unwrap().len(), 1);
+
+    let restart = ledger
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "* * * * *|UTC",
+            120_000,
+            90_000,
+            "schedule-storage-owner",
+        )
+        .unwrap();
+    assert_eq!(restart.next_due_at, 120_000);
+    ledger
+        .remove_daemon_owner("schedule-storage-owner")
+        .unwrap();
+    ledger
+        .register_daemon_owner("schedule-storage-owner-2", std::process::id())
+        .unwrap();
+    let after_downtime = ledger
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "* * * * *|UTC",
+            660_000,
+            630_000,
+            "schedule-storage-owner-2",
+        )
+        .unwrap();
+    assert_eq!(after_downtime.next_due_at, 660_000);
+    assert_eq!(ledger.tasks().unwrap().len(), 1);
+}
+
+#[test]
+fn live_schedule_owner_preserves_due_work_and_fingerprint_blocks_stale_daemon() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut first = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    first
+        .register_daemon_owner("schedule-owner-a", std::process::id())
+        .unwrap();
+    first
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "old|UTC",
+            60_000,
+            30_000,
+            "schedule-owner-a",
+        )
+        .unwrap();
+
+    let mut second = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    second
+        .register_daemon_owner("schedule-owner-b", std::process::id())
+        .unwrap();
+    let preserved = second
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "old|UTC",
+            120_000,
+            70_000,
+            "schedule-owner-b",
+        )
+        .unwrap();
+    assert_eq!(preserved.next_due_at, 60_000);
+
+    let conflict = second.initialize_schedule_cursor(
+        "owainlewis/factory",
+        "find-bugs",
+        "new|UTC",
+        90_000,
+        80_000,
+        "schedule-owner-b",
+    );
+    assert!(
+        format!("{:#}", conflict.unwrap_err()).contains("live owner using different fingerprint")
+    );
+    first.remove_daemon_owner("schedule-owner-a").unwrap();
+    let changed = second
+        .initialize_schedule_cursor(
+            "owainlewis/factory",
+            "find-bugs",
+            "new|UTC",
+            90_000,
+            80_000,
+            "schedule-owner-b",
+        )
+        .unwrap();
+    assert_eq!(changed.next_due_at, 90_000);
+    let mut stale_daemon = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    stale_daemon
+        .register_daemon_owner("schedule-owner-c", std::process::id())
+        .unwrap();
+    assert!(
+        stale_daemon
+            .initialize_schedule_cursor(
+                "owainlewis/factory",
+                "find-bugs",
+                "old|UTC",
+                120_000,
+                100_000,
+                "schedule-owner-c",
+            )
+            .is_err()
+    );
+    let stale =
+        TaskIdentity::scheduled("owainlewis/factory", "find-bugs", "1970-01-01T00:01:00Z").unwrap();
+    assert!(
+        first
+            .enqueue_scheduled_occurrence(
+                &stale,
+                r#"{"scheduled_at":"1970-01-01T00:01:00Z"}"#,
+                "old|UTC",
+                60_000,
+                120_000,
+            )
+            .unwrap()
+            .is_none()
+    );
+    let current =
+        TaskIdentity::scheduled("owainlewis/factory", "find-bugs", "1970-01-01T00:01:30Z").unwrap();
+    assert!(
+        second
+            .enqueue_scheduled_occurrence(
+                &current,
+                r#"{"scheduled_at":"1970-01-01T00:01:30Z"}"#,
+                "new|UTC",
+                90_000,
+                150_000,
+            )
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[test]
 fn concurrent_claim_has_exactly_one_winner() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("ledger.db");
@@ -261,7 +437,7 @@ fn migrates_a_version_one_ledger_without_losing_tasks() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
 }
 
 #[test]
@@ -285,7 +461,7 @@ fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
         "/worktrees/factory-3".to_owned(),
     )]);
     let interrupted = ledger
-        .claim_ticket_and_start_run_with_workdirs(
+        .claim_and_start_run_with_workdirs(
             &["owainlewis/factory".to_owned()],
             &runtimes,
             "interrupted-owner",
@@ -327,7 +503,7 @@ fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
         .register_daemon_owner("recovery-owner", std::process::id())
         .unwrap();
     let first_recovery = ledger
-        .claim_ticket_and_start_run_with_workdirs(
+        .claim_and_start_run_with_workdirs(
             &["owainlewis/factory".to_owned()],
             &runtimes,
             "recovery-owner",
@@ -359,7 +535,7 @@ fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
         .register_daemon_owner("recovery-owner", std::process::id())
         .unwrap();
     let final_recovery = ledger
-        .claim_ticket_and_start_run_with_workdirs(
+        .claim_and_start_run_with_workdirs(
             &["owainlewis/factory".to_owned()],
             &runtimes,
             "recovery-owner",
@@ -414,7 +590,7 @@ fn orphan_recovery_does_not_signal_a_reused_process_group() {
         "codex".to_owned(),
     )]);
     let run = ledger
-        .claim_ticket_and_start_run(
+        .claim_and_start_run(
             &["owainlewis/factory".to_owned()],
             &runtimes,
             "gone-owner",
@@ -478,7 +654,7 @@ fn cancellation_requests_are_durable_idempotent_and_force_cancelled_outcome() {
         .register_daemon_owner("storage-test-owner", std::process::id())
         .unwrap();
     let run = ledger
-        .claim_ticket_and_start_run(
+        .claim_and_start_run(
             &["owainlewis/factory".to_owned()],
             &runtimes,
             "storage-test-owner",
@@ -557,7 +733,7 @@ fn cancellation_rejects_a_reused_live_pid_when_the_owner_lease_is_stale() {
         "codex".to_owned(),
     )]);
     let run = ledger
-        .claim_ticket_and_start_run(
+        .claim_and_start_run(
             &["owainlewis/factory".to_owned()],
             &runtimes,
             "stale-owner",
@@ -601,7 +777,7 @@ fn orphan_recovery_completes_a_pending_cancellation_without_retrying() {
         .register_daemon_owner("cancelled-owner", std::process::id())
         .unwrap();
     let run = ledger
-        .claim_ticket_and_start_run(
+        .claim_and_start_run(
             &["owainlewis/factory".to_owned()],
             &runtimes,
             "cancelled-owner",
@@ -653,7 +829,7 @@ fn concurrent_completion_and_cancellation_always_leave_a_terminal_run() {
             .unwrap()
             .task;
         let run = setup
-            .claim_ticket_and_start_run(
+            .claim_and_start_run(
                 &["owainlewis/factory".to_owned()],
                 &runtimes,
                 "race-owner",

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -178,6 +178,28 @@ fn reports_all_invalid_workflows_without_hiding_valid_entries() {
 }
 
 #[test]
+fn missing_schedule_frontmatter_delimiter_stays_isolated_from_tickets() {
+    let fixture = Fixture::new();
+    fixture.workflow(
+        "broken-schedule.md",
+        "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nRun maintenance.\n",
+    );
+    fixture.workflow("valid-ticket.md", &label_workflow("Implement the ticket."));
+
+    let catalog = fixture.catalog();
+
+    assert_eq!(catalog.invalid_scheduled_entries().count(), 1);
+    assert!(catalog.validate_ticket_workflows().is_ok());
+    assert!(catalog.entries.iter().any(|entry| {
+        entry.id == "broken-schedule"
+            && entry
+                .errors
+                .iter()
+                .any(|error| error.contains("missing its closing +++ delimiter"))
+    }));
+}
+
+#[test]
 fn rejects_missing_trigger_timezone_and_invalid_timeout() {
     let fixture = Fixture::new();
     fixture.workflow("no-trigger.md", "+++\n+++\nPrompt.\n");

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -215,6 +215,21 @@ fn malformed_schedule_isolation_is_independent_of_key_order() {
 }
 
 #[test]
+fn malformed_same_line_mixed_triggers_remain_fail_fast() {
+    let fixture = Fixture::new();
+    fixture.workflow(
+        "ambiguous-workflow.md",
+        "+++\nschedule = \"0 9 * * 1\" label = \"factory:ready\"\n+++\nPrompt.\n",
+    );
+    fixture.workflow("valid-ticket.md", &label_workflow("Implement the ticket."));
+
+    let catalog = fixture.catalog();
+
+    assert_eq!(catalog.invalid_scheduled_entries().count(), 0);
+    assert!(catalog.validate_ticket_workflows().is_err());
+}
+
+#[test]
 fn rejects_missing_trigger_timezone_and_invalid_timeout() {
     let fixture = Fixture::new();
     fixture.workflow("no-trigger.md", "+++\n+++\nPrompt.\n");

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -200,6 +200,21 @@ fn missing_schedule_frontmatter_delimiter_stays_isolated_from_tickets() {
 }
 
 #[test]
+fn malformed_schedule_isolation_is_independent_of_key_order() {
+    let fixture = Fixture::new();
+    fixture.workflow(
+        "broken-schedule.md",
+        "+++\ntimezone = \"UTC\"\nruntime = \"codex\"\nschedule = \"unterminated\n+++\nPrompt.\n",
+    );
+    fixture.workflow("valid-ticket.md", &label_workflow("Implement the ticket."));
+
+    let catalog = fixture.catalog();
+
+    assert_eq!(catalog.invalid_scheduled_entries().count(), 1);
+    assert!(catalog.validate_ticket_workflows().is_ok());
+}
+
+#[test]
 fn rejects_missing_trigger_timezone_and_invalid_timeout() {
     let fixture = Fixture::new();
     fixture.workflow("no-trigger.md", "+++\n+++\nPrompt.\n");

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -182,7 +182,7 @@ fn missing_schedule_frontmatter_delimiter_stays_isolated_from_tickets() {
     let fixture = Fixture::new();
     fixture.workflow(
         "broken-schedule.md",
-        "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\nRun maintenance.\n",
+        "+++\nschedule = \"0 9 * * 1\"\ntimezone = \"UTC\"\ntimeout = O(n) before maintenance.\n",
     );
     fixture.workflow("valid-ticket.md", &label_workflow("Implement the ticket."));
 


### PR DESCRIPTION
Closes #9

## Summary

- evaluate five-field cron schedules in each workflow IANA timezone, including DST gaps and repeated local times
- persist fingerprinted schedule cursors and atomically enqueue one durable task per UTC occurrence
- skip offline backlog while preserving online due work across repeated ticks, restarts, and multiple daemon owners
- reject split-brain workflow fingerprints while live, then retry automatically after the prior owner exits
- dispatch scheduled and ticket work through the same claims, concurrency, Codex supervision, recovery, cancellation, and run history
- include scheduled instant, repository commit, and previous successful run time in scheduled prompts
- isolate invalid schedules and failed scheduled tasks from ticket polling
- document local schedule operations

## Acceptance proof

- tests cover ordinary occurrences, repeated ticks, restart deduplication, downtime skipping, disabled workflows, IANA timezone evaluation, DST gaps, DST repeats, concurrent daemons, fingerprint changes, concurrent ticket work, invalid workflows, failing tasks, prior success, inspected commit, and schema migration
- a disposable clean clone ran a harmless real scheduled workflow through authenticated gh and subscription-authenticated Codex
- the daemon was stopped immediately after the first success
- durable evidence contained exactly one task and one run with outcome succeeded and summary scheduled smoke test complete
- fresh subagent review found and verified fixes for the production CLI gate, concurrent owner cursor loss, fingerprint split brain, and retry after owner exit

## Checks

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (129 tests)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable cron-style scheduled workflow execution with timezone-aware scheduling (including DST gap/repeat handling).
  * Scheduled tasks persist across restarts with de-duplication, cursor recovery for overdue work, and shared capacity with ticket tasks.
  * Scheduled execution prompts now include scheduled occurrence time, repository/commit context, and prior successful run timing when available.
* **Bug Fixes**
  * Invalid scheduled workflows are skipped and reported without blocking valid ticket workflows.
  * Improved ledger reliability and stricter daemon lease enforcement during startup and claiming.
* **Documentation**
  * Expanded `factory run` documentation to cover scheduled execution, cursor persistence, and failure isolation. 
* **Tests**
  * Added/expanded coverage for scheduling, validation isolation, DST correctness, and restart/backlog behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->