### PR TITLE
feat(cli): make Factory repository-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ and Codex CLIs. It does not use model API keys.
 4. In a trusted target repository, run `factory init`.
 5. Create a workflow with `factory workflow create`.
 6. Review and commit the new file under `.factory/workflows/`.
-7. Run `factory validate`, `factory workflows`, then `factory run`.
+7. Run `factory validate`, `factory workflows`, then `factory daemon`.
 
-`factory init --check` previews setup without writes. Initialization only
-registers the repository, creates machine configuration and workspace storage,
-and creates the repository's workflow directory. It does not install an
+`factory init --check` previews setup without writes. Initialization creates
+`.factory/config.toml`, external machine state and worktree storage, and the
+repository's workflow directory. It does not install an
 opinionated workflow or create GitHub labels.
 
 Create a scheduled pull-request triage workflow without opening an editor:
@@ -39,8 +39,13 @@ prompt from standard input. Label-triggered workflows create their missing
 trigger label explicitly; scheduled workflows do not mutate labels during
 creation.
 
+`factory daemon` runs until Ctrl-C. `factory run --once` evaluates schedules
+and polls once, persists eligible tasks, and exits without launching Codex.
+If no schedule or issue matches, Factory launches no agent and uses no model
+tokens.
+
 See [`docs/local-v1.md`](docs/local-v1.md) for the current implementation's
-installation, setup, operation, recovery, and acceptance instructions. The next
+installation, setup, operation, recovery, and acceptance instructions. The
 repo-local architecture and product boundary are documented in
 [`docs/single-repository-v1/design.md`](docs/single-repository-v1/design.md).
 

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -45,10 +45,11 @@ cd /absolute/path/to/trusted/repository
 factory init
 ```
 
-The command creates or updates `~/.factory/config.toml`, creates the default
-`~/.factory/workspaces` directory, and creates `.factory/workflows/` in the
-repository. It does not install a workflow, inspect or mutate GitHub labels,
-commit files, start the daemon, launch Codex, or merge pull requests.
+The command creates `.factory/config.toml` and `.factory/workflows/` in the
+repository. It derives a stable state directory for this clone under the user
+data directory and creates its external worktree directory there. It does not
+install a workflow, inspect or mutate GitHub labels, commit files, start the
+daemon, launch Codex, or merge pull requests.
 
 Initialization is idempotent. Preview it without writes with:
 
@@ -110,7 +111,7 @@ apply the ready label:
 
 ```sh
 gh issue edit ISSUE_NUMBER --add-label factory:ready
-factory run
+factory daemon
 ```
 
 Keep the terminal open. The daemon polls GitHub, persists one task, atomically
@@ -128,7 +129,7 @@ factory inspect RUN_ID
 Exactly one task and run should represent the triggering issue revision. A
 normal daemon restart must not create another implementation or pull request.
 To exercise restart deduplication after the run is terminal, stop Factory with
-Ctrl-C, start `factory run` again, wait through at least one poll, and confirm
+Ctrl-C, start `factory daemon` again, wait through at least one poll, and confirm
 the task/run counts and linked pull request remain unchanged.
 
 Success means:
@@ -164,11 +165,24 @@ falls back once to a fresh session with current issue, Git, worktree, pull
 request, CI, and bounded prior evidence. Repeated failure remains inspectable;
 Factory never merges as part of recovery.
 
+Use a non-executing smoke test before starting the daemon:
+
+```sh
+factory run --once
+```
+
+This evaluates one schedule tick, polls GitHub once, and persists matching
+tasks without claiming them or launching Codex. If nothing matches, it uses no
+model tokens.
+
 ## Troubleshooting
 
 - Authentication errors: rerun `gh auth status` and `codex login status`.
-- Invalid configuration: run `factory validate` and correct the reported path
-  or concurrency constraint.
+- Invalid configuration: run `factory validate` and correct the reported
+  repository-local policy or concurrency constraint.
+- Legacy cutover blocked: stop the old global daemon and finish or cancel its
+  queued or running work for this repository. Factory leaves the old database
+  untouched and does not import its history.
 - Missing setup: run `factory init --check`, then `factory init` to create only
   the missing resources.
 - Invalid workflows: run `factory workflows`; ticket workflow errors fail fast,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,10 +1,11 @@
 # Factory operation
 
-`factory run` validates `gh` and Codex subscription authentication, evaluates
-scheduled workflows, polls all configured repositories, and dispatches durable
-scheduled and ready-ticket tasks. Global and
-per-repository concurrency are controlled by `max_concurrent_runs` and
-`max_concurrent_runs_per_repository`. The per-repository value defaults to 1.
+`factory daemon` discovers the enclosing Git root, loads
+`.factory/config.toml`, validates `gh` and Codex subscription authentication,
+evaluates scheduled workflows, polls that repository, and dispatches durable
+scheduled and ready-ticket tasks. `max_concurrent_runs` controls concurrency.
+Each clone has its own SQLite database and worktree directory outside the
+checkout.
 
 In continuous mode, Factory writes concise lifecycle events to standard error.
 It reports startup validation, polls that queue work, claimed tasks, runtime
@@ -62,5 +63,13 @@ Queued tasks remain durable for the next start. Failed and cancelled runs keep
 their bounded output, error, session, ticket, branch, and pull-request context
 for inspection. Factory never merges software pull requests.
 
-`factory run --once` performs one discovery poll and exits without claiming or
-launching tasks. It is intended for setup checks and safe polling smoke tests.
+`factory run --once` evaluates one schedule tick, performs one discovery poll,
+persists eligible tasks, and exits without claiming or launching them. It is
+intended for setup checks and safe polling smoke tests. An empty evaluation
+does not invoke Codex.
+
+Before first repository-local startup, Factory reads the old
+`~/.factory/factory.sqlite3` database without modifying it. If that database
+contains queued or running work for this repository, startup stops with
+instructions to stop the old daemon and finish or cancel the work. Terminal
+legacy history is not imported.

--- a/docs/single-repository-v1/design.md
+++ b/docs/single-repository-v1/design.md
@@ -22,7 +22,7 @@ state says useful, authorised work exists. Keeping agents busy is not a goal.
 
 ## Requirements
 
-- Running `factory run` anywhere inside a configured Git repository discovers
+- Running `factory daemon` anywhere inside a configured Git repository discovers
   its root and loads `.factory/config.toml`.
 - The repository contains shareable policy only: configuration and Markdown
   workflows. Credentials, SQLite state, logs, sockets, and worktrees stay in a
@@ -50,7 +50,7 @@ state says useful, authorised work exists. Keeping agents busy is not a goal.
 ## Acceptance criteria
 
 - From a clean repository, `factory init`, workflow creation, `factory
-  validate`, and `factory run` require no global repository registry or
+  validate`, and `factory daemon` require no global repository registry or
   repository arguments.
 - Repeated polls and daemon restarts create exactly one task while an issue
   continuously holds `factory:ready`.
@@ -436,7 +436,7 @@ flags:
 factory init
 factory init --check
 factory validate
-factory run
+factory daemon
 factory run --once
 factory workflows
 factory workflow create <id>

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,13 +1,9 @@
-# Copy this file to ~/.factory/config.toml, then replace the two paths.
-# Every repository must be a trusted local Git checkout with a GitHub remote.
-repositories = [
-  "/absolute/path/to/trusted/repository",
-]
+# Copy this file to <repository>/.factory/config.toml.
+# Repository identity and external state paths are derived from the Git root.
+version = 1
 
 poll_every = "30s"
 default_runtime = "codex"
 default_timeout = "2h"
 maximum_timeout = "8h"
 max_concurrent_runs = 2
-max_concurrent_runs_per_repository = 1
-workspace_root = "/absolute/path/to/factory-worktrees"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,10 +2,12 @@ use std::env;
 use std::fmt;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
