### PR TITLE
feat(daemon): report task lifecycle progress

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,6 +6,14 @@ scheduled and ready-ticket tasks. Global and
 per-repository concurrency are controlled by `max_concurrent_runs` and
 `max_concurrent_runs_per_repository`. The per-repository value defaults to 1.
 
+In continuous mode, Factory writes concise lifecycle events to standard error.
+It reports startup validation, polls that queue work, claimed tasks, runtime
+delegation, and terminal run outcomes. Runtime delegation includes the initial
+working directory and marks worktree creation as workflow-managed. The bundled
+ready-ticket workflow requires Codex to create or reuse an isolated
+ticket-numbered worktree; Factory does not create that worktree before starting
+Codex.
+
 Factory requires the conventional `factory:ready` and
 `factory:needs-review` labels. The explicit `factory init` setup command creates
 missing label definitions without changing existing ones. The daemon does not

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,7 +14,7 @@ use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
 use crate::config::Config;
-use crate::github::{GitHubClient, TicketContext};
+use crate::github::{GitHubClient, PollReport, TicketContext};
 use crate::runtime::{
     CodexRuntime, ExecutionResult, RuntimeCancelled, RuntimeObservation, Termination,
     observation_channel,
@@ -159,13 +159,14 @@ impl FactoryDaemon {
             let poll_cancellation = cancellation.clone();
             github_polls.spawn(async move {
                 let mut poll_ledger = Ledger::open(&ledger_path)?;
+                let activity_cancellation = poll_cancellation.clone();
                 github
                     .poll_until_cancelled(
                         &config,
                         &catalog,
                         &mut poll_ledger,
                         poll_cancellation,
-                        |_| {},
+                        move |report| report_poll_activity(report, &activity_cancellation),
                     )
                     .await
                     .context("GitHub polling failed")
@@ -491,6 +492,20 @@ fn dispatch_available(
             eprintln!("Factory rejected claimed task {}: {error}", task.id);
             continue;
         }
+        let source = match (task.kind.as_str(), task.source_item.as_deref()) {
+            ("ticket", Some(issue)) => format!("issue=#{issue}"),
+            (kind, Some(source)) => format!("{kind}={source}"),
+            (kind, None) => kind.to_owned(),
+        };
+        eprintln!(
+            "Factory task claimed: task={} {source} repository={} workflow={} run={run_id}",
+            task.id, task.repository, task.workflow
+        );
+        eprintln!(
+            "Factory runtime delegated: run={run_id} runtime={} cwd={} worktree=workflow-managed",
+            workflow.runtime,
+            target.path.display()
+        );
         *active.entry(repository.clone()).or_default() += 1;
         let codex = codex.clone();
         let cancellation = cancellation.clone();
@@ -514,7 +529,7 @@ fn dispatch_available(
 
 #[allow(clippy::too_many_arguments)]
 async fn execute_task(
-    mut ledger: Ledger,
+    ledger: Ledger,
     repository: &RepositoryTarget,
     workflow: &WorkflowTarget,
     codex: &CodexRuntime,
@@ -523,6 +538,37 @@ async fn execute_task(
     cancellation: CancellationToken,
     recovery_session: Option<String>,
 ) -> Result<()> {
+    let started = Instant::now();
+    let execution = execute_task_inner(
+        ledger,
+        repository,
+        workflow,
+        codex,
+        run_id,
+        prompt,
+        cancellation,
+        recovery_session,
+    )
+    .await;
+    let outcome = execution.as_deref().unwrap_or("failed");
+    eprintln!(
+        "Factory run finished: run={run_id} outcome={outcome} duration={}",
+        humantime::format_duration(started.elapsed())
+    );
+    execution.map(|_| ())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_task_inner(
+    mut ledger: Ledger,
+    repository: &RepositoryTarget,
+    workflow: &WorkflowTarget,
+    codex: &CodexRuntime,
+    run_id: i64,
+    prompt: String,
+    cancellation: CancellationToken,
+    recovery_session: Option<String>,
+) -> Result<&'static str> {
     let run_cancellation = cancellation.child_token();
     let execution_deadline = Instant::now() + workflow.timeout;
     let monitor_token = run_cancellation.clone();
@@ -631,7 +677,16 @@ async fn execute_task(
         )?;
     }
     match execution {
-        Ok(result) => record_execution(&mut ledger, run_id, &result),
+        Ok(result) => {
+            let outcome = match result.termination {
+                Termination::Cancelled => "cancelled",
+                Termination::TimedOut => "failed",
+                Termination::Exited if result.status.success() => "succeeded",
+                Termination::Exited => "failed",
+            };
+            record_execution(&mut ledger, run_id, &result)?;
+            Ok(outcome)
+        }
         Err(error) => {
             ledger.finish_run_and_task(
                 run_id,
@@ -641,6 +696,27 @@ async fn execute_task(
                 None,
             )?;
             Err(error)
+        }
+    }
+}
+
+fn report_poll_activity(report: &PollReport, cancellation: &CancellationToken) {
+    if cancellation.is_cancelled() {
+        return;
+    }
+    for repository in &report.repositories {
+        if let Some(error) = &repository.error {
+            eprintln!(
+                "Factory poll failed: repository={} error={error}",
+                repository.repository.display()
+            );
+        } else if repository.tasks_created > 0 {
+            eprintln!(
+                "Factory poll: repository={} issues_seen={} tasks_queued={}",
+                repository.name_with_owner.as_deref().unwrap_or("-"),
+                repository.issues_seen,
+                repository.tasks_created
+            );
         }
     }
 }

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -284,12 +284,8 @@ where
     .unwrap();
 }
 
-#[tokio::test]
-async fn cli_reports_live_startup_ready_and_shutdown_progress() {
-    let fixture = Fixture::new(&[vec![]], 1, 1);
-    fs::write(format!("{}.auth-block", fixture.gh.display()), "").unwrap();
-    let stderr_path = fixture._temp.path().join("factory.stderr");
-    let stderr = fs::File::create(&stderr_path).unwrap();
+fn spawn_daemon_cli(fixture: &Fixture, stderr_path: &Path) -> std::process::Child {
+    let stderr = fs::File::create(stderr_path).unwrap();
     let search_path = std::env::join_paths(
         std::iter::once(fixture.gh.parent().unwrap().to_path_buf()).chain(
             std::env::var_os("PATH")
@@ -312,7 +308,23 @@ async fn cli_reports_live_startup_ready_and_shutdown_progress() {
         .env("PATH", search_path)
         .stdout(Stdio::null())
         .stderr(Stdio::from(stderr));
-    let mut child = command.spawn().unwrap();
+    command.spawn().unwrap()
+}
+
+fn interrupt(child: &std::process::Child) {
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(i32::try_from(child.id()).unwrap()),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn cli_reports_live_startup_ready_and_shutdown_progress() {
+    let fixture = Fixture::new(&[vec![]], 1, 1);
+    fs::write(format!("{}.auth-block", fixture.gh.display()), "").unwrap();
+    let stderr_path = fixture._temp.path().join("factory.stderr");
+    let mut child = spawn_daemon_cli(&fixture, &stderr_path);
 
     wait_for(|| {
         fs::read_to_string(&stderr_path).is_ok_and(|contents| {
@@ -332,17 +344,79 @@ async fn cli_reports_live_startup_ready_and_shutdown_progress() {
             .is_ok_and(|contents| contents.contains("Factory ready: watching 1 repositories"))
     })
     .await;
-    nix::sys::signal::kill(
-        nix::unistd::Pid::from_raw(i32::try_from(child.id()).unwrap()),
-        nix::sys::signal::Signal::SIGINT,
-    )
-    .unwrap();
+    interrupt(&child);
     assert!(child.wait().unwrap().success());
     assert!(
         fs::read_to_string(&stderr_path)
             .unwrap()
             .contains("Factory stopped.")
     );
+}
+
+#[tokio::test]
+async fn cli_reports_ticket_and_runtime_lifecycle() {
+    let fixture = Fixture::new(&[vec![issue(42)]], 1, 1);
+    fixture.open_gate();
+    let stderr_path = fixture._temp.path().join("factory.stderr");
+    let mut child = spawn_daemon_cli(&fixture, &stderr_path);
+
+    wait_for(|| {
+        fs::read_to_string(&stderr_path)
+            .is_ok_and(|contents| contents.contains("Factory run finished: run=1"))
+    })
+    .await;
+    interrupt(&child);
+    assert!(child.wait().unwrap().success());
+
+    let output = fs::read_to_string(&stderr_path).unwrap();
+    assert!(
+        output.contains("Factory poll: repository=example/repo-0 issues_seen=1 tasks_queued=1")
+    );
+    assert!(output.contains(
+        "Factory task claimed: task=1 issue=#42 repository=example/repo-0 workflow=implement-ready-ticket run=1"
+    ));
+    assert!(output.contains(&format!(
+        "Factory runtime delegated: run=1 runtime=codex cwd={} worktree=workflow-managed",
+        fixture.config.repositories[0].display()
+    )));
+    assert!(output.contains("Factory run finished: run=1 outcome=succeeded duration="));
+    assert!(!output.contains("Factory poll failed"));
+}
+
+#[tokio::test]
+async fn cli_reports_failed_runtime_with_duration() {
+    let fixture = Fixture::new(&[vec![issue(43)]], 1, 1);
+    fs::write(fixture.runtime_dir.join("fail-all"), "").unwrap();
+    let stderr_path = fixture._temp.path().join("factory.stderr");
+    let mut child = spawn_daemon_cli(&fixture, &stderr_path);
+
+    wait_for(|| {
+        fs::read_to_string(&stderr_path).is_ok_and(|contents| {
+            contents.contains("Factory run finished: run=1 outcome=failed duration=")
+        })
+    })
+    .await;
+    interrupt(&child);
+    assert!(child.wait().unwrap().success());
+}
+
+#[tokio::test]
+async fn cli_reports_cancelled_runtime_with_duration() {
+    let fixture = Fixture::new(&[vec![issue(44)]], 1, 1);
+    let stderr_path = fixture._temp.path().join("factory.stderr");
+    let mut child = spawn_daemon_cli(&fixture, &stderr_path);
+
+    wait_for(|| {
+        fs::read_to_string(&stderr_path)
+            .is_ok_and(|contents| contents.contains("Factory runtime delegated: run=1"))
+    })
+    .await;
+    interrupt(&child);
+    assert!(child.wait().unwrap().success());
+
+    let output = fs::read_to_string(&stderr_path).unwrap();
+    assert!(output.contains("Factory run finished: run=1 outcome=cancelled duration="));
+    assert!(!output.contains("Factory poll failed"));
 }
 
 fn process_is_alive(process_id: u32) -> bool {


### PR DESCRIPTION
## What changed

- report GitHub polls only when they queue tasks or encounter real failures
- log claimed task, issue, repository, workflow, and durable run IDs
- log Codex runtime delegation with its initial working directory and explicit workflow-managed worktree policy
- log one terminal outcome and duration for success, failure, and cancellation
- suppress misleading poll failures during expected shutdown
- document how Factory and the workflow divide worktree ownership

## Why

Continuous `factory run` was largely silent while it discovered and executed work. Operators could inspect the ledger in a second command, but the foreground daemon did not explain whether it had queued a ticket, delegated to Codex, or finished.

## Example

```text
Factory poll: repository=example/repo issues_seen=1 tasks_queued=1
Factory task claimed: task=1 issue=#31 repository=example/repo workflow=implement-ready-ticket run=1
Factory runtime delegated: run=1 runtime=codex cwd=/path/to/repo worktree=workflow-managed
Factory run finished: run=1 outcome=succeeded duration=18ms
```

## Worktree behavior

Factory starts Codex in the configured repository. The bundled ready-ticket workflow requires Codex to create or reuse an isolated ticket-numbered worktree. This PR makes that ownership visible rather than changing the isolation model.

## Checks

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- focused startup, success, failure, and cancellation logging tests
- `cargo test`
- independent subagent review, including re-review after fixes: approved

PR #29 is merged. This PR is rebased directly onto `main`.