### PR TITLE
Separate workflow creation from repository initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,29 @@ and Codex CLIs. It does not use model API keys.
 2. Authenticate with `gh auth login` and `codex login`.
 3. Clone Factory and run `cargo install --path .`.
 4. In a trusted target repository, run `factory init`.
-5. Review and commit `.factory/workflows/implement-ready-ticket.md`.
-6. Run `factory validate`, `factory workflows`, then `factory run`.
+5. Create a workflow with `factory workflow create`.
+6. Review and commit the new file under `.factory/workflows/`.
+7. Run `factory validate`, `factory workflows`, then `factory run`.
 
-`factory init --check` previews setup without writes. Use `--no-labels` for
-offline local setup and `--update-workflow` only when you intend to replace a
-customized implementation workflow with the bundled version.
+`factory init --check` previews setup without writes. Initialization only
+registers the repository, creates machine configuration and workspace storage,
+and creates the repository's workflow directory. It does not install an
+opinionated workflow or create GitHub labels.
+
+Create a scheduled pull-request triage workflow without opening an editor:
+
+```sh
+factory workflow create triage-pull-requests \
+  --schedule "*/30 * * * *" \
+  --timezone Europe/London \
+  --timeout 1h \
+  --prompt "Review open pull requests with no labels. Process at most five per run. Read each diff, checks, and existing reviews; add appropriate repository labels and leave a review only for actionable findings. Never merge or close a pull request."
+```
+
+Use `--prompt-file PATH` for longer policies, or `--prompt-file -` to read the
+prompt from standard input. Label-triggered workflows create their missing
+trigger label explicitly; scheduled workflows do not mutate labels during
+creation.
 
 See [`docs/local-v1.md`](docs/local-v1.md) for complete installation, setup,
 operation, recovery, and acceptance instructions. The architecture and product

--- a/docs/design.md
+++ b/docs/design.md
@@ -234,7 +234,7 @@ Factory owns the reliability boundary:
 - run history and final outcome;
 - cleanup after terminal completion.
 
-The default implementation workflow remains active while CI runs so the agent can interpret failures and adapt in context. Human review may take hours or days, so a green pull request ends the run. Later ticket or review activity can create a new task that resumes the stored session when available. GitHub, Git, the prompt, and the run record remain enough to recover when a runtime session is lost.
+An implementation workflow remains active while CI runs so the agent can interpret failures and adapt in context. Human review may take hours or days, so a green pull request ends the run. Later ticket or review activity can create a new task that resumes the stored session when available. GitHub, Git, the prompt, and the run record remain enough to recover when a runtime session is lost.
 
 On an unexpected exit, Factory may resume the same agent or start a recovery run with current ticket, worktree, branch, pull request, CI, and previous-run context. Recovery asks the agent to reconcile real state rather than replaying deterministic steps.
 
@@ -255,9 +255,10 @@ V1 implements Codex completely and Claude Code second to prove portability. Runt
 The daemon runs as `factory run`, initially in a terminal and later under `launchd` or `systemd`. A small CLI exposes operational state:
 
 ```text
-factory init [--repository <path>] [--check] [--no-labels]
+factory init [--repository <path>] [--check]
 factory validate
 factory workflows
+factory workflow create <workflow-id> (--schedule <cron> --timezone <iana> | --label <label>) (--prompt <text> | --prompt-file <path>)
 factory workflow run <workflow-id> --repository <path>
 factory tasks
 factory runs [workflow]
@@ -267,11 +268,18 @@ factory cancel <run-id>
 
 SQLite lives under the Factory data directory. Workflows run against trusted repositories. An implementation agent may create its own worktree under the configured workspace root; Factory records the path reported by the agent or discovered from Git after the run.
 
-`factory init` is an explicit, idempotent setup mutation. It may install the
-bundled workflow, register the repository in local configuration, create the
-workspace directory, and create missing conventional GitHub labels. Daemon
-startup never performs these mutations, and initialization never commits,
-pushes, launches an agent, or enables pull-request merge.
+`factory init` is an explicit, idempotent setup mutation. It registers the
+repository in local configuration and creates the workspace and repository
+workflow directories. It does not install workflows or create GitHub labels.
+Daemon startup never performs setup mutations, and initialization never
+commits, pushes, launches an agent, or enables pull-request merge.
+
+`factory workflow create` creates one valid Markdown workflow from explicit
+command-line input. It never launches an editor. Exactly one schedule or label
+trigger and exactly one inline, file, or standard-input prompt are required.
+The command validates the complete generated workflow, refuses to overwrite an
+existing file, and creates a missing GitHub trigger label only for an explicit
+label-triggered workflow.
 
 The manual workflow command validates the selected repository and workflow,
 checks the configured runtime and authentication, streams runtime activity, and

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -45,11 +45,10 @@ cd /absolute/path/to/trusted/repository
 factory init
 ```
 
-The command creates the implementation workflow, creates or updates
-`~/.factory/config.toml`, creates the default `~/.factory/workspaces` directory,
-and creates missing `factory:ready` and `factory:needs-review` labels. It does
-not change existing label definitions, commit files, start the daemon, launch
-Codex, or merge pull requests.
+The command creates or updates `~/.factory/config.toml`, creates the default
+`~/.factory/workspaces` directory, and creates `.factory/workflows/` in the
+repository. It does not install a workflow, inspect or mutate GitHub labels,
+commit files, start the daemon, launch Codex, or merge pull requests.
 
 Initialization is idempotent. Preview it without writes with:
 
@@ -57,19 +56,35 @@ Initialization is idempotent. Preview it without writes with:
 factory init --check
 ```
 
-Use `factory init --no-labels` for offline local setup. A customized workflow is
-never overwritten by default; `factory init --update-workflow` is the explicit
-replacement operation. To initialize a repository without changing directory,
-use `factory init --repository /absolute/path/to/repository`.
+To initialize a repository without changing directory, pass its path:
 
-Review and commit the installed policy in the target repository:
+```sh
+factory init --repository /absolute/path/to/repository
+```
+
+Create an implementation workflow from explicit prompt input. For a substantial
+policy, put only the Markdown prompt body in a file and pass its path:
+
+```sh
+factory workflow create implement-ready-ticket \
+  --label factory:ready \
+  --timeout 4h \
+  --prompt-file /absolute/path/to/implementation-policy.md
+```
+
+The command does not open `$EDITOR`. Use `--prompt` for short policies or
+`--prompt-file -` to read from standard input. A label-triggered workflow
+creates its missing trigger label. Create any additional labels referenced by
+the policy, such as `factory:needs-review`, separately.
+
+Review and commit the generated policy in the target repository:
 
 ```sh
 git add .factory/workflows/implement-ready-ticket.md
 git commit -m "chore: configure Factory"
 ```
 
-Validate the machine-specific configuration without network or runtime work:
+Validate the machine-specific configuration without runtime work:
 
 ```sh
 factory validate

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,11 +14,11 @@ ready-ticket workflow requires Codex to create or reuse an isolated
 ticket-numbered worktree; Factory does not create that worktree before starting
 Codex.
 
-Factory requires the conventional `factory:ready` and
-`factory:needs-review` labels. The explicit `factory init` setup command creates
-missing label definitions without changing existing ones. The daemon does not
-create, remove, or otherwise mutate labels itself. The delegated workflow owns
-ticket and pull-request updates.
+Label-triggered workflows require their configured GitHub label. `factory
+workflow create --label LABEL` creates that label when it is missing without
+changing an existing definition. `factory init` does not inspect or mutate
+GitHub labels. The daemon does not create, remove, or otherwise mutate labels
+itself. The delegated workflow owns ticket and pull-request updates.
 
 Five-field cron schedules are evaluated in the IANA timezone declared by the
 workflow. Factory stores the next occurrence and atomically advances that

--- a/src/init.rs
+++ b/src/init.rs
@@ -6,34 +6,15 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use tempfile::NamedTempFile;
-use tokio_util::sync::CancellationToken;
 use toml_edit::{Array, DocumentMut, Item, Value, value};
 
 use crate::config::Config;
