### PR TITLE
feat(cli): add JSON validation output

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -255,7 +255,7 @@ V1 implements Codex completely and Claude Code second to prove portability. Runt
 The daemon runs as `factory run`, initially in a terminal and later under `launchd` or `systemd`. A small CLI exposes operational state:
 
 ```text
-factory validate
+factory validate [--json]
 factory workflows
 factory workflow run <workflow-id> --repository <path>
 factory tasks

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ enum Command {
     },
     /// Validate configuration without starting workers or network activity.
     Validate {
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
         /// Path to the Factory configuration file.
         #[arg(long)]
         config: Option<PathBuf>,
@@ -136,6 +139,37 @@ struct CancellationResponse {
     message: &'static str,
 }
 
+#[derive(Serialize)]
+struct ValidationResponse {
+    repositories: Vec<String>,
+    poll_every: String,
+    default_runtime: String,
+    default_timeout: String,
+    maximum_timeout: String,
+    max_concurrent_runs: usize,
+    max_concurrent_runs_per_repository: usize,
+    workspace_root: String,
+}
+
+impl From<&Config> for ValidationResponse {
+    fn from(config: &Config) -> Self {
+        Self {
+            repositories: config
+                .repositories
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect(),
+            poll_every: humantime::format_duration(config.poll_every).to_string(),
+            default_runtime: config.default_runtime.clone(),
+            default_timeout: humantime::format_duration(config.default_timeout).to_string(),
+            maximum_timeout: humantime::format_duration(config.maximum_timeout).to_string(),
+            max_concurrent_runs: config.max_concurrent_runs,
+            max_concurrent_runs_per_repository: config.max_concurrent_runs_per_repository,
+            workspace_root: config.workspace_root.display().to_string(),
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> ExitCode {
     match run_cli().await {
@@ -158,10 +192,14 @@ async fn run_cli() -> Result<u8> {
         } => {
             return run_poller(config, data_directory, once).await;
         }
-        Command::Validate { config } => {
+        Command::Validate { json, config } => {
             let path = config.unwrap_or_else(default_config_path);
             let config = Config::load(&path)?;
-            print!("{config}");
+            if json {
+                print_json(&ValidationResponse::from(&config))?;
+            } else {
+                print!("{config}");
+            }
         }
         Command::Workflows { config } => {
             let path = config.unwrap_or_else(default_config_path);

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -30,16 +30,54 @@ workspace_root = "{}"
 }
 
 #[test]
-fn validates_explicit_config() {
+fn default_output_remains_unchanged() {
     let (_temp, path) = valid_config();
+    let config_dir = path.parent().unwrap();
+    let repository = config_dir.join("repository").canonicalize().unwrap();
+    let workspace = config_dir.join("worktrees").canonicalize().unwrap();
+    let expected = format!(
+        "Configuration is valid.\nrepositories:\n  - {}\npoll_every: 30s\ndefault_runtime: codex\ndefault_timeout: 2h\nmaximum_timeout: 8h\nmax_concurrent_runs: 2\nmax_concurrent_runs_per_repository: 1\nworkspace_root: {}\n",
+        repository.display(),
+        workspace.display()
+    );
 
     Command::cargo_bin("factory")
         .unwrap()
         .args(["validate", "--config", path.to_str().unwrap()])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Configuration is valid."))
-        .stdout(predicate::str::contains("default_runtime: codex"));
+        .stdout(expected);
+}
+
+#[test]
+fn prints_resolved_config_as_json() {
+    let (_temp, path) = valid_config();
+    let config_dir = path.parent().unwrap();
+    let repository = config_dir.join("repository").canonicalize().unwrap();
+    let workspace = config_dir.join("worktrees").canonicalize().unwrap();
+
+    let output = Command::cargo_bin("factory")
+        .unwrap()
+        .args(["validate", "--json", "--config", path.to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        value,
+        serde_json::json!({
+            "repositories": [repository.display().to_string()],
+            "poll_every": "30s",
+            "default_runtime": "codex",
+            "default_timeout": "2h",
+            "maximum_timeout": "8h",
+            "max_concurrent_runs": 2,
+            "max_concurrent_runs_per_repository": 1,
+            "workspace_root": workspace.display().to_string(),
+        })
+    );
 }
 
 #[test]
@@ -57,6 +95,27 @@ fn reports_specific_validation_failures() {
         .args(["validate", "--config", path.to_str().unwrap()])
         .assert()
         .failure()
+        .stderr(predicate::str::contains(
+            "max_concurrent_runs must be greater than zero",
+        ));
+}
+
+#[test]
+fn json_mode_preserves_validation_failures() {
+    let (_temp, path) = valid_config();
+    let contents = fs::read_to_string(&path).unwrap();
+    fs::write(
+        &path,
+        contents.replace("max_concurrent_runs = 2", "max_concurrent_runs = 0"),
+    )
+    .unwrap();
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["validate", "--json", "--config", path.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stdout(predicate::str::is_empty())
         .stderr(predicate::str::contains(
             "max_concurrent_runs must be greater than zero",
         ));


### PR DESCRIPTION
## Why

Make `factory validate` usable in scripts without changing its existing human-readable behavior.

Closes #23

## Summary

- add `factory validate --json` with a stable object containing resolved paths, durations, runtime, and concurrency limits
- keep configuration loading and validation ahead of output so invalid configs still fail with actionable stderr
- lock down the existing text output and JSON failure behavior with CLI integration tests
- document the new optional flag in the CLI command list

## Acceptance proof

- JSON output parses as one object and asserts all requested resolved values
- durations assert the same human-readable values used by text output
- legacy text output is asserted exactly
- invalid JSON-mode configuration exits non-zero, writes no stdout, and retains the validation error
- independent review: no actionable findings

## Verification

- `cargo fmt --all --check` passed
- `cargo clippy --all-targets -- -D warnings` passed
- `cargo test` passed

## Risks

Low. The new response type is CLI-local, and the default output path is unchanged.
