### PR TITLE
fix(init): quote workflow staging command

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -147,8 +147,8 @@ impl fmt::Display for InitReport {
                 writeln!(
                     formatter,
                     "  git -C {} add {}",
-                    self.repository.display(),
-                    workflow.display()
+                    shell_quote(&self.repository),
+                    shell_quote(workflow)
                 )?;
             }
             writeln!(formatter, "  factory validate")?;
@@ -169,6 +169,10 @@ impl fmt::Display for InitReport {
             )
         }
     }
+}
+
+fn shell_quote(path: &Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
 }
 
 struct WorkflowPlan {

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -203,6 +203,45 @@ fn init_creates_complete_setup_and_is_idempotent() {
 }
 
 #[test]
+fn init_prints_a_shell_safe_workflow_staging_command() {
+    let mut fixture = Fixture::new();
+    let repository = fixture._temp.path().join("repository with ' quote");
+    fs::rename(&fixture.repository, &repository).unwrap();
+    fixture.repository = repository;
+
+    let output = fixture
+        .command()
+        .args(["init", "--no-labels"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let command = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("git -C "))
+        .unwrap()
+        .trim();
+    assert!(
+        ProcessCommand::new("sh")
+            .args(["-c", command])
+            .status()
+            .unwrap()
+            .success()
+    );
+    let staged = ProcessCommand::new("git")
+        .args(["diff", "--cached", "--name-only"])
+        .current_dir(&fixture.repository)
+        .output()
+        .unwrap();
+    assert!(staged.status.success());
+    assert_eq!(
+        String::from_utf8(staged.stdout).unwrap(),
+        ".factory/workflows/implement-ready-ticket.md\n"
+    );
+}
+
+#[test]
 fn init_accepts_credentialed_github_https_origin() {
     let fixture = Fixture::new();
     set_origin(
@@ -687,9 +726,9 @@ fn update_workflow_replaces_custom_ready_workflow_in_place() {
         .success()
         .stdout(predicate::str::contains("updated:"))
         .stdout(predicate::str::contains(
-            "git -C ".to_owned()
+            "git -C '".to_owned()
                 + fixture.repository.canonicalize().unwrap().to_str().unwrap()
-                + " add .factory/workflows/custom-ready-policy.md",
+                + "' add '.factory/workflows/custom-ready-policy.md'",
         ));
 
     assert_eq!(


### PR DESCRIPTION
## What changed

- quote the repository and workflow paths in the `git -C ... add ...` command printed by `factory init`
- escape embedded apostrophes using POSIX shell quoting
- add a regression test that executes the printed command for a repository path containing spaces and an apostrophe, then verifies only the intended workflow is staged

## Why

`factory init` previously printed raw paths. Copying its suggested staging command failed when the repository path contained shell-significant characters such as spaces or apostrophes.

Closes #31

## Checks

- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=/private/tmp/factory-run-1-target cargo clippy --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/factory-run-1-target cargo test`
- focused regression test rerun by independent reviewer
- `git show --check`
- GitHub CI `check`: passed
- independent review: approved with no blocker or important findings

## Review limitation

Arbitrary non-UTF-8 Unix paths were not added to scope; existing path reporting is already lossy for those paths.