### PR TITLE
feat(cli): add safe repository initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1009,6 +1010,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1209,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tempfile = "3.20"
 tokio = { version = "1.47", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = "0.7"
 toml = "0.9"
+toml_edit = "0.23"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30", features = ["signal"] }

--- a/README.md
+++ b/README.md
@@ -14,15 +14,13 @@ and Codex CLIs. It does not use model API keys.
 1. Install Rust, `git`, `gh`, and Codex CLI.
 2. Authenticate with `gh auth login` and `codex login`.
 3. Clone Factory and run `cargo install --path .`.
-4. Copy [`examples/config.toml`](examples/config.toml) to
-   `~/.factory/config.toml` and replace the two example paths.
-5. Copy
-   [`examples/implement-ready-ticket.md`](examples/implement-ready-ticket.md)
-   to `.factory/workflows/implement-ready-ticket.md` in each trusted target
-   repository.
-6. Create the `factory:ready` and `factory:needs-review` labels in each target
-   repository.
-7. Run `factory validate`, `factory workflows`, then `factory run`.
+4. In a trusted target repository, run `factory init`.
+5. Review and commit `.factory/workflows/implement-ready-ticket.md`.
+6. Run `factory validate`, `factory workflows`, then `factory run`.
+
+`factory init --check` previews setup without writes. Use `--no-labels` for
+offline local setup and `--update-workflow` only when you intend to replace a
+customized implementation workflow with the bundled version.
 
 See [`docs/local-v1.md`](docs/local-v1.md) for complete installation, setup,
 operation, recovery, and acceptance instructions. The architecture and product

--- a/docs/design.md
+++ b/docs/design.md
@@ -255,6 +255,7 @@ V1 implements Codex completely and Claude Code second to prove portability. Runt
 The daemon runs as `factory run`, initially in a terminal and later under `launchd` or `systemd`. A small CLI exposes operational state:
 
 ```text
+factory init [--repository <path>] [--check] [--no-labels]
 factory validate
 factory workflows
 factory workflow run <workflow-id> --repository <path>
@@ -265,6 +266,12 @@ factory cancel <run-id>
 ```
 
 SQLite lives under the Factory data directory. Workflows run against trusted repositories. An implementation agent may create its own worktree under the configured workspace root; Factory records the path reported by the agent or discovered from Git after the run.
+
+`factory init` is an explicit, idempotent setup mutation. It may install the
+bundled workflow, register the repository in local configuration, create the
+workspace directory, and create missing conventional GitHub labels. Daemon
+startup never performs these mutations, and initialization never commits,
+pushes, launches an agent, or enables pull-request merge.
 
 The manual workflow command validates the selected repository and workflow,
 checks the configured runtime and authentication, streams runtime activity, and

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -36,20 +36,38 @@ factory --version
 
 Re-run `cargo install --path . --force` after updating the checkout.
 
-## Configure Factory
+## Initialize a trusted repository
 
-Create the data and workspace directories, then copy the checked-in example:
+Run the explicit initializer from the repository Factory should manage:
 
 ```sh
-mkdir -p ~/.factory
-mkdir -p /absolute/path/to/factory-worktrees
-cp examples/config.toml ~/.factory/config.toml
+cd /absolute/path/to/trusted/repository
+factory init
 ```
 
-Edit only the repository and workspace paths to start. Each repository must be
-a trusted local Git checkout with an authenticated GitHub remote. The workspace
-must exist, be writable, and sit outside the repository and home-directory
-root.
+The command creates the implementation workflow, creates or updates
+`~/.factory/config.toml`, creates the default `~/.factory/workspaces` directory,
+and creates missing `factory:ready` and `factory:needs-review` labels. It does
+not change existing label definitions, commit files, start the daemon, launch
+Codex, or merge pull requests.
+
+Initialization is idempotent. Preview it without writes with:
+
+```sh
+factory init --check
+```
+
+Use `factory init --no-labels` for offline local setup. A customized workflow is
+never overwritten by default; `factory init --update-workflow` is the explicit
+replacement operation. To initialize a repository without changing directory,
+use `factory init --repository /absolute/path/to/repository`.
+
+Review and commit the installed policy in the target repository:
+
+```sh
+git add .factory/workflows/implement-ready-ticket.md
+git commit -m "chore: configure Factory"
+```
 
 Validate the machine-specific configuration without network or runtime work:
 
@@ -57,17 +75,7 @@ Validate the machine-specific configuration without network or runtime work:
 factory validate
 ```
 
-## Install the implementation workflow
-
-In each target repository:
-
-```sh
-mkdir -p .factory/workflows
-cp /path/to/factory/examples/implement-ready-ticket.md \
-  .factory/workflows/implement-ready-ticket.md
-```
-
-Commit the workflow in a normal repository. It is versioned policy: Codex owns
+The workflow is versioned policy: Codex owns
 ticket updates, worktree and branch creation, implementation, tests, diff
 review, draft pull-request creation, CI repair, and handoff. Factory owns the
 durable task, one claim, concurrency, supervision, cancellation, inspection,
@@ -78,23 +86,6 @@ Check the resolved workflow catalog:
 ```sh
 factory workflows
 ```
-
-## Create the labels
-
-Factory does not create or mutate label definitions. Create the two labels once
-per repository:
-
-```sh
-gh label create factory:ready \
-  --description "Implementation is authorised and sufficiently defined" \
-  --color 0E8A16
-gh label create factory:needs-review \
-  --description "A human must review a question, decision, or green PR" \
-  --color FBCA04
-```
-
-If a label already exists, inspect it with `gh label list` instead of replacing
-it.
 
 ## Start and prove one ticket
 
@@ -163,6 +154,8 @@ Factory never merges as part of recovery.
 - Authentication errors: rerun `gh auth status` and `codex login status`.
 - Invalid configuration: run `factory validate` and correct the reported path
   or concurrency constraint.
+- Missing setup: run `factory init --check`, then `factory init` to create only
+  the missing resources.
 - Invalid workflows: run `factory workflows`; ticket workflow errors fail fast,
   while invalid scheduled workflows are reported and isolated.
 - No task: confirm the issue is open, has `factory:ready`, belongs to the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,9 +7,10 @@ per-repository concurrency are controlled by `max_concurrent_runs` and
 `max_concurrent_runs_per_repository`. The per-repository value defaults to 1.
 
 Factory requires the conventional `factory:ready` and
-`factory:needs-review` labels to be created by repository maintainers. Factory
-does not create, remove, or otherwise mutate labels itself. The delegated
-workflow owns ticket and pull-request updates.
+`factory:needs-review` labels. The explicit `factory init` setup command creates
+missing label definitions without changing existing ones. The daemon does not
+create, remove, or otherwise mutate labels itself. The delegated workflow owns
+ticket and pull-request updates.
 
 Five-field cron schedules are evaluated in the IANA timezone declared by the
 workflow. Factory stores the next occurrence and atomically advances that

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,14 +35,18 @@ struct RawConfig {
 
 impl Config {
     pub fn load(path: &Path) -> Result<Self> {
-        Self::load_with_workspace_probe(path, ensure_workspace_writable)
+        Self::load_with_workspace_probe(path, ensure_workspace_writable, false)
     }
 
     pub(crate) fn load_without_workspace_probe(path: &Path) -> Result<Self> {
-        Self::load_with_workspace_probe(path, |_| Ok(()))
+        Self::load_with_workspace_probe(path, |_| Ok(()), true)
     }
 
-    fn load_with_workspace_probe<F>(path: &Path, workspace_probe: F) -> Result<Self>
+    fn load_with_workspace_probe<F>(
+        path: &Path,
+        workspace_probe: F,
+        allow_missing_workspace: bool,
+    ) -> Result<Self>
     where
         F: FnOnce(&Path) -> Result<()>,
     {
@@ -56,26 +60,32 @@ impl Config {
             .parent()
             .context("configuration path has no parent directory")?;
 
-        Self::resolve_with_workspace_probe(raw, config_dir, workspace_probe)
-            .with_context(|| format!("invalid Factory configuration in {}", path.display()))
+        Self::resolve_with_workspace_probe(
+            raw,
+            config_dir,
+            workspace_probe,
+            allow_missing_workspace,
+        )
+        .with_context(|| format!("invalid Factory configuration in {}", path.display()))
     }
 
     pub(crate) fn validate_candidate(contents: &str, config_dir: &Path) -> Result<Self> {
         let raw: RawConfig =
             toml::from_str(contents).context("failed to parse candidate config")?;
-        Self::resolve_with_workspace_probe(raw, config_dir, |_| Ok(()))
+        Self::resolve_with_workspace_probe(raw, config_dir, |_| Ok(()), true)
             .context("invalid candidate Factory configuration")
     }
 
     #[cfg(test)]
     fn resolve(raw: RawConfig, config_dir: &Path) -> Result<Self> {
-        Self::resolve_with_workspace_probe(raw, config_dir, ensure_workspace_writable)
+        Self::resolve_with_workspace_probe(raw, config_dir, ensure_workspace_writable, false)
     }
 
     fn resolve_with_workspace_probe<F>(
         raw: RawConfig,
         config_dir: &Path,
         workspace_probe: F,
+        allow_missing_workspace: bool,
     ) -> Result<Self>
     where
         F: FnOnce(&Path) -> Result<()>,
@@ -109,8 +119,15 @@ impl Config {
             .iter()
             .map(|path| canonical_directory("repository", Path::new(path), config_dir))
             .collect::<Result<Vec<_>>>()?;
-        let workspace_root =
-            canonical_directory("workspace_root", Path::new(&raw.workspace_root), config_dir)?;
+        let workspace_root = if allow_missing_workspace {
+            canonical_directory_or_missing(
+                "workspace_root",
+                Path::new(&raw.workspace_root),
+                config_dir,
+            )?
+        } else {
+            canonical_directory("workspace_root", Path::new(&raw.workspace_root), config_dir)?
+        };
         let home = canonical_home_dir()?;
         validate_workspace(&workspace_root, &repositories, home.as_deref())?;
         workspace_probe(&workspace_root)?;
@@ -197,6 +214,49 @@ fn canonical_directory(name: &str, path: &Path, base: &Path) -> Result<PathBuf> 
         bail!("{name} path is not a directory: {}", canonical.display());
     }
     Ok(canonical)
+}
+
+fn canonical_directory_or_missing(name: &str, path: &Path, base: &Path) -> Result<PathBuf> {
+    let expanded = expand_path(path, base)?;
+    let mut ancestor = expanded.as_path();
+    let mut missing = Vec::new();
+
+    loop {
+        match fs::symlink_metadata(ancestor) {
+            Ok(_) => {
+                let mut resolved = ancestor.canonicalize().with_context(|| {
+                    format!("failed to resolve {name} path: {}", ancestor.display())
+                })?;
+                if !resolved.is_dir() {
+                    bail!("{name} ancestor is not a directory: {}", resolved.display());
+                }
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let component = ancestor.file_name().with_context(|| {
+                    format!(
+                        "{name} path has no existing ancestor: {}",
+                        expanded.display()
+                    )
+                })?;
+                missing.push(component.to_os_string());
+                ancestor = ancestor.parent().with_context(|| {
+                    format!(
+                        "{name} path has no existing ancestor: {}",
+                        expanded.display()
+                    )
+                })?;
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to inspect {name} path: {}", ancestor.display())
+                });
+            }
+        }
+    }
 }
 
 fn expand_path(path: &Path, base: &Path) -> Result<PathBuf> {
@@ -475,6 +535,7 @@ mod tests {
             raw(&repository, &workspace),
             temp.path(),
             |path| bail!("workspace_root is not writable: {}", path.display()),
+            false,
         )
         .unwrap_err();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,17 @@ struct RawConfig {
 
 impl Config {
     pub fn load(path: &Path) -> Result<Self> {
+        Self::load_with_workspace_probe(path, ensure_workspace_writable)
+    }
+
+    pub(crate) fn load_without_workspace_probe(path: &Path) -> Result<Self> {
+        Self::load_with_workspace_probe(path, |_| Ok(()))
+    }
+
+    fn load_with_workspace_probe<F>(path: &Path, workspace_probe: F) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
         let current_dir = env::current_dir().context("failed to resolve current directory")?;
         let path = expand_path(path, &current_dir)?;
         let contents = fs::read_to_string(&path)
@@ -45,10 +56,18 @@ impl Config {
             .parent()
             .context("configuration path has no parent directory")?;
 
-        Self::resolve(raw, config_dir)
+        Self::resolve_with_workspace_probe(raw, config_dir, workspace_probe)
             .with_context(|| format!("invalid Factory configuration in {}", path.display()))
     }
 
+    pub(crate) fn validate_candidate(contents: &str, config_dir: &Path) -> Result<Self> {
+        let raw: RawConfig =
+            toml::from_str(contents).context("failed to parse candidate config")?;
+        Self::resolve_with_workspace_probe(raw, config_dir, |_| Ok(()))
+            .context("invalid candidate Factory configuration")
+    }
+
+    #[cfg(test)]
     fn resolve(raw: RawConfig, config_dir: &Path) -> Result<Self> {
         Self::resolve_with_workspace_probe(raw, config_dir, ensure_workspace_writable)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,6 +236,15 @@ fn canonical_directory_or_missing(name: &str, path: &Path, base: &Path) -> Resul
                 return Ok(resolved);
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                if matches!(
+                    ancestor.components().next_back(),
+                    Some(Component::ParentDir)
+                ) {
+                    bail!(
+                        "{name} path must not contain parent traversal in a missing suffix: {}",
+                        expanded.display()
+                    );
+                }
                 let component = ancestor.file_name().with_context(|| {
                     format!(
                         "{name} path has no existing ancestor: {}",

--- a/src/github.rs
+++ b/src/github.rs
@@ -352,7 +352,7 @@ impl GitHubClient {
         cancellation: &CancellationToken,
     ) -> Result<String> {
         let mut command = Command::new(&self.executable);
-        command.args(arguments);
+        command.args(arguments).env_remove("GH_REPO");
         if let Some(repository) = repository {
             command.current_dir(repository);
         }

--- a/src/github.rs
+++ b/src/github.rs
@@ -132,6 +132,52 @@ impl GitHubClient {
         Ok(name.to_owned())
     }
 
+    pub async fn labels(
+        &self,
+        repository: &Path,
+        cancellation: &CancellationToken,
+    ) -> Result<Vec<String>> {
+        let output = self
+            .run(
+                Some(repository),
+                &[
+                    "label", "list", "--limit", "1000", "--json", "name", "--jq", ".[].name",
+                ],
+                cancellation,
+            )
+            .await
+            .with_context(|| {
+                format!("GitHub CLI cannot list labels for {}", repository.display())
+            })?;
+        Ok(output.lines().map(str::to_owned).collect())
+    }
+
+    pub async fn create_label(
+        &self,
+        repository: &Path,
+        name: &str,
+        description: &str,
+        color: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<()> {
+        self.run(
+            Some(repository),
+            &[
+                "label",
+                "create",
+                name,
+                "--description",
+                description,
+                "--color",
+                color,
+            ],
+            cancellation,
+        )
+        .await
+        .with_context(|| format!("failed to create GitHub label {name:?}"))?;
+        Ok(())
+    }
+
     pub async fn poll_once(
         &self,
         config: &Config,

--- a/src/github.rs
+++ b/src/github.rs
@@ -141,13 +141,20 @@ impl GitHubClient {
             .run(
                 Some(repository),
                 &[
-                    "label", "list", "--limit", "1000", "--json", "name", "--jq", ".[].name",
+                    "api",
+                    "repos/{owner}/{repo}/labels",
+                    "--paginate",
+                    "--jq",
+                    ".[].name",
                 ],
                 cancellation,
             )
             .await
             .with_context(|| {
-                format!("GitHub CLI cannot list labels for {}", repository.display())
+                format!(
+                    "GitHub CLI cannot list all labels for {}",
+                    repository.display()
+                )
             })?;
         Ok(output.lines().map(str::to_owned).collect())
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -391,7 +391,7 @@ fn discover_repository(requested: &Path) -> Result<PathBuf> {
 fn is_github_origin(origin: &str) -> bool {
     origin.starts_with("git@github.com:")
         || https_origin_has_github_host(origin)
-        || origin.starts_with("ssh://git@github.com/")
+        || ssh_origin_has_github_host(origin)
 }
 
 fn https_origin_has_github_host(origin: &str) -> bool {
@@ -417,6 +417,35 @@ fn https_origin_has_github_host(origin: &str) -> bool {
         None => host_and_port,
     };
     host.eq_ignore_ascii_case("github.com")
+}
+
+fn ssh_origin_has_github_host(origin: &str) -> bool {
+    let Some(remainder) = origin.strip_prefix("ssh://") else {
+        return false;
+    };
+    let Some((authority, path)) = remainder.split_once('/') else {
+        return false;
+    };
+    if path.is_empty() {
+        return false;
+    }
+    let Some((user, host_and_port)) = authority.rsplit_once('@') else {
+        return false;
+    };
+    if user != "git" {
+        return false;
+    }
+    match host_and_port.rsplit_once(':') {
+        Some((host, "443")) => {
+            host.eq_ignore_ascii_case("github.com") || host.eq_ignore_ascii_case("ssh.github.com")
+        }
+        Some((host, port)) => {
+            host.eq_ignore_ascii_case("github.com")
+                && !port.is_empty()
+                && port.chars().all(|item| item.is_ascii_digit())
+        }
+        None => host_and_port.eq_ignore_ascii_case("github.com"),
+    }
 }
 
 fn git_output(repository: &Path, arguments: &[&str]) -> Result<String> {

--- a/src/init.rs
+++ b/src/init.rs
@@ -11,6 +11,7 @@ use toml_edit::{Array, DocumentMut, Item, Value, value};
 
 use crate::config::Config;
 use crate::github::GitHubClient;
+use crate::workflow::{Trigger, WorkflowCatalog};
 
 const WORKFLOW_RELATIVE_PATH: &str = ".factory/workflows/implement-ready-ticket.md";
 const DEFAULT_WORKFLOW: &str = include_str!("../examples/implement-ready-ticket.md");
@@ -83,6 +84,7 @@ pub struct InitReport {
     name_with_owner: Option<String>,
     resources: Vec<ResourceResult>,
     check: bool,
+    workflow_changed: bool,
 }
 
 impl InitReport {
@@ -141,12 +143,14 @@ impl fmt::Display for InitReport {
             }
         } else if self.exit_code() == 0 {
             writeln!(formatter, "Next:")?;
-            writeln!(
-                formatter,
-                "  git -C {} add {}",
-                self.repository.display(),
-                WORKFLOW_RELATIVE_PATH
-            )?;
+            if self.workflow_changed {
+                writeln!(
+                    formatter,
+                    "  git -C {} add {}",
+                    self.repository.display(),
+                    WORKFLOW_RELATIVE_PATH
+                )?;
+            }
             writeln!(formatter, "  factory validate")?;
             writeln!(formatter, "  factory run")
         } else if self
@@ -178,6 +182,7 @@ struct ConfigPlan {
     workspace_action: PlannedAction,
     action: PlannedAction,
     candidate: Option<String>,
+    effective: Config,
 }
 
 #[derive(Clone, Copy)]
@@ -189,8 +194,8 @@ struct Label {
 
 pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<InitReport> {
     let repository = discover_repository(&options.repository)?;
-    let workflow = plan_workflow(&repository, options.update_workflow)?;
     let config = plan_config(&options.config_path, &repository)?;
+    let workflow = plan_workflow(&repository, options.update_workflow, &config.effective)?;
     let cancellation = CancellationToken::new();
 
     let (name_with_owner, missing_labels) = if options.no_labels {
@@ -252,6 +257,7 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
             name_with_owner,
             resources,
             check: false,
+            workflow_changed: false,
         });
     }
     resources.push(ResourceResult {
@@ -276,6 +282,7 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
             name_with_owner,
             resources,
             check: false,
+            workflow_changed: false,
         });
     }
     resources.push(ResourceResult {
@@ -335,6 +342,10 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
                         name_with_owner,
                         resources,
                         check: false,
+                        workflow_changed: matches!(
+                            workflow.action,
+                            PlannedAction::Create | PlannedAction::Update
+                        ),
                     });
                 }
             }
@@ -346,6 +357,10 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
         name_with_owner,
         resources,
         check: false,
+        workflow_changed: matches!(
+            workflow.action,
+            PlannedAction::Create | PlannedAction::Update
+        ),
     })
 }
 
@@ -467,7 +482,7 @@ fn git_output(repository: &Path, arguments: &[&str]) -> Result<String> {
     String::from_utf8(output.stdout).context("git output was not valid UTF-8")
 }
 
-fn plan_workflow(repository: &Path, update: bool) -> Result<WorkflowPlan> {
+fn plan_workflow(repository: &Path, update: bool, config: &Config) -> Result<WorkflowPlan> {
     let factory_directory = repository.join(".factory");
     let workflow_directory = repository.join(".factory/workflows");
     validate_optional_directory(&factory_directory)?;
@@ -489,7 +504,23 @@ fn plan_workflow(repository: &Path, update: bool) -> Result<WorkflowPlan> {
                 PlannedAction::Conflict
             }
         }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => PlannedAction::Create,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let catalog = WorkflowCatalog::load(config)?;
+            if let Some(entry) = catalog.entries.iter().find(|entry| {
+                entry.repository == repository
+                    && entry.errors.is_empty()
+                    && matches!(
+                        entry.trigger.as_ref(),
+                        Some(Trigger::Label(label)) if label == "factory:ready"
+                    )
+            }) {
+                return Ok(WorkflowPlan {
+                    path: entry.path.clone(),
+                    action: PlannedAction::Unchanged,
+                });
+            }
+            PlannedAction::Create
+        }
         Err(error) => {
             return Err(error)
                 .with_context(|| format!("failed to inspect workflow {}", path.display()));
@@ -525,10 +556,11 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
             if config.repositories.iter().any(|item| item == repository) {
                 return Ok(ConfigPlan {
                     path,
-                    workspace: config.workspace_root,
+                    workspace: config.workspace_root.clone(),
                     workspace_action,
                     action: PlannedAction::Unchanged,
                     candidate: None,
+                    effective: config,
                 });
             }
             let contents = fs::read_to_string(&path)
@@ -544,7 +576,7 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
             let config_directory = path
                 .parent()
                 .context("configuration path has no parent directory")?;
-            Config::validate_candidate(&candidate, config_directory)
+            let effective = Config::validate_candidate(&candidate, config_directory)
                 .context("generated configuration is invalid")?;
             Ok(ConfigPlan {
                 path,
@@ -552,6 +584,7 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
                 workspace_action,
                 action: PlannedAction::Update,
                 candidate: Some(candidate),
+                effective,
             })
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -562,7 +595,7 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
             let candidate = default_config(repository, &candidate_workspace);
             let validated = Config::validate_candidate(&candidate, config_directory)
                 .context("generated configuration is invalid")?;
-            let workspace = validated.workspace_root;
+            let workspace = validated.workspace_root.clone();
             Ok(ConfigPlan {
                 path,
                 workspace: workspace.clone(),
@@ -573,6 +606,7 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
                 },
                 action: PlannedAction::Create,
                 candidate: Some(candidate),
+                effective: validated,
             })
         }
         Err(error) => {
@@ -665,6 +699,7 @@ fn preflight_report(
         name_with_owner,
         resources,
         check: options.check,
+        workflow_changed: false,
     }
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -84,7 +84,7 @@ pub struct InitReport {
     name_with_owner: Option<String>,
     resources: Vec<ResourceResult>,
     check: bool,
-    workflow_changed: bool,
+    workflow_to_stage: Option<PathBuf>,
 }
 
 impl InitReport {
@@ -143,12 +143,12 @@ impl fmt::Display for InitReport {
             }
         } else if self.exit_code() == 0 {
             writeln!(formatter, "Next:")?;
-            if self.workflow_changed {
+            if let Some(workflow) = &self.workflow_to_stage {
                 writeln!(
                     formatter,
                     "  git -C {} add {}",
                     self.repository.display(),
-                    WORKFLOW_RELATIVE_PATH
+                    workflow.display()
                 )?;
             }
             writeln!(formatter, "  factory validate")?;
@@ -257,7 +257,7 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
             name_with_owner,
             resources,
             check: false,
-            workflow_changed: false,
+            workflow_to_stage: None,
         });
     }
     resources.push(ResourceResult {
@@ -282,7 +282,7 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
             name_with_owner,
             resources,
             check: false,
-            workflow_changed: false,
+            workflow_to_stage: None,
         });
     }
     resources.push(ResourceResult {
@@ -338,14 +338,11 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
                         ));
                     }
                     return Ok(InitReport {
+                        workflow_to_stage: workflow_to_stage(&repository, &workflow),
                         repository,
                         name_with_owner,
                         resources,
                         check: false,
-                        workflow_changed: matches!(
-                            workflow.action,
-                            PlannedAction::Create | PlannedAction::Update
-                        ),
                     });
                 }
             }
@@ -353,14 +350,11 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
     }
 
     Ok(InitReport {
+        workflow_to_stage: workflow_to_stage(&repository, &workflow),
         repository,
         name_with_owner,
         resources,
         check: false,
-        workflow_changed: matches!(
-            workflow.action,
-            PlannedAction::Create | PlannedAction::Update
-        ),
     })
 }
 
@@ -516,7 +510,11 @@ fn plan_workflow(repository: &Path, update: bool, config: &Config) -> Result<Wor
             }) {
                 return Ok(WorkflowPlan {
                     path: entry.path.clone(),
-                    action: PlannedAction::Unchanged,
+                    action: if update {
+                        PlannedAction::Update
+                    } else {
+                        PlannedAction::Unchanged
+                    },
                 });
             }
             PlannedAction::Create
@@ -538,6 +536,20 @@ fn validate_optional_directory(path: &Path) -> Result<()> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error).with_context(|| format!("failed to inspect {}", path.display())),
     }
+}
+
+fn workflow_to_stage(repository: &Path, workflow: &WorkflowPlan) -> Option<PathBuf> {
+    matches!(
+        workflow.action,
+        PlannedAction::Create | PlannedAction::Update
+    )
+    .then(|| {
+        workflow
+            .path
+            .strip_prefix(repository)
+            .unwrap_or(&workflow.path)
+            .to_path_buf()
+    })
 }
 
 fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
@@ -699,7 +711,7 @@ fn preflight_report(
         name_with_owner,
         resources,
         check: options.check,
-        workflow_changed: false,
+        workflow_to_stage: None,
     }
 }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -383,15 +383,40 @@ fn discover_repository(requested: &Path) -> Result<PathBuf> {
     let origin = git_output(&repository, &["remote", "get-url", "origin"])
         .context("target repository has no origin remote")?;
     if !is_github_origin(origin.trim()) {
-        bail!("origin is not a GitHub remote: {}", origin.trim());
+        bail!("origin is not a supported GitHub remote");
     }
     Ok(repository)
 }
 
 fn is_github_origin(origin: &str) -> bool {
     origin.starts_with("git@github.com:")
-        || origin.starts_with("https://github.com/")
+        || https_origin_has_github_host(origin)
         || origin.starts_with("ssh://git@github.com/")
+}
+
+fn https_origin_has_github_host(origin: &str) -> bool {
+    let Some(remainder) = origin.strip_prefix("https://") else {
+        return false;
+    };
+    let Some((authority, path)) = remainder.split_once('/') else {
+        return false;
+    };
+    if path.is_empty() {
+        return false;
+    }
+    let host_and_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    let host = match host_and_port.rsplit_once(':') {
+        Some((host, port))
+            if !port.is_empty() && port.chars().all(|item| item.is_ascii_digit()) =>
+        {
+            host
+        }
+        Some(_) => return false,
+        None => host_and_port,
+    };
+    host.eq_ignore_ascii_case("github.com")
 }
 
 fn git_output(repository: &Path, arguments: &[&str]) -> Result<String> {

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::fs::{self, OpenOptions};
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -558,8 +558,11 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
             let config_directory = path
                 .parent()
                 .context("configuration path has no parent directory")?;
-            let workspace = config_directory.join("workspaces");
-            validate_non_overlapping_workspace(&workspace, repository)?;
+            let candidate_workspace = config_directory.join("workspaces");
+            let candidate = default_config(repository, &candidate_workspace);
+            let validated = Config::validate_candidate(&candidate, config_directory)
+                .context("generated configuration is invalid")?;
+            let workspace = validated.workspace_root;
             Ok(ConfigPlan {
                 path,
                 workspace: workspace.clone(),
@@ -569,7 +572,7 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
                     PlannedAction::Create
                 },
                 action: PlannedAction::Create,
-                candidate: Some(default_config(repository, &workspace)),
+                candidate: Some(candidate),
             })
         }
         Err(error) => {
@@ -586,20 +589,6 @@ fn absolute_path(path: &Path) -> Result<PathBuf> {
             .context("failed to resolve current directory")?
             .join(path))
     }
-}
-
-fn validate_non_overlapping_workspace(workspace: &Path, repository: &Path) -> Result<()> {
-    if workspace == repository
-        || workspace.starts_with(repository)
-        || repository.starts_with(workspace)
-    {
-        bail!(
-            "default workspace {} overlaps repository {}; use an existing custom config",
-            workspace.display(),
-            repository.display()
-        );
-    }
-    Ok(())
 }
 
 fn default_config(repository: &Path, workspace: &Path) -> String {
@@ -795,10 +784,16 @@ fn atomic_write(path: &Path, contents: &str) -> Result<()> {
     sync_parent(parent)
 }
 
+#[cfg(unix)]
 fn sync_parent(parent: &Path) -> Result<()> {
-    OpenOptions::new()
+    fs::OpenOptions::new()
         .read(true)
         .open(parent)
         .and_then(|directory| directory.sync_all())
         .with_context(|| format!("failed to sync directory {}", parent.display()))
+}
+
+#[cfg(not(unix))]
+fn sync_parent(_parent: &Path) -> Result<()> {
+    Ok(())
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -463,11 +463,16 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
                 bail!("config path must be a regular file: {}", path.display());
             }
             let config = Config::load_without_workspace_probe(&path)?;
+            let workspace_action = if config.workspace_root.exists() {
+                PlannedAction::Unchanged
+            } else {
+                PlannedAction::Create
+            };
             if config.repositories.iter().any(|item| item == repository) {
                 return Ok(ConfigPlan {
                     path,
                     workspace: config.workspace_root,
-                    workspace_action: PlannedAction::Unchanged,
+                    workspace_action,
                     action: PlannedAction::Unchanged,
                     candidate: None,
                 });
@@ -490,7 +495,7 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
             Ok(ConfigPlan {
                 path,
                 workspace: config.workspace_root,
-                workspace_action: PlannedAction::Unchanged,
+                workspace_action,
                 action: PlannedAction::Update,
                 candidate: Some(candidate),
             })
@@ -653,6 +658,14 @@ fn applied_status(action: PlannedAction) -> ResourceStatus {
 }
 
 fn apply_config(plan: &ConfigPlan) -> Result<()> {
+    if plan.workspace_action == PlannedAction::Create {
+        fs::create_dir_all(&plan.workspace).with_context(|| {
+            format!(
+                "failed to create workspace directory {}",
+                plan.workspace.display()
+            )
+        })?;
+    }
     if plan.action == PlannedAction::Unchanged {
         Config::load(&plan.path)?;
         return Ok(());
@@ -663,12 +676,6 @@ fn apply_config(plan: &ConfigPlan) -> Result<()> {
         .context("configuration path has no parent directory")?;
     fs::create_dir_all(parent)
         .with_context(|| format!("failed to create config directory {}", parent.display()))?;
-    fs::create_dir_all(&plan.workspace).with_context(|| {
-        format!(
-            "failed to create workspace directory {}",
-            plan.workspace.display()
-        )
-    })?;
     let candidate = plan
         .candidate
         .as_deref()

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,743 @@
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use tempfile::NamedTempFile;
+use tokio_util::sync::CancellationToken;
+use toml_edit::{Array, DocumentMut, Item, Value, value};
+
+use crate::config::Config;
+use crate::github::GitHubClient;
+
+const WORKFLOW_RELATIVE_PATH: &str = ".factory/workflows/implement-ready-ticket.md";
+const DEFAULT_WORKFLOW: &str = include_str!("../examples/implement-ready-ticket.md");
+
+const READY_LABEL: Label = Label {
+    name: "factory:ready",
+    description: "Implementation is authorised and ready for Factory",
+    color: "0E8A16",
+};
+const NEEDS_REVIEW_LABEL: Label = Label {
+    name: "factory:needs-review",
+    description: "A human must inspect a question, decision, or green PR",
+    color: "FBCA04",
+};
+
+#[derive(Debug, Clone)]
+pub struct InitOptions {
+    pub repository: PathBuf,
+    pub config_path: PathBuf,
+    pub no_labels: bool,
+    pub check: bool,
+    pub update_workflow: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlannedAction {
+    Create,
+    Update,
+    Unchanged,
+    Conflict,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResourceStatus {
+    Created,
+    Updated,
+    Unchanged,
+    WouldCreate,
+    WouldUpdate,
+    Conflict,
+    Failed,
+    Skipped,
+}
+
+impl ResourceStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Updated => "updated",
+            Self::Unchanged => "unchanged",
+            Self::WouldCreate => "would create",
+            Self::WouldUpdate => "would update",
+            Self::Conflict => "conflict",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResourceResult {
+    status: ResourceStatus,
+    resource: String,
+    detail: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InitReport {
+    repository: PathBuf,
+    name_with_owner: Option<String>,
+    resources: Vec<ResourceResult>,
+    check: bool,
+}
+
+impl InitReport {
+    pub fn exit_code(&self) -> u8 {
+        u8::from(self.resources.iter().any(|resource| {
+            matches!(
+                resource.status,
+                ResourceStatus::WouldCreate
+                    | ResourceStatus::WouldUpdate
+                    | ResourceStatus::Conflict
+                    | ResourceStatus::Failed
+            )
+        }))
+    }
+}
+
+impl fmt::Display for InitReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(name) = &self.name_with_owner {
+            writeln!(
+                formatter,
+                "Factory initialization for {name} ({})",
+                self.repository.display()
+            )?;
+        } else {
+            writeln!(
+                formatter,
+                "Factory initialization for {}",
+                self.repository.display()
+            )?;
+        }
+        for resource in &self.resources {
+            write!(
+                formatter,
+                "{}: {}",
+                resource.status.label(),
+                resource.resource
+            )?;
+            if let Some(detail) = &resource.detail {
+                write!(formatter, " ({detail})")?;
+            }
+            writeln!(formatter)?;
+        }
+
+        if self.check {
+            if self.exit_code() == 0 {
+                writeln!(
+                    formatter,
+                    "Factory setup is complete; no changes were made."
+                )
+            } else {
+                writeln!(
+                    formatter,
+                    "Factory setup is incomplete; run factory init to apply these changes."
+                )
+            }
+        } else if self.exit_code() == 0 {
+            writeln!(formatter, "Next:")?;
+            writeln!(
+                formatter,
+                "  git -C {} add {}",
+                self.repository.display(),
+                WORKFLOW_RELATIVE_PATH
+            )?;
+            writeln!(formatter, "  factory validate")?;
+            writeln!(formatter, "  factory run")
+        } else if self
+            .resources
+            .iter()
+            .any(|resource| resource.status == ResourceStatus::Conflict)
+        {
+            writeln!(
+                formatter,
+                "Factory did not overwrite conflicting resources."
+            )
+        } else {
+            writeln!(
+                formatter,
+                "Factory initialization stopped after a failed resource; fix the error and retry."
+            )
+        }
+    }
+}
+
+struct WorkflowPlan {
+    path: PathBuf,
+    action: PlannedAction,
+}
+
+struct ConfigPlan {
+    path: PathBuf,
+    workspace: PathBuf,
+    workspace_action: PlannedAction,
+    action: PlannedAction,
+    candidate: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+struct Label {
+    name: &'static str,
+    description: &'static str,
+    color: &'static str,
+}
+
+pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<InitReport> {
+    let repository = discover_repository(&options.repository)?;
+    let workflow = plan_workflow(&repository, options.update_workflow)?;
+    let config = plan_config(&options.config_path, &repository)?;
+    let cancellation = CancellationToken::new();
+
+    let (name_with_owner, missing_labels) = if options.no_labels {
+        (None, Vec::new())
+    } else {
+        github.validate_global(&cancellation).await?;
+        let name = github
+            .validate_repository(&repository, &cancellation)
+            .await?;
+        let existing = github.labels(&repository, &cancellation).await?;
+        let missing = [READY_LABEL, NEEDS_REVIEW_LABEL]
+            .into_iter()
+            .filter(|label| !existing.iter().any(|name| name == label.name))
+            .collect::<Vec<_>>();
+        (Some(name), missing)
+    };
+
+    let has_conflict = workflow.action == PlannedAction::Conflict;
+    if options.check || has_conflict {
+        return Ok(preflight_report(
+            &options,
+            repository,
+            name_with_owner,
+            &workflow,
+            &config,
+            &missing_labels,
+        ));
+    }
+
+    let mut resources = Vec::new();
+    if let Err(error) = apply_config(&config) {
+        if config.workspace.exists() {
+            resources.push(ResourceResult {
+                status: applied_status(config.workspace_action),
+                resource: config.workspace.display().to_string(),
+                detail: Some("workspace directory".to_owned()),
+            });
+            resources.push(failed_resource(config.path.display().to_string(), error));
+        } else {
+            resources.push(failed_resource(
+                config.workspace.display().to_string(),
+                error,
+            ));
+            resources.push(skipped_resource(
+                config.path.display().to_string(),
+                "workspace setup failed",
+            ));
+        }
+        resources.push(skipped_resource(
+            workflow.path.display().to_string(),
+            "configuration setup failed",
+        ));
+        resources.push(skipped_resource(
+            "GitHub labels".to_owned(),
+            "configuration setup failed",
+        ));
+        return Ok(InitReport {
+            repository,
+            name_with_owner,
+            resources,
+            check: false,
+        });
+    }
+    resources.push(ResourceResult {
+        status: applied_status(config.action),
+        resource: config.path.display().to_string(),
+        detail: Some("global configuration".to_owned()),
+    });
+    resources.push(ResourceResult {
+        status: applied_status(config.workspace_action),
+        resource: config.workspace.display().to_string(),
+        detail: Some("workspace directory".to_owned()),
+    });
+
+    if let Err(error) = apply_workflow(&workflow) {
+        resources.push(failed_resource(workflow.path.display().to_string(), error));
+        resources.push(skipped_resource(
+            "GitHub labels".to_owned(),
+            "workflow setup failed",
+        ));
+        return Ok(InitReport {
+            repository,
+            name_with_owner,
+            resources,
+            check: false,
+        });
+    }
+    resources.push(ResourceResult {
+        status: applied_status(workflow.action),
+        resource: workflow.path.display().to_string(),
+        detail: Some("implementation workflow".to_owned()),
+    });
+
+    if options.no_labels {
+        resources.push(ResourceResult {
+            status: ResourceStatus::Skipped,
+            resource: "GitHub labels".to_owned(),
+            detail: Some("--no-labels".to_owned()),
+        });
+    } else {
+        let labels = [READY_LABEL, NEEDS_REVIEW_LABEL];
+        for (index, label) in labels.iter().enumerate() {
+            if !missing_labels
+                .iter()
+                .any(|missing| missing.name == label.name)
+            {
+                resources.push(ResourceResult {
+                    status: ResourceStatus::Unchanged,
+                    resource: format!("GitHub label {}", label.name),
+                    detail: None,
+                });
+                continue;
+            }
+            match github
+                .create_label(
+                    &repository,
+                    label.name,
+                    label.description,
+                    label.color,
+                    &cancellation,
+                )
+                .await
+            {
+                Ok(()) => resources.push(ResourceResult {
+                    status: ResourceStatus::Created,
+                    resource: format!("GitHub label {}", label.name),
+                    detail: None,
+                }),
+                Err(error) => {
+                    resources.push(failed_resource(
+                        format!("GitHub label {}", label.name),
+                        error,
+                    ));
+                    for remaining in &labels[index + 1..] {
+                        resources.push(skipped_resource(
+                            format!("GitHub label {}", remaining.name),
+                            "earlier label setup failed",
+                        ));
+                    }
+                    return Ok(InitReport {
+                        repository,
+                        name_with_owner,
+                        resources,
+                        check: false,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(InitReport {
+        repository,
+        name_with_owner,
+        resources,
+        check: false,
+    })
+}
+
+fn failed_resource(resource: String, error: anyhow::Error) -> ResourceResult {
+    ResourceResult {
+        status: ResourceStatus::Failed,
+        resource,
+        detail: Some(format!("{error:#}")),
+    }
+}
+
+fn skipped_resource(resource: String, reason: &str) -> ResourceResult {
+    ResourceResult {
+        status: ResourceStatus::Skipped,
+        resource,
+        detail: Some(reason.to_owned()),
+    }
+}
+
+fn discover_repository(requested: &Path) -> Result<PathBuf> {
+    let requested = requested
+        .canonicalize()
+        .with_context(|| format!("repository path does not exist: {}", requested.display()))?;
+    if !requested.is_dir() {
+        bail!(
+            "repository path is not a directory: {}",
+            requested.display()
+        );
+    }
+    let root = git_output(&requested, &["rev-parse", "--show-toplevel"])
+        .context("target is not a Git repository")?;
+    let repository = PathBuf::from(root.trim())
+        .canonicalize()
+        .context("failed to resolve Git repository root")?;
+    let origin = git_output(&repository, &["remote", "get-url", "origin"])
+        .context("target repository has no origin remote")?;
+    if !is_github_origin(origin.trim()) {
+        bail!("origin is not a GitHub remote: {}", origin.trim());
+    }
+    Ok(repository)
+}
+
+fn is_github_origin(origin: &str) -> bool {
+    origin.starts_with("git@github.com:")
+        || origin.starts_with("https://github.com/")
+        || origin.starts_with("ssh://git@github.com/")
+}
+
+fn git_output(repository: &Path, arguments: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repository)
+        .args(arguments)
+        .output()
+        .context("failed to start git")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!(
+            "git {} failed with status {}: {}",
+            arguments.join(" "),
+            output.status,
+            stderr.trim()
+        );
+    }
+    String::from_utf8(output.stdout).context("git output was not valid UTF-8")
+}
+
+fn plan_workflow(repository: &Path, update: bool) -> Result<WorkflowPlan> {
+    let factory_directory = repository.join(".factory");
+    let workflow_directory = repository.join(".factory/workflows");
+    validate_optional_directory(&factory_directory)?;
+    validate_optional_directory(&workflow_directory)?;
+
+    let path = repository.join(WORKFLOW_RELATIVE_PATH);
+    let action = match fs::symlink_metadata(&path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                bail!("workflow path must be a regular file: {}", path.display());
+            }
+            let current = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read workflow {}", path.display()))?;
+            if current == DEFAULT_WORKFLOW {
+                PlannedAction::Unchanged
+            } else if update {
+                PlannedAction::Update
+            } else {
+                PlannedAction::Conflict
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => PlannedAction::Create,
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect workflow {}", path.display()));
+        }
+    };
+    Ok(WorkflowPlan { path, action })
+}
+
+fn validate_optional_directory(path: &Path) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            bail!("setup path must be a regular directory: {}", path.display())
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("failed to inspect {}", path.display())),
+    }
+}
+
+fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
+    let path = absolute_path(path)?;
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                bail!("config path must be a regular file: {}", path.display());
+            }
+            let config = Config::load_without_workspace_probe(&path)?;
+            if config.repositories.iter().any(|item| item == repository) {
+                return Ok(ConfigPlan {
+                    path,
+                    workspace: config.workspace_root,
+                    workspace_action: PlannedAction::Unchanged,
+                    action: PlannedAction::Unchanged,
+                    candidate: None,
+                });
+            }
+            let contents = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read config {}", path.display()))?;
+            let mut document = contents
+                .parse::<DocumentMut>()
+                .with_context(|| format!("failed to edit config {}", path.display()))?;
+            let repositories = document["repositories"]
+                .as_array_mut()
+                .context("config repositories must be an array")?;
+            repositories.push(repository.display().to_string());
+            let candidate = document.to_string();
+            let config_directory = path
+                .parent()
+                .context("configuration path has no parent directory")?;
+            Config::validate_candidate(&candidate, config_directory)
+                .context("generated configuration is invalid")?;
+            Ok(ConfigPlan {
+                path,
+                workspace: config.workspace_root,
+                workspace_action: PlannedAction::Unchanged,
+                action: PlannedAction::Update,
+                candidate: Some(candidate),
+            })
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let config_directory = path
+                .parent()
+                .context("configuration path has no parent directory")?;
+            let workspace = config_directory.join("workspaces");
+            validate_non_overlapping_workspace(&workspace, repository)?;
+            Ok(ConfigPlan {
+                path,
+                workspace: workspace.clone(),
+                workspace_action: if workspace.exists() {
+                    PlannedAction::Unchanged
+                } else {
+                    PlannedAction::Create
+                },
+                action: PlannedAction::Create,
+                candidate: Some(default_config(repository, &workspace)),
+            })
+        }
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to inspect config {}", path.display()))
+        }
+    }
+}
+
+fn absolute_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()
+            .context("failed to resolve current directory")?
+            .join(path))
+    }
+}
+
+fn validate_non_overlapping_workspace(workspace: &Path, repository: &Path) -> Result<()> {
+    if workspace == repository
+        || workspace.starts_with(repository)
+        || repository.starts_with(workspace)
+    {
+        bail!(
+            "default workspace {} overlaps repository {}; use an existing custom config",
+            workspace.display(),
+            repository.display()
+        );
+    }
+    Ok(())
+}
+
+fn default_config(repository: &Path, workspace: &Path) -> String {
+    let mut document = DocumentMut::new();
+    let mut repositories = Array::new();
+    repositories.push(repository.display().to_string());
+    document["repositories"] = Item::Value(Value::Array(repositories));
+    document["poll_every"] = value("30s");
+    document["default_runtime"] = value("codex");
+    document["default_timeout"] = value("2h");
+    document["maximum_timeout"] = value("8h");
+    document["max_concurrent_runs"] = value(2);
+    document["max_concurrent_runs_per_repository"] = value(1);
+    document["workspace_root"] = value(workspace.display().to_string());
+    document.to_string()
+}
+
+fn preflight_report(
+    options: &InitOptions,
+    repository: PathBuf,
+    name_with_owner: Option<String>,
+    workflow: &WorkflowPlan,
+    config: &ConfigPlan,
+    missing_labels: &[Label],
+) -> InitReport {
+    let mut resources = vec![
+        planned_resource(
+            config.action,
+            &config.path,
+            "global configuration",
+            options.check,
+        ),
+        ResourceResult {
+            status: match config.workspace_action {
+                PlannedAction::Create => ResourceStatus::WouldCreate,
+                PlannedAction::Update => ResourceStatus::WouldUpdate,
+                PlannedAction::Unchanged => ResourceStatus::Unchanged,
+                PlannedAction::Conflict => ResourceStatus::Conflict,
+            },
+            resource: config.workspace.display().to_string(),
+            detail: Some("workspace directory".to_owned()),
+        },
+        planned_resource(
+            workflow.action,
+            &workflow.path,
+            "implementation workflow",
+            options.check,
+        ),
+    ];
+    if options.no_labels {
+        resources.push(ResourceResult {
+            status: ResourceStatus::Skipped,
+            resource: "GitHub labels".to_owned(),
+            detail: Some("--no-labels".to_owned()),
+        });
+    } else {
+        for label in [READY_LABEL, NEEDS_REVIEW_LABEL] {
+            resources.push(ResourceResult {
+                status: if missing_labels
+                    .iter()
+                    .any(|missing| missing.name == label.name)
+                {
+                    ResourceStatus::WouldCreate
+                } else {
+                    ResourceStatus::Unchanged
+                },
+                resource: format!("GitHub label {}", label.name),
+                detail: None,
+            });
+        }
+    }
+    InitReport {
+        repository,
+        name_with_owner,
+        resources,
+        check: options.check,
+    }
+}
+
+fn planned_resource(
+    action: PlannedAction,
+    path: &Path,
+    detail: &str,
+    check: bool,
+) -> ResourceResult {
+    let status = match action {
+        PlannedAction::Create => ResourceStatus::WouldCreate,
+        PlannedAction::Update => ResourceStatus::WouldUpdate,
+        PlannedAction::Unchanged => ResourceStatus::Unchanged,
+        PlannedAction::Conflict => ResourceStatus::Conflict,
+    };
+    ResourceResult {
+        status,
+        resource: path.display().to_string(),
+        detail: Some(if action == PlannedAction::Conflict && !check {
+            "customized workflow; use --update-workflow".to_owned()
+        } else {
+            detail.to_owned()
+        }),
+    }
+}
+
+fn applied_status(action: PlannedAction) -> ResourceStatus {
+    match action {
+        PlannedAction::Create => ResourceStatus::Created,
+        PlannedAction::Update => ResourceStatus::Updated,
+        PlannedAction::Unchanged => ResourceStatus::Unchanged,
+        PlannedAction::Conflict => ResourceStatus::Conflict,
+    }
+}
+
+fn apply_config(plan: &ConfigPlan) -> Result<()> {
+    if plan.action == PlannedAction::Unchanged {
+        Config::load(&plan.path)?;
+        return Ok(());
+    }
+    let parent = plan
+        .path
+        .parent()
+        .context("configuration path has no parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create config directory {}", parent.display()))?;
+    fs::create_dir_all(&plan.workspace).with_context(|| {
+        format!(
+            "failed to create workspace directory {}",
+            plan.workspace.display()
+        )
+    })?;
+    let candidate = plan
+        .candidate
+        .as_deref()
+        .context("configuration update has no candidate contents")?;
+    validated_atomic_config_write(&plan.path, candidate)
+}
+
+fn validated_atomic_config_write(path: &Path, contents: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("configuration path has no parent directory")?;
+    let mut temporary = NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary config in {}", parent.display()))?;
+    temporary
+        .write_all(contents.as_bytes())
+        .context("failed to write temporary configuration")?;
+    temporary
+        .as_file_mut()
+        .sync_all()
+        .context("failed to sync temporary configuration")?;
+    Config::load(temporary.path()).context("generated configuration is invalid")?;
+    if let Ok(metadata) = fs::metadata(path) {
+        temporary
+            .as_file()
+            .set_permissions(metadata.permissions())
+            .context("failed to preserve config permissions")?;
+    }
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to replace config {}", path.display()))?;
+    sync_parent(parent)
+}
+
+fn apply_workflow(plan: &WorkflowPlan) -> Result<()> {
+    if plan.action == PlannedAction::Unchanged {
+        return Ok(());
+    }
+    let parent = plan
+        .path
+        .parent()
+        .context("workflow path has no parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create workflow directory {}", parent.display()))?;
+    atomic_write(&plan.path, DEFAULT_WORKFLOW)
+}
+
+fn atomic_write(path: &Path, contents: &str) -> Result<()> {
+    let parent = path.parent().context("path has no parent directory")?;
+    let mut temporary = NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary file in {}", parent.display()))?;
+    temporary
+        .write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write temporary file for {}", path.display()))?;
+    temporary
+        .as_file_mut()
+        .sync_all()
+        .with_context(|| format!("failed to sync temporary file for {}", path.display()))?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to replace {}", path.display()))?;
+    sync_parent(parent)
+}
+
+fn sync_parent(parent: &Path) -> Result<()> {
+    OpenOptions::new()
+        .read(true)
+        .open(parent)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| format!("failed to sync directory {}", parent.display()))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod daemon;
 pub mod execution;
 pub mod github;
+pub mod init;
 pub mod inspection;
 pub mod runtime;
 pub mod storage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use factory::config::{Config, default_config_path};
 use factory::daemon::FactoryDaemon;
 use factory::execution::ResolvedWorkflow;
 use factory::github::{GitHubClient, PollReport};
+use factory::init::{InitOptions, initialize};
 use factory::inspection::{
     RunInspection, RunView, TaskView, print_inspection, print_runs, print_tasks,
 };
@@ -28,6 +29,21 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Prepare a trusted GitHub repository for Factory.
+    Init {
+        /// Repository to initialize. Defaults to the current directory.
+        #[arg(long)]
+        repository: Option<PathBuf>,
+        /// Skip GitHub label discovery and creation.
+        #[arg(long)]
+        no_labels: bool,
+        /// Report required changes without writing anything.
+        #[arg(long)]
+        check: bool,
+        /// Replace a customized implementation workflow with the bundled version.
+        #[arg(long)]
+        update_workflow: bool,
+    },
     /// Poll configured repositories and persist eligible ticket tasks.
     Run {
         /// Poll once and exit without waiting for the next interval.
@@ -151,6 +167,29 @@ async fn run_cli() -> Result<u8> {
     let cli = Cli::parse();
 
     match cli.command {
+        Command::Init {
+            repository,
+            no_labels,
+            check,
+            update_workflow,
+        } => {
+            let repository = repository
+                .unwrap_or(std::env::current_dir().context("failed to resolve current directory")?);
+            let report = initialize(
+                InitOptions {
+                    repository,
+                    config_path: default_config_path(),
+                    no_labels,
+                    check,
+                    update_workflow,
+                },
+                &GitHubClient::default(),
+            )
+            .await?;
+            let exit_code = report.exit_code();
+            print!("{report}");
+            return Ok(exit_code);
+        }
         Command::Run {
             once,
             config,
@@ -318,6 +357,16 @@ async fn run_poller(
     let path = config_path.unwrap_or_else(default_config_path);
     let config = Config::load(&path)?;
     let catalog = WorkflowCatalog::load(&config)?;
+    for repository in catalog.repositories_without_ready_workflow(&config) {
+        write_stderr_best_effort(
+            format!(
+                "No valid factory:ready implementation workflow found for {}; run factory init --repository {}\n",
+                repository.display(),
+                repository.display()
+            )
+            .as_bytes(),
+        );
+    }
     let ticket_validation = catalog.validate_ticket_workflows();
     if once || ticket_validation.is_err() {
         for entry in catalog.invalid_scheduled_entries() {

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -113,6 +113,23 @@ impl WorkflowCatalog {
         }
         Ok(())
     }
+
+    pub fn repositories_without_ready_workflow<'a>(
+        &'a self,
+        config: &'a Config,
+    ) -> impl Iterator<Item = &'a PathBuf> {
+        config.repositories.iter().filter(|repository| {
+            !self.entries.iter().any(|entry| {
+                &entry.repository == *repository
+                    && entry.id == "implement-ready-ticket"
+                    && entry.errors.is_empty()
+                    && matches!(
+                        entry.trigger.as_ref(),
+                        Some(Trigger::Label(label)) if label == "factory:ready"
+                    )
+            })
+        })
+    }
 }
 
 impl fmt::Display for WorkflowCatalog {

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -121,7 +121,6 @@ impl WorkflowCatalog {
         config.repositories.iter().filter(|repository| {
             !self.entries.iter().any(|entry| {
                 &entry.repository == *repository
-                    && entry.id == "implement-ready-ticket"
                     && entry.errors.is_empty()
                     && matches!(
                         entry.trigger.as_ref(),

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -109,6 +109,17 @@ fn init_git_repository(path: &Path, origin: &str) {
     );
 }
 
+fn set_origin(path: &Path, origin: &str) {
+    assert!(
+        ProcessCommand::new("git")
+            .args(["remote", "set-url", "origin", origin])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
+}
+
 fn write_config(path: &Path, repositories: &[&Path], workspace: &Path, prefix: &str) -> String {
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::create_dir_all(workspace).unwrap();
@@ -176,6 +187,46 @@ fn init_creates_complete_setup_and_is_idempotent() {
         fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
         "factory:ready\nfactory:needs-review\n"
     );
+}
+
+#[test]
+fn init_accepts_credentialed_github_https_origin() {
+    let fixture = Fixture::new();
+    set_origin(
+        &fixture.repository,
+        "https://user:secret@github.com/example/repository.git",
+    );
+
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .success();
+
+    assert!(fixture.workflow().is_file());
+    assert!(fixture.config_path().is_file());
+}
+
+#[test]
+fn init_rejects_github_lookalike_origin_without_leaking_credentials() {
+    let fixture = Fixture::new();
+    set_origin(
+        &fixture.repository,
+        "https://user:secret@github.com.example.test/example/repository.git",
+    );
+
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "origin is not a supported GitHub remote",
+        ))
+        .stderr(predicate::str::contains("secret").not());
+
+    assert!(!fixture.workflow().exists());
+    assert!(!fixture.config_path().exists());
 }
 
 #[test]

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -256,6 +256,38 @@ fn check_does_not_probe_existing_workspace_writability() {
 }
 
 #[test]
+fn init_recreates_workspace_missing_from_existing_config() {
+    let fixture = Fixture::new();
+    let original = write_config(
+        &fixture.config_path(),
+        &[&fixture.repository],
+        &fixture.workspace(),
+        "# keep this comment\n",
+    );
+    fs::remove_dir(fixture.workspace()).unwrap();
+
+    fixture
+        .command()
+        .args(["init", "--no-labels", "--check"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("would create:"))
+        .stdout(predicate::str::contains("workspace directory"));
+    assert!(!fixture.workspace().exists());
+
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("created:"))
+        .stdout(predicate::str::contains("workspace directory"));
+
+    assert!(fixture.workspace().is_dir());
+    assert_eq!(fs::read_to_string(fixture.config_path()).unwrap(), original);
+}
+
+#[test]
 fn no_labels_never_invokes_github_cli() {
     let fixture = Fixture::new();
 

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -288,6 +288,43 @@ fn init_recreates_workspace_missing_from_existing_config() {
 }
 
 #[test]
+fn init_rejects_parent_traversal_in_missing_workspace_without_writes() {
+    let fixture = Fixture::new();
+    let safe_workspace = fixture._temp.path().join("safe-workspace");
+    let original = write_config(
+        &fixture.config_path(),
+        &[&fixture.repository],
+        &safe_workspace,
+        "",
+    );
+    let dangerous_workspace = fixture
+        ._temp
+        .path()
+        .join("missing/../repository/workspaces");
+    fs::remove_dir(&safe_workspace).unwrap();
+    fs::write(
+        fixture.config_path(),
+        original.replace(
+            safe_workspace.to_str().unwrap(),
+            dangerous_workspace.to_str().unwrap(),
+        ),
+    )
+    .unwrap();
+
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "must not contain parent traversal in a missing suffix",
+        ));
+
+    assert!(!fixture.repository.join("workspaces").exists());
+    assert!(!fixture.workflow().exists());
+}
+
+#[test]
 fn no_labels_never_invokes_github_cli() {
     let fixture = Fixture::new();
 

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -585,3 +585,34 @@ fn run_hints_at_init_when_ready_workflow_is_missing() {
         ))
         .stderr(predicate::str::contains("run factory init --repository"));
 }
+
+#[test]
+fn run_accepts_valid_custom_ready_workflow_as_initialized() {
+    let fixture = Fixture::new();
+    let workspace = fixture._temp.path().join("workspaces");
+    write_config(
+        &fixture.config_path(),
+        &[&fixture.repository],
+        &workspace,
+        "",
+    );
+    let workflows = fixture.repository.join(".factory/workflows");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::write(
+        workflows.join("custom-ready-policy.md"),
+        "+++\nlabel = \"factory:ready\"\n+++\n\nUse the repository-specific delivery policy.\n",
+    )
+    .unwrap();
+
+    fixture
+        .command()
+        .args(["run", "--once", "--config"])
+        .arg(fixture.config_path())
+        .arg("--data-directory")
+        .arg(fixture._temp.path().join("data"))
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("No valid factory:ready implementation workflow found").not(),
+        );
+}

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -156,6 +156,10 @@ fn init_creates_complete_setup_and_is_idempotent() {
         .success()
         .stdout(predicate::str::contains("created: "))
         .stdout(predicate::str::contains("GitHub label factory:ready"))
+        .stdout(predicate::str::contains("git -C "))
+        .stdout(predicate::str::contains(
+            ".factory/workflows/implement-ready-ticket.md",
+        ))
         .stdout(predicate::str::contains("factory validate"));
 
     assert_eq!(
@@ -615,4 +619,31 @@ fn run_accepts_valid_custom_ready_workflow_as_initialized() {
         .stderr(
             predicate::str::contains("No valid factory:ready implementation workflow found").not(),
         );
+}
+
+#[test]
+fn init_does_not_install_duplicate_beside_custom_ready_workflow() {
+    let fixture = Fixture::new();
+    let workflows = fixture.repository.join(".factory/workflows");
+    let custom = workflows.join("custom-ready-policy.md");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::write(
+        &custom,
+        "+++\nlabel = \"factory:ready\"\n+++\n\nUse the repository-specific delivery policy.\n",
+    )
+    .unwrap();
+
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(custom.to_str().unwrap()))
+        .stdout(predicate::str::contains("unchanged:"))
+        .stdout(predicate::str::contains("git -C").not())
+        .stdout(predicate::str::contains("implement-ready-ticket.md").not());
+
+    assert!(!fixture.workflow().exists());
+    assert!(custom.is_file());
+    assert!(fixture.config_path().is_file());
 }

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -2,6 +2,7 @@
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
@@ -409,6 +410,28 @@ fn init_rejects_parent_traversal_in_missing_workspace_without_writes() {
 
     assert!(!fixture.repository.join("workspaces").exists());
     assert!(!fixture.workflow().exists());
+}
+
+#[test]
+fn init_resolves_symlinked_config_ancestors_before_workspace_writes() {
+    let fixture = Fixture::new();
+    let state = fixture.repository.join(".factory-state");
+    fs::create_dir(&state).unwrap();
+    symlink(&state, fixture.home.join(".factory")).unwrap();
+
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "generated configuration is invalid",
+        ))
+        .stderr(predicate::str::contains("must not overlap"));
+
+    assert!(!state.join("workspaces").exists());
+    assert!(!fixture.workflow().exists());
+    assert!(!fixture.config_path().exists());
 }
 
 #[test]

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -30,6 +30,7 @@ impl Fixture {
             &gh,
             r#"#!/bin/sh
 printf '%s\n' "$*" >> .gh-calls
+if [ -n "${GH_REPO:-}" ]; then echo "GH_REPO leaked into gh" >&2; exit 65; fi
 if [ "$1" = "--version" ]; then echo "gh version 2.80.0"; exit 0; fi
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo "logged in"; exit 0; fi
 if [ "$1" = "repo" ] && [ "$2" = "view" ]; then echo "example/repository"; exit 0; fi
@@ -246,6 +247,25 @@ fn label_discovery_uses_uncapped_paginated_api() {
     let calls = fs::read_to_string(fixture.repository.join(".gh-calls")).unwrap();
     assert!(calls.contains("api repos/{owner}/{repo}/labels --paginate --jq .[].name"));
     assert!(!calls.contains("--limit"));
+}
+
+#[test]
+fn init_ignores_gh_repo_environment_override() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .env("GH_REPO", "wrong/repository")
+        .args(["init", "--repository"])
+        .arg(&fixture.repository)
+        .assert()
+        .success();
+
+    assert!(fixture.workflow().is_file());
+    assert_eq!(
+        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
+        "factory:ready\nfactory:needs-review\n"
+    );
 }
 
 #[test]
@@ -646,4 +666,35 @@ fn init_does_not_install_duplicate_beside_custom_ready_workflow() {
     assert!(!fixture.workflow().exists());
     assert!(custom.is_file());
     assert!(fixture.config_path().is_file());
+}
+
+#[test]
+fn update_workflow_replaces_custom_ready_workflow_in_place() {
+    let fixture = Fixture::new();
+    let workflows = fixture.repository.join(".factory/workflows");
+    let custom = workflows.join("custom-ready-policy.md");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::write(
+        &custom,
+        "+++\nlabel = \"factory:ready\"\n+++\n\nUse the repository-specific delivery policy.\n",
+    )
+    .unwrap();
+
+    fixture
+        .command()
+        .args(["init", "--no-labels", "--update-workflow"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("updated:"))
+        .stdout(predicate::str::contains(
+            "git -C ".to_owned()
+                + fixture.repository.canonicalize().unwrap().to_str().unwrap()
+                + " add .factory/workflows/custom-ready-policy.md",
+        ));
+
+    assert_eq!(
+        fs::read_to_string(&custom).unwrap(),
+        include_str!("../examples/implement-ready-ticket.md")
+    );
+    assert!(!fixture.workflow().exists());
 }

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -1,0 +1,408 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+
+use assert_cmd::Command;
+use factory::config::Config;
+use predicates::prelude::*;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    home: PathBuf,
+    repository: PathBuf,
+    executable_path: String,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let repository = temp.path().join("repository");
+        fs::create_dir(&home).unwrap();
+        init_git_repository(&repository, "git@github.com:example/repository.git");
+
+        let gh = temp.path().join("gh");
+        fs::write(
+            &gh,
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> .gh-calls
+if [ "$1" = "--version" ]; then echo "gh version 2.80.0"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo "logged in"; exit 0; fi
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then echo "example/repository"; exit 0; fi
+if [ "$1" = "label" ] && [ "$2" = "list" ]; then
+  if [ -f .factory-test-labels ]; then cat .factory-test-labels; fi
+  exit 0
+fi
+if [ "$1" = "label" ] && [ "$2" = "create" ]; then
+  if [ "$3" = "factory:needs-review" ] && [ -f .fail-needs-review ]; then
+    echo "simulated label failure" >&2
+    exit 1
+  fi
+  printf '%s\n' "$3" >> .factory-test-labels
+  exit 0
+fi
+if [ "$1" = "api" ]; then printf '[[]]'; exit 0; fi
+echo "unexpected fake gh arguments: $*" >&2
+exit 64
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&gh).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&gh, permissions).unwrap();
+        let executable_path = format!(
+            "{}:{}",
+            temp.path().display(),
+            std::env::var("PATH").unwrap()
+        );
+        Self {
+            _temp: temp,
+            home,
+            repository,
+            executable_path,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::cargo_bin("factory").unwrap();
+        command
+            .current_dir(&self.repository)
+            .env("HOME", &self.home)
+            .env("PATH", &self.executable_path);
+        command
+    }
+
+    fn config_path(&self) -> PathBuf {
+        self.home.join(".factory/config.toml")
+    }
+
+    fn workspace(&self) -> PathBuf {
+        self.home.join(".factory/workspaces")
+    }
+
+    fn workflow(&self) -> PathBuf {
+        self.repository
+            .join(".factory/workflows/implement-ready-ticket.md")
+    }
+}
+
+fn init_git_repository(path: &Path, origin: &str) {
+    fs::create_dir_all(path).unwrap();
+    assert!(
+        ProcessCommand::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        ProcessCommand::new("git")
+            .args(["remote", "add", "origin", origin])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success()
+    );
+}
+
+fn write_config(path: &Path, repositories: &[&Path], workspace: &Path, prefix: &str) -> String {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::create_dir_all(workspace).unwrap();
+    let repositories = repositories
+        .iter()
+        .map(|repository| format!("\"{}\"", repository.display()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let contents = format!(
+        "{prefix}repositories = [{repositories}]\npoll_every = \"30s\"\ndefault_runtime = \"codex\"\ndefault_timeout = \"2h\"\nmaximum_timeout = \"8h\"\nmax_concurrent_runs = 2\nmax_concurrent_runs_per_repository = 1\nworkspace_root = \"{}\"\n",
+        workspace.display()
+    );
+    fs::write(path, &contents).unwrap();
+    contents
+}
+
+#[test]
+fn init_creates_complete_setup_and_is_idempotent() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args(["init", "--repository"])
+        .arg(&fixture.repository)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("created: "))
+        .stdout(predicate::str::contains("GitHub label factory:ready"))
+        .stdout(predicate::str::contains("factory validate"));
+
+    assert_eq!(
+        fs::read_to_string(fixture.workflow()).unwrap(),
+        include_str!("../examples/implement-ready-ticket.md")
+    );
+    let config = Config::load(&fixture.config_path()).unwrap();
+    assert_eq!(
+        config.repositories,
+        vec![fixture.repository.canonicalize().unwrap()]
+    );
+    assert_eq!(
+        config.workspace_root,
+        fixture.workspace().canonicalize().unwrap()
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
+        "factory:ready\nfactory:needs-review\n"
+    );
+
+    fixture
+        .command()
+        .args(["init", "--repository"])
+        .arg(&fixture.repository)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("unchanged:"));
+
+    let contents = fs::read_to_string(fixture.config_path()).unwrap();
+    assert_eq!(
+        contents
+            .matches(fixture.repository.to_str().unwrap())
+            .count(),
+        1
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
+        "factory:ready\nfactory:needs-review\n"
+    );
+}
+
+#[test]
+fn partial_label_failure_reports_every_applied_and_failed_resource() {
+    let fixture = Fixture::new();
+    fs::write(fixture.repository.join(".fail-needs-review"), "").unwrap();
+
+    fixture
+        .command()
+        .args(["init", "--repository"])
+        .arg(&fixture.repository)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("created: "))
+        .stdout(predicate::str::contains("GitHub label factory:ready"))
+        .stdout(predicate::str::contains(
+            "failed: GitHub label factory:needs-review",
+        ))
+        .stdout(predicate::str::contains("simulated label failure"))
+        .stdout(predicate::str::contains("stopped after a failed resource"));
+
+    assert!(fixture.config_path().is_file());
+    assert!(fixture.workflow().is_file());
+    assert_eq!(
+        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
+        "factory:ready\n"
+    );
+}
+
+#[test]
+fn check_reports_every_missing_resource_without_writes() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args(["init", "--check", "--repository"])
+        .arg(&fixture.repository)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("would create:"))
+        .stdout(predicate::str::contains("Factory setup is incomplete"));
+
+    assert!(!fixture.config_path().exists());
+    assert!(!fixture.workspace().exists());
+    assert!(!fixture.workflow().exists());
+    assert!(!fixture.repository.join(".factory-test-labels").exists());
+    let calls = fs::read_to_string(fixture.repository.join(".gh-calls")).unwrap();
+    assert!(!calls.contains("label create"));
+}
+
+#[test]
+fn check_does_not_probe_existing_workspace_writability() {
+    let fixture = Fixture::new();
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .success();
+    let mut permissions = fs::metadata(fixture.workspace()).unwrap().permissions();
+    permissions.set_mode(0o555);
+    fs::set_permissions(fixture.workspace(), permissions).unwrap();
+
+    let output = fixture
+        .command()
+        .args(["init", "--no-labels", "--check"])
+        .output()
+        .unwrap();
+
+    let mut permissions = fs::metadata(fixture.workspace()).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(fixture.workspace(), permissions).unwrap();
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .contains("no changes were made")
+    );
+}
+
+#[test]
+fn no_labels_never_invokes_github_cli() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("skipped: GitHub labels"));
+
+    assert!(!fixture.repository.join(".gh-calls").exists());
+    assert!(fixture.workflow().is_file());
+    assert!(fixture.config_path().is_file());
+}
+
+#[test]
+fn customized_workflow_requires_explicit_update() {
+    let fixture = Fixture::new();
+    fs::create_dir_all(fixture.workflow().parent().unwrap()).unwrap();
+    fs::write(fixture.workflow(), "custom policy\n").unwrap();
+
+    fixture
+        .command()
+        .args(["init", "--no-labels", "--repository"])
+        .arg(&fixture.repository)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("conflict:"))
+        .stdout(predicate::str::contains("--update-workflow"));
+    assert_eq!(
+        fs::read_to_string(fixture.workflow()).unwrap(),
+        "custom policy\n"
+    );
+    assert!(!fixture.config_path().exists());
+
+    fixture
+        .command()
+        .args(["init", "--no-labels", "--update-workflow", "--repository"])
+        .arg(&fixture.repository)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("updated:"));
+    assert_eq!(
+        fs::read_to_string(fixture.workflow()).unwrap(),
+        include_str!("../examples/implement-ready-ticket.md")
+    );
+}
+
+#[test]
+fn existing_config_preserves_comments_and_registers_repository_once() {
+    let fixture = Fixture::new();
+    let other = fixture._temp.path().join("other");
+    fs::create_dir(&other).unwrap();
+    let workspace = fixture._temp.path().join("workspaces");
+    write_config(
+        &fixture.config_path(),
+        &[&other],
+        &workspace,
+        "# keep this comment\n",
+    );
+
+    for _ in 0..2 {
+        fixture
+            .command()
+            .args(["init", "--no-labels", "--repository"])
+            .arg(&fixture.repository)
+            .assert()
+            .success();
+    }
+
+    let contents = fs::read_to_string(fixture.config_path()).unwrap();
+    assert!(contents.starts_with("# keep this comment\n"));
+    assert_eq!(
+        contents
+            .matches(fixture.repository.to_str().unwrap())
+            .count(),
+        1
+    );
+    let config = Config::load(&fixture.config_path()).unwrap();
+    assert_eq!(config.repositories.len(), 2);
+}
+
+#[test]
+fn invalid_candidate_leaves_existing_config_and_workflow_untouched() {
+    let fixture = Fixture::new();
+    let other = fixture._temp.path().join("other");
+    fs::create_dir(&other).unwrap();
+    let workspace = fixture._temp.path().join("workspaces");
+    let nested_repository = workspace.join("nested-repository");
+    init_git_repository(
+        &nested_repository,
+        "https://github.com/example/nested-repository.git",
+    );
+    let original = write_config(
+        &fixture.config_path(),
+        &[&other],
+        &workspace,
+        "# must survive\n",
+    );
+
+    fixture
+        .command()
+        .args(["init", "--no-labels", "--repository"])
+        .arg(&nested_repository)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "generated configuration is invalid",
+        ));
+
+    assert_eq!(fs::read_to_string(fixture.config_path()).unwrap(), original);
+    assert!(
+        !nested_repository
+            .join(".factory/workflows/implement-ready-ticket.md")
+            .exists()
+    );
+}
+
+#[test]
+fn run_hints_at_init_when_ready_workflow_is_missing() {
+    let fixture = Fixture::new();
+    let workspace = fixture._temp.path().join("workspaces");
+    write_config(
+        &fixture.config_path(),
+        &[&fixture.repository],
+        &workspace,
+        "",
+    );
+    fs::create_dir_all(fixture.repository.join(".factory/workflows")).unwrap();
+    fs::write(
+        fixture
+            .repository
+            .join(".factory/workflows/nightly-maintenance.md"),
+        "+++\nschedule = \"0 2 * * *\"\ntimezone = \"UTC\"\n+++\n\nMaintain the repository.\n",
+    )
+    .unwrap();
+
+    fixture
+        .command()
+        .args(["run", "--once", "--config"])
+        .arg(fixture.config_path())
+        .arg("--data-directory")
+        .arg(fixture._temp.path().join("data"))
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "No valid factory:ready implementation workflow found",
+        ))
+        .stderr(predicate::str::contains("run factory init --repository"));
+}

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -44,7 +44,14 @@ if [ "$1" = "label" ] && [ "$2" = "create" ]; then
   printf '%s\n' "$3" >> .factory-test-labels
   exit 0
 fi
-if [ "$1" = "api" ]; then printf '[[]]'; exit 0; fi
+if [ "$1" = "api" ]; then
+  if [ "$2" = 'repos/{owner}/{repo}/labels' ]; then
+    if [ -f .factory-test-labels ]; then cat .factory-test-labels; fi
+  else
+    printf '[[]]'
+  fi
+  exit 0
+fi
 echo "unexpected fake gh arguments: $*" >&2
 exit 64
 "#,
@@ -205,6 +212,35 @@ fn init_accepts_credentialed_github_https_origin() {
 
     assert!(fixture.workflow().is_file());
     assert!(fixture.config_path().is_file());
+}
+
+#[test]
+fn init_accepts_github_ssh_over_port_443_origin() {
+    let fixture = Fixture::new();
+    set_origin(
+        &fixture.repository,
+        "ssh://git@ssh.github.com:443/example/repository.git",
+    );
+
+    fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .assert()
+        .success();
+
+    assert!(fixture.workflow().is_file());
+    assert!(fixture.config_path().is_file());
+}
+
+#[test]
+fn label_discovery_uses_uncapped_paginated_api() {
+    let fixture = Fixture::new();
+
+    fixture.command().arg("init").assert().success();
+
+    let calls = fs::read_to_string(fixture.repository.join(".gh-calls")).unwrap();
+    assert!(calls.contains("api repos/{owner}/{repo}/labels --paginate --jq .[].name"));
+    assert!(!calls.contains("--limit"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #26.

## Summary

- add `factory init` with safe defaults, dry-run checks, and explicit workflow updates
- register repositories in the global config while preserving existing TOML structure and comments
- create required GitHub labels without modifying existing definitions
- improve daemon startup guidance when the ready-ticket workflow is missing or invalid
- replace manual onboarding steps in the local v1 documentation

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (139 tests passed)
- fresh independent diff review: approved with no actionable findings

## Safety

- customized workflows are never overwritten without `--update-workflow`
- `--check` performs no filesystem or GitHub writes
- config writes are validated and atomic
- initialization does not start Factory, run Codex, commit changes, or merge pull requests