### PR TITLE
fix(cli): report daemon startup progress

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -106,6 +106,7 @@ impl FactoryDaemon {
     }
 
     pub async fn run(&self, cancellation: CancellationToken) -> Result<()> {
+        eprintln!("Factory checking authenticated GitHub and Codex CLIs...");
         if let Err(error) = self.validate(&cancellation).await {
             if cancellation.is_cancelled() {
                 return Ok(());
@@ -140,6 +141,16 @@ impl FactoryDaemon {
         let mut active = HashMap::<String, usize>::new();
         let mut runs = JoinSet::<(String, Result<()>)>::new();
         let mut github_polls = JoinSet::<Result<()>>::new();
+        let workflow_count = targets
+            .values()
+            .map(|target| target.workflows.len())
+            .sum::<usize>();
+        eprintln!(
+            "Factory ready: watching {} repositories and {} workflows; polling every {}; press Ctrl-C to stop.",
+            targets.len(),
+            workflow_count,
+            humantime::format_duration(self.config.poll_every)
+        );
         {
             let config = self.config.clone();
             let catalog = self.catalog.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,6 +355,10 @@ async fn run_poller(
     once: bool,
 ) -> Result<u8> {
     let path = config_path.unwrap_or_else(default_config_path);
+    let mode = if once { "once" } else { "continuous" };
+    write_stderr_best_effort(
+        format!("Factory starting: mode={mode} config={}\n", path.display()).as_bytes(),
+    );
     let config = Config::load(&path)?;
     let catalog = WorkflowCatalog::load(&config)?;
     for repository in catalog.repositories_without_ready_workflow(&config) {
@@ -383,9 +387,20 @@ async fn run_poller(
             .unwrap_or_else(|| std::path::Path::new("."))
             .to_path_buf()
     });
+    write_stderr_best_effort(
+        format!(
+            "Factory loaded: repositories={} workflows={} data={} poll_every={}\n",
+            config.repositories.len(),
+            catalog.entries.len(),
+            data_directory.display(),
+            humantime::format_duration(config.poll_every)
+        )
+        .as_bytes(),
+    );
     let mut ledger = Ledger::open_in(&data_directory)?;
     let github = GitHubClient::default();
     if once {
+        write_stderr_best_effort(b"Factory polling GitHub once...\n");
         let report = github.poll_once(&config, &catalog, &mut ledger).await?;
         print_poll_report(&report);
         return Ok(u8::from(report.failures() > 0));
@@ -401,6 +416,7 @@ async fn run_poller(
     let daemon = FactoryDaemon::new(config, catalog, ledger.path());
     daemon.run(cancellation).await?;
     signal_task.abort();
+    write_stderr_best_effort(b"Factory stopped.\n");
     Ok(0)
 }
 

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -88,6 +88,9 @@ impl Fixture {
             r#"#!/bin/sh
 if [ "$1" = "--version" ]; then echo "gh version 2.80.0"; exit 0; fi
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  if [ -f "$0.auth-block" ]; then
+    while [ ! -f "$0.auth-release" ]; do sleep 0.02; done
+  fi
   if [ -f "$0.auth-fail" ]; then echo "authentication expired" >&2; exit 1; fi
   echo "logged in"; exit 0
 fi
@@ -279,6 +282,67 @@ where
     })
     .await
     .unwrap();
+}
+
+#[tokio::test]
+async fn cli_reports_live_startup_ready_and_shutdown_progress() {
+    let fixture = Fixture::new(&[vec![]], 1, 1);
+    fs::write(format!("{}.auth-block", fixture.gh.display()), "").unwrap();
+    let stderr_path = fixture._temp.path().join("factory.stderr");
+    let stderr = fs::File::create(&stderr_path).unwrap();
+    let search_path = std::env::join_paths(
+        std::iter::once(fixture.gh.parent().unwrap().to_path_buf()).chain(
+            std::env::var_os("PATH")
+                .as_deref()
+                .map(std::env::split_paths)
+                .into_iter()
+                .flatten(),
+        ),
+    )
+    .unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_factory"));
+    command
+        .args([
+            "run",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            fixture.ledger_path.parent().unwrap().to_str().unwrap(),
+        ])
+        .env("PATH", search_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr));
+    let mut child = command.spawn().unwrap();
+
+    wait_for(|| {
+        fs::read_to_string(&stderr_path).is_ok_and(|contents| {
+            contents.contains("Factory checking authenticated GitHub and Codex CLIs...")
+        })
+    })
+    .await;
+    assert!(child.try_wait().unwrap().is_none());
+    let blocked_output = fs::read_to_string(&stderr_path).unwrap();
+    assert!(blocked_output.contains("Factory starting: mode=continuous"));
+    assert!(blocked_output.contains("Factory loaded: repositories=1 workflows=1"));
+    assert!(!blocked_output.contains("Factory ready:"));
+
+    fs::write(format!("{}.auth-release", fixture.gh.display()), "").unwrap();
+    wait_for(|| {
+        fs::read_to_string(&stderr_path)
+            .is_ok_and(|contents| contents.contains("Factory ready: watching 1 repositories"))
+    })
+    .await;
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(i32::try_from(child.id()).unwrap()),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .unwrap();
+    assert!(child.wait().unwrap().success());
+    assert!(
+        fs::read_to_string(&stderr_path)
+            .unwrap()
+            .contains("Factory stopped.")
+    );
 }
 
 fn process_is_alive(process_id: u32) -> bool {

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -171,7 +171,12 @@ fn factory_run_once_persists_a_task_without_launching_codex() {
         .env("PATH", path)
         .assert()
         .success()
-        .stdout(predicates::str::contains("tasks_created=1"));
+        .stdout(predicates::str::contains("tasks_created=1"))
+        .stderr(predicates::str::contains("Factory starting: mode=once"))
+        .stderr(predicates::str::contains(
+            "Factory loaded: repositories=1 workflows=1",
+        ))
+        .stderr(predicates::str::contains("Factory polling GitHub once..."));
 
     assert!(!codex_marker.exists());
     let mut ledger = Ledger::open_in(&data).unwrap();
@@ -179,6 +184,41 @@ fn factory_run_once_persists_a_task_without_launching_codex() {
         ledger.claim_next().unwrap().unwrap().source_item.as_deref(),
         Some("9")
     );
+}
+
+#[test]
+fn factory_run_once_reports_progress_before_authentication_failure() {
+    let fixture = Fixture::new(1);
+    fs::write(format!("{}.auth-fail", fixture.gh.display()), "").unwrap();
+    let data = fixture._temp.path().join("data");
+    let path = format!(
+        "{}:{}",
+        fixture._temp.path().display(),
+        std::env::var("PATH").unwrap()
+    );
+
+    let output = AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            data.to_str().unwrap(),
+        ])
+        .env("PATH", path)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    let starting = stderr.find("Factory starting: mode=once").unwrap();
+    let polling = stderr.find("Factory polling GitHub once...").unwrap();
+    let failure = stderr.find("Error:").unwrap();
+    assert!(starting < polling);
+    assert!(polling < failure);
+    assert!(stderr.contains("run gh auth login"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- print immediate startup mode and configuration path for `factory run`
- report loaded repository, workflow, state, and polling details
- announce authenticated CLI checks, daemon readiness, one-shot polling, and clean shutdown
- prove continuous output is visible while authentication is still blocked

## Why

`factory run` previously displayed a blank terminal while startup validation was in progress, making a healthy process look broken.

## Checks

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (152 tests)
- fresh independent review, with all findings addressed