-use crate::github::GitHubClient;
-use crate::workflow::{Trigger, WorkflowCatalog};
-
-const WORKFLOW_RELATIVE_PATH: &str = ".factory/workflows/implement-ready-ticket.md";
-const DEFAULT_WORKFLOW: &str = include_str!("../examples/implement-ready-ticket.md");
-
-const READY_LABEL: Label = Label {
-    name: "factory:ready",
-    description: "Implementation is authorised and ready for Factory",
-    color: "0E8A16",
-};
-const NEEDS_REVIEW_LABEL: Label = Label {
-    name: "factory:needs-review",
-    description: "A human must inspect a question, decision, or green PR",
-    color: "FBCA04",
-};
 
 #[derive(Debug, Clone)]
 pub struct InitOptions {
     pub repository: PathBuf,
     pub config_path: PathBuf,
-    pub no_labels: bool,
     pub check: bool,
-    pub update_workflow: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -41,7 +22,6 @@ enum PlannedAction {
     Create,
     Update,
     Unchanged,
-    Conflict,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -51,7 +31,6 @@ enum ResourceStatus {
     Unchanged,
     WouldCreate,
     WouldUpdate,
-    Conflict,
     Failed,
     Skipped,
 }
@@ -64,7 +43,6 @@ impl ResourceStatus {
             Self::Unchanged => "unchanged",
             Self::WouldCreate => "would create",
             Self::WouldUpdate => "would update",
-            Self::Conflict => "conflict",
             Self::Failed => "failed",
             Self::Skipped => "skipped",
         }
@@ -81,10 +59,8 @@ struct ResourceResult {
 #[derive(Debug, Clone)]
 pub struct InitReport {
     repository: PathBuf,
-    name_with_owner: Option<String>,
     resources: Vec<ResourceResult>,
     check: bool,
-    workflow_to_stage: Option<PathBuf>,
 }
 
 impl InitReport {
@@ -92,10 +68,7 @@ impl InitReport {
         u8::from(self.resources.iter().any(|resource| {
             matches!(
                 resource.status,
-                ResourceStatus::WouldCreate
-                    | ResourceStatus::WouldUpdate
-                    | ResourceStatus::Conflict
-                    | ResourceStatus::Failed
+                ResourceStatus::WouldCreate | ResourceStatus::WouldUpdate | ResourceStatus::Failed
             )
         }))
     }
@@ -103,19 +76,11 @@ impl InitReport {
 
 impl fmt::Display for InitReport {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(name) = &self.name_with_owner {
-            writeln!(
-                formatter,
-                "Factory initialization for {name} ({})",
-                self.repository.display()
-            )?;
-        } else {
-            writeln!(
-                formatter,
-                "Factory initialization for {}",
-                self.repository.display()
-            )?;
-        }
+        writeln!(
+            formatter,
+            "Factory initialization for {}",
+            self.repository.display()
+        )?;
         for resource in &self.resources {
             write!(
                 formatter,
@@ -143,25 +108,9 @@ impl fmt::Display for InitReport {
             }
         } else if self.exit_code() == 0 {
             writeln!(formatter, "Next:")?;
-            if let Some(workflow) = &self.workflow_to_stage {
-                writeln!(
-                    formatter,
-                    "  git -C {} add {}",
-                    shell_quote(&self.repository),
-                    shell_quote(workflow)
-                )?;
-            }
+            writeln!(formatter, "  factory workflow create <workflow-id> --help")?;
             writeln!(formatter, "  factory validate")?;
             writeln!(formatter, "  factory run")
-        } else if self
-            .resources
-            .iter()
-            .any(|resource| resource.status == ResourceStatus::Conflict)
-        {
-            writeln!(
-                formatter,
-                "Factory did not overwrite conflicting resources."
-            )
         } else {
             writeln!(
                 formatter,
@@ -171,11 +120,7 @@ impl fmt::Display for InitReport {
     }
 }
 
-fn shell_quote(path: &Path) -> String {
-    format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
-}
-
-struct WorkflowPlan {
+struct DirectoryPlan {
     path: PathBuf,
     action: PlannedAction,
 }
@@ -186,47 +131,27 @@ struct ConfigPlan {
     workspace_action: PlannedAction,
     action: PlannedAction,
     candidate: Option<String>,
-    effective: Config,
 }
 
-#[derive(Clone, Copy)]
-struct Label {
-    name: &'static str,
-    description: &'static str,
-    color: &'static str,
-}
-
-pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<InitReport> {
+pub fn initialize(options: InitOptions) -> Result<InitReport> {
     let repository = discover_repository(&options.repository)?;
     let config = plan_config(&options.config_path, &repository)?;
-    let workflow = plan_workflow(&repository, options.update_workflow, &config.effective)?;
-    let cancellation = CancellationToken::new();
+    let workflows = plan_workflow_directory(&repository)?;
 
-    let (name_with_owner, missing_labels) = if options.no_labels {
-        (None, Vec::new())
-    } else {
-        github.validate_global(&cancellation).await?;
-        let name = github
-            .validate_repository(&repository, &cancellation)
-            .await?;
-        let existing = github.labels(&repository, &cancellation).await?;
-        let missing = [READY_LABEL, NEEDS_REVIEW_LABEL]
-            .into_iter()
-            .filter(|label| !existing.iter().any(|name| name == label.name))
-            .collect::<Vec<_>>();
-        (Some(name), missing)
-    };
-
-    let has_conflict = workflow.action == PlannedAction::Conflict;
-    if options.check || has_conflict {
-        return Ok(preflight_report(
-            &options,
+    if options.check {
+        return Ok(InitReport {
             repository,
-            name_with_owner,
-            &workflow,
-            &config,
-            &missing_labels,
-        ));
+            resources: vec![
+                planned_resource(config.action, &config.path, "global configuration"),
+                planned_resource(
+                    config.workspace_action,
+                    &config.workspace,
+                    "workspace directory",
+                ),
+                planned_resource(workflows.action, &workflows.path, "workflow directory"),
+            ],
+            check: true,
+        });
     }
 
     let mut resources = Vec::new();
@@ -249,19 +174,13 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
             ));
         }
         resources.push(skipped_resource(
-            workflow.path.display().to_string(),
-            "configuration setup failed",
-        ));
-        resources.push(skipped_resource(
-            "GitHub labels".to_owned(),
+            workflows.path.display().to_string(),
             "configuration setup failed",
         ));
         return Ok(InitReport {
             repository,
-            name_with_owner,
             resources,
             check: false,
-            workflow_to_stage: None,
         });
     }
     resources.push(ResourceResult {
@@ -275,88 +194,22 @@ pub async fn initialize(options: InitOptions, github: &GitHubClient) -> Result<I
         detail: Some("workspace directory".to_owned()),
     });
 
-    if let Err(error) = apply_workflow(&workflow) {
-        resources.push(failed_resource(workflow.path.display().to_string(), error));
-        resources.push(skipped_resource(
-            "GitHub labels".to_owned(),
-            "workflow setup failed",
-        ));
+    if let Err(error) = apply_directory(&workflows) {
+        resources.push(failed_resource(workflows.path.display().to_string(), error));
         return Ok(InitReport {
             repository,
-            name_with_owner,
             resources,
             check: false,
-            workflow_to_stage: None,
         });
     }
     resources.push(ResourceResult {
-        status: applied_status(workflow.action),
-        resource: workflow.path.display().to_string(),
-        detail: Some("implementation workflow".to_owned()),
+        status: applied_status(workflows.action),
+        resource: workflows.path.display().to_string(),
+        detail: Some("workflow directory".to_owned()),
     });
 
-    if options.no_labels {
-        resources.push(ResourceResult {
-            status: ResourceStatus::Skipped,
-            resource: "GitHub labels".to_owned(),
-            detail: Some("--no-labels".to_owned()),
-        });
-    } else {
-        let labels = [READY_LABEL, NEEDS_REVIEW_LABEL];
-        for (index, label) in labels.iter().enumerate() {
-            if !missing_labels
-                .iter()
-                .any(|missing| missing.name == label.name)
-            {
-                resources.push(ResourceResult {
-                    status: ResourceStatus::Unchanged,
-                    resource: format!("GitHub label {}", label.name),
-                    detail: None,
-                });
-                continue;
-            }
-            match github
-                .create_label(
-                    &repository,
-                    label.name,
-                    label.description,
-                    label.color,
-                    &cancellation,
-                )
-                .await
-            {
-                Ok(()) => resources.push(ResourceResult {
-                    status: ResourceStatus::Created,
-                    resource: format!("GitHub label {}", label.name),
-                    detail: None,
-                }),
-                Err(error) => {
-                    resources.push(failed_resource(
-                        format!("GitHub label {}", label.name),
-                        error,
-                    ));
-                    for remaining in &labels[index + 1..] {
-                        resources.push(skipped_resource(
-                            format!("GitHub label {}", remaining.name),
-                            "earlier label setup failed",
-                        ));
-                    }
-                    return Ok(InitReport {
-                        workflow_to_stage: workflow_to_stage(&repository, &workflow),
-                        repository,
-                        name_with_owner,
-                        resources,
-                        check: false,
-                    });
-                }
-            }
-        }
-    }
-
     Ok(InitReport {
-        workflow_to_stage: workflow_to_stage(&repository, &workflow),
         repository,
-        name_with_owner,
         resources,
         check: false,
     })
@@ -378,7 +231,7 @@ fn skipped_resource(resource: String, reason: &str) -> ResourceResult {
     }
 }
 
-fn discover_repository(requested: &Path) -> Result<PathBuf> {
+pub(crate) fn discover_repository(requested: &Path) -> Result<PathBuf> {
     let requested = requested
         .canonicalize()
         .with_context(|| format!("repository path does not exist: {}", requested.display()))?;
@@ -480,58 +333,22 @@ fn git_output(repository: &Path, arguments: &[&str]) -> Result<String> {
     String::from_utf8(output.stdout).context("git output was not valid UTF-8")
 }
 
-fn plan_workflow(repository: &Path, update: bool, config: &Config) -> Result<WorkflowPlan> {
+fn plan_workflow_directory(repository: &Path) -> Result<DirectoryPlan> {
     let factory_directory = repository.join(".factory");
-    let workflow_directory = repository.join(".factory/workflows");
     validate_optional_directory(&factory_directory)?;
-    validate_optional_directory(&workflow_directory)?;
-
-    let path = repository.join(WORKFLOW_RELATIVE_PATH);
-    let action = match fs::symlink_metadata(&path) {
-        Ok(metadata) => {
-            if metadata.file_type().is_symlink() || !metadata.is_file() {
-                bail!("workflow path must be a regular file: {}", path.display());
-            }
-            let current = fs::read_to_string(&path)
-                .with_context(|| format!("failed to read workflow {}", path.display()))?;
-            if current == DEFAULT_WORKFLOW {
-                PlannedAction::Unchanged
-            } else if update {
-                PlannedAction::Update
-            } else {
-                PlannedAction::Conflict
-            }
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let catalog = WorkflowCatalog::load(config)?;
-            if let Some(entry) = catalog.entries.iter().find(|entry| {
-                entry.repository == repository
-                    && entry.errors.is_empty()
-                    && matches!(
-                        entry.trigger.as_ref(),
-                        Some(Trigger::Label(label)) if label == "factory:ready"
-                    )
-            }) {
-                return Ok(WorkflowPlan {
-                    path: entry.path.clone(),
-                    action: if update {
-                        PlannedAction::Update
-                    } else {
-                        PlannedAction::Unchanged
-                    },
-                });
-            }
+    let path = factory_directory.join("workflows");
+    validate_optional_directory(&path)?;
+    Ok(DirectoryPlan {
+        action: if path.exists() {
+            PlannedAction::Unchanged
+        } else {
             PlannedAction::Create
-        }
-        Err(error) => {
-            return Err(error)
-                .with_context(|| format!("failed to inspect workflow {}", path.display()));
-        }
-    };
-    Ok(WorkflowPlan { path, action })
+        },
+        path,
+    })
 }
 
-fn validate_optional_directory(path: &Path) -> Result<()> {
+pub(crate) fn validate_optional_directory(path: &Path) -> Result<()> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
             bail!("setup path must be a regular directory: {}", path.display())
@@ -540,20 +357,6 @@ fn validate_optional_directory(path: &Path) -> Result<()> {
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error).with_context(|| format!("failed to inspect {}", path.display())),
     }
-}
-
-fn workflow_to_stage(repository: &Path, workflow: &WorkflowPlan) -> Option<PathBuf> {
-    matches!(
-        workflow.action,
-        PlannedAction::Create | PlannedAction::Update
-    )
-    .then(|| {
-        workflow
-            .path
-            .strip_prefix(repository)
-            .unwrap_or(&workflow.path)
-            .to_path_buf()
-    })
 }
 
 fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
@@ -572,11 +375,10 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
             if config.repositories.iter().any(|item| item == repository) {
                 return Ok(ConfigPlan {
                     path,
-                    workspace: config.workspace_root.clone(),
+                    workspace: config.workspace_root,
                     workspace_action,
                     action: PlannedAction::Unchanged,
                     candidate: None,
-                    effective: config,
                 });
             }
             let contents = fs::read_to_string(&path)
@@ -596,11 +398,10 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
                 .context("generated configuration is invalid")?;
             Ok(ConfigPlan {
                 path,
-                workspace: config.workspace_root,
+                workspace: effective.workspace_root,
                 workspace_action,
                 action: PlannedAction::Update,
                 candidate: Some(candidate),
-                effective,
             })
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -611,7 +412,7 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
             let candidate = default_config(repository, &candidate_workspace);
             let validated = Config::validate_candidate(&candidate, config_directory)
                 .context("generated configuration is invalid")?;
-            let workspace = validated.workspace_root.clone();
+            let workspace = validated.workspace_root;
             Ok(ConfigPlan {
                 path,
                 workspace: workspace.clone(),
@@ -622,7 +423,6 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
                 },
                 action: PlannedAction::Create,
                 candidate: Some(candidate),
-                effective: validated,
             })
         }
         Err(error) => {
@@ -656,89 +456,16 @@ fn default_config(repository: &Path, workspace: &Path) -> String {
     document.to_string()
 }
 
-fn preflight_report(
-    options: &InitOptions,
-    repository: PathBuf,
-    name_with_owner: Option<String>,
-    workflow: &WorkflowPlan,
-    config: &ConfigPlan,
-    missing_labels: &[Label],
-) -> InitReport {
-    let mut resources = vec![
-        planned_resource(
-            config.action,
-            &config.path,
-            "global configuration",
-            options.check,
-        ),
-        ResourceResult {
-            status: match config.workspace_action {
-                PlannedAction::Create => ResourceStatus::WouldCreate,
-                PlannedAction::Update => ResourceStatus::WouldUpdate,
-                PlannedAction::Unchanged => ResourceStatus::Unchanged,
-                PlannedAction::Conflict => ResourceStatus::Conflict,
-            },
-            resource: config.workspace.display().to_string(),
-            detail: Some("workspace directory".to_owned()),
-        },
-        planned_resource(
-            workflow.action,
-            &workflow.path,
-            "implementation workflow",
-            options.check,
-        ),
-    ];
-    if options.no_labels {
-        resources.push(ResourceResult {
-            status: ResourceStatus::Skipped,
-            resource: "GitHub labels".to_owned(),
-            detail: Some("--no-labels".to_owned()),
-        });
-    } else {
-        for label in [READY_LABEL, NEEDS_REVIEW_LABEL] {
-            resources.push(ResourceResult {
-                status: if missing_labels
-                    .iter()
-                    .any(|missing| missing.name == label.name)
-                {
-                    ResourceStatus::WouldCreate
-                } else {
-                    ResourceStatus::Unchanged
-                },
-                resource: format!("GitHub label {}", label.name),
-                detail: None,
-            });
-        }
-    }
-    InitReport {
-        repository,
-        name_with_owner,
-        resources,
-        check: options.check,
-        workflow_to_stage: None,
-    }
-}
-
-fn planned_resource(
-    action: PlannedAction,
-    path: &Path,
-    detail: &str,
-    check: bool,
-) -> ResourceResult {
+fn planned_resource(action: PlannedAction, path: &Path, detail: &str) -> ResourceResult {
     let status = match action {
         PlannedAction::Create => ResourceStatus::WouldCreate,
         PlannedAction::Update => ResourceStatus::WouldUpdate,
         PlannedAction::Unchanged => ResourceStatus::Unchanged,
-        PlannedAction::Conflict => ResourceStatus::Conflict,
     };
     ResourceResult {
         status,
         resource: path.display().to_string(),
-        detail: Some(if action == PlannedAction::Conflict && !check {
-            "customized workflow; use --update-workflow".to_owned()
-        } else {
-            detail.to_owned()
-        }),
+        detail: Some(detail.to_owned()),
     }
 }
 
@@ -747,7 +474,6 @@ fn applied_status(action: PlannedAction) -> ResourceStatus {
         PlannedAction::Create => ResourceStatus::Created,
         PlannedAction::Update => ResourceStatus::Updated,
         PlannedAction::Unchanged => ResourceStatus::Unchanged,
-        PlannedAction::Conflict => ResourceStatus::Conflict,
     }
 }
 
@@ -804,35 +530,21 @@ fn validated_atomic_config_write(path: &Path, contents: &str) -> Result<()> {
     sync_parent(parent)
 }
 
-fn apply_workflow(plan: &WorkflowPlan) -> Result<()> {
-    if plan.action == PlannedAction::Unchanged {
-        return Ok(());
+fn apply_directory(plan: &DirectoryPlan) -> Result<()> {
+    if plan.action == PlannedAction::Create {
+        fs::create_dir_all(&plan.path).with_context(|| {
+            format!(
+                "failed to create workflow directory {}",
+                plan.path.display()
+            )
+        })?;
+        sync_parent(
+            plan.path
+                .parent()
+                .context("workflow directory has no parent")?,
+        )?;
     }
-    let parent = plan
-        .path
-        .parent()
-        .context("workflow path has no parent directory")?;
-    fs::create_dir_all(parent)
-        .with_context(|| format!("failed to create workflow directory {}", parent.display()))?;
-    atomic_write(&plan.path, DEFAULT_WORKFLOW)
-}
-
-fn atomic_write(path: &Path, contents: &str) -> Result<()> {
-    let parent = path.parent().context("path has no parent directory")?;
-    let mut temporary = NamedTempFile::new_in(parent)
-        .with_context(|| format!("failed to create temporary file in {}", parent.display()))?;
-    temporary
-        .write_all(contents.as_bytes())
-        .with_context(|| format!("failed to write temporary file for {}", path.display()))?;
-    temporary
-        .as_file_mut()
-        .sync_all()
-        .with_context(|| format!("failed to sync temporary file for {}", path.display()))?;
-    temporary
-        .persist(path)
-        .map_err(|error| error.error)
-        .with_context(|| format!("failed to replace {}", path.display()))?;
-    sync_parent(parent)
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod inspection;
 pub mod runtime;
 pub mod storage;
 pub mod workflow;
+pub mod workflow_create;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use anyhow::{Context, Result, bail};
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Parser, Subcommand};
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
@@ -19,6 +19,7 @@ use factory::runtime::{
 };
 use factory::storage::{CancellationRequest, Ledger};
 use factory::workflow::WorkflowCatalog;
+use factory::workflow_create::{CreateWorkflowOptions, create_workflow};
 
 #[derive(Debug, Parser)]
 #[command(name = "factory", version, about)]
@@ -34,15 +35,9 @@ enum Command {
         /// Repository to initialize. Defaults to the current directory.
         #[arg(long)]
         repository: Option<PathBuf>,
-        /// Skip GitHub label discovery and creation.
-        #[arg(long)]
-        no_labels: bool,
         /// Report required changes without writing anything.
         #[arg(long)]
         check: bool,
-        /// Replace a customized implementation workflow with the bundled version.
-        #[arg(long)]
-        update_workflow: bool,
     },
     /// Poll configured repositories and persist eligible ticket tasks.
     Run {
@@ -129,6 +124,48 @@ enum Command {
 
 #[derive(Debug, Subcommand)]
 enum WorkflowCommand {
+    /// Create a workflow from explicit trigger and prompt input.
+    #[command(group(
+        ArgGroup::new("trigger")
+            .required(true)
+            .args(["schedule", "label"])
+    ))]
+    #[command(group(
+        ArgGroup::new("prompt_source")
+            .required(true)
+            .args(["prompt", "prompt_file"])
+    ))]
+    Create {
+        /// Lowercase kebab-case workflow ID.
+        workflow_id: String,
+        /// Five-field cron expression.
+        #[arg(long, requires = "timezone")]
+        schedule: Option<String>,
+        /// IANA timezone for a scheduled workflow.
+        #[arg(long, requires = "schedule")]
+        timezone: Option<String>,
+        /// GitHub label for a label-triggered workflow.
+        #[arg(long)]
+        label: Option<String>,
+        /// Runtime override. Inherits the configured default when omitted.
+        #[arg(long)]
+        runtime: Option<String>,
+        /// Timeout override. Inherits the configured default when omitted.
+        #[arg(long)]
+        timeout: Option<String>,
+        /// Workflow prompt text.
+        #[arg(long)]
+        prompt: Option<String>,
+        /// Read workflow prompt text from this file, or from stdin with `-`.
+        #[arg(long, value_name = "PATH")]
+        prompt_file: Option<PathBuf>,
+        /// Configured repository to create the workflow in. Defaults to the current directory.
+        #[arg(long)]
+        repository: Option<PathBuf>,
+        /// Path to the Factory configuration file.
+        #[arg(long)]
+        config: Option<PathBuf>,
+    },
     /// Run one validated workflow against a configured repository.
     Run {
         /// Workflow ID, derived from its Markdown filename.
@@ -167,25 +204,14 @@ async fn run_cli() -> Result<u8> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Init {
-            repository,
-            no_labels,
-            check,
-            update_workflow,
-        } => {
+        Command::Init { repository, check } => {
             let repository = repository
                 .unwrap_or(std::env::current_dir().context("failed to resolve current directory")?);
-            let report = initialize(
-                InitOptions {
-                    repository,
-                    config_path: default_config_path(),
-                    no_labels,
-                    check,
-                    update_workflow,
-                },
-                &GitHubClient::default(),
-            )
-            .await?;
+            let report = initialize(InitOptions {
+                repository,
+                config_path: default_config_path(),
+                check,
+            })?;
             let exit_code = report.exit_code();
             print!("{report}");
             return Ok(exit_code);
@@ -211,6 +237,41 @@ async fn run_cli() -> Result<u8> {
             if invalid > 0 {
                 anyhow::bail!("workflow catalog contains {invalid} invalid workflow(s)");
             }
+        }
+        Command::Workflow {
+            command:
+                WorkflowCommand::Create {
+                    workflow_id,
+                    schedule,
+                    timezone,
+                    label,
+                    runtime,
+                    timeout,
+                    prompt,
+                    prompt_file,
+                    repository,
+                    config,
+                },
+        } => {
+            let report = create_workflow(
+                CreateWorkflowOptions {
+                    id: workflow_id,
+                    repository: repository.unwrap_or(
+                        std::env::current_dir().context("failed to resolve current directory")?,
+                    ),
+                    config_path: config.unwrap_or_else(default_config_path),
+                    schedule,
+                    timezone,
+                    label,
+                    runtime,
+                    timeout,
+                    prompt,
+                    prompt_file,
+                },
+                &GitHubClient::default(),
+            )
+            .await?;
+            print!("{report}");
         }
         Command::Workflow {
             command:
@@ -364,7 +425,7 @@ async fn run_poller(
     for repository in catalog.repositories_without_ready_workflow(&config) {
         write_stderr_best_effort(
             format!(
-                "No valid factory:ready implementation workflow found for {}; run factory init --repository {}\n",
+                "No valid factory:ready implementation workflow found for {}; create one with factory workflow create --repository {}\n",
                 repository.display(),
                 repository.display()
             )

--- a/src/workflow_create.rs
+++ b/src/workflow_create.rs
@@ -1,0 +1,302 @@
+use std::fmt;
+use std::fs;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use tempfile::NamedTempFile;
+use tokio_util::sync::CancellationToken;
+use toml_edit::{DocumentMut, value};
+
+use crate::config::Config;
+use crate::github::GitHubClient;
+use crate::init::{discover_repository, validate_optional_directory};
+use crate::workflow::WorkflowCatalog;
+
+#[derive(Debug, Clone)]
+pub struct CreateWorkflowOptions {
+    pub id: String,
+    pub repository: PathBuf,
+    pub config_path: PathBuf,
+    pub schedule: Option<String>,
+    pub timezone: Option<String>,
+    pub label: Option<String>,
+    pub runtime: Option<String>,
+    pub timeout: Option<String>,
+    pub prompt: Option<String>,
+    pub prompt_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateWorkflowReport {
+    repository: PathBuf,
+    path: PathBuf,
+    created_label: Option<String>,
+}
+
+impl fmt::Display for CreateWorkflowReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(formatter, "Created workflow {}", self.path.display())?;
+        if let Some(label) = &self.created_label {
+            writeln!(formatter, "Created GitHub label {label}")?;
+        }
+        writeln!(formatter, "Next:")?;
+        writeln!(
+            formatter,
+            "  git -C {} add {}",
+            shell_quote(&self.repository),
+            shell_quote(
+                self.path
+                    .strip_prefix(&self.repository)
+                    .unwrap_or(&self.path)
+            )
+        )?;
+        writeln!(formatter, "  factory workflows")?;
+        writeln!(formatter, "  factory run")
+    }
+}
+
+pub async fn create_workflow(
+    options: CreateWorkflowOptions,
+    github: &GitHubClient,
+) -> Result<CreateWorkflowReport> {
+    validate_workflow_id(&options.id)?;
+    validate_options(&options)?;
+
+    let repository = discover_repository(&options.repository)?;
+    let config = Config::load(&options.config_path)?;
+    if !config.repositories.iter().any(|item| item == &repository) {
+        bail!(
+            "repository is not configured: {}; run factory init --repository {}",
+            repository.display(),
+            repository.display()
+        );
+    }
+
+    let factory_directory = repository.join(".factory");
+    let workflow_directory = factory_directory.join("workflows");
+    validate_optional_directory(&factory_directory)?;
+    validate_optional_directory(&workflow_directory)?;
+    if !workflow_directory.is_dir() {
+        bail!(
+            "workflow directory does not exist: {}; run factory init --repository {}",
+            workflow_directory.display(),
+            repository.display()
+        );
+    }
+
+    let path = workflow_directory.join(format!("{}.md", options.id));
+    match fs::symlink_metadata(&path) {
+        Ok(_) => bail!("workflow already exists: {}", path.display()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect workflow {}", path.display()));
+        }
+    }
+
+    let prompt = read_prompt(&options)?;
+    let contents = render_workflow(&options, &prompt);
+    persist_new_file(&path, &contents)?;
+
+    let catalog = WorkflowCatalog::load(&config)?;
+    let validation_errors = catalog
+        .entries
+        .iter()
+        .find(|entry| entry.repository == repository && entry.path == path)
+        .map(|entry| entry.errors.clone());
+    let Some(validation_errors) = validation_errors else {
+        rollback_new_file(&path, "created workflow was not discovered")?;
+        bail!("created workflow was not discovered");
+    };
+    if !validation_errors.is_empty() {
+        rollback_new_file(&path, "created workflow was invalid")?;
+        bail!("workflow is invalid: {}", validation_errors.join("; "));
+    }
+
+    let created_label = if let Some(label) = &options.label {
+        match ensure_label(github, &repository, &options.id, label).await {
+            Ok(created) => created.then(|| label.clone()),
+            Err(error) => {
+                rollback_new_file(&path, "GitHub label setup failed")?;
+                return Err(error);
+            }
+        }
+    } else {
+        None
+    };
+
+    Ok(CreateWorkflowReport {
+        repository,
+        path,
+        created_label,
+    })
+}
+
+async fn ensure_label(
+    github: &GitHubClient,
+    repository: &Path,
+    workflow_id: &str,
+    label: &str,
+) -> Result<bool> {
+    let cancellation = CancellationToken::new();
+    github.validate_global(&cancellation).await?;
+    github
+        .validate_repository(repository, &cancellation)
+        .await?;
+    let labels = github.labels(repository, &cancellation).await?;
+    if labels.iter().any(|existing| existing == label) {
+        return Ok(false);
+    }
+    github
+        .create_label(
+            repository,
+            label,
+            &format!("Triggers the {workflow_id} Factory workflow"),
+            "5319E7",
+            &cancellation,
+        )
+        .await?;
+    Ok(true)
+}
+
+fn validate_options(options: &CreateWorkflowOptions) -> Result<()> {
+    match (&options.schedule, &options.label) {
+        (Some(_), Some(_)) => bail!("workflow must declare exactly one trigger"),
+        (None, None) => bail!("workflow must declare exactly one trigger: schedule or label"),
+        (Some(_), None) if options.timezone.is_none() => {
+            bail!("scheduled workflow must declare a timezone")
+        }
+        (None, Some(_)) if options.timezone.is_some() => {
+            bail!("timezone is only valid with a schedule trigger")
+        }
+        _ => {}
+    }
+    match (&options.prompt, &options.prompt_file) {
+        (Some(_), Some(_)) => bail!("use exactly one of --prompt or --prompt-file"),
+        (None, None) => bail!("use exactly one of --prompt or --prompt-file"),
+        _ => Ok(()),
+    }
+}
+
+fn validate_workflow_id(id: &str) -> Result<()> {
+    let valid = !id.is_empty()
+        && id.split('-').all(|part| {
+            !part.is_empty()
+                && part
+                    .chars()
+                    .all(|character| character.is_ascii_lowercase() || character.is_ascii_digit())
+        });
+    if !valid {
+        bail!("workflow ID must be lowercase kebab-case, got {id:?}");
+    }
+    Ok(())
+}
+
+fn read_prompt(options: &CreateWorkflowOptions) -> Result<String> {
+    let prompt = if let Some(prompt) = &options.prompt {
+        prompt.clone()
+    } else {
+        let path = options
+            .prompt_file
+            .as_deref()
+            .context("prompt source was not provided")?;
+        if path == Path::new("-") {
+            let mut prompt = String::new();
+            std::io::stdin()
+                .read_to_string(&mut prompt)
+                .context("failed to read workflow prompt from stdin")?;
+            prompt
+        } else {
+            fs::read_to_string(path)
+                .with_context(|| format!("failed to read prompt file {}", path.display()))?
+        }
+    };
+    if prompt.trim().is_empty() {
+        bail!("workflow prompt must not be empty");
+    }
+    Ok(prompt)
+}
+
+fn render_workflow(options: &CreateWorkflowOptions, prompt: &str) -> String {
+    let mut frontmatter = DocumentMut::new();
+    if let Some(schedule) = &options.schedule {
+        frontmatter["schedule"] = value(schedule);
+    }
+    if let Some(timezone) = &options.timezone {
+        frontmatter["timezone"] = value(timezone);
+    }
+    if let Some(label) = &options.label {
+        frontmatter["label"] = value(label);
+    }
+    if let Some(runtime) = &options.runtime {
+        frontmatter["runtime"] = value(runtime);
+    }
+    if let Some(timeout) = &options.timeout {
+        frontmatter["timeout"] = value(timeout);
+    }
+    format!("+++\n{}+++\n\n{}\n", frontmatter, prompt.trim())
+}
+
+fn persist_new_file(path: &Path, contents: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("workflow path has no parent directory")?;
+    let mut temporary = NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "failed to create temporary workflow in {}",
+            parent.display()
+        )
+    })?;
+    temporary
+        .write_all(contents.as_bytes())
+        .with_context(|| format!("failed to write temporary workflow for {}", path.display()))?;
+    temporary
+        .as_file_mut()
+        .sync_all()
+        .with_context(|| format!("failed to sync temporary workflow for {}", path.display()))?;
+    temporary
+        .persist_noclobber(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to create workflow {}", path.display()))?;
+    if let Err(error) = sync_parent(parent) {
+        if let Err(cleanup_error) = rollback_new_file(path, "workflow directory sync failed") {
+            return Err(error.context(format!("rollback also failed: {cleanup_error:#}")));
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn rollback_new_file(path: &Path, reason: &str) -> Result<()> {
+    fs::remove_file(path).with_context(|| {
+        format!(
+            "{reason} and the new workflow could not be removed: {}",
+            path.display()
+        )
+    })?;
+    let parent = path
+        .parent()
+        .context("workflow path has no parent directory")?;
+    sync_parent(parent).with_context(|| {
+        format!("{reason}; the new workflow was removed but the rollback could not be synced")
+    })
+}
+
+fn shell_quote(path: &Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "'\"'\"'"))
+}
+
+#[cfg(unix)]
+fn sync_parent(parent: &Path) -> Result<()> {
+    fs::OpenOptions::new()
+        .read(true)
+        .open(parent)
+        .and_then(|directory| directory.sync_all())
+        .with_context(|| format!("failed to sync directory {}", parent.display()))
+}
+
+#[cfg(not(unix))]
+fn sync_parent(_parent: &Path) -> Result<()> {
+    Ok(())
+}

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -1,8 +1,7 @@
 #![cfg(unix)]
 
 use std::fs;
-use std::os::unix::fs::PermissionsExt;
-use std::os::unix::fs::symlink;
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
@@ -14,7 +13,6 @@ struct Fixture {
     _temp: tempfile::TempDir,
     home: PathBuf,
     repository: PathBuf,
-    executable_path: String,
 }
 
 impl Fixture {
@@ -24,54 +22,10 @@ impl Fixture {
         let repository = temp.path().join("repository");
         fs::create_dir(&home).unwrap();
         init_git_repository(&repository, "git@github.com:example/repository.git");
-
-        let gh = temp.path().join("gh");
-        fs::write(
-            &gh,
-            r#"#!/bin/sh
-printf '%s\n' "$*" >> .gh-calls
-if [ -n "${GH_REPO:-}" ]; then echo "GH_REPO leaked into gh" >&2; exit 65; fi
-if [ "$1" = "--version" ]; then echo "gh version 2.80.0"; exit 0; fi
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo "logged in"; exit 0; fi
-if [ "$1" = "repo" ] && [ "$2" = "view" ]; then echo "example/repository"; exit 0; fi
-if [ "$1" = "label" ] && [ "$2" = "list" ]; then
-  if [ -f .factory-test-labels ]; then cat .factory-test-labels; fi
-  exit 0
-fi
-if [ "$1" = "label" ] && [ "$2" = "create" ]; then
-  if [ "$3" = "factory:needs-review" ] && [ -f .fail-needs-review ]; then
-    echo "simulated label failure" >&2
-    exit 1
-  fi
-  printf '%s\n' "$3" >> .factory-test-labels
-  exit 0
-fi
-if [ "$1" = "api" ]; then
-  if [ "$2" = 'repos/{owner}/{repo}/labels' ]; then
-    if [ -f .factory-test-labels ]; then cat .factory-test-labels; fi
-  else
-    printf '[[]]'
-  fi
-  exit 0
-fi
-echo "unexpected fake gh arguments: $*" >&2
-exit 64
-"#,
-        )
-        .unwrap();
-        let mut permissions = fs::metadata(&gh).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&gh, permissions).unwrap();
-        let executable_path = format!(
-            "{}:{}",
-            temp.path().display(),
-            std::env::var("PATH").unwrap()
-        );
         Self {
             _temp: temp,
             home,
             repository,
-            executable_path,
         }
     }
 
@@ -79,8 +33,7 @@ exit 64
         let mut command = Command::cargo_bin("factory").unwrap();
         command
             .current_dir(&self.repository)
-            .env("HOME", &self.home)
-            .env("PATH", &self.executable_path);
+            .env("HOME", &self.home);
         command
     }
 
@@ -92,9 +45,8 @@ exit 64
         self.home.join(".factory/workspaces")
     }
 
-    fn workflow(&self) -> PathBuf {
-        self.repository
-            .join(".factory/workflows/implement-ready-ticket.md")
+    fn workflows(&self) -> PathBuf {
+        self.repository.join(".factory/workflows")
     }
 }
 
@@ -146,27 +98,20 @@ fn write_config(path: &Path, repositories: &[&Path], workspace: &Path, prefix: &
 }
 
 #[test]
-fn init_creates_complete_setup_and_is_idempotent() {
+fn init_creates_only_configuration_and_workflow_directory() {
     let fixture = Fixture::new();
 
     fixture
         .command()
-        .args(["init", "--repository"])
-        .arg(&fixture.repository)
+        .arg("init")
         .assert()
         .success()
-        .stdout(predicate::str::contains("created: "))
-        .stdout(predicate::str::contains("GitHub label factory:ready"))
-        .stdout(predicate::str::contains("git -C "))
-        .stdout(predicate::str::contains(
-            ".factory/workflows/implement-ready-ticket.md",
-        ))
-        .stdout(predicate::str::contains("factory validate"));
+        .stdout(predicate::str::contains("global configuration"))
+        .stdout(predicate::str::contains("workflow directory"))
+        .stdout(predicate::str::contains("factory workflow create"))
+        .stdout(predicate::str::contains("GitHub label").not())
+        .stdout(predicate::str::contains("implement-ready-ticket.md").not());
 
-    assert_eq!(
-        fs::read_to_string(fixture.workflow()).unwrap(),
-        include_str!("../examples/implement-ready-ticket.md")
-    );
     let config = Config::load(&fixture.config_path()).unwrap();
     assert_eq!(
         config.repositories,
@@ -176,20 +121,75 @@ fn init_creates_complete_setup_and_is_idempotent() {
         config.workspace_root,
         fixture.workspace().canonicalize().unwrap()
     );
-    assert_eq!(
-        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
-        "factory:ready\nfactory:needs-review\n"
-    );
+    assert!(fixture.workflows().is_dir());
+    assert_eq!(fs::read_dir(fixture.workflows()).unwrap().count(), 0);
+    assert!(!fixture.repository.join(".gh-calls").exists());
 
     fixture
         .command()
-        .args(["init", "--repository"])
-        .arg(&fixture.repository)
+        .arg("init")
         .assert()
         .success()
         .stdout(predicate::str::contains("unchanged:"));
+    assert_eq!(
+        fs::read_to_string(fixture.config_path())
+            .unwrap()
+            .matches(fixture.repository.to_str().unwrap())
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn check_reports_missing_resources_without_writes() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args(["init", "--check"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("would create:"))
+        .stdout(predicate::str::contains("global configuration"))
+        .stdout(predicate::str::contains("workspace directory"))
+        .stdout(predicate::str::contains("workflow directory"));
+
+    assert!(!fixture.config_path().exists());
+    assert!(!fixture.workspace().exists());
+    assert!(!fixture.repository.join(".factory").exists());
+}
+
+#[test]
+fn init_does_not_touch_existing_workflows() {
+    let fixture = Fixture::new();
+    fs::create_dir_all(fixture.workflows()).unwrap();
+    let workflow = fixture.workflows().join("custom.md");
+    fs::write(&workflow, "custom policy\n").unwrap();
+
+    fixture.command().arg("init").assert().success();
+
+    assert_eq!(fs::read_to_string(workflow).unwrap(), "custom policy\n");
+}
+
+#[test]
+fn existing_config_preserves_comments_and_registers_repository_once() {
+    let fixture = Fixture::new();
+    let other = fixture._temp.path().join("other");
+    fs::create_dir(&other).unwrap();
+    let workspace = fixture._temp.path().join("workspaces");
+    write_config(
+        &fixture.config_path(),
+        &[&other],
+        &workspace,
+        "# keep this comment\n",
+    );
+
+    for _ in 0..2 {
+        fixture.command().arg("init").assert().success();
+    }
 
     let contents = fs::read_to_string(fixture.config_path()).unwrap();
+    assert!(contents.starts_with("# keep this comment\n"));
     assert_eq!(
         contents
             .matches(fixture.repository.to_str().unwrap())
@@ -197,212 +197,11 @@ fn init_creates_complete_setup_and_is_idempotent() {
         1
     );
     assert_eq!(
-        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
-        "factory:ready\nfactory:needs-review\n"
-    );
-}
-
-#[test]
-fn init_prints_a_shell_safe_workflow_staging_command() {
-    let mut fixture = Fixture::new();
-    let repository = fixture._temp.path().join("repository with ' quote");
-    fs::rename(&fixture.repository, &repository).unwrap();
-    fixture.repository = repository;
-
-    let output = fixture
-        .command()
-        .args(["init", "--no-labels"])
-        .output()
-        .unwrap();
-
-    assert!(output.status.success());
-    let stdout = String::from_utf8(output.stdout).unwrap();
-    let command = stdout
-        .lines()
-        .find(|line| line.trim_start().starts_with("git -C "))
-        .unwrap()
-        .trim();
-    assert!(
-        ProcessCommand::new("sh")
-            .args(["-c", command])
-            .status()
+        Config::load(&fixture.config_path())
             .unwrap()
-            .success()
-    );
-    let staged = ProcessCommand::new("git")
-        .args(["diff", "--cached", "--name-only"])
-        .current_dir(&fixture.repository)
-        .output()
-        .unwrap();
-    assert!(staged.status.success());
-    assert_eq!(
-        String::from_utf8(staged.stdout).unwrap(),
-        ".factory/workflows/implement-ready-ticket.md\n"
-    );
-}
-
-#[test]
-fn init_accepts_credentialed_github_https_origin() {
-    let fixture = Fixture::new();
-    set_origin(
-        &fixture.repository,
-        "https://user:secret@github.com/example/repository.git",
-    );
-
-    fixture
-        .command()
-        .args(["init", "--no-labels"])
-        .assert()
-        .success();
-
-    assert!(fixture.workflow().is_file());
-    assert!(fixture.config_path().is_file());
-}
-
-#[test]
-fn init_accepts_github_ssh_over_port_443_origin() {
-    let fixture = Fixture::new();
-    set_origin(
-        &fixture.repository,
-        "ssh://git@ssh.github.com:443/example/repository.git",
-    );
-
-    fixture
-        .command()
-        .args(["init", "--no-labels"])
-        .assert()
-        .success();
-
-    assert!(fixture.workflow().is_file());
-    assert!(fixture.config_path().is_file());
-}
-
-#[test]
-fn label_discovery_uses_uncapped_paginated_api() {
-    let fixture = Fixture::new();
-
-    fixture.command().arg("init").assert().success();
-
-    let calls = fs::read_to_string(fixture.repository.join(".gh-calls")).unwrap();
-    assert!(calls.contains("api repos/{owner}/{repo}/labels --paginate --jq .[].name"));
-    assert!(!calls.contains("--limit"));
-}
-
-#[test]
-fn init_ignores_gh_repo_environment_override() {
-    let fixture = Fixture::new();
-
-    fixture
-        .command()
-        .env("GH_REPO", "wrong/repository")
-        .args(["init", "--repository"])
-        .arg(&fixture.repository)
-        .assert()
-        .success();
-
-    assert!(fixture.workflow().is_file());
-    assert_eq!(
-        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
-        "factory:ready\nfactory:needs-review\n"
-    );
-}
-
-#[test]
-fn init_rejects_github_lookalike_origin_without_leaking_credentials() {
-    let fixture = Fixture::new();
-    set_origin(
-        &fixture.repository,
-        "https://user:secret@github.com.example.test/example/repository.git",
-    );
-
-    fixture
-        .command()
-        .args(["init", "--no-labels"])
-        .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "origin is not a supported GitHub remote",
-        ))
-        .stderr(predicate::str::contains("secret").not());
-
-    assert!(!fixture.workflow().exists());
-    assert!(!fixture.config_path().exists());
-}
-
-#[test]
-fn partial_label_failure_reports_every_applied_and_failed_resource() {
-    let fixture = Fixture::new();
-    fs::write(fixture.repository.join(".fail-needs-review"), "").unwrap();
-
-    fixture
-        .command()
-        .args(["init", "--repository"])
-        .arg(&fixture.repository)
-        .assert()
-        .failure()
-        .stdout(predicate::str::contains("created: "))
-        .stdout(predicate::str::contains("GitHub label factory:ready"))
-        .stdout(predicate::str::contains(
-            "failed: GitHub label factory:needs-review",
-        ))
-        .stdout(predicate::str::contains("simulated label failure"))
-        .stdout(predicate::str::contains("stopped after a failed resource"));
-
-    assert!(fixture.config_path().is_file());
-    assert!(fixture.workflow().is_file());
-    assert_eq!(
-        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
-        "factory:ready\n"
-    );
-}
-
-#[test]
-fn check_reports_every_missing_resource_without_writes() {
-    let fixture = Fixture::new();
-
-    fixture
-        .command()
-        .args(["init", "--check", "--repository"])
-        .arg(&fixture.repository)
-        .assert()
-        .failure()
-        .stdout(predicate::str::contains("would create:"))
-        .stdout(predicate::str::contains("Factory setup is incomplete"));
-
-    assert!(!fixture.config_path().exists());
-    assert!(!fixture.workspace().exists());
-    assert!(!fixture.workflow().exists());
-    assert!(!fixture.repository.join(".factory-test-labels").exists());
-    let calls = fs::read_to_string(fixture.repository.join(".gh-calls")).unwrap();
-    assert!(!calls.contains("label create"));
-}
-
-#[test]
-fn check_does_not_probe_existing_workspace_writability() {
-    let fixture = Fixture::new();
-    fixture
-        .command()
-        .args(["init", "--no-labels"])
-        .assert()
-        .success();
-    let mut permissions = fs::metadata(fixture.workspace()).unwrap().permissions();
-    permissions.set_mode(0o555);
-    fs::set_permissions(fixture.workspace(), permissions).unwrap();
-
-    let output = fixture
-        .command()
-        .args(["init", "--no-labels", "--check"])
-        .output()
-        .unwrap();
-
-    let mut permissions = fs::metadata(fixture.workspace()).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(fixture.workspace(), permissions).unwrap();
-    assert!(output.status.success());
-    assert!(
-        String::from_utf8(output.stdout)
-            .unwrap()
-            .contains("no changes were made")
+            .repositories
+            .len(),
+        2
     );
 }
 
@@ -419,27 +218,44 @@ fn init_recreates_workspace_missing_from_existing_config() {
 
     fixture
         .command()
-        .args(["init", "--no-labels", "--check"])
+        .args(["init", "--check"])
         .assert()
         .failure()
         .stdout(predicate::str::contains("would create:"))
         .stdout(predicate::str::contains("workspace directory"));
-    assert!(!fixture.workspace().exists());
-
-    fixture
-        .command()
-        .args(["init", "--no-labels"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("created:"))
-        .stdout(predicate::str::contains("workspace directory"));
+    fixture.command().arg("init").assert().success();
 
     assert!(fixture.workspace().is_dir());
     assert_eq!(fs::read_to_string(fixture.config_path()).unwrap(), original);
 }
 
 #[test]
-fn init_rejects_parent_traversal_in_missing_workspace_without_writes() {
+fn check_does_not_probe_existing_workspace_writability() {
+    let fixture = Fixture::new();
+    fixture.command().arg("init").assert().success();
+    let mut permissions = fs::metadata(fixture.workspace()).unwrap().permissions();
+    permissions.set_mode(0o555);
+    fs::set_permissions(fixture.workspace(), permissions).unwrap();
+
+    let output = fixture
+        .command()
+        .args(["init", "--check"])
+        .output()
+        .unwrap();
+
+    let mut permissions = fs::metadata(fixture.workspace()).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(fixture.workspace(), permissions).unwrap();
+    assert!(output.status.success());
+    assert!(
+        String::from_utf8(output.stdout)
+            .unwrap()
+            .contains("no changes were made")
+    );
+}
+
+#[test]
+fn init_rejects_parent_traversal_without_repository_writes() {
     let fixture = Fixture::new();
     let safe_workspace = fixture._temp.path().join("safe-workspace");
     let original = write_config(
@@ -464,19 +280,18 @@ fn init_rejects_parent_traversal_in_missing_workspace_without_writes() {
 
     fixture
         .command()
-        .args(["init", "--no-labels"])
+        .arg("init")
         .assert()
         .failure()
         .stderr(predicate::str::contains(
             "must not contain parent traversal in a missing suffix",
         ));
 
-    assert!(!fixture.repository.join("workspaces").exists());
-    assert!(!fixture.workflow().exists());
+    assert!(!fixture.repository.join(".factory").exists());
 }
 
 #[test]
-fn init_resolves_symlinked_config_ancestors_before_workspace_writes() {
+fn init_resolves_symlinked_config_ancestors_before_writes() {
     let fixture = Fixture::new();
     let state = fixture.repository.join(".factory-state");
     fs::create_dir(&state).unwrap();
@@ -484,7 +299,7 @@ fn init_resolves_symlinked_config_ancestors_before_workspace_writes() {
 
     fixture
         .command()
-        .args(["init", "--no-labels"])
+        .arg("init")
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -493,95 +308,11 @@ fn init_resolves_symlinked_config_ancestors_before_workspace_writes() {
         .stderr(predicate::str::contains("must not overlap"));
 
     assert!(!state.join("workspaces").exists());
-    assert!(!fixture.workflow().exists());
-    assert!(!fixture.config_path().exists());
+    assert!(!fixture.repository.join(".factory").exists());
 }
 
 #[test]
-fn no_labels_never_invokes_github_cli() {
-    let fixture = Fixture::new();
-
-    fixture
-        .command()
-        .args(["init", "--no-labels"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("skipped: GitHub labels"));
-
-    assert!(!fixture.repository.join(".gh-calls").exists());
-    assert!(fixture.workflow().is_file());
-    assert!(fixture.config_path().is_file());
-}
-
-#[test]
-fn customized_workflow_requires_explicit_update() {
-    let fixture = Fixture::new();
-    fs::create_dir_all(fixture.workflow().parent().unwrap()).unwrap();
-    fs::write(fixture.workflow(), "custom policy\n").unwrap();
-
-    fixture
-        .command()
-        .args(["init", "--no-labels", "--repository"])
-        .arg(&fixture.repository)
-        .assert()
-        .failure()
-        .stdout(predicate::str::contains("conflict:"))
-        .stdout(predicate::str::contains("--update-workflow"));
-    assert_eq!(
-        fs::read_to_string(fixture.workflow()).unwrap(),
-        "custom policy\n"
-    );
-    assert!(!fixture.config_path().exists());
-
-    fixture
-        .command()
-        .args(["init", "--no-labels", "--update-workflow", "--repository"])
-        .arg(&fixture.repository)
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("updated:"));
-    assert_eq!(
-        fs::read_to_string(fixture.workflow()).unwrap(),
-        include_str!("../examples/implement-ready-ticket.md")
-    );
-}
-
-#[test]
-fn existing_config_preserves_comments_and_registers_repository_once() {
-    let fixture = Fixture::new();
-    let other = fixture._temp.path().join("other");
-    fs::create_dir(&other).unwrap();
-    let workspace = fixture._temp.path().join("workspaces");
-    write_config(
-        &fixture.config_path(),
-        &[&other],
-        &workspace,
-        "# keep this comment\n",
-    );
-
-    for _ in 0..2 {
-        fixture
-            .command()
-            .args(["init", "--no-labels", "--repository"])
-            .arg(&fixture.repository)
-            .assert()
-            .success();
-    }
-
-    let contents = fs::read_to_string(fixture.config_path()).unwrap();
-    assert!(contents.starts_with("# keep this comment\n"));
-    assert_eq!(
-        contents
-            .matches(fixture.repository.to_str().unwrap())
-            .count(),
-        1
-    );
-    let config = Config::load(&fixture.config_path()).unwrap();
-    assert_eq!(config.repositories.len(), 2);
-}
-
-#[test]
-fn invalid_candidate_leaves_existing_config_and_workflow_untouched() {
+fn invalid_candidate_leaves_existing_config_and_repository_untouched() {
     let fixture = Fixture::new();
     let other = fixture._temp.path().join("other");
     fs::create_dir(&other).unwrap();
@@ -600,7 +331,7 @@ fn invalid_candidate_leaves_existing_config_and_workflow_untouched() {
 
     fixture
         .command()
-        .args(["init", "--no-labels", "--repository"])
+        .args(["init", "--repository"])
         .arg(&nested_repository)
         .assert()
         .failure()
@@ -609,131 +340,36 @@ fn invalid_candidate_leaves_existing_config_and_workflow_untouched() {
         ));
 
     assert_eq!(fs::read_to_string(fixture.config_path()).unwrap(), original);
-    assert!(
-        !nested_repository
-            .join(".factory/workflows/implement-ready-ticket.md")
-            .exists()
-    );
+    assert!(!nested_repository.join(".factory").exists());
 }
 
 #[test]
-fn run_hints_at_init_when_ready_workflow_is_missing() {
+fn init_accepts_supported_github_origins() {
+    for origin in [
+        "https://token@github.com/example/repository.git",
+        "ssh://git@ssh.github.com:443/example/repository.git",
+    ] {
+        let fixture = Fixture::new();
+        set_origin(&fixture.repository, origin);
+        fixture.command().arg("init").assert().success();
+    }
+}
+
+#[test]
+fn init_rejects_github_lookalike_origin_without_leaking_credentials() {
     let fixture = Fixture::new();
-    let workspace = fixture._temp.path().join("workspaces");
-    write_config(
-        &fixture.config_path(),
-        &[&fixture.repository],
-        &workspace,
-        "",
+    set_origin(
+        &fixture.repository,
+        "https://secret-token@github.com.example.org/example/repository.git",
     );
-    fs::create_dir_all(fixture.repository.join(".factory/workflows")).unwrap();
-    fs::write(
-        fixture
-            .repository
-            .join(".factory/workflows/nightly-maintenance.md"),
-        "+++\nschedule = \"0 2 * * *\"\ntimezone = \"UTC\"\n+++\n\nMaintain the repository.\n",
-    )
-    .unwrap();
 
     fixture
         .command()
-        .args(["run", "--once", "--config"])
-        .arg(fixture.config_path())
-        .arg("--data-directory")
-        .arg(fixture._temp.path().join("data"))
+        .arg("init")
         .assert()
-        .success()
+        .failure()
         .stderr(predicate::str::contains(
-            "No valid factory:ready implementation workflow found",
+            "origin is not a supported GitHub remote",
         ))
-        .stderr(predicate::str::contains("run factory init --repository"));
-}
-
-#[test]
-fn run_accepts_valid_custom_ready_workflow_as_initialized() {
-    let fixture = Fixture::new();
-    let workspace = fixture._temp.path().join("workspaces");
-    write_config(
-        &fixture.config_path(),
-        &[&fixture.repository],
-        &workspace,
-        "",
-    );
-    let workflows = fixture.repository.join(".factory/workflows");
-    fs::create_dir_all(&workflows).unwrap();
-    fs::write(
-        workflows.join("custom-ready-policy.md"),
-        "+++\nlabel = \"factory:ready\"\n+++\n\nUse the repository-specific delivery policy.\n",
-    )
-    .unwrap();
-
-    fixture
-        .command()
-        .args(["run", "--once", "--config"])
-        .arg(fixture.config_path())
-        .arg("--data-directory")
-        .arg(fixture._temp.path().join("data"))
-        .assert()
-        .success()
-        .stderr(
-            predicate::str::contains("No valid factory:ready implementation workflow found").not(),
-        );
-}
-
-#[test]
-fn init_does_not_install_duplicate_beside_custom_ready_workflow() {
-    let fixture = Fixture::new();
-    let workflows = fixture.repository.join(".factory/workflows");
-    let custom = workflows.join("custom-ready-policy.md");
-    fs::create_dir_all(&workflows).unwrap();
-    fs::write(
-        &custom,
-        "+++\nlabel = \"factory:ready\"\n+++\n\nUse the repository-specific delivery policy.\n",
-    )
-    .unwrap();
-
-    fixture
-        .command()
-        .args(["init", "--no-labels"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains(custom.to_str().unwrap()))
-        .stdout(predicate::str::contains("unchanged:"))
-        .stdout(predicate::str::contains("git -C").not())
-        .stdout(predicate::str::contains("implement-ready-ticket.md").not());
-
-    assert!(!fixture.workflow().exists());
-    assert!(custom.is_file());
-    assert!(fixture.config_path().is_file());
-}
-
-#[test]
-fn update_workflow_replaces_custom_ready_workflow_in_place() {
-    let fixture = Fixture::new();
-    let workflows = fixture.repository.join(".factory/workflows");
-    let custom = workflows.join("custom-ready-policy.md");
-    fs::create_dir_all(&workflows).unwrap();
-    fs::write(
-        &custom,
-        "+++\nlabel = \"factory:ready\"\n+++\n\nUse the repository-specific delivery policy.\n",
-    )
-    .unwrap();
-
-    fixture
-        .command()
-        .args(["init", "--no-labels", "--update-workflow"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("updated:"))
-        .stdout(predicate::str::contains(
-            "git -C '".to_owned()
-                + fixture.repository.canonicalize().unwrap().to_str().unwrap()
-                + "' add '.factory/workflows/custom-ready-policy.md'",
-        ));
-
-    assert_eq!(
-        fs::read_to_string(&custom).unwrap(),
-        include_str!("../examples/implement-ready-ticket.md")
-    );
-    assert!(!fixture.workflow().exists());
+        .stderr(predicate::str::contains("secret-token").not());
 }

--- a/tests/workflow_create_cli.rs
+++ b/tests/workflow_create_cli.rs
@@ -1,0 +1,406 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Command as ProcessCommand;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    home: PathBuf,
+    repository: PathBuf,
+    executable_path: String,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let repository = temp.path().join("repository");
+        fs::create_dir(&home).unwrap();
+        fs::create_dir(&repository).unwrap();
+        let gh = temp.path().join("gh");
+        fs::write(
+            &gh,
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> .gh-calls
+if [ "$1" = "--version" ]; then echo "gh version 2.80.0"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo "logged in"; exit 0; fi
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then echo "example/repository"; exit 0; fi
+if [ "$1" = "api" ]; then
+  if [ -f .factory-test-labels ]; then cat .factory-test-labels; fi
+  exit 0
+fi
+if [ "$1" = "label" ] && [ "$2" = "create" ]; then
+  if [ -f .fail-label ]; then echo "simulated label failure" >&2; exit 1; fi
+  printf '%s\n' "$3" >> .factory-test-labels
+  exit 0
+fi
+echo "unexpected fake gh arguments: $*" >&2
+exit 64
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&gh).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&gh, permissions).unwrap();
+        let executable_path = format!(
+            "{}:{}",
+            temp.path().display(),
+            std::env::var("PATH").unwrap()
+        );
+        assert!(
+            ProcessCommand::new("git")
+                .args(["init", "--quiet"])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            ProcessCommand::new("git")
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "git@github.com:example/repository.git",
+                ])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let fixture = Self {
+            _temp: temp,
+            home,
+            repository,
+            executable_path,
+        };
+        fixture.command().arg("init").assert().success();
+        fixture
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::cargo_bin("factory").unwrap();
+        command
+            .current_dir(&self.repository)
+            .env("HOME", &self.home)
+            .env("PATH", &self.executable_path);
+        command
+    }
+
+    fn workflow(&self, id: &str) -> PathBuf {
+        self.repository
+            .join(".factory/workflows")
+            .join(format!("{id}.md"))
+    }
+}
+
+#[test]
+fn creates_scheduled_workflow_from_inline_prompt_without_editor() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "triage-pull-requests",
+            "--schedule",
+            "*/30 * * * *",
+            "--timezone",
+            "Europe/London",
+            "--runtime",
+            "codex",
+            "--timeout",
+            "1h",
+            "--prompt",
+            "Review and triage open pull requests without labels.",
+        ])
+        .env("EDITOR", "/path/that/must/not/run")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created workflow"))
+        .stdout(predicate::str::contains("git -C"));
+
+    assert_eq!(
+        fs::read_to_string(fixture.workflow("triage-pull-requests")).unwrap(),
+        "+++\nschedule = \"*/30 * * * *\"\ntimezone = \"Europe/London\"\nruntime = \"codex\"\ntimeout = \"1h\"\n+++\n\nReview and triage open pull requests without labels.\n"
+    );
+    assert!(!fixture.repository.join(".gh-calls").exists());
+}
+
+#[test]
+fn creates_label_workflow_from_prompt_file() {
+    let fixture = Fixture::new();
+    let prompt = fixture._temp.path().join("policy.md");
+    fs::write(
+        &prompt,
+        "# Review a ticket\n\nClassify the supplied ticket.\n",
+    )
+    .unwrap();
+
+    fixture
+        .command()
+        .args(["workflow", "create", "triage-ticket", "--label", "triage"])
+        .arg("--prompt-file")
+        .arg(&prompt)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created GitHub label triage"));
+
+    let contents = fs::read_to_string(fixture.workflow("triage-ticket")).unwrap();
+    assert!(contents.contains("label = \"triage\""));
+    assert!(contents.contains("# Review a ticket"));
+    assert_eq!(
+        fs::read_to_string(fixture.repository.join(".factory-test-labels")).unwrap(),
+        "triage\n"
+    );
+}
+
+#[test]
+fn creates_workflow_from_standard_input() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "stdin-policy",
+            "--label",
+            "triage",
+            "--prompt-file",
+            "-",
+        ])
+        .write_stdin("Use the supplied ticket.\n")
+        .assert()
+        .success();
+
+    assert!(
+        fs::read_to_string(fixture.workflow("stdin-policy"))
+            .unwrap()
+            .contains("Use the supplied ticket.")
+    );
+}
+
+#[test]
+fn existing_trigger_label_is_not_recreated() {
+    let fixture = Fixture::new();
+    fs::write(fixture.repository.join(".factory-test-labels"), "triage\n").unwrap();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "existing-label",
+            "--label",
+            "triage",
+            "--prompt",
+            "Do work.",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Created GitHub label").not());
+
+    let calls = fs::read_to_string(fixture.repository.join(".gh-calls")).unwrap();
+    assert!(!calls.contains("label create"));
+}
+
+#[test]
+fn label_creation_failure_rolls_back_new_workflow() {
+    let fixture = Fixture::new();
+    fs::write(fixture.repository.join(".fail-label"), "").unwrap();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "failed-label",
+            "--label",
+            "triage",
+            "--prompt",
+            "Do work.",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("failed to create GitHub label"));
+
+    assert!(!fixture.workflow("failed-label").exists());
+}
+
+#[test]
+fn requires_explicit_trigger_and_prompt_source() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "missing-trigger",
+            "--prompt",
+            "Do work.",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--schedule <SCHEDULE>|--label <LABEL>",
+        ));
+
+    fixture
+        .command()
+        .args(["workflow", "create", "missing-prompt", "--label", "triage"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--prompt <PROMPT>|--prompt-file <PATH>",
+        ));
+}
+
+#[test]
+fn schedule_requires_timezone() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "scheduled",
+            "--schedule",
+            "0 9 * * 1",
+            "--prompt",
+            "Do work.",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--timezone <TIMEZONE>"));
+}
+
+#[test]
+fn invalid_workflow_is_not_left_behind() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "bad-schedule",
+            "--schedule",
+            "eventually",
+            "--timezone",
+            "UTC",
+            "--prompt",
+            "Do work.",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("workflow is invalid"));
+
+    assert!(!fixture.workflow("bad-schedule").exists());
+}
+
+#[test]
+fn refuses_to_overwrite_existing_workflow() {
+    let fixture = Fixture::new();
+    let path = fixture.workflow("existing");
+    fs::write(&path, "keep me\n").unwrap();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "existing",
+            "--label",
+            "triage",
+            "--prompt",
+            "Replace it.",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("workflow already exists"));
+
+    assert_eq!(fs::read_to_string(path).unwrap(), "keep me\n");
+}
+
+#[test]
+fn rejects_invalid_workflow_id_before_writing() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args([
+            "workflow",
+            "create",
+            "../escape",
+            "--label",
+            "triage",
+            "--prompt",
+            "Do work.",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("lowercase kebab-case"));
+
+    assert!(!fixture.repository.join(".factory/escape.md").exists());
+}
+
+#[test]
+fn requires_repository_initialization() {
+    let fixture = Fixture::new();
+    fs::remove_dir(fixture.repository.join(".factory/workflows")).unwrap();
+
+    fixture
+        .command()
+        .args([
+            "workflow", "create", "triage", "--label", "triage", "--prompt", "Do work.",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("run factory init"));
+}
+
+#[test]
+fn staging_command_is_shell_safe() {
+    let mut fixture = Fixture::new();
+    let old_repository = fixture.repository.canonicalize().unwrap();
+    let repository = fixture._temp.path().join("repository with ' quote");
+    fs::rename(&fixture.repository, &repository).unwrap();
+    fixture.repository = repository;
+    let config = fixture.home.join(".factory/config.toml");
+    let contents = fs::read_to_string(&config).unwrap().replace(
+        old_repository.to_str().unwrap(),
+        fixture.repository.canonicalize().unwrap().to_str().unwrap(),
+    );
+    fs::write(config, contents).unwrap();
+
+    let output = fixture
+        .command()
+        .args([
+            "workflow", "create", "safe", "--label", "triage", "--prompt", "Do work.",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let command = stdout
+        .lines()
+        .find(|line| line.trim_start().starts_with("git -C "))
+        .unwrap()
+        .trim();
+    assert!(
+        ProcessCommand::new("sh")
+            .args(["-c", command])
+            .status()
+            .unwrap()
+            .success()
+    );
+}


### PR DESCRIPTION
## Summary

- make `factory init` configure and register a repository without installing a workflow or creating labels
- add non-interactive `factory workflow create` support for scheduled and label-triggered workflows using inline, file, or standard-input prompts
- validate generated workflows, refuse overwrites, create explicitly declared trigger labels, and roll back partial failures
- update CLI guidance, operational documentation, and integration coverage

## Why

Initialization previously installed an opinionated ready-ticket workflow and conventional labels even when a repository needed a different automation. This separates repository setup from workflow authoring and supports the pull-request triage flow directly without opening `$EDITOR`.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- independent diff review: approved after fixing a post-persist directory-sync rollback path

## Notes

The pre-existing local edit to `.factory/workflows/implement-ready-ticket.md` is not included in this pull request.