@@ -17,20 +19,18 @@ pub struct Config {
     pub max_concurrent_runs: usize,
     pub max_concurrent_runs_per_repository: usize,
     pub workspace_root: PathBuf,
+    pub data_directory: PathBuf,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawConfig {
-    repositories: Vec<String>,
+    version: u8,
     poll_every: String,
     default_runtime: String,
     default_timeout: String,
     maximum_timeout: String,
     max_concurrent_runs: usize,
-    #[serde(default = "default_repository_concurrency")]
-    max_concurrent_runs_per_repository: usize,
-    workspace_root: String,
 }
 
 impl Config {
@@ -59,48 +59,58 @@ impl Config {
         let config_dir = path
             .parent()
             .context("configuration path has no parent directory")?;
+        if config_dir.file_name().and_then(|name| name.to_str()) != Some(".factory") {
+            bail!(
+                "Factory v1 requires repository-local configuration at <git-root>/.factory/config.toml; legacy global configuration is not executable"
+            );
+        }
+        let repository = config_dir
+            .parent()
+            .context(".factory configuration has no repository parent")?;
+        let expected = repository_config_path(repository);
+        if path != expected {
+            bail!(
+                "Factory repository configuration must be {}; got {}",
+                expected.display(),
+                path.display()
+            );
+        }
 
         Self::resolve_with_workspace_probe(
             raw,
-            config_dir,
+            repository,
             workspace_probe,
             allow_missing_workspace,
         )
         .with_context(|| format!("invalid Factory configuration in {}", path.display()))
     }
 
-    pub(crate) fn validate_candidate(contents: &str, config_dir: &Path) -> Result<Self> {
+    pub(crate) fn validate_candidate(contents: &str, repository: &Path) -> Result<Self> {
         let raw: RawConfig =
             toml::from_str(contents).context("failed to parse candidate config")?;
-        Self::resolve_with_workspace_probe(raw, config_dir, |_| Ok(()), true)
+        Self::resolve_with_workspace_probe(raw, repository, |_| Ok(()), true)
             .context("invalid candidate Factory configuration")
     }
 
     #[cfg(test)]
-    fn resolve(raw: RawConfig, config_dir: &Path) -> Result<Self> {
-        Self::resolve_with_workspace_probe(raw, config_dir, ensure_workspace_writable, false)
+    fn resolve(raw: RawConfig, repository: &Path) -> Result<Self> {
+        Self::resolve_with_workspace_probe(raw, repository, |_| Ok(()), true)
     }
 
     fn resolve_with_workspace_probe<F>(
         raw: RawConfig,
-        config_dir: &Path,
+        repository: &Path,
         workspace_probe: F,
         allow_missing_workspace: bool,
     ) -> Result<Self>
     where
         F: FnOnce(&Path) -> Result<()>,
     {
-        if raw.repositories.is_empty() {
-            bail!("repositories must contain at least one path");
+        if raw.version != 1 {
+            bail!("version must be 1");
         }
         if raw.max_concurrent_runs == 0 {
             bail!("max_concurrent_runs must be greater than zero");
-        }
-        if raw.max_concurrent_runs_per_repository == 0 {
-            bail!("max_concurrent_runs_per_repository must be greater than zero");
-        }
-        if raw.max_concurrent_runs_per_repository > raw.max_concurrent_runs {
-            bail!("max_concurrent_runs_per_repository must not exceed max_concurrent_runs");
         }
         let default_runtime = raw.default_runtime.trim();
         if default_runtime.is_empty() {
@@ -114,33 +124,32 @@ impl Config {
             bail!("default_timeout must not exceed maximum_timeout");
         }
 
-        let repositories = raw
-            .repositories
-            .iter()
-            .map(|path| canonical_directory("repository", Path::new(path), config_dir))
-            .collect::<Result<Vec<_>>>()?;
+        let repository = canonical_directory("repository", repository, repository)?;
+        let data_directory = repository_data_directory(&repository)?;
+        let workspace_candidate = data_directory.join("worktrees");
         let workspace_root = if allow_missing_workspace {
-            canonical_directory_or_missing(
-                "workspace_root",
-                Path::new(&raw.workspace_root),
-                config_dir,
-            )?
+            canonical_directory_or_missing("workspace_root", &workspace_candidate, &repository)?
         } else {
-            canonical_directory("workspace_root", Path::new(&raw.workspace_root), config_dir)?
+            canonical_directory("workspace_root", &workspace_candidate, &repository)?
         };
         let home = canonical_home_dir()?;
-        validate_workspace(&workspace_root, &repositories, home.as_deref())?;
+        validate_workspace(
+            &workspace_root,
+            std::slice::from_ref(&repository),
+            home.as_deref(),
+        )?;
         workspace_probe(&workspace_root)?;
 
         Ok(Self {
-            repositories,
+            repositories: vec![repository],
             poll_every,
             default_runtime: default_runtime.to_owned(),
             default_timeout,
             maximum_timeout,
             max_concurrent_runs: raw.max_concurrent_runs,
-            max_concurrent_runs_per_repository: raw.max_concurrent_runs_per_repository,
+            max_concurrent_runs_per_repository: raw.max_concurrent_runs,
             workspace_root,
+            data_directory,
         })
     }
 }
@@ -148,10 +157,7 @@ impl Config {
 impl fmt::Display for Config {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(formatter, "Configuration is valid.")?;
-        writeln!(formatter, "repositories:")?;
-        for repository in &self.repositories {
-            writeln!(formatter, "  - {}", repository.display())?;
-        }
+        writeln!(formatter, "repository: {}", self.repositories[0].display())?;
         writeln!(
             formatter,
             "poll_every: {}",
@@ -175,25 +181,135 @@ impl fmt::Display for Config {
         )?;
         writeln!(
             formatter,
-            "max_concurrent_runs_per_repository: {}",
-            self.max_concurrent_runs_per_repository
+            "state_directory: {}",
+            self.data_directory.display()
         )?;
-        writeln!(
-            formatter,
-            "workspace_root: {}",
-            self.workspace_root.display()
-        )
+        writeln!(formatter, "worktrees: {}", self.workspace_root.display())
     }
 }
 
-fn default_repository_concurrency() -> usize {
-    1
+pub fn repository_config_path(repository: &Path) -> PathBuf {
+    repository.join(".factory/config.toml")
 }
 
-pub fn default_config_path() -> PathBuf {
-    dirs::home_dir()
-        .map(|home| home.join(".factory/config.toml"))
-        .unwrap_or_else(|| PathBuf::from(".factory/config.toml"))
+pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
+    let repository = repository
+        .canonicalize()
+        .with_context(|| format!("failed to resolve repository {}", repository.display()))?;
+    ensure_primary_checkout(&repository)?;
+    let identity = repository_remote_identity(&repository)?;
+    let mut hasher = Sha256::new();
+    hasher.update(identity.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(repository.as_os_str().as_encoded_bytes());
+    let digest = format!("{:x}", hasher.finalize());
+    let base = env::var_os("FACTORY_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::data_local_dir().map(|path| path.join("factory")))
+        .context("could not determine Factory data directory")?;
+    let base = if base.is_absolute() {
+        base
+    } else {
+        env::current_dir()
+            .context("failed to resolve current directory")?
+            .join(base)
+    };
+    Ok(base.join(&digest[..20]))
+}
+
+pub fn repository_remote_identity(repository: &Path) -> Result<String> {
+    let origin = git_output(repository, &["remote", "get-url", "origin"])
+        .context("repository has no readable origin remote")?;
+    canonical_github_identity(origin.trim()).context("origin is not a supported GitHub remote")
+}
+
+fn canonical_github_identity(origin: &str) -> Result<String> {
+    let path = if let Some(path) = origin.strip_prefix("git@github.com:") {
+        path
+    } else if let Some(remainder) = origin.strip_prefix("https://") {
+        let (authority, path) = remainder
+            .split_once('/')
+            .context("GitHub HTTPS origin has no repository path")?;
+        let host = authority
+            .rsplit_once('@')
+            .map_or(authority, |(_, host)| host);
+        let host = host.split_once(':').map_or(host, |(host, _)| host);
+        if !host.eq_ignore_ascii_case("github.com") {
+            bail!("GitHub HTTPS origin has an unsupported host");
+        }
+        path
+    } else if let Some(remainder) = origin.strip_prefix("ssh://git@") {
+        let (authority, path) = remainder
+            .split_once('/')
+            .context("GitHub SSH origin has no repository path")?;
+        let host = authority
+            .split_once(':')
+            .map_or(authority, |(host, _)| host);
+        if !host.eq_ignore_ascii_case("github.com") && !host.eq_ignore_ascii_case("ssh.github.com")
+        {
+            bail!("GitHub SSH origin has an unsupported host");
+        }
+        path
+    } else {
+        bail!("unsupported GitHub origin syntax");
+    };
+    let path = path.trim_end_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    let mut segments = path.split('/');
+    let owner = segments
+        .next()
+        .filter(|value| !value.is_empty())
+        .context("GitHub origin has no owner")?;
+    let repository = segments
+        .next()
+        .filter(|value| !value.is_empty())
+        .context("GitHub origin has no repository")?;
+    if segments.next().is_some() {
+        bail!("GitHub origin has an invalid repository path");
+    }
+    Ok(format!(
+        "{}/{}",
+        owner.to_ascii_lowercase(),
+        repository.to_ascii_lowercase()
+    ))
+}
+
+fn ensure_primary_checkout(repository: &Path) -> Result<()> {
+    let git_dir = git_output(
+        repository,
+        &["rev-parse", "--path-format=absolute", "--git-dir"],
+    )?;
+    let common_dir = git_output(
+        repository,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?;
+    let git_dir = PathBuf::from(git_dir.trim())
+        .canonicalize()
+        .context("failed to resolve Git directory")?;
+    let common_dir = PathBuf::from(common_dir.trim())
+        .canonicalize()
+        .context("failed to resolve common Git directory")?;
+    if git_dir != common_dir {
+        bail!("Factory must run from the primary checkout, not a linked Git worktree");
+    }
+    Ok(())
+}
+
+fn git_output(repository: &Path, arguments: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repository)
+        .args(arguments)
+        .output()
+        .context("failed to start git")?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            arguments.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    String::from_utf8(output.stdout).context("git output was not valid UTF-8")
 }
 
 fn parse_positive_duration(name: &str, value: &str) -> Result<Duration> {
@@ -373,16 +489,38 @@ fn ensure_workspace_writable(workspace: &Path) -> Result<()> {
 mod tests {
     use super::*;
 
-    fn raw(repository: &Path, workspace: &Path) -> RawConfig {
+    fn raw(repository: &Path, _workspace: &Path) -> RawConfig {
+        fs::create_dir_all(repository).unwrap();
+        if !repository.join(".git").exists() {
+            assert!(
+                Command::new("git")
+                    .args(["init", "--quiet"])
+                    .current_dir(repository)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+            assert!(
+                Command::new("git")
+                    .args([
+                        "remote",
+                        "add",
+                        "origin",
+                        "git@github.com:example/repository.git"
+                    ])
+                    .current_dir(repository)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+        }
         RawConfig {
-            repositories: vec![repository.display().to_string()],
+            version: 1,
             poll_every: "30s".into(),
             default_runtime: "codex".into(),
             default_timeout: "2h".into(),
             maximum_timeout: "8h".into(),
             max_concurrent_runs: 2,
-            max_concurrent_runs_per_repository: 1,
-            workspace_root: workspace.display().to_string(),
         }
     }
 
@@ -391,16 +529,13 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let repository = temp.path().join("repo");
         let workspace = temp.path().join("worktrees");
-        fs::create_dir(&repository).unwrap();
-        fs::create_dir(&workspace).unwrap();
-
-        let config = Config::resolve(raw(&repository, &workspace), temp.path()).unwrap();
+        let config = Config::resolve(raw(&repository, &workspace), &repository).unwrap();
 
         assert_eq!(
             config.repositories,
             vec![repository.canonicalize().unwrap()]
         );
-        assert_eq!(config.workspace_root, workspace.canonicalize().unwrap());
+        assert!(config.workspace_root.ends_with("worktrees"));
         assert_eq!(config.poll_every, Duration::from_secs(30));
     }
 
@@ -409,12 +544,10 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let repository = temp.path().join("repo");
         let workspace = temp.path().join("worktrees");
-        fs::create_dir(&repository).unwrap();
-        fs::create_dir(&workspace).unwrap();
         let mut input = raw(&repository, &workspace);
         input.default_runtime = "  codex  ".into();
 
-        let config = Config::resolve(input, temp.path()).unwrap();
+        let config = Config::resolve(input, &repository).unwrap();
 
         assert_eq!(config.default_runtime, "codex");
     }
@@ -424,8 +557,6 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let repository = temp.path().join("repo");
         let workspace = temp.path().join("worktrees");
-        fs::create_dir(&repository).unwrap();
-        fs::create_dir(&workspace).unwrap();
         let mut config = raw(&repository, &workspace);
         config.poll_every = "eventually".into();
 
@@ -454,28 +585,17 @@ mod tests {
     }
 
     #[test]
-    fn rejects_invalid_repository_concurrency() {
+    fn rejects_unsupported_version() {
         let temp = tempfile::tempdir().unwrap();
         let repository = temp.path().join("repo");
         let workspace = temp.path().join("worktrees");
-        fs::create_dir(&repository).unwrap();
-        fs::create_dir(&workspace).unwrap();
         let mut config = raw(&repository, &workspace);
-        config.max_concurrent_runs_per_repository = 0;
+        config.version = 2;
         assert!(
             Config::resolve(config, temp.path())
                 .unwrap_err()
                 .to_string()
-                .contains("must be greater than zero")
-        );
-
-        let mut config = raw(&repository, &workspace);
-        config.max_concurrent_runs_per_repository = 3;
-        assert!(
-            Config::resolve(config, temp.path())
-                .unwrap_err()
-                .to_string()
-                .contains("must not exceed")
+                .contains("version must be 1")
         );
     }
 
@@ -484,33 +604,26 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let workspace = temp.path().join("worktrees");
         fs::create_dir(&workspace).unwrap();
-        let config = raw(&temp.path().join("missing"), &workspace);
+        let config = RawConfig {
+            version: 1,
+            poll_every: "30s".into(),
+            default_runtime: "codex".into(),
+            default_timeout: "2h".into(),
+            maximum_timeout: "8h".into(),
+            max_concurrent_runs: 1,
+        };
 
-        let error = Config::resolve(config, temp.path()).unwrap_err();
+        let error = Config::resolve(config, &temp.path().join("missing")).unwrap_err();
 
         assert!(error.to_string().contains("repository path does not exist"));
     }
 
     #[test]
-    fn rejects_workspace_inside_repository() {
+    fn derives_workspace_outside_repository() {
         let temp = tempfile::tempdir().unwrap();
         let workspace = temp.path().join("worktrees");
-        fs::create_dir(&workspace).unwrap();
-
-        let error = Config::resolve(raw(temp.path(), &workspace), temp.path()).unwrap_err();
-
-        assert!(error.to_string().contains("must not overlap"));
-    }
-
-    #[test]
-    fn rejects_repository_inside_workspace() {
-        let temp = tempfile::tempdir().unwrap();
-        let repository = temp.path().join("repo");
-        fs::create_dir(&repository).unwrap();
-
-        let error = Config::resolve(raw(&repository, temp.path()), temp.path()).unwrap_err();
-
-        assert!(error.to_string().contains("must not overlap"));
+        let config = Config::resolve(raw(temp.path(), &workspace), temp.path()).unwrap();
+        assert!(!config.workspace_root.starts_with(temp.path()));
     }
 
     #[cfg(unix)]
@@ -537,18 +650,119 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let repository = temp.path().join("repo");
         let workspace = temp.path().join("worktrees");
-        fs::create_dir(&repository).unwrap();
-        fs::create_dir(&workspace).unwrap();
-
         let error = Config::resolve_with_workspace_probe(
             raw(&repository, &workspace),
-            temp.path(),
+            &repository,
             |path| bail!("workspace_root is not writable: {}", path.display()),
-            false,
+            true,
         )
         .unwrap_err();
 
-        assert!(error.to_string().contains("workspace_root is not writable"));
-        assert!(error.to_string().contains(workspace.to_str().unwrap()));
+        assert!(
+            error.to_string().contains("workspace_root is not writable"),
+            "{error:#}"
+        );
+        assert!(error.to_string().contains("worktrees"));
+    }
+
+    #[test]
+    fn repository_config_requires_version_and_rejects_legacy_registry_keys() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repo");
+        let workspace = temp.path().join("worktrees");
+        let valid = raw(&repository, &workspace);
+        let valid = toml::to_string(&serde_json::json!({
+            "version": valid.version,
+            "poll_every": valid.poll_every,
+            "default_runtime": valid.default_runtime,
+            "default_timeout": valid.default_timeout,
+            "maximum_timeout": valid.maximum_timeout,
+            "max_concurrent_runs": valid.max_concurrent_runs,
+        }))
+        .unwrap();
+        let missing_version = valid
+            .lines()
+            .filter(|line| !line.starts_with("version ="))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let error = Config::validate_candidate(&missing_version, &repository).unwrap_err();
+        assert!(format!("{error:#}").contains("missing field `version`"));
+        for legacy in [
+            "repositories = [\"/tmp/repo\"]",
+            "workspace_root = \"/tmp/worktrees\"",
+            "max_concurrent_runs_per_repository = 1",
+        ] {
+            let error = Config::validate_candidate(&format!("{valid}\n{legacy}\n"), &repository)
+                .unwrap_err();
+            assert!(format!("{error:#}").contains("unknown field"), "{error:#}");
+        }
+    }
+
+    #[test]
+    fn state_identity_normalizes_remote_syntax_but_distinguishes_clones() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first");
+        let second = temp.path().join("second");
+        raw(&first, temp.path());
+        raw(&second, temp.path());
+        let ssh = repository_data_directory(&first).unwrap();
+        assert!(
+            Command::new("git")
+                .args([
+                    "remote",
+                    "set-url",
+                    "origin",
+                    "https://github.com/Example/Repository.git",
+                ])
+                .current_dir(&first)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert_eq!(ssh, repository_data_directory(&first).unwrap());
+        assert_ne!(ssh, repository_data_directory(&second).unwrap());
+    }
+
+    #[test]
+    fn linked_git_worktree_is_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repo");
+        raw(&repository, temp.path());
+        fs::write(repository.join("README.md"), "test\n").unwrap();
+        assert!(
+            Command::new("git")
+                .args(["add", "."])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .args([
+                    "-c",
+                    "user.name=Test",
+                    "-c",
+                    "user.email=test@example.com",
+                    "commit",
+                    "-m",
+                    "test"
+                ])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let linked = temp.path().join("linked");
+        assert!(
+            Command::new("git")
+                .args(["worktree", "add", "-b", "linked", linked.to_str().unwrap()])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let error = repository_data_directory(&linked).unwrap_err();
+        assert!(error.to_string().contains("primary checkout"), "{error:#}");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -78,6 +78,11 @@ pub struct FactoryDaemon {
     codex: CodexRuntime,
 }
 
+pub struct OneShotReport {
+    pub github: PollReport,
+    pub scheduled_tasks_created: usize,
+}
+
 impl FactoryDaemon {
     pub fn new(config: Config, catalog: WorkflowCatalog, ledger_path: impl Into<PathBuf>) -> Self {
         Self::with_clients(
@@ -274,6 +279,45 @@ impl FactoryDaemon {
             return Err(error);
         }
         Ok(())
+    }
+
+    pub async fn evaluate_once(&self, cancellation: CancellationToken) -> Result<OneShotReport> {
+        for entry in self.catalog.invalid_scheduled_entries() {
+            eprintln!(
+                "Factory skipped invalid scheduled workflow {}: {}",
+                entry.path.display(),
+                entry.errors.join("; ")
+            );
+        }
+        self.catalog.validate_ticket_workflows()?;
+        self.github.validate_global(&cancellation).await?;
+        let targets = self.resolve_targets(&cancellation).await?;
+        let mut ledger = Ledger::open(&self.ledger_path)?;
+        let scheduled_before = ledger
+            .tasks()?
+            .into_iter()
+            .filter(|task| task.kind == "scheduled")
+            .count();
+        let owner = DaemonOwner::new()?;
+        ledger.register_daemon_owner(&owner.id, owner.pid)?;
+        let now = Utc::now();
+        let mut schedules =
+            initialize_schedules_preserving_due(&mut ledger, &targets, now, &owner.id);
+        evaluate_schedules_once(&mut ledger, &mut schedules, now);
+        ledger.remove_daemon_owner(&owner.id)?;
+        let scheduled_after = ledger
+            .tasks()?
+            .into_iter()
+            .filter(|task| task.kind == "scheduled")
+            .count();
+        let github = self
+            .github
+            .poll_once(&self.config, &self.catalog, &mut ledger)
+            .await?;
+        Ok(OneShotReport {
+            github,
+            scheduled_tasks_created: scheduled_after.saturating_sub(scheduled_before),
+        })
     }
 
     async fn validate(&self, cancellation: &CancellationToken) -> Result<()> {
@@ -983,6 +1027,25 @@ fn initialize_schedules(
     startup_at: DateTime<Utc>,
     owner_id: &str,
 ) -> Vec<ScheduledTarget> {
+    initialize_schedules_with_policy(ledger, targets, startup_at, owner_id, false)
+}
+
+fn initialize_schedules_preserving_due(
+    ledger: &mut Ledger,
+    targets: &HashMap<String, RepositoryTarget>,
+    startup_at: DateTime<Utc>,
+    owner_id: &str,
+) -> Vec<ScheduledTarget> {
+    initialize_schedules_with_policy(ledger, targets, startup_at, owner_id, true)
+}
+
+fn initialize_schedules_with_policy(
+    ledger: &mut Ledger,
+    targets: &HashMap<String, RepositoryTarget>,
+    startup_at: DateTime<Utc>,
+    owner_id: &str,
+    preserve_existing_due: bool,
+) -> Vec<ScheduledTarget> {
     let mut schedules = Vec::new();
     for (repository, target) in targets {
         for (workflow, target) in &target.workflows {
@@ -1009,7 +1072,11 @@ fn initialize_schedules(
                     workflow,
                     &fingerprint,
                     calculated.timestamp_millis(),
-                    startup_at.timestamp_millis(),
+                    if preserve_existing_due {
+                        i64::MIN
+                    } else {
+                        startup_at.timestamp_millis()
+                    },
                     owner_id,
                 )?;
                 let next_due = DateTime::<Utc>::from_timestamp_millis(cursor.next_due_at)
@@ -1041,23 +1108,7 @@ fn evaluate_schedules(
 ) {
     for target in schedules {
         while target.next_due <= through {
-            let due = target.next_due;
-            let result = (|| -> Result<DateTime<Utc>> {
-                let next = next_occurrence(&target.schedule, target.timezone, due)?;
-                let scheduled_at = due.to_rfc3339_opts(SecondsFormat::Secs, true);
-                let identity =
-                    TaskIdentity::scheduled(&target.repository, &target.workflow, &scheduled_at)?;
-                let payload = serde_json::json!({ "scheduled_at": scheduled_at }).to_string();
-                ledger.enqueue_scheduled_occurrence(
-                    &identity,
-                    &payload,
-                    &target.fingerprint,
-                    due.timestamp_millis(),
-                    next.timestamp_millis(),
-                )?;
-                Ok(next)
-            })();
-            match result {
+            match evaluate_schedule(ledger, target) {
                 Ok(next) => target.next_due = next,
                 Err(error) => {
                     eprintln!(
@@ -1069,6 +1120,41 @@ fn evaluate_schedules(
             }
         }
     }
+}
+
+fn evaluate_schedules_once(
+    ledger: &mut Ledger,
+    schedules: &mut [ScheduledTarget],
+    through: DateTime<Utc>,
+) {
+    for target in schedules {
+        if target.next_due > through {
+            continue;
+        }
+        match evaluate_schedule(ledger, target) {
+            Ok(next) => target.next_due = next,
+            Err(error) => eprintln!(
+                "Factory schedule tick failed for {}/{}: {error:#}",
+                target.repository, target.workflow
+            ),
+        }
+    }
+}
+
+fn evaluate_schedule(ledger: &mut Ledger, target: &ScheduledTarget) -> Result<DateTime<Utc>> {
+    let due = target.next_due;
+    let next = next_occurrence(&target.schedule, target.timezone, due)?;
+    let scheduled_at = due.to_rfc3339_opts(SecondsFormat::Secs, true);
+    let identity = TaskIdentity::scheduled(&target.repository, &target.workflow, &scheduled_at)?;
+    let payload = serde_json::json!({ "scheduled_at": scheduled_at }).to_string();
+    ledger.enqueue_scheduled_occurrence(
+        &identity,
+        &payload,
+        &target.fingerprint,
+        due.timestamp_millis(),
+        next.timestamp_millis(),
+    )?;
+    Ok(next)
 }
 
 fn next_occurrence(

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -32,7 +32,7 @@ impl ResolvedWorkflow {
         })?;
         if !config.repositories.contains(&repository) {
             bail!(
-                "repository {} is not listed in Factory configuration",
+                "repository {} does not match the repository-local Factory configuration",
                 repository.display()
             );
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 use tempfile::NamedTempFile;
-use toml_edit::{Array, DocumentMut, Item, Value, value};
+use toml_edit::{DocumentMut, value};
 
 use crate::config::Config;
 
@@ -20,17 +20,14 @@ pub struct InitOptions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PlannedAction {
     Create,
-    Update,
     Unchanged,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ResourceStatus {
     Created,
-    Updated,
     Unchanged,
     WouldCreate,
-    WouldUpdate,
     Failed,
     Skipped,
 }
@@ -39,10 +36,8 @@ impl ResourceStatus {
     fn label(self) -> &'static str {
         match self {
             Self::Created => "created",
-            Self::Updated => "updated",
             Self::Unchanged => "unchanged",
             Self::WouldCreate => "would create",
-            Self::WouldUpdate => "would update",
             Self::Failed => "failed",
             Self::Skipped => "skipped",
         }
@@ -68,7 +63,7 @@ impl InitReport {
         u8::from(self.resources.iter().any(|resource| {
             matches!(
                 resource.status,
-                ResourceStatus::WouldCreate | ResourceStatus::WouldUpdate | ResourceStatus::Failed
+                ResourceStatus::WouldCreate | ResourceStatus::Failed
             )
         }))
     }
@@ -110,7 +105,7 @@ impl fmt::Display for InitReport {
             writeln!(formatter, "Next:")?;
             writeln!(formatter, "  factory workflow create <workflow-id> --help")?;
             writeln!(formatter, "  factory validate")?;
-            writeln!(formatter, "  factory run")
+            writeln!(formatter, "  factory daemon")
         } else {
             writeln!(
                 formatter,
@@ -135,14 +130,14 @@ struct ConfigPlan {
 
 pub fn initialize(options: InitOptions) -> Result<InitReport> {
     let repository = discover_repository(&options.repository)?;
-    let config = plan_config(&options.config_path, &repository)?;
     let workflows = plan_workflow_directory(&repository)?;
+    let config = plan_config(&options.config_path, &repository)?;
 
     if options.check {
         return Ok(InitReport {
             repository,
             resources: vec![
-                planned_resource(config.action, &config.path, "global configuration"),
+                planned_resource(config.action, &config.path, "repository configuration"),
                 planned_resource(
                     config.workspace_action,
                     &config.workspace,
@@ -186,7 +181,7 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
     resources.push(ResourceResult {
         status: applied_status(config.action),
         resource: config.path.display().to_string(),
-        detail: Some("global configuration".to_owned()),
+        detail: Some("repository configuration".to_owned()),
     });
     resources.push(ResourceResult {
         status: applied_status(config.workspace_action),
@@ -231,7 +226,7 @@ fn skipped_resource(resource: String, reason: &str) -> ResourceResult {
     }
 }
 
-pub(crate) fn discover_repository(requested: &Path) -> Result<PathBuf> {
+pub fn discover_repository(requested: &Path) -> Result<PathBuf> {
     let requested = requested
         .canonicalize()
         .with_context(|| format!("repository path does not exist: {}", requested.display()))?;
@@ -361,6 +356,14 @@ pub(crate) fn validate_optional_directory(path: &Path) -> Result<()> {
 
 fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
     let path = absolute_path(path)?;
+    let expected = repository.join(".factory/config.toml");
+    if path != expected {
+        bail!(
+            "repository configuration must be {}; got {}",
+            expected.display(),
+            path.display()
+        );
+    }
     match fs::symlink_metadata(&path) {
         Ok(metadata) => {
             if metadata.file_type().is_symlink() || !metadata.is_file() {
@@ -372,45 +375,17 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
             } else {
                 PlannedAction::Create
             };
-            if config.repositories.iter().any(|item| item == repository) {
-                return Ok(ConfigPlan {
-                    path,
-                    workspace: config.workspace_root,
-                    workspace_action,
-                    action: PlannedAction::Unchanged,
-                    candidate: None,
-                });
-            }
-            let contents = fs::read_to_string(&path)
-                .with_context(|| format!("failed to read config {}", path.display()))?;
-            let mut document = contents
-                .parse::<DocumentMut>()
-                .with_context(|| format!("failed to edit config {}", path.display()))?;
-            let repositories = document["repositories"]
-                .as_array_mut()
-                .context("config repositories must be an array")?;
-            repositories.push(repository.display().to_string());
-            let candidate = document.to_string();
-            let config_directory = path
-                .parent()
-                .context("configuration path has no parent directory")?;
-            let effective = Config::validate_candidate(&candidate, config_directory)
-                .context("generated configuration is invalid")?;
             Ok(ConfigPlan {
                 path,
-                workspace: effective.workspace_root,
+                workspace: config.workspace_root,
                 workspace_action,
-                action: PlannedAction::Update,
-                candidate: Some(candidate),
+                action: PlannedAction::Unchanged,
+                candidate: None,
             })
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let config_directory = path
-                .parent()
-                .context("configuration path has no parent directory")?;
-            let candidate_workspace = config_directory.join("workspaces");
-            let candidate = default_config(repository, &candidate_workspace);
-            let validated = Config::validate_candidate(&candidate, config_directory)
+            let candidate = default_config();
+            let validated = Config::validate_candidate(&candidate, repository)
                 .context("generated configuration is invalid")?;
             let workspace = validated.workspace_root;
             Ok(ConfigPlan {
@@ -441,25 +416,20 @@ fn absolute_path(path: &Path) -> Result<PathBuf> {
     }
 }
 
-fn default_config(repository: &Path, workspace: &Path) -> String {
+fn default_config() -> String {
     let mut document = DocumentMut::new();
-    let mut repositories = Array::new();
-    repositories.push(repository.display().to_string());
-    document["repositories"] = Item::Value(Value::Array(repositories));
+    document["version"] = value(1);
     document["poll_every"] = value("30s");
     document["default_runtime"] = value("codex");
     document["default_timeout"] = value("2h");
     document["maximum_timeout"] = value("8h");
-    document["max_concurrent_runs"] = value(2);
-    document["max_concurrent_runs_per_repository"] = value(1);
-    document["workspace_root"] = value(workspace.display().to_string());
+    document["max_concurrent_runs"] = value(1);
     document.to_string()
 }
 
 fn planned_resource(action: PlannedAction, path: &Path, detail: &str) -> ResourceResult {
     let status = match action {
         PlannedAction::Create => ResourceStatus::WouldCreate,
-        PlannedAction::Update => ResourceStatus::WouldUpdate,
         PlannedAction::Unchanged => ResourceStatus::Unchanged,
     };
     ResourceResult {
@@ -472,7 +442,6 @@ fn planned_resource(action: PlannedAction, path: &Path, detail: &str) -> Resourc
 fn applied_status(action: PlannedAction) -> ResourceStatus {
     match action {
         PlannedAction::Create => ResourceStatus::Created,
-        PlannedAction::Update => ResourceStatus::Updated,
         PlannedAction::Unchanged => ResourceStatus::Unchanged,
     }
 }
@@ -516,7 +485,13 @@ fn validated_atomic_config_write(path: &Path, contents: &str) -> Result<()> {
         .as_file_mut()
         .sync_all()
         .context("failed to sync temporary configuration")?;
-    Config::load(temporary.path()).context("generated configuration is invalid")?;
+    let repository = parent
+        .parent()
+        .context("repository configuration has no repository parent")?;
+    let written =
+        fs::read_to_string(temporary.path()).context("failed to read temporary configuration")?;
+    Config::validate_candidate(&written, repository)
+        .context("generated configuration is invalid")?;
     if let Ok(metadata) = fs::metadata(path) {
         temporary
             .as_file()

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use clap::{ArgGroup, Parser, Subcommand};
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
-use factory::config::{Config, default_config_path};
+use factory::config::{Config, repository_config_path, repository_remote_identity};
 use factory::daemon::FactoryDaemon;
 use factory::execution::ResolvedWorkflow;
 use factory::github::{GitHubClient, PollReport};
@@ -17,7 +17,7 @@ use factory::inspection::{
 use factory::runtime::{
     CodexRuntime, RuntimeCancelled, Termination, write_stderr_best_effort, write_stdout_best_effort,
 };
-use factory::storage::{CancellationRequest, Ledger};
+use factory::storage::{CancellationRequest, DATABASE_NAME, Ledger};
 use factory::workflow::WorkflowCatalog;
 use factory::workflow_create::{CreateWorkflowOptions, create_workflow};
 
@@ -39,12 +39,21 @@ enum Command {
         #[arg(long)]
         check: bool,
     },
-    /// Poll configured repositories and persist eligible ticket tasks.
+    /// Poll this repository once and persist eligible tasks without executing them.
     Run {
-        /// Poll once and exit without waiting for the next interval.
-        #[arg(long)]
+        /// Required safety flag confirming this is a non-executing single evaluation.
+        #[arg(long, required = true)]
         once: bool,
         /// Path to the Factory configuration file.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Directory containing the durable Factory database.
+        #[arg(long)]
+        data_directory: Option<PathBuf>,
+    },
+    /// Continuously evaluate schedules, poll for work, and execute eligible tasks.
+    Daemon {
+        /// Path to the repository-local Factory configuration file.
         #[arg(long)]
         config: Option<PathBuf>,
         /// Directory containing the durable Factory database.
@@ -170,9 +179,9 @@ enum WorkflowCommand {
     Run {
         /// Workflow ID, derived from its Markdown filename.
         workflow_id: String,
-        /// Configured repository to use as the workflow target.
+        /// Repository to use. Defaults to the enclosing Git repository.
         #[arg(long)]
-        repository: PathBuf,
+        repository: Option<PathBuf>,
         /// Path to the Factory configuration file.
         #[arg(long)]
         config: Option<PathBuf>,
@@ -207,9 +216,10 @@ async fn run_cli() -> Result<u8> {
         Command::Init { repository, check } => {
             let repository = repository
                 .unwrap_or(std::env::current_dir().context("failed to resolve current directory")?);
+            let repository = factory::init::discover_repository(&repository)?;
             let report = initialize(InitOptions {
+                config_path: repository_config_path(&repository),
                 repository,
-                config_path: default_config_path(),
                 check,
             })?;
             let exit_code = report.exit_code();
@@ -221,15 +231,22 @@ async fn run_cli() -> Result<u8> {
             config,
             data_directory,
         } => {
-            return run_poller(config, data_directory, once).await;
+            debug_assert!(once);
+            return run_poller(config, data_directory, true).await;
+        }
+        Command::Daemon {
+            config,
+            data_directory,
+        } => {
+            return run_poller(config, data_directory, false).await;
         }
         Command::Validate { config } => {
-            let path = config.unwrap_or_else(default_config_path);
+            let path = resolve_config_path(config)?;
             let config = Config::load(&path)?;
             print!("{config}");
         }
         Command::Workflows { config } => {
-            let path = config.unwrap_or_else(default_config_path);
+            let path = resolve_config_path(config)?;
             let config = Config::load(&path)?;
             let catalog = WorkflowCatalog::load(&config)?;
             print!("{catalog}");
@@ -259,7 +276,7 @@ async fn run_cli() -> Result<u8> {
                     repository: repository.unwrap_or(
                         std::env::current_dir().context("failed to resolve current directory")?,
                     ),
-                    config_path: config.unwrap_or_else(default_config_path),
+                    config_path: resolve_config_path(config)?,
                     schedule,
                     timezone,
                     label,
@@ -281,6 +298,9 @@ async fn run_cli() -> Result<u8> {
                     config,
                 },
         } => {
+            let repository = repository
+                .unwrap_or(std::env::current_dir().context("failed to resolve current directory")?);
+            let repository = factory::init::discover_repository(&repository)?;
             return run_workflow(&workflow_id, &repository, config).await;
         }
         Command::Tasks {
@@ -392,14 +412,21 @@ fn open_data_ledger(
     config_path: Option<PathBuf>,
     data_directory: Option<PathBuf>,
 ) -> Result<Ledger> {
-    let config_path = config_path.unwrap_or_else(default_config_path);
-    let data_directory = data_directory.unwrap_or_else(|| {
-        config_path
-            .parent()
-            .unwrap_or_else(|| std::path::Path::new("."))
-            .to_path_buf()
-    });
-    Ledger::open_in(&data_directory)
+    if let Some(data_directory) = data_directory {
+        return Ledger::open_in(&data_directory);
+    }
+    let config_path = resolve_config_path(config_path)?;
+    let config = Config::load(&config_path)?;
+    Ledger::open_in(&config.data_directory)
+}
+
+fn resolve_config_path(config_path: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(path) = config_path {
+        return Ok(path);
+    }
+    let current = std::env::current_dir().context("failed to resolve current directory")?;
+    let repository = factory::init::discover_repository(&current)?;
+    Ok(repository_config_path(&repository))
 }
 
 fn print_json(value: &impl serde::Serialize) -> Result<()> {
@@ -415,25 +442,26 @@ async fn run_poller(
     data_directory: Option<PathBuf>,
     once: bool,
 ) -> Result<u8> {
-    let path = config_path.unwrap_or_else(default_config_path);
+    let path = resolve_config_path(config_path)?;
     let mode = if once { "once" } else { "continuous" };
     write_stderr_best_effort(
         format!("Factory starting: mode={mode} config={}\n", path.display()).as_bytes(),
     );
     let config = Config::load(&path)?;
+    let data_directory = data_directory.unwrap_or_else(|| config.data_directory.clone());
+    ensure_legacy_cutover(&config, &data_directory)?;
     let catalog = WorkflowCatalog::load(&config)?;
     for repository in catalog.repositories_without_ready_workflow(&config) {
         write_stderr_best_effort(
             format!(
-                "No valid factory:ready implementation workflow found for {}; create one with factory workflow create --repository {}\n",
-                repository.display(),
+                "No valid factory:ready implementation workflow found for {}; create one with factory workflow create <workflow-id>\n",
                 repository.display()
             )
             .as_bytes(),
         );
     }
     let ticket_validation = catalog.validate_ticket_workflows();
-    if once || ticket_validation.is_err() {
+    if !once && ticket_validation.is_err() {
         for entry in catalog.invalid_scheduled_entries() {
             eprintln!(
                 "Factory skipped invalid scheduled workflow {}: {}",
@@ -443,11 +471,6 @@ async fn run_poller(
         }
     }
     ticket_validation?;
-    let data_directory = data_directory.unwrap_or_else(|| {
-        path.parent()
-            .unwrap_or_else(|| std::path::Path::new("."))
-            .to_path_buf()
-    });
     write_stderr_best_effort(
         format!(
             "Factory loaded: repositories={} workflows={} data={} poll_every={}\n",
@@ -458,13 +481,20 @@ async fn run_poller(
         )
         .as_bytes(),
     );
-    let mut ledger = Ledger::open_in(&data_directory)?;
-    let github = GitHubClient::default();
+    let ledger = Ledger::open_in(&data_directory)?;
     if once {
-        write_stderr_best_effort(b"Factory polling GitHub once...\n");
-        let report = github.poll_once(&config, &catalog, &mut ledger).await?;
-        print_poll_report(&report);
-        return Ok(u8::from(report.failures() > 0));
+        write_stderr_best_effort(b"Factory evaluating schedules and polling GitHub once...\n");
+        let daemon = FactoryDaemon::new(config, catalog, ledger.path());
+        let report = daemon.evaluate_once(CancellationToken::new()).await?;
+        write_stdout_best_effort(
+            format!(
+                "scheduled_tasks_created={}\n",
+                report.scheduled_tasks_created
+            )
+            .as_bytes(),
+        );
+        print_poll_report(&report.github);
+        return Ok(u8::from(report.github.failures() > 0));
     }
 
     let cancellation = CancellationToken::new();
@@ -479,6 +509,55 @@ async fn run_poller(
     signal_task.abort();
     write_stderr_best_effort(b"Factory stopped.\n");
     Ok(0)
+}
+
+fn ensure_legacy_cutover(config: &Config, data_directory: &std::path::Path) -> Result<()> {
+    let legacy_directory = std::env::var_os("FACTORY_LEGACY_DATA_DIRECTORY")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|home| home.join(".factory")))
+        .context("could not determine legacy Factory data directory")?;
+    let legacy_database = legacy_directory.join(DATABASE_NAME);
+    if !legacy_database.is_file() {
+        return Ok(());
+    }
+    if data_directory
+        .components()
+        .any(|component| component == std::path::Component::ParentDir)
+    {
+        bail!(
+            "Factory data directory must not contain parent traversal: {}",
+            data_directory.display()
+        );
+    }
+    let legacy_directory = legacy_directory
+        .canonicalize()
+        .context("failed to resolve legacy Factory data directory")?;
+    let effective_data_directory = if data_directory.exists() {
+        data_directory
+            .canonicalize()
+            .context("failed to resolve Factory data directory")?
+    } else if data_directory.is_absolute() {
+        data_directory.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to resolve current directory")?
+            .join(data_directory)
+    };
+    if effective_data_directory == legacy_directory {
+        bail!(
+            "repository-local Factory cannot use the legacy data directory {}; choose the derived repository state directory and leave legacy history untouched",
+            legacy_directory.display()
+        );
+    }
+    let repository = repository_remote_identity(&config.repositories[0])?;
+    let active = Ledger::existing_non_terminal_tasks_for_repository(&legacy_database, &repository)?;
+    if active > 0 {
+        bail!(
+            "legacy Factory has {active} non-terminal task(s) for {repository}; stop the old daemon and finish or cancel that work before starting repository-local Factory. The legacy database was left unchanged at {}",
+            legacy_database.display()
+        );
+    }
+    Ok(())
 }
 
 fn print_poll_report(report: &PollReport) {
@@ -510,7 +589,7 @@ async fn run_workflow(
     repository: &std::path::Path,
     config_path: Option<PathBuf>,
 ) -> Result<u8> {
-    let path = config_path.unwrap_or_else(default_config_path);
+    let path = resolve_config_path(config_path)?;
     let config = Config::load(&path)?;
     let catalog = WorkflowCatalog::load(&config)?;
     let workflow = ResolvedWorkflow::resolve(&config, &catalog, workflow_id, repository)?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -5,9 +5,9 @@ use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
-use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
+use rusqlite::{Connection, OpenFlags, OptionalExtension, TransactionBehavior, params};
 
-const DATABASE_NAME: &str = "factory.sqlite3";
+pub const DATABASE_NAME: &str = "factory.sqlite3";
 const SCHEMA_VERSION: i64 = 5;
 pub const MAX_RESULT_BYTES: usize = 256 * 1024;
 pub const MAX_ERROR_BYTES: usize = 64 * 1024;
@@ -297,6 +297,24 @@ pub struct Ledger {
 }
 
 impl Ledger {
+    pub fn existing_non_terminal_tasks_for_repository(
+        path: &Path,
+        repository: &str,
+    ) -> Result<usize> {
+        let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .with_context(|| format!("failed to inspect legacy database {}", path.display()))?;
+        let count = connection
+            .query_row(
+                "SELECT COUNT(*) FROM tasks
+                 WHERE lower(repository) = lower(?1)
+                   AND state IN ('queued', 'running')",
+                [repository],
+                |row| row.get::<_, i64>(0),
+            )
+            .context("failed to inspect non-terminal legacy Factory tasks")?;
+        usize::try_from(count).context("legacy task count is outside the supported range")
+    }
+
     pub fn open_in(data_directory: &Path) -> Result<Self> {
         fs::create_dir_all(data_directory).with_context(|| {
             format!(

--- a/src/workflow_create.rs
+++ b/src/workflow_create.rs
@@ -52,7 +52,7 @@ impl fmt::Display for CreateWorkflowReport {
             )
         )?;
         writeln!(formatter, "  factory workflows")?;
-        writeln!(formatter, "  factory run")
+        writeln!(formatter, "  factory daemon")
     }
 }
 
@@ -67,8 +67,7 @@ pub async fn create_workflow(
     let config = Config::load(&options.config_path)?;
     if !config.repositories.iter().any(|item| item == &repository) {
         bail!(
-            "repository is not configured: {}; run factory init --repository {}",
-            repository.display(),
+            "repository is not configured: {}; run factory init from that repository",
             repository.display()
         );
     }
@@ -79,9 +78,8 @@ pub async fn create_workflow(
     validate_optional_directory(&workflow_directory)?;
     if !workflow_directory.is_dir() {
         bail!(
-            "workflow directory does not exist: {}; run factory init --repository {}",
-            workflow_directory.display(),
-            repository.display()
+            "workflow directory does not exist: {}; run factory init from that repository",
+            workflow_directory.display()
         );
     }
 

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -26,6 +26,7 @@ struct Fixture {
     gh: PathBuf,
     codex: PathBuf,
     runtime_dir: PathBuf,
+    data_home: PathBuf,
 }
 
 impl Fixture {
@@ -37,6 +38,27 @@ impl Fixture {
         for (index, issues) in issue_pages.iter().enumerate() {
             let repository = temp.path().join(format!("repo-{index}"));
             fs::create_dir_all(repository.join(".factory/workflows")).unwrap();
+            assert!(
+                Command::new("git")
+                    .args(["init", "--quiet"])
+                    .current_dir(&repository)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+            assert!(
+                Command::new("git")
+                    .args([
+                        "remote",
+                        "add",
+                        "origin",
+                        &format!("git@github.com:example/repo-{index}.git")
+                    ])
+                    .current_dir(&repository)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
             fs::write(
                 repository.join(".factory/workflows/implement-ready-ticket.md"),
                 "+++\nlabel = \"factory:ready\"\nruntime = \"codex\"\ntimeout = \"10s\"\n+++\n\nCUSTOM WORKFLOW: deliver a green draft PR and never merge it.\n",
@@ -62,25 +84,37 @@ impl Fixture {
                 )
                 .unwrap();
             }
-            repositories.push(repository);
+            repositories.push(repository.canonicalize().unwrap());
         }
         let workspace = temp.path().join("worktrees");
         fs::create_dir(&workspace).unwrap();
-        let config_path = temp.path().join("config.toml");
-        let repository_values = repositories
-            .iter()
-            .map(|path| format!("\"{}\"", path.display()))
-            .collect::<Vec<_>>()
-            .join(", ");
+        let data_home = temp.path().join("factory-data");
+        let config_path = repositories[0].join(".factory/config.toml");
+        AssertCommand::cargo_bin("factory")
+            .unwrap()
+            .current_dir(&repositories[0])
+            .env("FACTORY_DATA_HOME", &data_home)
+            .arg("init")
+            .assert()
+            .success();
         fs::write(
             &config_path,
             format!(
-                "repositories = [{repository_values}]\npoll_every = \"20ms\"\ndefault_runtime = \"codex\"\ndefault_timeout = \"2h\"\nmaximum_timeout = \"8h\"\nmax_concurrent_runs = {global_limit}\nmax_concurrent_runs_per_repository = {repository_limit}\nworkspace_root = \"{}\"\n",
-                workspace.display()
+                "version = 1\npoll_every = \"20ms\"\ndefault_runtime = \"codex\"\ndefault_timeout = \"2h\"\nmaximum_timeout = \"8h\"\nmax_concurrent_runs = {global_limit}\n"
             ),
         )
         .unwrap();
-        let config = Config::load(&config_path).unwrap();
+        let config = Config {
+            repositories,
+            poll_every: Duration::from_millis(20),
+            default_runtime: "codex".into(),
+            default_timeout: Duration::from_secs(2 * 60 * 60),
+            maximum_timeout: Duration::from_secs(8 * 60 * 60),
+            max_concurrent_runs: global_limit,
+            max_concurrent_runs_per_repository: repository_limit,
+            workspace_root: workspace,
+            data_directory: temp.path().join("data"),
+        };
         let catalog = WorkflowCatalog::load(&config).unwrap();
         let gh = temp.path().join("gh");
         write_executable(
@@ -177,6 +211,7 @@ exit 0
             gh,
             codex,
             runtime_dir,
+            data_home,
         }
     }
 
@@ -299,12 +334,13 @@ fn spawn_daemon_cli(fixture: &Fixture, stderr_path: &Path) -> std::process::Chil
     let mut command = Command::new(env!("CARGO_BIN_EXE_factory"));
     command
         .args([
-            "run",
+            "daemon",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
             fixture.ledger_path.parent().unwrap().to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", search_path)
         .stdout(Stdio::null())
         .stderr(Stdio::from(stderr));
@@ -351,6 +387,57 @@ async fn cli_reports_live_startup_ready_and_shutdown_progress() {
             .unwrap()
             .contains("Factory stopped.")
     );
+}
+
+#[tokio::test]
+async fn daemon_discovers_repository_from_nested_directory_and_restarts_cleanly() {
+    let fixture = Fixture::new(&[vec![]], 1, 1);
+    let nested = fixture.config.repositories[0].join("nested/directory");
+    fs::create_dir_all(&nested).unwrap();
+    let legacy = fixture._temp.path().join("empty-legacy");
+    let search_path = std::env::join_paths(
+        std::iter::once(fixture.gh.parent().unwrap().to_path_buf()).chain(
+            std::env::var_os("PATH")
+                .as_deref()
+                .map(std::env::split_paths)
+                .into_iter()
+                .flatten(),
+        ),
+    )
+    .unwrap();
+
+    for attempt in 1..=2 {
+        let stderr_path = fixture
+            ._temp
+            .path()
+            .join(format!("nested-{attempt}.stderr"));
+        let mut child = Command::new(env!("CARGO_BIN_EXE_factory"))
+            .arg("daemon")
+            .current_dir(&nested)
+            .env("FACTORY_DATA_HOME", &fixture.data_home)
+            .env("FACTORY_LEGACY_DATA_DIRECTORY", &legacy)
+            .env("PATH", &search_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(fs::File::create(&stderr_path).unwrap()))
+            .spawn()
+            .unwrap();
+        wait_for(|| {
+            fs::read_to_string(&stderr_path)
+                .is_ok_and(|output| output.contains("Factory ready: watching 1 repositories"))
+        })
+        .await;
+        interrupt(&child);
+        assert!(child.wait().unwrap().success());
+    }
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args(["tasks", "--json"])
+        .current_dir(&nested)
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("[]"));
 }
 
 #[tokio::test]
@@ -806,12 +893,13 @@ async fn subprocess_restart_kills_the_surviving_anchored_process_tree() {
     let mut first = Command::new(env!("CARGO_BIN_EXE_factory"));
     first
         .args([
-            "run",
+            "daemon",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
             fixture.ledger_path.parent().unwrap().to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", &search_path);
     let mut first = first.spawn().unwrap();
     wait_for(|| fixture.started_slots().len() == 1).await;
@@ -857,12 +945,13 @@ async fn subprocess_restart_kills_the_surviving_anchored_process_tree() {
     let mut second = Command::new(env!("CARGO_BIN_EXE_factory"));
     second
         .args([
-            "run",
+            "daemon",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
             fixture.ledger_path.parent().unwrap().to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", &search_path);
     let mut second = second.spawn().unwrap();
     wait_for(|| fixture.started_slots().len() == 2).await;
@@ -1393,12 +1482,13 @@ async fn invalid_scheduled_workflow_does_not_block_valid_ticket_workflow() {
     let mut daemon = Command::new(env!("CARGO_BIN_EXE_factory"));
     daemon
         .args([
-            "run",
+            "daemon",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
             fixture.ledger_path.parent().unwrap().to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", search_path);
     let mut daemon = daemon.spawn().unwrap();
 
@@ -1447,12 +1537,13 @@ fn invalid_label_workflow_fails_daemon_startup() {
     AssertCommand::cargo_bin("factory")
         .unwrap()
         .args([
-            "run",
+            "daemon",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
             fixture.ledger_path.parent().unwrap().to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", search_path)
         .assert()
         .failure()
@@ -1490,12 +1581,13 @@ fn ambiguous_schedule_and_label_workflow_fails_daemon_startup() {
     AssertCommand::cargo_bin("factory")
         .unwrap()
         .args([
-            "run",
+            "daemon",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
             fixture.ledger_path.parent().unwrap().to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", search_path)
         .assert()
         .failure()

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -8,16 +8,19 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use assert_cmd::Command as AssertCommand;
+use chrono::Utc;
 use factory::config::Config;
 use factory::github::{GitHubClient, TicketContext};
-use factory::storage::{Ledger, RunOutcome};
-use factory::workflow::WorkflowCatalog;
+use factory::storage::{Ledger, RunOutcome, TaskIdentity};
+use factory::workflow::{Trigger, WorkflowCatalog, scheduled_workflow_fingerprint};
 use tokio_util::sync::CancellationToken;
 
 struct Fixture {
     _temp: tempfile::TempDir,
     repositories: Vec<PathBuf>,
     config_path: PathBuf,
+    config: Config,
+    data_home: PathBuf,
     ledger_path: PathBuf,
     gh: PathBuf,
 }
@@ -29,6 +32,27 @@ impl Fixture {
         for index in 0..repository_count {
             let repository = temp.path().join(format!("repo-{index}"));
             fs::create_dir_all(repository.join(".factory/workflows")).unwrap();
+            assert!(
+                Command::new("git")
+                    .args(["init", "--quiet"])
+                    .current_dir(&repository)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+            assert!(
+                Command::new("git")
+                    .args([
+                        "remote",
+                        "add",
+                        "origin",
+                        &format!("git@github.com:example/repo-{index}.git")
+                    ])
+                    .current_dir(&repository)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
             fs::write(
                 repository.join(".factory/workflows/implement-ready-ticket.md"),
                 "+++\nlabel = \"factory:ready\"\n+++\n\nImplement the ticket.\n",
@@ -40,24 +64,35 @@ impl Fixture {
             )
             .unwrap();
             fs::write(repository.join(".issues.json"), "[[]]").unwrap();
-            repositories.push(repository);
+            repositories.push(repository.canonicalize().unwrap());
         }
         let workspace = temp.path().join("worktrees");
         fs::create_dir(&workspace).unwrap();
-        let config_path = temp.path().join("config.toml");
-        let repository_values = repositories
-            .iter()
-            .map(|path| format!("\"{}\"", path.display()))
-            .collect::<Vec<_>>()
-            .join(", ");
+        let data_home = temp.path().join("factory-data");
+        let config_path = repositories[0].join(".factory/config.toml");
+        AssertCommand::cargo_bin("factory")
+            .unwrap()
+            .current_dir(&repositories[0])
+            .env("FACTORY_DATA_HOME", &data_home)
+            .arg("init")
+            .assert()
+            .success();
         fs::write(
             &config_path,
-            format!(
-                "repositories = [{repository_values}]\npoll_every = \"20ms\"\ndefault_runtime = \"codex\"\ndefault_timeout = \"2h\"\nmaximum_timeout = \"8h\"\nmax_concurrent_runs = 2\nworkspace_root = \"{}\"\n",
-                workspace.display()
-            ),
+            "version = 1\npoll_every = \"20ms\"\ndefault_runtime = \"codex\"\ndefault_timeout = \"2h\"\nmaximum_timeout = \"8h\"\nmax_concurrent_runs = 2\n",
         )
         .unwrap();
+        let config = Config {
+            repositories: repositories.clone(),
+            poll_every: Duration::from_millis(20),
+            default_runtime: "codex".into(),
+            default_timeout: Duration::from_secs(2 * 60 * 60),
+            maximum_timeout: Duration::from_secs(8 * 60 * 60),
+            max_concurrent_runs: 2,
+            max_concurrent_runs_per_repository: 2,
+            workspace_root: workspace,
+            data_directory: temp.path().join("data"),
+        };
         let gh = temp.path().join("gh");
         fs::write(
             &gh,
@@ -98,13 +133,15 @@ exit 64
             _temp: temp,
             repositories,
             config_path,
+            config,
+            data_home,
             ledger_path,
             gh,
         }
     }
 
     async fn poll(&self) -> anyhow::Result<(factory::github::PollReport, Ledger)> {
-        let config = Config::load(&self.config_path).unwrap();
+        let config = self.config.clone();
         let catalog = WorkflowCatalog::load(&config).unwrap();
         let mut ledger = Ledger::open(&self.ledger_path).unwrap();
         let report = GitHubClient::new(&self.gh)
@@ -168,6 +205,7 @@ fn factory_run_once_persists_a_task_without_launching_codex() {
             "--data-directory",
             data.to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", path)
         .assert()
         .success()
@@ -176,7 +214,9 @@ fn factory_run_once_persists_a_task_without_launching_codex() {
         .stderr(predicates::str::contains(
             "Factory loaded: repositories=1 workflows=1",
         ))
-        .stderr(predicates::str::contains("Factory polling GitHub once..."));
+        .stderr(predicates::str::contains(
+            "Factory evaluating schedules and polling GitHub once...",
+        ));
 
     assert!(!codex_marker.exists());
     let mut ledger = Ledger::open_in(&data).unwrap();
@@ -207,6 +247,7 @@ fn factory_run_once_reports_progress_before_authentication_failure() {
             "--data-directory",
             data.to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", path)
         .output()
         .unwrap();
@@ -214,7 +255,9 @@ fn factory_run_once_reports_progress_before_authentication_failure() {
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).unwrap();
     let starting = stderr.find("Factory starting: mode=once").unwrap();
-    let polling = stderr.find("Factory polling GitHub once...").unwrap();
+    let polling = stderr
+        .find("Factory evaluating schedules and polling GitHub once...")
+        .unwrap();
     let failure = stderr.find("Error:").unwrap();
     assert!(starting < polling);
     assert!(polling < failure);
@@ -246,6 +289,7 @@ fn factory_run_once_fails_for_invalid_ticket_workflow() {
             "--data-directory",
             data.to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", path)
         .assert()
         .failure()
@@ -287,6 +331,7 @@ fn factory_run_once_skips_invalid_schedule_and_polls_tickets() {
             "--data-directory",
             data.to_str().unwrap(),
         ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .env("PATH", path)
         .assert()
         .success()
@@ -451,7 +496,7 @@ async fn malformed_output_and_rate_limiting_are_isolated_from_healthy_repositori
 #[tokio::test]
 async fn polling_repeats_at_the_configured_interval_and_stops_on_cancellation() {
     let fixture = Fixture::new(1);
-    let config = Config::load(&fixture.config_path).unwrap();
+    let config = fixture.config.clone();
     let catalog = WorkflowCatalog::load(&config).unwrap();
     let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
     let cancellation = CancellationToken::new();
@@ -483,7 +528,7 @@ async fn cancellation_terminates_a_hung_gh_process() {
     let fixture = Fixture::new(1);
     fs::write(format!("{}.hang", fixture.gh.display()), "").unwrap();
     let pid_path = PathBuf::from(format!("{}.hang.pid", fixture.gh.display()));
-    let config = Config::load(&fixture.config_path).unwrap();
+    let config = fixture.config.clone();
     let catalog = WorkflowCatalog::load(&config).unwrap();
     let mut ledger = Ledger::open(&fixture.ledger_path).unwrap();
     let cancellation = CancellationToken::new();
@@ -521,4 +566,220 @@ async fn cancellation_terminates_a_hung_gh_process() {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     assert!(gone, "hung gh process {pid:?} survived cancellation");
+}
+
+#[test]
+fn factory_run_once_evaluates_due_schedules_without_launching_codex() {
+    let fixture = Fixture::new(1);
+    fs::write(
+        fixture.repositories[0].join(".factory/workflows/scheduled.md"),
+        "+++\nschedule = \"* * * * *\"\ntimezone = \"UTC\"\n+++\n\nReview the repository.\n",
+    )
+    .unwrap();
+    let catalog = WorkflowCatalog::load(&fixture.config).unwrap();
+    let workflow = catalog
+        .entries
+        .iter()
+        .find(|entry| entry.id == "scheduled")
+        .unwrap();
+    let Trigger::Schedule {
+        expression,
+        timezone,
+    } = workflow.trigger.as_ref().unwrap()
+    else {
+        panic!("scheduled workflow has the wrong trigger");
+    };
+    let fingerprint = scheduled_workflow_fingerprint(
+        expression,
+        *timezone,
+        workflow.runtime.as_deref().unwrap(),
+        workflow.timeout.unwrap(),
+        workflow.prompt.as_deref().unwrap(),
+    )
+    .unwrap();
+    let data = fixture._temp.path().join("schedule-data");
+    let mut ledger = Ledger::open_in(&data).unwrap();
+    ledger
+        .register_daemon_owner("schedule-seed", std::process::id())
+        .unwrap();
+    let now = Utc::now().timestamp_millis();
+    let due = now.div_euclid(60_000) * 60_000;
+    ledger
+        .initialize_schedule_cursor(
+            "example/repo-0",
+            "scheduled",
+            &fingerprint,
+            due,
+            due - 1,
+            "schedule-seed",
+        )
+        .unwrap();
+    ledger.remove_daemon_owner("schedule-seed").unwrap();
+    drop(ledger);
+    let path = format!(
+        "{}:{}",
+        fixture._temp.path().display(),
+        std::env::var("PATH").unwrap()
+    );
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            data.to_str().unwrap(),
+        ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
+        .env("PATH", path)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("scheduled_tasks_created=1"));
+
+    let ledger = Ledger::open_in(&data).unwrap();
+    assert_eq!(
+        ledger
+            .tasks()
+            .unwrap()
+            .iter()
+            .filter(|task| task.kind == "scheduled")
+            .count(),
+        1
+    );
+    assert!(ledger.runs(None).unwrap().is_empty());
+}
+
+#[test]
+fn repository_local_startup_blocks_active_legacy_work_without_mutating_it() {
+    let fixture = Fixture::new(1);
+    let legacy = fixture._temp.path().join("legacy");
+    let mut ledger = Ledger::open_in(&legacy).unwrap();
+    ledger
+        .enqueue(
+            &TaskIdentity::ticket(
+                "example/repo-0",
+                "implement-ready-ticket",
+                "77",
+                "legacy-revision",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    drop(ledger);
+    let database = legacy.join(factory::storage::DATABASE_NAME);
+    let before = fs::read(&database).unwrap();
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            fixture._temp.path().join("new-data").to_str().unwrap(),
+        ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
+        .env("FACTORY_LEGACY_DATA_DIRECTORY", &legacy)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("stop the old daemon"))
+        .stderr(predicates::str::contains("left unchanged"));
+
+    assert_eq!(fs::read(database).unwrap(), before);
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            legacy.to_str().unwrap(),
+        ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
+        .env("FACTORY_LEGACY_DATA_DIRECTORY", &legacy)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "cannot use the legacy data directory",
+        ));
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            legacy.join("missing/..").to_str().unwrap(),
+        ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
+        .env("FACTORY_LEGACY_DATA_DIRECTORY", &legacy)
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "must not contain parent traversal",
+        ));
+}
+
+#[test]
+fn terminal_or_unrelated_legacy_work_does_not_block_repository_local_startup() {
+    let fixture = Fixture::new(1);
+    let legacy = fixture._temp.path().join("legacy");
+    let mut ledger = Ledger::open_in(&legacy).unwrap();
+    let terminal = ledger
+        .enqueue(
+            &TaskIdentity::ticket(
+                "example/repo-0",
+                "implement-ready-ticket",
+                "78",
+                "legacy-terminal",
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .task;
+    ledger.claim_next().unwrap().unwrap();
+    let run = ledger.start_run(terminal.id, "codex").unwrap();
+    ledger
+        .finish_run_and_task(run.id, RunOutcome::Succeeded, Some("done"), None, None)
+        .unwrap();
+    ledger
+        .enqueue(
+            &TaskIdentity::ticket(
+                "example/other",
+                "implement-ready-ticket",
+                "79",
+                "legacy-other",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+    drop(ledger);
+    let path = format!(
+        "{}:{}",
+        fixture._temp.path().display(),
+        std::env::var("PATH").unwrap()
+    );
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .args([
+            "run",
+            "--once",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+            "--data-directory",
+            fixture._temp.path().join("new-data").to_str().unwrap(),
+        ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
+        .env("FACTORY_LEGACY_DATA_DIRECTORY", &legacy)
+        .env("PATH", path)
+        .assert()
+        .success();
 }

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -6,12 +6,12 @@ use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
 use assert_cmd::Command;
-use factory::config::Config;
 use predicates::prelude::*;
 
 struct Fixture {
     _temp: tempfile::TempDir,
     home: PathBuf,
+    data_home: PathBuf,
     repository: PathBuf,
 }
 
@@ -20,11 +20,13 @@ impl Fixture {
         let temp = tempfile::tempdir().unwrap();
         let home = temp.path().join("home");
         let repository = temp.path().join("repository");
+        let data_home = temp.path().join("factory-data");
         fs::create_dir(&home).unwrap();
         init_git_repository(&repository, "git@github.com:example/repository.git");
         Self {
             _temp: temp,
             home,
+            data_home,
             repository,
         }
     }
@@ -33,16 +35,23 @@ impl Fixture {
         let mut command = Command::cargo_bin("factory").unwrap();
         command
             .current_dir(&self.repository)
-            .env("HOME", &self.home);
+            .env("HOME", &self.home)
+            .env("FACTORY_DATA_HOME", &self.data_home);
         command
     }
 
     fn config_path(&self) -> PathBuf {
-        self.home.join(".factory/config.toml")
+        self.repository.join(".factory/config.toml")
     }
 
     fn workspace(&self) -> PathBuf {
-        self.home.join(".factory/workspaces")
+        let state = fs::read_dir(&self.data_home)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        state.join("worktrees")
     }
 
     fn workflows(&self) -> PathBuf {
@@ -81,22 +90,6 @@ fn set_origin(path: &Path, origin: &str) {
     );
 }
 
-fn write_config(path: &Path, repositories: &[&Path], workspace: &Path, prefix: &str) -> String {
-    fs::create_dir_all(path.parent().unwrap()).unwrap();
-    fs::create_dir_all(workspace).unwrap();
-    let repositories = repositories
-        .iter()
-        .map(|repository| format!("\"{}\"", repository.display()))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let contents = format!(
-        "{prefix}repositories = [{repositories}]\npoll_every = \"30s\"\ndefault_runtime = \"codex\"\ndefault_timeout = \"2h\"\nmaximum_timeout = \"8h\"\nmax_concurrent_runs = 2\nmax_concurrent_runs_per_repository = 1\nworkspace_root = \"{}\"\n",
-        workspace.display()
-    );
-    fs::write(path, &contents).unwrap();
-    contents
-}
-
 #[test]
 fn init_creates_only_configuration_and_workflow_directory() {
     let fixture = Fixture::new();
@@ -106,21 +99,17 @@ fn init_creates_only_configuration_and_workflow_directory() {
         .arg("init")
         .assert()
         .success()
-        .stdout(predicate::str::contains("global configuration"))
+        .stdout(predicate::str::contains("repository configuration"))
         .stdout(predicate::str::contains("workflow directory"))
         .stdout(predicate::str::contains("factory workflow create"))
         .stdout(predicate::str::contains("GitHub label").not())
         .stdout(predicate::str::contains("implement-ready-ticket.md").not());
 
-    let config = Config::load(&fixture.config_path()).unwrap();
-    assert_eq!(
-        config.repositories,
-        vec![fixture.repository.canonicalize().unwrap()]
-    );
-    assert_eq!(
-        config.workspace_root,
-        fixture.workspace().canonicalize().unwrap()
-    );
+    let config = fs::read_to_string(fixture.config_path()).unwrap();
+    assert!(config.contains("version = 1"));
+    assert!(!config.contains("repositories"));
+    assert!(!config.contains("workspace_root"));
+    assert!(fixture.workspace().is_dir());
     assert!(fixture.workflows().is_dir());
     assert_eq!(fs::read_dir(fixture.workflows()).unwrap().count(), 0);
     assert!(!fixture.repository.join(".gh-calls").exists());
@@ -131,13 +120,7 @@ fn init_creates_only_configuration_and_workflow_directory() {
         .assert()
         .success()
         .stdout(predicate::str::contains("unchanged:"));
-    assert_eq!(
-        fs::read_to_string(fixture.config_path())
-            .unwrap()
-            .matches(fixture.repository.to_str().unwrap())
-            .count(),
-        1
-    );
+    assert_eq!(fs::read_to_string(fixture.config_path()).unwrap(), config);
 }
 
 #[test]
@@ -150,12 +133,12 @@ fn check_reports_missing_resources_without_writes() {
         .assert()
         .failure()
         .stdout(predicate::str::contains("would create:"))
-        .stdout(predicate::str::contains("global configuration"))
+        .stdout(predicate::str::contains("repository configuration"))
         .stdout(predicate::str::contains("workspace directory"))
         .stdout(predicate::str::contains("workflow directory"));
 
     assert!(!fixture.config_path().exists());
-    assert!(!fixture.workspace().exists());
+    assert!(!fixture.data_home.exists());
     assert!(!fixture.repository.join(".factory").exists());
 }
 
@@ -172,48 +155,25 @@ fn init_does_not_touch_existing_workflows() {
 }
 
 #[test]
-fn existing_config_preserves_comments_and_registers_repository_once() {
+fn existing_config_is_preserved_byte_for_byte() {
     let fixture = Fixture::new();
-    let other = fixture._temp.path().join("other");
-    fs::create_dir(&other).unwrap();
-    let workspace = fixture._temp.path().join("workspaces");
-    write_config(
-        &fixture.config_path(),
-        &[&other],
-        &workspace,
-        "# keep this comment\n",
-    );
+    fixture.command().arg("init").assert().success();
+    let original = fs::read_to_string(fixture.config_path()).unwrap();
+    let original = format!("# keep this comment\n{original}");
+    fs::write(fixture.config_path(), &original).unwrap();
 
     for _ in 0..2 {
         fixture.command().arg("init").assert().success();
     }
 
-    let contents = fs::read_to_string(fixture.config_path()).unwrap();
-    assert!(contents.starts_with("# keep this comment\n"));
-    assert_eq!(
-        contents
-            .matches(fixture.repository.to_str().unwrap())
-            .count(),
-        1
-    );
-    assert_eq!(
-        Config::load(&fixture.config_path())
-            .unwrap()
-            .repositories
-            .len(),
-        2
-    );
+    assert_eq!(fs::read_to_string(fixture.config_path()).unwrap(), original);
 }
 
 #[test]
 fn init_recreates_workspace_missing_from_existing_config() {
     let fixture = Fixture::new();
-    let original = write_config(
-        &fixture.config_path(),
-        &[&fixture.repository],
-        &fixture.workspace(),
-        "# keep this comment\n",
-    );
+    fixture.command().arg("init").assert().success();
+    let original = fs::read_to_string(fixture.config_path()).unwrap();
     fs::remove_dir(fixture.workspace()).unwrap();
 
     fixture
@@ -255,28 +215,11 @@ fn check_does_not_probe_existing_workspace_writability() {
 }
 
 #[test]
-fn init_rejects_parent_traversal_without_repository_writes() {
+fn init_rejects_a_symlinked_factory_directory() {
     let fixture = Fixture::new();
-    let safe_workspace = fixture._temp.path().join("safe-workspace");
-    let original = write_config(
-        &fixture.config_path(),
-        &[&fixture.repository],
-        &safe_workspace,
-        "",
-    );
-    let dangerous_workspace = fixture
-        ._temp
-        .path()
-        .join("missing/../repository/workspaces");
-    fs::remove_dir(&safe_workspace).unwrap();
-    fs::write(
-        fixture.config_path(),
-        original.replace(
-            safe_workspace.to_str().unwrap(),
-            dangerous_workspace.to_str().unwrap(),
-        ),
-    )
-    .unwrap();
+    let outside = fixture._temp.path().join("outside");
+    fs::create_dir(&outside).unwrap();
+    symlink(&outside, fixture.repository.join(".factory")).unwrap();
 
     fixture
         .command()
@@ -284,18 +227,18 @@ fn init_rejects_parent_traversal_without_repository_writes() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "must not contain parent traversal in a missing suffix",
+            "setup path must be a regular directory",
         ));
 
-    assert!(!fixture.repository.join(".factory").exists());
+    assert!(!outside.join("config.toml").exists());
 }
 
 #[test]
 fn init_resolves_symlinked_config_ancestors_before_writes() {
     let fixture = Fixture::new();
-    let state = fixture.repository.join(".factory-state");
+    let state = fixture._temp.path().join("factory-state");
     fs::create_dir(&state).unwrap();
-    symlink(&state, fixture.home.join(".factory")).unwrap();
+    symlink(&state, fixture.repository.join(".factory")).unwrap();
 
     fixture
         .command()
@@ -303,44 +246,29 @@ fn init_resolves_symlinked_config_ancestors_before_writes() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            "generated configuration is invalid",
-        ))
-        .stderr(predicate::str::contains("must not overlap"));
+            "setup path must be a regular directory",
+        ));
 
-    assert!(!state.join("workspaces").exists());
-    assert!(!fixture.repository.join(".factory").exists());
+    assert!(!state.join("config.toml").exists());
 }
 
 #[test]
-fn invalid_candidate_leaves_existing_config_and_repository_untouched() {
+fn init_targets_the_selected_repository_only() {
     let fixture = Fixture::new();
-    let other = fixture._temp.path().join("other");
-    fs::create_dir(&other).unwrap();
-    let workspace = fixture._temp.path().join("workspaces");
-    let nested_repository = workspace.join("nested-repository");
+    let nested_repository = fixture._temp.path().join("nested-repository");
     init_git_repository(
         &nested_repository,
         "https://github.com/example/nested-repository.git",
     );
-    let original = write_config(
-        &fixture.config_path(),
-        &[&other],
-        &workspace,
-        "# must survive\n",
-    );
-
     fixture
         .command()
         .args(["init", "--repository"])
         .arg(&nested_repository)
         .assert()
-        .failure()
-        .stderr(predicate::str::contains(
-            "generated configuration is invalid",
-        ));
+        .success();
 
-    assert_eq!(fs::read_to_string(fixture.config_path()).unwrap(), original);
-    assert!(!nested_repository.join(".factory").exists());
+    assert!(!fixture.config_path().exists());
+    assert!(nested_repository.join(".factory/config.toml").is_file());
 }
 
 #[test]

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -11,38 +11,53 @@ use std::time::{Duration, Instant};
 use assert_cmd::Command;
 use predicates::prelude::*;
 
+fn initialize_repository(repository: &std::path::Path, data_home: &std::path::Path) {
+    assert!(
+        std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(repository)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        std::process::Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:example/repository.git"
+            ])
+            .current_dir(repository)
+            .status()
+            .unwrap()
+            .success()
+    );
+    Command::cargo_bin("factory")
+        .unwrap()
+        .current_dir(repository)
+        .env("FACTORY_DATA_HOME", data_home)
+        .arg("init")
+        .assert()
+        .success();
+}
+
 #[test]
 fn manual_workflow_run_resolves_context_and_invokes_codex() {
     let temp = tempfile::tempdir().unwrap();
     let repository = temp.path().join("repository");
     let workflows = repository.join(".factory/workflows");
     let workspace = temp.path().join("worktrees");
+    let data_home = temp.path().join("factory-data");
     let binaries = temp.path().join("bin");
     fs::create_dir_all(&workflows).unwrap();
-    fs::create_dir(&workspace).unwrap();
     fs::create_dir(&binaries).unwrap();
     fs::write(
         workflows.join("read-only.md"),
         "+++\nlabel = \"factory:ready\"\ntimeout = \"30s\"\n+++\n\nInspect without changing files.\n",
     )
     .unwrap();
-    let config = temp.path().join("config.toml");
-    fs::write(
-        &config,
-        format!(
-            r#"repositories = ["{}"]
-poll_every = "30s"
-default_runtime = "codex"
-default_timeout = "2h"
-maximum_timeout = "8h"
-max_concurrent_runs = 2
-workspace_root = "{}"
-"#,
-            repository.display(),
-            workspace.display()
-        ),
-    )
-    .unwrap();
+    initialize_repository(&repository, &data_home);
     let prompt_capture = temp.path().join("prompt.txt");
     let executable = binaries.join("codex");
     fs::write(
@@ -81,15 +96,9 @@ printf 'Read-only workflow complete.' > "$output"
 
     Command::cargo_bin("factory")
         .unwrap()
-        .args([
-            "workflow",
-            "run",
-            "read-only",
-            "--repository",
-            repository.to_str().unwrap(),
-            "--config",
-            config.to_str().unwrap(),
-        ])
+        .args(["workflow", "run", "read-only"])
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", &data_home)
         .env("PATH", path)
         .env("FACTORY_PROMPT_CAPTURE", &prompt_capture)
         .assert()
@@ -114,33 +123,16 @@ fn concurrent_manual_runs_exit_when_shared_output_is_full_and_unread() {
     let temp = tempfile::tempdir().unwrap();
     let repository = temp.path().join("repository");
     let workflows = repository.join(".factory/workflows");
-    let workspace = temp.path().join("worktrees");
+    let data_home = temp.path().join("factory-data");
     let binaries = temp.path().join("bin");
     fs::create_dir_all(&workflows).unwrap();
-    fs::create_dir(&workspace).unwrap();
     fs::create_dir(&binaries).unwrap();
     fs::write(
         workflows.join("verbose.md"),
         "+++\nlabel = \"factory:ready\"\ntimeout = \"30s\"\n+++\n\nBe verbose.\n",
     )
     .unwrap();
-    let config = temp.path().join("config.toml");
-    fs::write(
-        &config,
-        format!(
-            r#"repositories = ["{}"]
-poll_every = "30s"
-default_runtime = "codex"
-default_timeout = "2h"
-maximum_timeout = "8h"
-max_concurrent_runs = 2
-workspace_root = "{}"
-"#,
-            repository.display(),
-            workspace.display()
-        ),
-    )
-    .unwrap();
+    initialize_repository(&repository, &data_home);
     let executable = binaries.join("codex");
     fs::write(
         &executable,
@@ -185,15 +177,9 @@ printf 'Verbose workflow complete.' > "$output"
     let mut children = (0..2)
         .map(|_| {
             std::process::Command::new(assert_cmd::cargo::cargo_bin!("factory"))
-                .args([
-                    "workflow",
-                    "run",
-                    "verbose",
-                    "--repository",
-                    repository.to_str().unwrap(),
-                    "--config",
-                    config.to_str().unwrap(),
-                ])
+                .args(["workflow", "run", "verbose"])
+                .current_dir(&repository)
+                .env("FACTORY_DATA_HOME", &data_home)
                 .env("PATH", &path)
                 .stdout(Stdio::from(std::os::fd::OwnedFd::from(
                     shared_output.try_clone().unwrap(),

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -1,41 +1,70 @@
 use std::fs;
+use std::process::Command as ProcessCommand;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-fn valid_config() -> (tempfile::TempDir, std::path::PathBuf) {
+fn valid_config() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    std::path::PathBuf,
+    std::path::PathBuf,
+) {
     let temp = tempfile::tempdir().unwrap();
     let repository = temp.path().join("repository");
-    let workspace = temp.path().join("worktrees");
-    fs::create_dir(&repository).unwrap();
-    fs::create_dir(&workspace).unwrap();
-    let path = temp.path().join("config.toml");
+    let data_home = temp.path().join("data");
+    fs::create_dir_all(repository.join(".factory")).unwrap();
+    assert!(
+        ProcessCommand::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repository)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        ProcessCommand::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:example/repository.git"
+            ])
+            .current_dir(&repository)
+            .status()
+            .unwrap()
+            .success()
+    );
+    Command::cargo_bin("factory")
+        .unwrap()
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", &data_home)
+        .arg("init")
+        .assert()
+        .success();
+    let path = repository.join(".factory/config.toml");
     fs::write(
         &path,
-        format!(
-            r#"repositories = ["{}"]
+        r#"version = 1
 poll_every = "30s"
 default_runtime = "codex"
 default_timeout = "2h"
 maximum_timeout = "8h"
 max_concurrent_runs = 2
-workspace_root = "{}"
 "#,
-            repository.display(),
-            workspace.display()
-        ),
     )
     .unwrap();
-    (temp, path)
+    (temp, path, repository, data_home)
 }
 
 #[test]
 fn validates_explicit_config() {
-    let (_temp, path) = valid_config();
+    let (_temp, path, _repository, data_home) = valid_config();
 
     Command::cargo_bin("factory")
         .unwrap()
         .args(["validate", "--config", path.to_str().unwrap()])
+        .env("FACTORY_DATA_HOME", data_home)
         .assert()
         .success()
         .stdout(predicate::str::contains("Configuration is valid."))
@@ -44,7 +73,7 @@ fn validates_explicit_config() {
 
 #[test]
 fn reports_specific_validation_failures() {
-    let (_temp, path) = valid_config();
+    let (_temp, path, _repository, data_home) = valid_config();
     let contents = fs::read_to_string(&path).unwrap();
     fs::write(
         &path,
@@ -55,6 +84,7 @@ fn reports_specific_validation_failures() {
     Command::cargo_bin("factory")
         .unwrap()
         .args(["validate", "--config", path.to_str().unwrap()])
+        .env("FACTORY_DATA_HOME", data_home)
         .assert()
         .failure()
         .stderr(predicate::str::contains(
@@ -64,16 +94,14 @@ fn reports_specific_validation_failures() {
 
 #[test]
 fn uses_default_config_path() {
-    let (temp, path) = valid_config();
-    let home = temp.path().join("home");
-    let config_dir = home.join(".factory");
-    fs::create_dir_all(&config_dir).unwrap();
-    fs::copy(path, config_dir.join("config.toml")).unwrap();
+    let (_temp, _path, repository, data_home) = valid_config();
+    fs::create_dir_all(repository.join("nested/directory")).unwrap();
 
     Command::cargo_bin("factory")
         .unwrap()
         .arg("validate")
-        .env("HOME", home)
+        .current_dir(repository.join("nested/directory"))
+        .env("FACTORY_DATA_HOME", data_home)
         .assert()
         .success()
         .stdout(predicate::str::contains("Configuration is valid."));
@@ -81,34 +109,17 @@ fn uses_default_config_path() {
 
 #[test]
 fn resolves_relative_paths_from_config_directory() {
-    let temp = tempfile::tempdir().unwrap();
-    let config_dir = temp.path().join("configuration");
-    let repository = config_dir.join("repository");
-    let workspace = config_dir.join("worktrees");
-    let launch_dir = temp.path().join("launch");
-    fs::create_dir_all(&repository).unwrap();
-    fs::create_dir(&workspace).unwrap();
+    let (_temp, path, repository, data_home) = valid_config();
+    let launch_dir = repository.join("nested");
     fs::create_dir(&launch_dir).unwrap();
-    let path = config_dir.join("config.toml");
-    fs::write(
-        &path,
-        r#"repositories = ["repository"]
-poll_every = "30s"
-default_runtime = "codex"
-default_timeout = "2h"
-maximum_timeout = "8h"
-max_concurrent_runs = 2
-workspace_root = "worktrees"
-"#,
-    )
-    .unwrap();
 
     Command::cargo_bin("factory")
         .unwrap()
         .current_dir(launch_dir)
         .args(["validate", "--config", path.to_str().unwrap()])
+        .env("FACTORY_DATA_HOME", &data_home)
         .assert()
         .success()
         .stdout(predicate::str::contains(repository.to_str().unwrap()))
-        .stdout(predicate::str::contains(workspace.to_str().unwrap()));
+        .stdout(predicate::str::contains(data_home.to_str().unwrap()));
 }

--- a/tests/workflow_create_cli.rs
+++ b/tests/workflow_create_cli.rs
@@ -11,6 +11,7 @@ use predicates::prelude::*;
 struct Fixture {
     _temp: tempfile::TempDir,
     home: PathBuf,
+    data_home: PathBuf,
     repository: PathBuf,
     executable_path: String,
 }
@@ -20,6 +21,7 @@ impl Fixture {
         let temp = tempfile::tempdir().unwrap();
         let home = temp.path().join("home");
         let repository = temp.path().join("repository");
+        let data_home = temp.path().join("factory-data");
         fs::create_dir(&home).unwrap();
         fs::create_dir(&repository).unwrap();
         let gh = temp.path().join("gh");
@@ -76,6 +78,7 @@ exit 64
         let fixture = Self {
             _temp: temp,
             home,
+            data_home,
             repository,
             executable_path,
         };
@@ -88,6 +91,7 @@ exit 64
         command
             .current_dir(&self.repository)
             .env("HOME", &self.home)
+            .env("FACTORY_DATA_HOME", &self.data_home)
             .env("PATH", &self.executable_path);
         command
     }
@@ -371,16 +375,10 @@ fn requires_repository_initialization() {
 #[test]
 fn staging_command_is_shell_safe() {
     let mut fixture = Fixture::new();
-    let old_repository = fixture.repository.canonicalize().unwrap();
     let repository = fixture._temp.path().join("repository with ' quote");
     fs::rename(&fixture.repository, &repository).unwrap();
     fixture.repository = repository;
-    let config = fixture.home.join(".factory/config.toml");
-    let contents = fs::read_to_string(&config).unwrap().replace(
-        old_repository.to_str().unwrap(),
-        fixture.repository.canonicalize().unwrap().to_str().unwrap(),
-    );
-    fs::write(config, contents).unwrap();
+    fixture.command().arg("init").assert().success();
 
     let output = fixture
         .command()

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
 use assert_cmd::Command;
@@ -10,7 +10,9 @@ use predicates::prelude::*;
 struct Fixture {
     _temp: tempfile::TempDir,
     repository: PathBuf,
-    config: PathBuf,
+    config_path: PathBuf,
+    config: Config,
+    data_home: PathBuf,
 }
 
 impl Fixture {
@@ -19,14 +21,49 @@ impl Fixture {
         let repository = temp.path().join("repository");
         let workflows = repository.join(".factory/workflows");
         let workspace = temp.path().join("worktrees");
+        let data_home = temp.path().join("factory-data");
         fs::create_dir_all(&workflows).unwrap();
         fs::create_dir(&workspace).unwrap();
-        let config = temp.path().join("config.toml");
-        write_config(&config, &[&repository], &workspace);
+        assert!(
+            std::process::Command::new("git")
+                .args(["init", "--quiet"])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            std::process::Command::new("git")
+                .args([
+                    "remote",
+                    "add",
+                    "origin",
+                    "git@github.com:example/repository.git"
+                ])
+                .current_dir(&repository)
+                .status()
+                .unwrap()
+                .success()
+        );
+        Command::cargo_bin("factory")
+            .unwrap()
+            .current_dir(&repository)
+            .env("FACTORY_DATA_HOME", &data_home)
+            .arg("init")
+            .assert()
+            .success();
+        let config_path = repository.join(".factory/config.toml");
+        let config = test_config(
+            vec![repository.canonicalize().unwrap()],
+            workspace,
+            temp.path().join("data"),
+        );
         Self {
             _temp: temp,
             repository,
+            config_path,
             config,
+            data_home,
         }
     }
 
@@ -37,32 +74,22 @@ impl Fixture {
     }
 
     fn catalog(&self) -> WorkflowCatalog {
-        let config = Config::load(&self.config).unwrap();
-        WorkflowCatalog::load(&config).unwrap()
+        WorkflowCatalog::load(&self.config).unwrap()
     }
 }
 
-fn write_config(path: &Path, repositories: &[&Path], workspace: &Path) {
-    let repositories = repositories
-        .iter()
-        .map(|repository| format!("\"{}\"", repository.display()))
-        .collect::<Vec<_>>()
-        .join(", ");
-    fs::write(
-        path,
-        format!(
-            r#"repositories = [{repositories}]
-poll_every = "30s"
-default_runtime = "codex"
-default_timeout = "2h"
-maximum_timeout = "8h"
-max_concurrent_runs = 2
-workspace_root = "{}"
-"#,
-            workspace.display()
-        ),
-    )
-    .unwrap();
+fn test_config(repositories: Vec<PathBuf>, workspace: PathBuf, data: PathBuf) -> Config {
+    Config {
+        repositories,
+        poll_every: Duration::from_secs(30),
+        default_runtime: "codex".into(),
+        default_timeout: Duration::from_secs(2 * 60 * 60),
+        maximum_timeout: Duration::from_secs(8 * 60 * 60),
+        max_concurrent_runs: 2,
+        max_concurrent_runs_per_repository: 2,
+        workspace_root: workspace,
+        data_directory: data,
+    }
 }
 
 fn scheduled_workflow(prompt: &str) -> String {
@@ -303,14 +330,12 @@ fn rejects_missing_trigger_timezone_and_invalid_timeout() {
 
 #[test]
 fn duplicate_ids_are_reported_for_every_duplicate_entry() {
-    let fixture = Fixture::new();
+    let mut fixture = Fixture::new();
     fixture.workflow("same.md", &label_workflow("Prompt."));
-    let workspace = fixture._temp.path().join("worktrees");
-    write_config(
-        &fixture.config,
-        &[&fixture.repository, &fixture.repository],
-        &workspace,
-    );
+    fixture
+        .config
+        .repositories
+        .push(fixture.repository.canonicalize().unwrap());
 
     let catalog = fixture.catalog();
 
@@ -366,14 +391,14 @@ fn unsafe_workflow_directory_does_not_hide_other_repositories() {
 
     let workspace = temp.path().join("worktrees");
     fs::create_dir(&workspace).unwrap();
-    let config_path = temp.path().join("config.toml");
-    write_config(
-        &config_path,
-        &[&valid_repository, &unsafe_repository],
-        &workspace,
+    let config = test_config(
+        vec![
+            valid_repository.canonicalize().unwrap(),
+            unsafe_repository.canonicalize().unwrap(),
+        ],
+        workspace,
+        temp.path().join("data"),
     );
-
-    let config = Config::load(&config_path).unwrap();
     let catalog = WorkflowCatalog::load(&config).unwrap();
 
     assert_eq!(catalog.entries.len(), 2);
@@ -406,10 +431,11 @@ fn rejects_workflows_reached_through_symlinked_factory_ancestor() {
     )
     .unwrap();
     symlink(&outside_factory, repository.join(".factory")).unwrap();
-    let config_path = temp.path().join("config.toml");
-    write_config(&config_path, &[&repository], &workspace);
-
-    let config = Config::load(&config_path).unwrap();
+    let config = test_config(
+        vec![repository.canonicalize().unwrap()],
+        workspace,
+        temp.path().join("data"),
+    );
     let catalog = WorkflowCatalog::load(&config).unwrap();
 
     assert_eq!(catalog.invalid_count(), 1);
@@ -426,7 +452,12 @@ fn workflows_command_lists_resolved_catalog_and_fails_for_invalid_entries() {
 
     Command::cargo_bin("factory")
         .unwrap()
-        .args(["workflows", "--config", fixture.config.to_str().unwrap()])
+        .args([
+            "workflows",
+            "--config",
+            fixture.config_path.to_str().unwrap(),
+        ])
+        .env("FACTORY_DATA_HOME", &fixture.data_home)
         .assert()
         .failure()
         .stdout(predicate::str::contains("REPOSITORY\tWORKFLOW"))
@@ -482,6 +513,7 @@ fn catalog_output_escapes_control_characters_in_every_dynamic_cell() {
         max_concurrent_runs: 1,
         max_concurrent_runs_per_repository: 1,
         workspace_root: workspace,
+        data_directory: temp.path().join("data"),
     };
 
     let output = WorkflowCatalog::load(&config).unwrap().to_string();


### PR DESCRIPTION
## Summary

- load strict policy from the enclosing repository at `.factory/config.toml`
- add `factory daemon` for continuous schedules, polling, and supervised execution
- make `factory run --once` evaluate one schedule tick and poll without launching Codex
- derive isolated per-clone state, reject linked worktrees, and fail closed around legacy active work
- update setup, operations, examples, and integration coverage

## Checks

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- fresh independent code review: approved

Closes #37