### PR TITLE
feat: make Factory own task worktrees

### DIFF
--- a/.factory/workflows/implement-ready-ticket.md
+++ b/.factory/workflows/implement-ready-ticket.md
@@ -29,8 +29,9 @@ the blocker.
 
 ## Step 4: Implement the ticket
 
-Create an isolated ticket-numbered branch and worktree using the repository's
-documented conventions. Implement the complete acceptance criteria without
+Factory has already created and recorded the ticket branch and worktree. Work
+only in the supplied working directory. Do not create, switch, or remove
+another worktree. Implement the complete acceptance criteria without
 placeholders. Preserve unrelated user changes. Add or update tests where they
 provide useful proof.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Factory is a local-first daemon that turns trusted GitHub issues and scheduled
 prompts into supervised Codex runs. Factory owns durable scheduling, task
-claims, concurrency, process supervision, inspection, cancellation, and
-recovery. Codex owns the adaptive development procedure and leaves software
-pull requests for human merge.
+claims, concurrency, Factory-created branches and worktrees, process
+supervision, inspection, cancellation, cleanup, and recovery. Codex owns the
+adaptive development procedure inside the supplied worktree and leaves
+software pull requests for human merge.
 
 Factory v1 supports Unix-like systems and uses the authenticated local `gh`
 and Codex CLIs. It does not use model API keys.

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -91,11 +91,11 @@ Validate the machine-specific configuration without runtime work:
 factory validate
 ```
 
-The workflow is versioned policy: Codex owns
-ticket updates, worktree and branch creation, implementation, tests, diff
-review, draft pull-request creation, CI repair, and handoff. Factory owns the
+The workflow is versioned policy: Codex owns ticket updates, implementation,
+tests, diff review, draft pull-request creation, CI repair, and handoff inside
+the supplied worktree. Factory owns the base commit, branch and worktree,
 durable task, one claim, concurrency, supervision, cancellation, inspection,
-deduplication, and recovery.
+deduplication, cleanup, and recovery.
 
 Check the resolved workflow catalog:
 
@@ -136,7 +136,8 @@ the task/run counts and linked pull request remain unchanged.
 
 Success means:
 
-- one Codex run produced one ticket-numbered branch or worktree;
+- one Codex run used the recorded Factory branch and worktree without changing
+  the canonical checkout;
 - one linked draft pull request contains a useful summary and verification;
 - required CI and automated review are complete with no actionable feedback;
 - the issue has `factory:needs-review` and a useful handoff comment;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,10 +10,10 @@ checkout.
 In continuous mode, Factory writes concise lifecycle events to standard error.
 It reports startup validation, polls that queue work, claimed tasks, runtime
 delegation, and terminal run outcomes. Runtime delegation includes the initial
-working directory and marks worktree creation as workflow-managed. The bundled
-ready-ticket workflow requires Codex to create or reuse an isolated
-ticket-numbered worktree; Factory does not create that worktree before starting
-Codex.
+working directory and marks the worktree as Factory-owned. Before Codex starts,
+Factory queries GitHub's default branch, fetches its exact commit, reserves a
+stable `factory/<issue>-<slug>` branch and worktree, records them durably, and
+launches Codex there. The canonical checkout is never used for agent changes.
 
 The ready label is a wake signal, not authority. `factory approve ISSUE_NUMBER`
 binds the current title, body, delivery workflow hash, stable trusted GitHub
@@ -66,7 +66,11 @@ On Ctrl-C, Factory stops polling and claiming immediately, cancels active
 Codex process trees, waits for the workers to record `cancelled`, and exits.
 Queued tasks remain durable for the next start. Failed and cancelled runs keep
 their bounded output, error, session, ticket, branch, and pull-request context
-for inspection. Factory never merges software pull requests.
+for inspection. Scheduled proposal workspaces are detached and removed at a
+terminal outcome. Failed, cancelled, dirty, or unpublished delivery worktrees
+are retained, up to ten. Preview cleanup with `factory cleanup RUN_ID`; removal
+requires `factory cleanup RUN_ID --confirm` and preserves the local branch.
+Factory never merges software pull requests.
 
 `factory run --once` evaluates one schedule tick, performs one discovery poll,
 persists eligible tasks, and exits without claiming or launching them. It is

--- a/docs/single-repository-v1/design.md
+++ b/docs/single-repository-v1/design.md
@@ -462,26 +462,26 @@ without claiming or launching work.
 
 This document is the target repo-local design, not a claim that every interface
 already exists. The current binary can demonstrate the durable core today by
-following `docs/local-v1.md`: it loads a global repository list, polls a ready
-label, supervises Codex, and can produce a green draft pull request. It does not
-yet implement repo-local configuration, label-actor and content-generation
-approval, Factory-owned worktrees, effect profiles, or task-scoped commands.
+following `docs/local-v1.md`: it loads repository-local policy, verifies exact
+approval artifacts and label events, creates and records Factory-owned
+worktrees, supervises Codex, and can produce a green draft pull request. Effect
+profiles and task-scoped publication commands remain later milestones.
 
 The smallest implementation milestone for the repo-local demo is ordered to
 preserve a runnable system throughout:
 
-1. Stop the legacy daemon and require every legacy task for this repository to
+1. **Complete.** Stop the legacy daemon and require every legacy task for this repository to
    be terminal. V1 does not import legacy history. It leaves the global database
    untouched and starts a new repo-keyed database. Startup fails with cutover
    instructions if it detects non-terminal legacy work, avoiding duplicate
    claims while keeping the old history recoverable with the old binary.
-2. Resolve the enclosing Git root and load `.factory/config.toml`, while keeping
+2. **Complete.** Resolve the enclosing Git root and load `.factory/config.toml`, while keeping
    existing workflow frontmatter and the durable storage implementation.
-3. Remove the repository list, repository command arguments, and
+3. **Complete.** Remove the repository list, repository command arguments, and
    per-repository concurrency from the user interface.
-4. Implement `factory approve`, approval artifacts, GitHub label events, and the
+4. **Complete.** Implement `factory approve`, approval artifacts, GitHub label events, and the
    claim-time approval-generation algorithm.
-5. Move branch, worktree, and bounded cleanup ownership from the delivery prompt
+5. **Complete.** Move branch, worktree, and bounded cleanup ownership from the delivery prompt
    into Factory.
 6. Add effect profiles and the small task-scoped command surface, starting with
    proposal creation and idempotent draft publication.

--- a/examples/implement-ready-ticket.md
+++ b/examples/implement-ready-ticket.md
@@ -29,8 +29,9 @@ the blocker.
 
 ## Step 4: Implement the ticket
 
-Create an isolated ticket-numbered branch and worktree using the repository's
-documented conventions. Implement the complete acceptance criteria without
+Factory has already created and recorded the ticket branch and worktree. Work
+only in the supplied working directory. Do not create, switch, or remove
+another worktree. Implement the complete acceptance criteria without
 placeholders. Preserve unrelated user changes. Add or update tests where they
 provide useful proof.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,8 +275,8 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
 }
 
 pub fn repository_remote_identity(repository: &Path) -> Result<String> {
-    let origin = git_output(repository, &["remote", "get-url", "origin"])
-        .context("repository has no readable origin remote")?;
+    let origin = git_output(repository, &["config", "--get", "remote.origin.url"])
+        .context("repository has no configured origin remote")?;
     canonical_github_identity(origin.trim()).context("origin is not a supported GitHub remote")
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -909,7 +909,7 @@ async fn prepare_task_workspace(
             reuse,
         )?
     } else {
-        manager.prepare_proposal(task.id, &workspace.base_branch, &workspace.base_sha)?
+        manager.prepare_proposal(task.id, &workspace.base_branch, &workspace.base_sha, reuse)?
     };
     if prepared.path != workspace.path
         || prepared.branch != workspace.factory_branch
@@ -2176,7 +2176,7 @@ mod tests {
         ledger.claim_next().unwrap().unwrap();
         let proposal_run = ledger.start_run(proposal_task.id, "codex").unwrap();
         let proposal = manager
-            .prepare_proposal(proposal_task.id, "main", &base_sha)
+            .prepare_proposal(proposal_task.id, "main", &base_sha, DeliveryReuse::Reject)
             .unwrap();
         ledger
             .reserve_task_workspace(&TaskWorkspace {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -19,10 +19,14 @@ use crate::runtime::{
     CodexRuntime, ExecutionResult, RuntimeCancelled, RuntimeObservation, Termination,
     observation_channel,
 };
-use crate::storage::{Ledger, Run, RunOutcome, Task, TaskIdentity};
+use crate::storage::{
+    AUTOMATIC_DELIVERY_CLEANUP, Ledger, OPERATOR_CONFIRMED_CLEANUP, Run, RunOutcome, Task,
+    TaskIdentity, TaskState, TaskWorkspace,
+};
 use crate::workflow::{
     Trigger, WorkflowCatalog, WorkflowEntry, scheduled_workflow_fingerprint, workflow_content_hash,
 };
+use crate::workspace::{DeliveryReuse, WorkspaceKind, WorkspaceManager};
 
 const HUMAN_MERGE_POLICY: &str = "Factory-created software pull requests must remain for human merge. Never merge or enable automatic merge.";
 const RECOVERY_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -127,7 +131,15 @@ impl FactoryDaemon {
             Err(error) => return Err(error),
         };
         let mut ledger = Ledger::open(&self.ledger_path)?;
-        report_recovery(ledger.recover_orphaned_runs()?);
+        if let Err(error) = reconcile_recovery_state(
+            &mut ledger,
+            &self.ledger_path,
+            &self.config.repositories[0],
+            &self.config.workspace_root,
+        ) {
+            eprintln!("Factory workspace startup reconciliation failed: {error:#}");
+            return Err(error);
+        }
         let owner = DaemonOwner::new()?;
         ledger.register_daemon_owner(&owner.id, owner.pid)?;
         let owner_heartbeat_shutdown = CancellationToken::new();
@@ -147,6 +159,7 @@ impl FactoryDaemon {
         };
         let mut schedules = initialize_schedules(&mut ledger, &targets, Utc::now(), &owner.id);
         let mut active = HashMap::<String, usize>::new();
+        let mut retention_warning_shown = false;
         let mut runs = JoinSet::<(String, Result<()>)>::new();
         let mut github_polls = JoinSet::<Result<()>>::new();
         let workflow_count = targets
@@ -202,6 +215,8 @@ impl FactoryDaemon {
                     &self.codex,
                     &self.github,
                     &self.config.github,
+                    &self.config.workspace_root,
+                    &mut retention_warning_shown,
                     &cancellation,
                     &owner,
                 )?;
@@ -209,7 +224,12 @@ impl FactoryDaemon {
                 tokio::select! {
                     _ = cancellation.cancelled() => return Ok(()),
                     _ = recovery_interval.tick() => {
-                        report_recovery(ledger.recover_orphaned_runs()?);
+                        reconcile_recovery_state(
+                            &mut ledger,
+                            &self.ledger_path,
+                            &self.config.repositories[0],
+                            &self.config.workspace_root,
+                        )?;
                     }
                     _ = schedule_interval.tick() => {
                         schedules = initialize_schedules(
@@ -377,6 +397,153 @@ impl FactoryDaemon {
     }
 }
 
+fn reconcile_recovery_state(
+    ledger: &mut Ledger,
+    ledger_path: &Path,
+    canonical_repository: &Path,
+    workspace_root: &Path,
+) -> Result<()> {
+    report_recovery(ledger.recover_orphaned_runs()?);
+    reconcile_pending_cleanup(ledger, canonical_repository, workspace_root)?;
+    reconcile_terminal_workspaces(ledger, ledger_path, canonical_repository, workspace_root)
+}
+
+fn reconcile_pending_cleanup(
+    ledger: &Ledger,
+    canonical_repository: &Path,
+    workspace_root: &Path,
+) -> Result<()> {
+    let manager = WorkspaceManager::new(canonical_repository, workspace_root)?;
+    manager.reconcile_startup()?;
+    for workspace in ledger.task_workspaces_in_state("cleanup_pending")? {
+        if !workspace.path.exists() {
+            ledger.update_task_workspace_state(
+                workspace.task_id,
+                "cleaned",
+                Some("completed interrupted cleanup at startup"),
+            )?;
+            continue;
+        }
+        let cleanup = if workspace.kind == "proposal" {
+            manager.cleanup_disposable(&workspace.path).map(|_| ())
+        } else if workspace.status_summary.as_deref() == Some(OPERATOR_CONFIRMED_CLEANUP) {
+            manager.cleanup(&workspace.path, true).map(|_| ())
+        } else if workspace.status_summary.as_deref() == Some(AUTOMATIC_DELIVERY_CLEANUP) {
+            match automatic_cleanup_is_still_safe(ledger, &manager, &workspace) {
+                Ok(true) => manager.cleanup_clean(&workspace.path).map(|_| ()),
+                Ok(false) => {
+                    ledger.update_task_workspace_state(
+                        workspace.task_id,
+                        "retained",
+                        Some("retained after interrupted automatic cleanup revalidation"),
+                    )?;
+                    continue;
+                }
+                Err(error) => {
+                    ledger.update_task_workspace_state(
+                        workspace.task_id,
+                        "retained",
+                        Some("retained because automatic cleanup could not be revalidated"),
+                    )?;
+                    eprintln!(
+                        "Factory retained interrupted cleanup for task {}: {error:#}",
+                        workspace.task_id
+                    );
+                    continue;
+                }
+            }
+        } else {
+            ledger.update_task_workspace_state(
+                workspace.task_id,
+                "retained",
+                Some("retained cleanup with unknown confirmation provenance"),
+            )?;
+            continue;
+        };
+        match cleanup {
+            Ok(()) => ledger.update_task_workspace_state(
+                workspace.task_id,
+                "cleaned",
+                Some("completed interrupted cleanup at startup"),
+            )?,
+            Err(error) => eprintln!(
+                "Factory retained interrupted cleanup for task {}: {error:#}",
+                workspace.task_id
+            ),
+        }
+    }
+    Ok(())
+}
+
+fn automatic_cleanup_is_still_safe(
+    ledger: &Ledger,
+    manager: &WorkspaceManager,
+    workspace: &TaskWorkspace,
+) -> Result<bool> {
+    let task = ledger
+        .task(workspace.task_id)?
+        .with_context(|| format!("task {} disappeared", workspace.task_id))?;
+    if task.state != TaskState::Succeeded {
+        return Ok(false);
+    }
+    let run = ledger
+        .runs_for_task(task.id)?
+        .into_iter()
+        .next_back()
+        .context("successful task has no run history")?;
+    let handed_off = run
+        .result
+        .as_deref()
+        .is_some_and(|result| !result.trim().is_empty())
+        && run.pull_request.is_some();
+    let clean = !manager.preview_cleanup(&workspace.path)?.dirty;
+    let published = match workspace.factory_branch.as_deref() {
+        Some(branch) => manager.branch_is_pushed(branch)?,
+        None => false,
+    };
+    Ok(clean && published && handed_off)
+}
+
+fn reconcile_terminal_workspaces(
+    ledger: &Ledger,
+    ledger_path: &Path,
+    canonical_repository: &Path,
+    workspace_root: &Path,
+) -> Result<()> {
+    for workspace in ledger.active_task_workspaces()? {
+        if matches!(workspace.state.as_str(), "cleanup_pending" | "retained") {
+            continue;
+        }
+        let task = ledger
+            .task(workspace.task_id)?
+            .with_context(|| format!("task {} disappeared", workspace.task_id))?;
+        if !task.state.is_terminal() {
+            continue;
+        }
+        let Some(run) = ledger.runs_for_task(task.id)?.into_iter().next_back() else {
+            ledger.update_task_workspace_state(
+                task.id,
+                "retained",
+                Some("terminal task has no run history for workspace reconciliation"),
+            )?;
+            continue;
+        };
+        if let Err(error) = finalize_task_workspace(
+            ledger_path,
+            canonical_repository,
+            workspace_root,
+            task.id,
+            run.id,
+        ) {
+            eprintln!(
+                "Factory retained terminal workspace for task {} during startup reconciliation: {error:#}",
+                task.id
+            );
+        }
+    }
+    Ok(())
+}
+
 fn report_recovery(report: crate::storage::RecoveryReport) {
     for run_id in report.recovered_run_ids {
         eprintln!("Factory queued one bounded recovery for interrupted run {run_id}");
@@ -429,6 +596,8 @@ fn dispatch_available(
     codex: &CodexRuntime,
     github: &GitHubClient,
     github_config: &crate::config::GitHubConfig,
+    workspace_root: &Path,
+    retention_warning_shown: &mut bool,
     cancellation: &CancellationToken,
     owner: &DaemonOwner,
 ) -> Result<()> {
@@ -457,13 +626,29 @@ fn dispatch_available(
             .iter()
             .map(|(repository, target)| (repository.clone(), target.path.display().to_string()))
             .collect::<HashMap<_, _>>();
+        let delivery_slots_available = ledger.retained_delivery_workspace_count()? < 10;
+        if !delivery_slots_available && !*retention_warning_shown {
+            let run_ids = ledger
+                .retained_delivery_run_ids()?
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            eprintln!(
+                "Factory delivery worktree limit reached; polling continues but delivery launch is paused. Run `factory cleanup <run-id>` for one of: {run_ids}"
+            );
+            *retention_warning_shown = true;
+        } else if delivery_slots_available {
+            *retention_warning_shown = false;
+        }
         let mut worker_ledger = Ledger::open(ledger_path)?;
-        let Some(claimed) = ledger.claim_and_start_run_with_workdirs(
+        let Some(claimed) = ledger.claim_and_start_run_with_workdirs_filtered(
             &available,
             &workflow_runtimes,
             &owner.id,
             owner.pid,
             &working_directories,
+            delivery_slots_available,
         )?
         else {
             break;
@@ -502,33 +687,6 @@ fn dispatch_available(
         } else {
             None
         };
-        let prompt_result = execution_prompt(
-            &task,
-            run_id,
-            &target,
-            &workflow,
-            prior_session.as_deref(),
-            prior_successful_run_at,
-        )
-        .map(|prompt| {
-            recovery_source.as_ref().map_or(prompt.clone(), |previous| {
-                recovery_prompt(&prompt, previous, &target)
-            })
-        });
-        let prompt = match prompt_result {
-            Ok(prompt) => prompt,
-            Err(error) => {
-                worker_ledger.finish_run_and_task(
-                    run_id,
-                    RunOutcome::Failed,
-                    None,
-                    Some(&format!("{error:#}")),
-                    None,
-                )?;
-                eprintln!("Factory rejected claimed task {}: {error:#}", task.id);
-                continue;
-            }
-        };
         if workflow.runtime != "codex" {
             let error = format!(
                 "unsupported runtime {:?}; Factory v1 supports codex",
@@ -557,6 +715,8 @@ fn dispatch_available(
         let codex = codex.clone();
         let github = github.clone();
         let github_config = github_config.clone();
+        let workspace_root = workspace_root.to_owned();
+        let finalization_ledger_path = ledger_path.to_owned();
         let cancellation = cancellation.clone();
         runs.spawn(async move {
             if task.kind == "ticket"
@@ -583,14 +743,64 @@ fn dispatch_available(
                 eprintln!("Factory authorization rejected task {}: {error:#}", task.id);
                 return (repository, Ok(()));
             }
+            let execution_target = match prepare_task_workspace(
+                &mut worker_ledger,
+                &github,
+                &target,
+                &workspace_root,
+                &task,
+                run_id,
+                &cancellation,
+            )
+            .await
+            {
+                Ok(target) => target,
+                Err(error) => {
+                    if let Err(finish_error) = worker_ledger.fail_prelaunch_and_requeue(
+                        run_id,
+                        &format!("workspace preparation failed: {error:#}"),
+                    ) {
+                        return (repository, Err(finish_error));
+                    }
+                    eprintln!(
+                        "Factory workspace preparation failed for task {}: {error:#}",
+                        task.id
+                    );
+                    return (repository, Ok(()));
+                }
+            };
+            let prompt = match execution_prompt(
+                &task,
+                run_id,
+                &execution_target,
+                &workflow,
+                prior_session.as_deref(),
+                prior_successful_run_at,
+            )
+            .map(|prompt| {
+                recovery_source.as_ref().map_or(prompt.clone(), |previous| {
+                    recovery_prompt(&prompt, previous, &execution_target)
+                })
+            }) {
+                Ok(prompt) => prompt,
+                Err(error) => {
+                    if let Err(finish_error) = worker_ledger.fail_prelaunch_and_requeue(
+                        run_id,
+                        &format!("execution prompt preparation failed: {error:#}"),
+                    ) {
+                        return (repository, Err(finish_error));
+                    }
+                    return (repository, Ok(()));
+                }
+            };
             eprintln!(
-                "Factory runtime delegated: run={run_id} runtime={} cwd={} worktree=workflow-managed",
+                "Factory runtime delegated: run={run_id} runtime={} cwd={} worktree=factory-owned",
                 workflow.runtime,
-                target.path.display()
+                execution_target.path.display()
             );
             let result = execute_task(
                 worker_ledger,
-                &target,
+                &execution_target,
                 &workflow,
                 &codex,
                 run_id,
@@ -599,8 +809,244 @@ fn dispatch_available(
                 recovery_source.and_then(|previous| previous.session_id),
             )
             .await;
+            if let Err(error) = finalize_task_workspace(
+                &finalization_ledger_path,
+                &target.path,
+                &workspace_root,
+                task.id,
+                run_id,
+            ) {
+                eprintln!("Factory workspace finalization failed for run {run_id}: {error:#}");
+            }
             (repository, result)
         });
+    }
+    Ok(())
+}
+
+async fn prepare_task_workspace(
+    ledger: &mut Ledger,
+    github: &GitHubClient,
+    canonical_target: &RepositoryTarget,
+    workspace_root: &Path,
+    task: &Task,
+    run_id: i64,
+    cancellation: &CancellationToken,
+) -> Result<RepositoryTarget> {
+    let workspace_root = workspace_root
+        .canonicalize()
+        .context("failed to canonicalize Factory workspace root")?;
+    let manager = WorkspaceManager::new(&canonical_target.path, &workspace_root)?;
+    let existing = ledger.task_workspace(task.id)?;
+    let reuse = match existing.as_ref().map(|workspace| workspace.state.as_str()) {
+        None => DeliveryReuse::Reject,
+        Some("preparing") => DeliveryReuse::ExactBase,
+        Some(_) => DeliveryReuse::Owned,
+    };
+    let workspace = if let Some(existing) = existing {
+        if existing.state == "cleaned" {
+            bail!("task {} workspace was already cleaned", task.id);
+        }
+        existing
+    } else {
+        let base_branch = github
+            .repository_default_branch(&canonical_target.path, cancellation)
+            .await?;
+        let base_sha = manager.fetch_default_branch(&base_branch)?;
+        let confirmed_branch = github
+            .repository_default_branch(&canonical_target.path, cancellation)
+            .await?;
+        if confirmed_branch != base_branch {
+            bail!(
+                "GitHub default branch changed from {base_branch:?} to {confirmed_branch:?} during workspace preparation"
+            );
+        }
+        let now = 0;
+        let candidate = if task.kind == "ticket" {
+            let ticket = ticket_context(task)?;
+            TaskWorkspace {
+                task_id: task.id,
+                kind: "delivery".to_owned(),
+                repository: task.repository.clone(),
+                base_branch,
+                base_sha,
+                factory_branch: Some(WorkspaceManager::delivery_branch(
+                    ticket.number,
+                    &ticket.title,
+                )),
+                path: workspace_root.join(format!("issue-{}", ticket.number)),
+                state: "preparing".to_owned(),
+                status_summary: None,
+                created_at: now,
+                updated_at: now,
+                cleaned_at: None,
+            }
+        } else {
+            TaskWorkspace {
+                task_id: task.id,
+                kind: "proposal".to_owned(),
+                repository: task.repository.clone(),
+                base_branch,
+                base_sha,
+                factory_branch: None,
+                path: workspace_root.join(format!("proposal-{}", task.id)),
+                state: "preparing".to_owned(),
+                status_summary: None,
+                created_at: now,
+                updated_at: now,
+                cleaned_at: None,
+            }
+        };
+        ledger.reserve_task_workspace(&candidate)?
+    };
+    let prepared = if workspace.kind == "delivery" {
+        let ticket = ticket_context(task)?;
+        manager.prepare_delivery(
+            ticket.number,
+            &ticket.title,
+            &workspace.base_branch,
+            &workspace.base_sha,
+            reuse,
+        )?
+    } else {
+        manager.prepare_proposal(task.id, &workspace.base_branch, &workspace.base_sha)?
+    };
+    if prepared.path != workspace.path
+        || prepared.branch != workspace.factory_branch
+        || prepared.base_branch != workspace.base_branch
+        || prepared.base_sha != workspace.base_sha
+    {
+        bail!(
+            "Git workspace does not match task {} durable reservation",
+            task.id
+        );
+    }
+    ledger.update_task_workspace_state(task.id, "ready", None)?;
+    ledger.record_run_workspace(
+        run_id,
+        &prepared.path,
+        &prepared.base_branch,
+        &prepared.base_sha,
+        prepared.branch.as_deref(),
+        match prepared.kind {
+            WorkspaceKind::Delivery => "delivery",
+            WorkspaceKind::Proposal => "proposal",
+        },
+    )?;
+    Ok(RepositoryTarget {
+        path: prepared.path,
+        workflows: canonical_target.workflows.clone(),
+    })
+}
+
+fn ticket_context(task: &Task) -> Result<TicketContext> {
+    let payload = task
+        .payload
+        .as_deref()
+        .context("ticket task has no source payload")?;
+    serde_json::from_str(payload).context("ticket task contains invalid source context")
+}
+
+fn finalize_task_workspace(
+    ledger_path: &Path,
+    canonical_repository: &Path,
+    workspace_root: &Path,
+    task_id: i64,
+    run_id: i64,
+) -> Result<()> {
+    let ledger = Ledger::open(ledger_path)?;
+    let task = ledger
+        .task(task_id)?
+        .with_context(|| format!("task {task_id} disappeared during workspace finalization"))?;
+    let workspace = ledger
+        .task_workspace(task_id)?
+        .with_context(|| format!("task {task_id} has no workspace to finalize"))?;
+    if !task.state.is_terminal() {
+        return Ok(());
+    }
+    let manager = WorkspaceManager::new(canonical_repository, workspace_root)?;
+    if workspace.kind == "proposal" {
+        ledger.update_task_workspace_state(
+            task_id,
+            "cleanup_pending",
+            Some("terminal proposal"),
+        )?;
+        if !workspace.path.exists() {
+            ledger.update_task_workspace_state(
+                task_id,
+                "cleaned",
+                Some("terminal proposal workspace was already absent"),
+            )?;
+            return Ok(());
+        }
+        let preview = manager.cleanup_disposable(&workspace.path)?;
+        let summary = if preview.dirty {
+            "discarded terminal proposal workspace with uncommitted changes"
+        } else {
+            "removed terminal proposal workspace"
+        };
+        ledger.update_task_workspace_state(task_id, "cleaned", Some(summary))?;
+        return Ok(());
+    }
+    if !workspace.path.exists() {
+        ledger.update_task_workspace_state(
+            task_id,
+            "cleaned",
+            Some("terminal delivery workspace was already absent; local branch preserved"),
+        )?;
+        return Ok(());
+    }
+    let run = ledger
+        .run(run_id)?
+        .with_context(|| format!("run {run_id} disappeared during workspace finalization"))?;
+    let preview = match manager.preview_cleanup(&workspace.path) {
+        Ok(preview) => preview,
+        Err(error) => {
+            ledger.update_task_workspace_state(
+                task_id,
+                "retained",
+                Some("retained delivery because Git worktree inspection failed"),
+            )?;
+            return Err(error.context("failed to inspect terminal delivery workspace"));
+        }
+    };
+    let published = match workspace.factory_branch.as_deref() {
+        Some(branch) => match manager.branch_is_pushed(branch) {
+            Ok(published) => published,
+            Err(error) => {
+                ledger.update_task_workspace_state(
+                    task_id,
+                    "retained",
+                    Some("retained delivery because remote branch inspection failed"),
+                )?;
+                return Err(error.context("failed to inspect published delivery branch"));
+            }
+        },
+        None => false,
+    };
+    let handed_off = run
+        .result
+        .as_deref()
+        .is_some_and(|result| !result.trim().is_empty())
+        && run.pull_request.is_some();
+    if task.state == TaskState::Succeeded && !preview.dirty && published && handed_off {
+        ledger.update_task_workspace_state(
+            task_id,
+            "cleanup_pending",
+            Some(AUTOMATIC_DELIVERY_CLEANUP),
+        )?;
+        manager.cleanup_clean(&workspace.path)?;
+        ledger.update_task_workspace_state(
+            task_id,
+            "cleaned",
+            Some("delivery worktree removed"),
+        )?;
+    } else {
+        let summary = format!(
+            "retained delivery: task={:?} dirty={} published={} handoff={}",
+            task.state, preview.dirty, published, handed_off
+        );
+        ledger.update_task_workspace_state(task_id, "retained", Some(&summary))?;
     }
     Ok(())
 }
@@ -1579,6 +2025,10 @@ mod tests {
             working_directory: Some(repository.display().to_string()),
             recovery_of: None,
             recovery_attempt: 0,
+            base_branch: None,
+            base_sha: None,
+            factory_branch: None,
+            workspace_kind: None,
         };
 
         let prompt = recovery_prompt("base", &previous, &target);
@@ -1589,5 +2039,251 @@ mod tests {
         assert!(prompt.contains("https://github.com/owainlewis/factory/pull/99"));
         assert!(prompt.contains("Codex event: item.completed"));
         assert!(prompt.contains("runtime interrupted"));
+    }
+
+    #[test]
+    fn startup_retains_delivery_that_became_dirty_during_automatic_cleanup() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repository");
+        let workspace_root = temp.path().join("worktrees");
+        std::fs::create_dir(&repository).unwrap();
+        std::fs::create_dir(&workspace_root).unwrap();
+        let git = |directory: &Path, arguments: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(arguments)
+                .current_dir(directory)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {} failed: {}",
+                arguments.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&repository, &["init", "-b", "main"]);
+        git(
+            &repository,
+            &["config", "user.email", "factory@example.test"],
+        );
+        git(&repository, &["config", "user.name", "Factory Test"]);
+        std::fs::write(repository.join("README.md"), "fixture\n").unwrap();
+        git(&repository, &["add", "README.md"]);
+        git(&repository, &["commit", "-m", "fixture"]);
+        let remote = temp.path().join("origin.git");
+        git(
+            temp.path(),
+            &[
+                "clone",
+                "--bare",
+                repository.to_str().unwrap(),
+                remote.to_str().unwrap(),
+            ],
+        );
+        git(
+            &repository,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        let repository = repository.canonicalize().unwrap();
+        let workspace_root = workspace_root.canonicalize().unwrap();
+        let manager = WorkspaceManager::new(&repository, &workspace_root).unwrap();
+        let base_sha = manager.fetch_default_branch("main").unwrap();
+        let prepared = manager
+            .prepare_delivery(39, "Cleanup race", "main", &base_sha, DeliveryReuse::Reject)
+            .unwrap();
+        let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+        let task = ledger
+            .enqueue(&TaskIdentity::ticket("example/repo", "deliver", "39", "approval").unwrap())
+            .unwrap()
+            .task;
+        ledger.claim_next().unwrap().unwrap();
+        let run = ledger.start_run(task.id, "codex").unwrap();
+        ledger
+            .reserve_task_workspace(&TaskWorkspace {
+                task_id: task.id,
+                kind: "delivery".into(),
+                repository: task.repository,
+                base_branch: "main".into(),
+                base_sha: base_sha.clone(),
+                factory_branch: prepared.branch.clone(),
+                path: prepared.path.clone(),
+                state: "preparing".into(),
+                status_summary: None,
+                created_at: 0,
+                updated_at: 0,
+                cleaned_at: None,
+            })
+            .unwrap();
+        ledger
+            .record_run_workspace(
+                run.id,
+                &prepared.path,
+                "main",
+                &base_sha,
+                prepared.branch.as_deref(),
+                "delivery",
+            )
+            .unwrap();
+        ledger
+            .observe_run(
+                run.id,
+                None,
+                None,
+                None,
+                Some("https://github.com/example/repo/pull/1"),
+                None,
+            )
+            .unwrap();
+        ledger
+            .finish_run_and_task_terminal(
+                run.id,
+                RunOutcome::Succeeded,
+                Some("handoff"),
+                None,
+                None,
+            )
+            .unwrap();
+        ledger
+            .update_task_workspace_state(
+                task.id,
+                "cleanup_pending",
+                Some(AUTOMATIC_DELIVERY_CLEANUP),
+            )
+            .unwrap();
+        std::fs::write(prepared.path.join("late-change.txt"), "keep me\n").unwrap();
+
+        reconcile_pending_cleanup(&ledger, &repository, &workspace_root).unwrap();
+
+        assert!(prepared.path.join("late-change.txt").exists());
+        assert_eq!(
+            ledger.task_workspace(task.id).unwrap().unwrap().state,
+            "retained"
+        );
+        std::fs::rename(&remote, temp.path().join("origin-unavailable.git")).unwrap();
+        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root)
+            .unwrap();
+        assert_eq!(
+            ledger.task_workspace(task.id).unwrap().unwrap().state,
+            "retained"
+        );
+
+        let proposal_task = ledger
+            .enqueue(
+                &TaskIdentity::scheduled("example/repo", "review", "2026-07-21T10:00:00Z").unwrap(),
+            )
+            .unwrap()
+            .task;
+        ledger.claim_next().unwrap().unwrap();
+        let proposal_run = ledger.start_run(proposal_task.id, "codex").unwrap();
+        let proposal = manager
+            .prepare_proposal(proposal_task.id, "main", &base_sha)
+            .unwrap();
+        ledger
+            .reserve_task_workspace(&TaskWorkspace {
+                task_id: proposal_task.id,
+                kind: "proposal".into(),
+                repository: proposal_task.repository,
+                base_branch: "main".into(),
+                base_sha: base_sha.clone(),
+                factory_branch: None,
+                path: proposal.path.clone(),
+                state: "preparing".into(),
+                status_summary: None,
+                created_at: 0,
+                updated_at: 0,
+                cleaned_at: None,
+            })
+            .unwrap();
+        ledger
+            .record_run_workspace(
+                proposal_run.id,
+                &proposal.path,
+                "main",
+                &base_sha,
+                None,
+                "proposal",
+            )
+            .unwrap();
+        ledger
+            .update_task_workspace_state(proposal_task.id, "ready", None)
+            .unwrap();
+        ledger
+            .finish_run_and_task_terminal(
+                proposal_run.id,
+                RunOutcome::Cancelled,
+                None,
+                Some("daemon stopped before finalization"),
+                None,
+            )
+            .unwrap();
+
+        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root)
+            .unwrap();
+
+        assert!(!proposal.path.exists());
+        assert_eq!(
+            ledger
+                .task_workspace(proposal_task.id)
+                .unwrap()
+                .unwrap()
+                .state,
+            "cleaned"
+        );
+
+        let absent_task = ledger
+            .enqueue(&TaskIdentity::ticket("example/repo", "deliver", "40", "approval").unwrap())
+            .unwrap()
+            .task;
+        ledger.claim_next().unwrap().unwrap();
+        let absent_run = ledger.start_run(absent_task.id, "codex").unwrap();
+        let absent_path = workspace_root.join("issue-40");
+        ledger
+            .reserve_task_workspace(&TaskWorkspace {
+                task_id: absent_task.id,
+                kind: "delivery".into(),
+                repository: absent_task.repository,
+                base_branch: "main".into(),
+                base_sha: base_sha.clone(),
+                factory_branch: Some("factory/40-never-created".into()),
+                path: absent_path.clone(),
+                state: "preparing".into(),
+                status_summary: None,
+                created_at: 0,
+                updated_at: 0,
+                cleaned_at: None,
+            })
+            .unwrap();
+        ledger
+            .record_run_workspace(
+                absent_run.id,
+                &absent_path,
+                "main",
+                &base_sha,
+                Some("factory/40-never-created"),
+                "delivery",
+            )
+            .unwrap();
+        ledger
+            .finish_run_and_task_terminal(
+                absent_run.id,
+                RunOutcome::Failed,
+                None,
+                Some("workspace creation failed"),
+                None,
+            )
+            .unwrap();
+
+        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root)
+            .unwrap();
+
+        assert!(!absent_path.exists());
+        assert_eq!(
+            ledger
+                .task_workspace(absent_task.id)
+                .unwrap()
+                .unwrap()
+                .state,
+            "cleaned"
+        );
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -54,6 +54,11 @@ pub struct IssueSnapshot {
     pub updated_at: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct ApiRepository {
+    default_branch: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RepositoryPoll {
     pub repository: PathBuf,
@@ -236,6 +241,58 @@ impl GitHubClient {
             )
             .await?;
         Ok(IssueSnapshot::from(issue))
+    }
+
+    pub async fn default_branch(
+        &self,
+        repository: &Path,
+        name: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
+        let response: ApiRepository = self
+            .api_json(Some(repository), &format!("repos/{name}"), cancellation)
+            .await?;
+        let branch = response.default_branch.trim();
+        if branch.is_empty()
+            || branch.starts_with('-')
+            || branch
+                .chars()
+                .any(|character| matches!(character, '\0' | '\n' | '\r'))
+        {
+            bail!("GitHub returned invalid default branch {branch:?}");
+        }
+        Ok(branch.to_owned())
+    }
+
+    pub async fn repository_default_branch(
+        &self,
+        repository: &Path,
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
+        let output = self
+            .run(
+                Some(repository),
+                &[
+                    "repo",
+                    "view",
+                    "--json",
+                    "defaultBranchRef",
+                    "--jq",
+                    ".defaultBranchRef.name",
+                ],
+                cancellation,
+            )
+            .await?;
+        let branch = output.trim();
+        if branch.is_empty()
+            || branch.starts_with('-')
+            || branch
+                .chars()
+                .any(|character| matches!(character, '\0' | '\n' | '\r'))
+        {
+            bail!("GitHub returned invalid default branch {branch:?}");
+        }
+        Ok(branch.to_owned())
     }
 
     pub async fn issue_comments(

--- a/src/init.rs
+++ b/src/init.rs
@@ -241,7 +241,7 @@ pub fn discover_repository(requested: &Path) -> Result<PathBuf> {
     let repository = PathBuf::from(root.trim())
         .canonicalize()
         .context("failed to resolve Git repository root")?;
-    let origin = git_output(&repository, &["remote", "get-url", "origin"])
+    let origin = git_output(&repository, &["config", "--get", "remote.origin.url"])
         .context("target repository has no origin remote")?;
     if !is_github_origin(origin.trim()) {
         bail!("origin is not a supported GitHub remote");

--- a/src/inspection.rs
+++ b/src/inspection.rs
@@ -56,6 +56,10 @@ pub struct RunView {
     pub working_directory: Option<String>,
     pub recovery_of: Option<i64>,
     pub recovery_attempt: u32,
+    pub base_branch: Option<String>,
+    pub base_sha: Option<String>,
+    pub factory_branch: Option<String>,
+    pub workspace_kind: Option<String>,
 }
 
 impl From<&Run> for RunView {
@@ -90,6 +94,10 @@ impl From<&Run> for RunView {
             working_directory: run.working_directory.clone(),
             recovery_of: run.recovery_of,
             recovery_attempt: run.recovery_attempt,
+            base_branch: run.base_branch.clone(),
+            base_sha: run.base_sha.clone(),
+            factory_branch: run.factory_branch.clone(),
+            workspace_kind: run.workspace_kind.clone(),
         }
     }
 }
@@ -193,6 +201,19 @@ pub fn print_inspection(inspection: &RunInspection) {
     println!(
         "Working directory: {}",
         safe_text(inspection.run.working_directory.as_deref().unwrap_or("-"))
+    );
+    println!(
+        "Workspace kind: {}",
+        safe_text(inspection.run.workspace_kind.as_deref().unwrap_or("-"))
+    );
+    println!(
+        "Base: {} @ {}",
+        safe_text(inspection.run.base_branch.as_deref().unwrap_or("-")),
+        safe_text(inspection.run.base_sha.as_deref().unwrap_or("-"))
+    );
+    println!(
+        "Factory branch: {}",
+        safe_text(inspection.run.factory_branch.as_deref().unwrap_or("-"))
     );
     println!(
         "Pull request: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,4 @@ pub mod runtime;
 pub mod storage;
 pub mod workflow;
 pub mod workflow_create;
+pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,6 +471,13 @@ async fn run_cli() -> Result<u8> {
             let workspace = ledger
                 .task_workspace(task.id)?
                 .with_context(|| format!("run {run_id} has no Factory-owned workspace"))?;
+            if workspace.state == "cleaned" {
+                println!("run: {run_id}");
+                println!("workspace: {}", workspace.path.display());
+                println!("branch preserved: true");
+                println!("action: workspace reservation is already cleaned; no changes made");
+                return Ok(0);
+            }
             let manager = WorkspaceManager::new(&config.repositories[0], &config.workspace_root)?;
             if !workspace.path.exists() {
                 println!("run: {run_id}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,12 @@ use factory::inspection::{
 use factory::runtime::{
     CodexRuntime, RuntimeCancelled, Termination, write_stderr_best_effort, write_stdout_best_effort,
 };
-use factory::storage::{CancellationRequest, DATABASE_NAME, Ledger};
+use factory::storage::{
+    CancellationRequest, DATABASE_NAME, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState,
+};
 use factory::workflow::WorkflowCatalog;
 use factory::workflow_create::{CreateWorkflowOptions, create_workflow};
+use factory::workspace::WorkspaceManager;
 
 #[derive(Debug, Parser)]
 #[command(name = "factory", version, about)]
@@ -135,6 +138,19 @@ enum Command {
         #[arg(long)]
         json: bool,
         /// Path to the Factory configuration file used to locate the data directory.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Directory containing the durable Factory database.
+        #[arg(long)]
+        data_directory: Option<PathBuf>,
+    },
+    /// Preview or confirm removal of one retained Factory worktree.
+    Cleanup {
+        run_id: i64,
+        /// Confirm removal after reviewing the preview. Dirty files are discarded.
+        #[arg(long)]
+        confirm: bool,
+        /// Path to the repository-local Factory configuration file.
         #[arg(long)]
         config: Option<PathBuf>,
         /// Directory containing the durable Factory database.
@@ -434,6 +450,89 @@ async fn run_cli() -> Result<u8> {
                     "Run {}: {} ({})",
                     response.run_id, response.message, response.status
                 );
+            }
+        }
+        Command::Cleanup {
+            run_id,
+            confirm,
+            config,
+            data_directory,
+        } => {
+            let path = resolve_config_path(config)?;
+            let config = Config::load(&path)?;
+            let data_directory = data_directory.unwrap_or_else(|| config.data_directory.clone());
+            let ledger = Ledger::open_in(&data_directory)?;
+            let run = ledger
+                .run(run_id)?
+                .with_context(|| format!("run {run_id} does not exist"))?;
+            let task = ledger
+                .task(run.task_id)?
+                .with_context(|| format!("task {} for run {run_id} does not exist", run.task_id))?;
+            let workspace = ledger
+                .task_workspace(task.id)?
+                .with_context(|| format!("run {run_id} has no Factory-owned workspace"))?;
+            let manager = WorkspaceManager::new(&config.repositories[0], &config.workspace_root)?;
+            if !workspace.path.exists() {
+                println!("run: {run_id}");
+                println!("workspace: {}", workspace.path.display());
+                println!(
+                    "branch: {}",
+                    workspace.factory_branch.as_deref().unwrap_or("detached")
+                );
+                println!("workspace exists: false");
+                println!("branch preserved: true");
+                if !confirm {
+                    println!(
+                        "action: preview only; rerun with --confirm to release the workspace reservation"
+                    );
+                } else {
+                    if matches!(task.state, TaskState::Queued | TaskState::Running) {
+                        bail!(
+                            "refusing to release workspace for {:?} task {}; cancel or finish it first",
+                            task.state,
+                            task.id
+                        );
+                    }
+                    ledger.update_task_workspace_state(
+                        task.id,
+                        "cleaned",
+                        Some("operator confirmed absent workspace; local branch preserved"),
+                    )?;
+                    println!("action: released workspace reservation; local branch preserved");
+                }
+                return Ok(0);
+            }
+            let preview = manager.preview_cleanup(&workspace.path)?;
+            println!("run: {run_id}");
+            println!("workspace: {}", preview.path.display());
+            println!(
+                "branch: {}",
+                preview.branch.as_deref().unwrap_or("detached")
+            );
+            println!("dirty: {}", preview.dirty);
+            println!("branch preserved: true");
+            if !confirm {
+                println!("action: preview only; rerun with --confirm to remove the worktree");
+            } else {
+                if matches!(task.state, TaskState::Queued | TaskState::Running) {
+                    bail!(
+                        "refusing to clean workspace for {:?} task {}; cancel or finish it first",
+                        task.state,
+                        task.id
+                    );
+                }
+                ledger.update_task_workspace_state(
+                    task.id,
+                    "cleanup_pending",
+                    Some(OPERATOR_CONFIRMED_CLEANUP),
+                )?;
+                manager.cleanup(&workspace.path, true)?;
+                ledger.update_task_workspace_state(
+                    task.id,
+                    "cleaned",
+                    Some("operator-confirmed cleanup completed"),
+                )?;
+                println!("action: removed worktree; local branch preserved");
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,12 +8,15 @@ use anyhow::{Context, Result, bail};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, TransactionBehavior, params};
 
 pub const DATABASE_NAME: &str = "factory.sqlite3";
-const SCHEMA_VERSION: i64 = 6;
+const SCHEMA_VERSION: i64 = 7;
 pub const MAX_RESULT_BYTES: usize = 256 * 1024;
 pub const MAX_ERROR_BYTES: usize = 64 * 1024;
 pub const MAX_SESSION_ID_BYTES: usize = 1024;
 pub const MAX_ACTIVITY_BYTES: usize = 64 * 1024;
 pub const MAX_RECOVERY_ATTEMPTS: u32 = 2;
+pub const AUTOMATIC_DELIVERY_CLEANUP: &str =
+    "clean published delivery with recorded pull request and handoff";
+pub const OPERATOR_CONFIRMED_CLEANUP: &str = "operator-confirmed cleanup";
 const DAEMON_OWNER_LEASE_MILLIS: i64 = 10_000;
 const APPROVAL_RESERVATION_TTL_MILLIS: i64 = 10 * 60 * 1000;
 
@@ -235,6 +238,22 @@ pub struct ApprovalEvidence<'a> {
     pub source_revision: &'a str,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskWorkspace {
+    pub task_id: i64,
+    pub kind: String,
+    pub repository: String,
+    pub base_branch: String,
+    pub base_sha: String,
+    pub factory_branch: Option<String>,
+    pub path: PathBuf,
+    pub state: String,
+    pub status_summary: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub cleaned_at: Option<i64>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunOutcome {
     Running,
@@ -279,6 +298,10 @@ pub struct Run {
     pub working_directory: Option<String>,
     pub recovery_of: Option<i64>,
     pub recovery_attempt: u32,
+    pub base_branch: Option<String>,
+    pub base_sha: Option<String>,
+    pub factory_branch: Option<String>,
+    pub workspace_kind: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -711,6 +734,224 @@ impl Ledger {
         query_task(&self.connection, id)
     }
 
+    pub fn record_run_workspace(
+        &self,
+        run_id: i64,
+        working_directory: &Path,
+        base_branch: &str,
+        base_sha: &str,
+        factory_branch: Option<&str>,
+        workspace_kind: &str,
+    ) -> Result<()> {
+        let changed = self.connection.execute(
+            "UPDATE runs SET working_directory = ?1, base_branch = ?2, base_sha = ?3,
+                    factory_branch = ?4, workspace_kind = ?5
+             WHERE id = ?6 AND outcome = 'running'",
+            params![
+                working_directory.display().to_string(),
+                base_branch,
+                base_sha,
+                factory_branch,
+                workspace_kind,
+                run_id
+            ],
+        )?;
+        if changed != 1 {
+            bail!("running run {run_id} disappeared before workspace persistence");
+        }
+        Ok(())
+    }
+
+    pub fn task_workspace(&self, task_id: i64) -> Result<Option<TaskWorkspace>> {
+        self.connection
+            .query_row(
+                "SELECT task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+                        state, status_summary, created_at, updated_at, cleaned_at
+                 FROM task_workspaces WHERE task_id = ?1",
+                [task_id],
+                |row| {
+                    Ok(TaskWorkspace {
+                        task_id: row.get(0)?,
+                        kind: row.get(1)?,
+                        repository: row.get(2)?,
+                        base_branch: row.get(3)?,
+                        base_sha: row.get(4)?,
+                        factory_branch: row.get(5)?,
+                        path: PathBuf::from(row.get::<_, String>(6)?),
+                        state: row.get(7)?,
+                        status_summary: row.get(8)?,
+                        created_at: row.get(9)?,
+                        updated_at: row.get(10)?,
+                        cleaned_at: row.get(11)?,
+                    })
+                },
+            )
+            .optional()
+            .context("failed to query task workspace")
+    }
+
+    pub fn reserve_task_workspace(&mut self, workspace: &TaskWorkspace) -> Result<TaskWorkspace> {
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .context("failed to begin workspace reservation transaction")?;
+        let existing = query_task_workspace(&transaction, workspace.task_id)?;
+        if let Some(existing) = existing {
+            ensure_same_workspace(&existing, workspace)?;
+            transaction
+                .commit()
+                .context("failed to finish existing workspace reservation")?;
+            return Ok(existing);
+        }
+        if workspace.kind == "delivery" {
+            let retained: i64 = transaction
+                .query_row(
+                    "SELECT COUNT(*) FROM task_workspaces
+                     WHERE kind = 'delivery' AND state != 'cleaned'",
+                    [],
+                    |row| row.get(0),
+                )
+                .context("failed to count retained delivery workspaces")?;
+            if retained >= 10 {
+                bail!(
+                    "Factory retains at most ten delivery worktrees; run `factory cleanup <run-id>` for one of: {}",
+                    retained_delivery_run_ids(&transaction)?
+                );
+            }
+        }
+        let now = now_millis()?;
+        transaction
+            .execute(
+                "INSERT INTO task_workspaces
+                 (task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+                  state, status_summary, created_at, updated_at, cleaned_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'preparing', NULL, ?8, ?8, NULL)",
+                params![
+                    workspace.task_id,
+                    workspace.kind,
+                    workspace.repository,
+                    workspace.base_branch,
+                    workspace.base_sha,
+                    workspace.factory_branch,
+                    workspace.path.display().to_string(),
+                    now,
+                ],
+            )
+            .context("failed to reserve task workspace")?;
+        let reserved = query_task_workspace(&transaction, workspace.task_id)?
+            .context("reserved task workspace disappeared")?;
+        transaction
+            .commit()
+            .context("failed to commit workspace reservation")?;
+        Ok(reserved)
+    }
+
+    pub fn update_task_workspace_state(
+        &self,
+        task_id: i64,
+        state: &str,
+        status_summary: Option<&str>,
+    ) -> Result<()> {
+        if !matches!(
+            state,
+            "preparing" | "ready" | "retained" | "cleanup_pending" | "cleaned"
+        ) {
+            bail!("invalid task workspace state {state:?}");
+        }
+        let now = now_millis()?;
+        let cleaned_at = (state == "cleaned").then_some(now);
+        let changed = self.connection.execute(
+            "UPDATE task_workspaces SET state = ?1, status_summary = ?2, updated_at = ?3,
+                    cleaned_at = CASE WHEN ?1 = 'cleaned' THEN ?4 ELSE cleaned_at END
+             WHERE task_id = ?5",
+            params![state, status_summary, now, cleaned_at, task_id],
+        )?;
+        if changed != 1 {
+            bail!("task {task_id} has no workspace to update");
+        }
+        Ok(())
+    }
+
+    pub fn retained_delivery_workspace_count(&self) -> Result<usize> {
+        let count = self.connection.query_row(
+            "SELECT COUNT(*) FROM task_workspaces
+             WHERE kind = 'delivery' AND state != 'cleaned'",
+            [],
+            |row| row.get::<_, usize>(0),
+        )?;
+        Ok(count)
+    }
+
+    pub fn retained_delivery_run_ids(&self) -> Result<Vec<i64>> {
+        let mut statement = self.connection.prepare(
+            "SELECT COALESCE(MAX(r.id), 0)
+             FROM task_workspaces w
+             LEFT JOIN runs r ON r.task_id = w.task_id
+             WHERE w.kind = 'delivery' AND w.state != 'cleaned'
+             GROUP BY w.task_id ORDER BY w.created_at, w.task_id",
+        )?;
+        Ok(statement
+            .query_map([], |row| row.get::<_, i64>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?
+            .into_iter()
+            .filter(|id| *id > 0)
+            .collect())
+    }
+
+    pub fn task_workspaces_in_state(&self, state: &str) -> Result<Vec<TaskWorkspace>> {
+        let mut statement = self.connection.prepare(
+            "SELECT task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+                    state, status_summary, created_at, updated_at, cleaned_at
+             FROM task_workspaces WHERE state = ?1 ORDER BY task_id",
+        )?;
+        statement
+            .query_map([state], |row| {
+                Ok(TaskWorkspace {
+                    task_id: row.get(0)?,
+                    kind: row.get(1)?,
+                    repository: row.get(2)?,
+                    base_branch: row.get(3)?,
+                    base_sha: row.get(4)?,
+                    factory_branch: row.get(5)?,
+                    path: PathBuf::from(row.get::<_, String>(6)?),
+                    state: row.get(7)?,
+                    status_summary: row.get(8)?,
+                    created_at: row.get(9)?,
+                    updated_at: row.get(10)?,
+                    cleaned_at: row.get(11)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("failed to read task workspaces")
+    }
+
+    pub fn active_task_workspaces(&self) -> Result<Vec<TaskWorkspace>> {
+        let mut statement = self.connection.prepare(
+            "SELECT task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+                    state, status_summary, created_at, updated_at, cleaned_at
+             FROM task_workspaces WHERE state != 'cleaned' ORDER BY task_id",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok(TaskWorkspace {
+                    task_id: row.get(0)?,
+                    kind: row.get(1)?,
+                    repository: row.get(2)?,
+                    base_branch: row.get(3)?,
+                    base_sha: row.get(4)?,
+                    factory_branch: row.get(5)?,
+                    path: PathBuf::from(row.get::<_, String>(6)?),
+                    state: row.get(7)?,
+                    status_summary: row.get(8)?,
+                    created_at: row.get(9)?,
+                    updated_at: row.get(10)?,
+                    cleaned_at: row.get(11)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("failed to read active task workspaces")
+    }
+
     pub fn claim_next(&mut self) -> Result<Option<Task>> {
         self.claim_next_matching(None)
     }
@@ -969,6 +1210,25 @@ impl Ledger {
         owner_pid: u32,
         working_directories: &HashMap<String, String>,
     ) -> Result<Option<ClaimedRun>> {
+        self.claim_and_start_run_with_workdirs_filtered(
+            available_repositories,
+            workflow_runtimes,
+            owner_id,
+            owner_pid,
+            working_directories,
+            true,
+        )
+    }
+
+    pub fn claim_and_start_run_with_workdirs_filtered(
+        &mut self,
+        available_repositories: &[String],
+        workflow_runtimes: &HashMap<(String, String, String), String>,
+        owner_id: &str,
+        owner_pid: u32,
+        working_directories: &HashMap<String, String>,
+        allow_new_ticket_tasks: bool,
+    ) -> Result<Option<ClaimedRun>> {
         if available_repositories.is_empty() {
             return Ok(None);
         }
@@ -1017,6 +1277,16 @@ impl Ledger {
                 .collect::<rusqlite::Result<HashMap<_, _>>>()
                 .context("failed to read schedule ownership")?
         };
+        let tasks_with_workspaces = {
+            let mut statement = transaction
+                .prepare("SELECT task_id FROM task_workspaces WHERE state != 'cleaned'")
+                .context("failed to prepare workspace ownership query")?;
+            statement
+                .query_map([], |row| row.get::<_, i64>(0))
+                .context("failed to query workspace ownership")?
+                .collect::<rusqlite::Result<std::collections::HashSet<_>>>()
+                .context("failed to read workspace ownership")?
+        };
         let candidates = {
             let mut statement = transaction
                 .prepare(
@@ -1032,6 +1302,12 @@ impl Ledger {
                 .context("failed to read queued tasks")?
         };
         let Some(task) = candidates.into_iter().find(|task| {
+            if task.kind == "ticket"
+                && !allow_new_ticket_tasks
+                && !tasks_with_workspaces.contains(&task.id)
+            {
+                return false;
+            }
             if !available.contains(&task.repository)
                 || !workflow_runtimes.contains_key(&(
                     task.repository.clone(),
@@ -1296,6 +1572,57 @@ impl Ledger {
         session_id: Option<&str>,
     ) -> Result<Run> {
         self.finish_run_and_task_with_recovery(id, outcome, result, error, session_id, false)
+    }
+
+    pub fn fail_prelaunch_and_requeue(&mut self, id: i64, error: &str) -> Result<Run> {
+        let error = truncate_utf8(
+            &crate::inspection::sanitize_for_storage(error),
+            MAX_ERROR_BYTES,
+        );
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .context("failed to begin prelaunch recovery transaction")?;
+        let (task_id, recovery_attempt) = transaction
+            .query_row(
+                "SELECT task_id, recovery_attempt FROM runs
+                 WHERE id = ?1 AND outcome = 'running' AND process_id IS NULL",
+                [id],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, u32>(1)?)),
+            )
+            .optional()?
+            .with_context(|| format!("run {id} is missing, terminal, or already launched"))?;
+        let now = now_millis()?;
+        let changed = transaction.execute(
+            "UPDATE runs SET outcome = 'failed', finished_at = ?1, error = ?2
+             WHERE id = ?3 AND outcome = 'running'",
+            params![now, error, id],
+        )?;
+        if changed != 1 {
+            bail!("run {id} changed during prelaunch recovery");
+        }
+        let changed = if recovery_attempt < MAX_RECOVERY_ATTEMPTS {
+            transaction.execute(
+                "UPDATE tasks SET state = 'queued', updated_at = ?1,
+                        recovery_source_run_id = ?2
+                 WHERE id = ?3 AND state = 'running'",
+                params![now, id, task_id],
+            )?
+        } else {
+            transaction.execute(
+                "UPDATE tasks SET state = 'failed', updated_at = ?1
+                 WHERE id = ?2 AND state = 'running'",
+                params![now, task_id],
+            )?
+        };
+        if changed != 1 {
+            bail!("task {task_id} changed during prelaunch recovery");
+        }
+        let run = query_run(&transaction, id)?.context("failed prelaunch run disappeared")?;
+        transaction
+            .commit()
+            .context("failed to commit prelaunch recovery")?;
+        Ok(run)
     }
 
     fn finish_run_and_task_with_recovery(
@@ -1784,6 +2111,9 @@ fn migrate(connection: &Connection) -> Result<()> {
         if version < 6 {
             migrate_v6(connection)?;
         }
+        if version < 7 {
+            migrate_v7(connection)?;
+        }
         Ok(())
     })();
     match result {
@@ -1958,11 +2288,109 @@ fn migrate_v6(connection: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v7(connection: &Connection) -> Result<()> {
+    connection
+        .execute_batch(
+            "ALTER TABLE runs ADD COLUMN base_branch TEXT;
+             ALTER TABLE runs ADD COLUMN base_sha TEXT;
+             ALTER TABLE runs ADD COLUMN factory_branch TEXT;
+             ALTER TABLE runs ADD COLUMN workspace_kind TEXT;
+             CREATE TABLE task_workspaces (
+                 task_id INTEGER PRIMARY KEY REFERENCES tasks(id),
+                 kind TEXT NOT NULL CHECK (kind IN ('delivery', 'proposal')),
+                 repository TEXT NOT NULL,
+                 base_branch TEXT NOT NULL,
+                 base_sha TEXT NOT NULL,
+                 factory_branch TEXT,
+                 path TEXT NOT NULL,
+                 state TEXT NOT NULL CHECK (state IN
+                     ('preparing', 'ready', 'retained', 'cleanup_pending', 'cleaned')),
+                 status_summary TEXT,
+                 created_at INTEGER NOT NULL,
+                 updated_at INTEGER NOT NULL,
+                 cleaned_at INTEGER
+             );
+             CREATE UNIQUE INDEX task_workspaces_active_branch_idx
+                 ON task_workspaces(factory_branch)
+                 WHERE factory_branch IS NOT NULL AND state != 'cleaned';
+             CREATE UNIQUE INDEX task_workspaces_active_path_idx
+                 ON task_workspaces(path) WHERE state != 'cleaned';
+             INSERT INTO schema_migrations(version, applied_at)
+                 VALUES (7, unixepoch('subsec') * 1000);
+             PRAGMA user_version = 7;",
+        )
+        .context("failed to migrate SQLite ledger to version 7")?;
+    Ok(())
+}
+
 fn query_task(connection: &Connection, id: i64) -> Result<Option<Task>> {
     connection
         .query_row("SELECT * FROM tasks WHERE id = ?1", [id], row_to_task)
         .optional()
         .context("failed to query task")
+}
+
+fn query_task_workspace(connection: &Connection, task_id: i64) -> Result<Option<TaskWorkspace>> {
+    connection
+        .query_row(
+            "SELECT task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+                    state, status_summary, created_at, updated_at, cleaned_at
+             FROM task_workspaces WHERE task_id = ?1",
+            [task_id],
+            |row| {
+                Ok(TaskWorkspace {
+                    task_id: row.get(0)?,
+                    kind: row.get(1)?,
+                    repository: row.get(2)?,
+                    base_branch: row.get(3)?,
+                    base_sha: row.get(4)?,
+                    factory_branch: row.get(5)?,
+                    path: PathBuf::from(row.get::<_, String>(6)?),
+                    state: row.get(7)?,
+                    status_summary: row.get(8)?,
+                    created_at: row.get(9)?,
+                    updated_at: row.get(10)?,
+                    cleaned_at: row.get(11)?,
+                })
+            },
+        )
+        .optional()
+        .context("failed to query task workspace")
+}
+
+fn ensure_same_workspace(existing: &TaskWorkspace, requested: &TaskWorkspace) -> Result<()> {
+    if existing.kind != requested.kind
+        || existing.repository != requested.repository
+        || existing.base_branch != requested.base_branch
+        || existing.base_sha != requested.base_sha
+        || existing.factory_branch != requested.factory_branch
+        || existing.path != requested.path
+    {
+        bail!(
+            "task {} already owns a different workspace; refusing to replace durable Git ownership",
+            requested.task_id
+        );
+    }
+    Ok(())
+}
+
+fn retained_delivery_run_ids(connection: &Connection) -> Result<String> {
+    let mut statement = connection.prepare(
+        "SELECT COALESCE(MAX(r.id), 0)
+         FROM task_workspaces w
+         LEFT JOIN runs r ON r.task_id = w.task_id
+         WHERE w.kind = 'delivery' AND w.state != 'cleaned'
+         GROUP BY w.task_id ORDER BY w.created_at, w.task_id",
+    )?;
+    let ids = statement
+        .query_map([], |row| row.get::<_, i64>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(ids
+        .into_iter()
+        .filter(|id| *id > 0)
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>()
+        .join(", "))
 }
 
 fn query_task_by_key(connection: &Connection, key: &str) -> Result<Option<Task>> {
@@ -2032,6 +2460,10 @@ fn row_to_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<Run> {
         working_directory: row.get("working_directory")?,
         recovery_of: row.get("recovery_of")?,
         recovery_attempt: row.get("recovery_attempt")?,
+        base_branch: row.get("base_branch")?,
+        base_sha: row.get("base_sha")?,
+        factory_branch: row.get("factory_branch")?,
+        workspace_kind: row.get("workspace_kind")?,
     })
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,885 @@
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+pub const MAX_RETAINED_WORKSPACES: usize = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceKind {
+    Delivery,
+    Proposal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkspaceDisposition {
+    Created,
+    Reused,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryReuse {
+    Reject,
+    ExactBase,
+    Owned,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Workspace {
+    pub kind: WorkspaceKind,
+    pub path: PathBuf,
+    pub branch: Option<String>,
+    pub base_branch: String,
+    pub base_sha: String,
+    pub disposition: WorkspaceDisposition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CleanupPreview {
+    pub path: PathBuf,
+    pub branch: Option<String>,
+    pub dirty: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleanupOutcome {
+    Previewed,
+    Removed,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkspaceManager {
+    repository: PathBuf,
+    workspace_root: PathBuf,
+}
+
+impl WorkspaceManager {
+    pub fn new(repository: &Path, workspace_root: &Path) -> Result<Self> {
+        let repository = canonical_directory("repository", repository)?;
+        let workspace_root = canonical_directory("workspace root", workspace_root)?;
+        if repository == workspace_root
+            || repository.starts_with(&workspace_root)
+            || workspace_root.starts_with(&repository)
+        {
+            bail!(
+                "workspace root {} must not overlap repository {}",
+                workspace_root.display(),
+                repository.display()
+            );
+        }
+        let manager = Self {
+            repository,
+            workspace_root,
+        };
+        let actual = PathBuf::from(manager.git(["rev-parse", "--show-toplevel"])?.trim())
+            .canonicalize()
+            .context("failed to canonicalize Git repository root")?;
+        if actual != manager.repository {
+            bail!(
+                "configured repository {} is not Git's primary checkout {}",
+                manager.repository.display(),
+                actual.display()
+            );
+        }
+        Ok(manager)
+    }
+
+    pub fn delivery_branch(issue: u64, title: &str) -> String {
+        format!("factory/{issue}-{}", slug(title))
+    }
+
+    pub fn reconcile_startup(&self) -> Result<()> {
+        self.prune()
+    }
+
+    /// Fetch the provider's live default branch without consulting either local
+    /// HEAD or origin/HEAD, then return its exact commit SHA.
+    pub fn fetch_default_branch(&self, base_branch: &str) -> Result<String> {
+        self.validate_branch(base_branch)?;
+        let source = format!("refs/heads/{base_branch}");
+        let remote = format!("refs/remotes/origin/{base_branch}");
+        let refspec = format!("+{source}:{remote}");
+        self.git(["fetch", "--no-tags", "origin", &refspec])
+            .with_context(|| format!("failed to fetch origin default branch {base_branch}"))?;
+        self.resolve_commit(&remote)
+    }
+
+    pub fn prepare_delivery(
+        &self,
+        issue: u64,
+        title: &str,
+        base_branch: &str,
+        base_sha: &str,
+        reuse: DeliveryReuse,
+    ) -> Result<Workspace> {
+        if issue == 0 {
+            bail!("issue number must be greater than zero");
+        }
+        self.validate_branch(base_branch)?;
+        let base_sha = self.resolve_commit(base_sha)?;
+        self.prune()?;
+        let branch = Self::delivery_branch(issue, title);
+        self.validate_branch(&branch)?;
+
+        if let Some(path) = self.worktree_for_branch(&branch)? {
+            if reuse == DeliveryReuse::Reject {
+                bail!(
+                    "Factory branch {branch} already has a worktree; a new task cannot adopt prior or unowned Git state"
+                );
+            }
+            self.ensure_managed_path(&path)?;
+            if reuse == DeliveryReuse::ExactBase {
+                self.require_clean_exact_base(&path, &base_sha)?;
+            }
+            return Ok(Workspace {
+                kind: WorkspaceKind::Delivery,
+                path,
+                branch: Some(branch),
+                base_branch: base_branch.to_owned(),
+                base_sha,
+                disposition: WorkspaceDisposition::Reused,
+            });
+        }
+
+        self.require_capacity()?;
+        let path = self.workspace_root.join(format!("issue-{issue}"));
+        self.ensure_available_target(&path)?;
+        if self.branch_exists(&branch)? {
+            if reuse == DeliveryReuse::Reject {
+                bail!(
+                    "Factory branch {branch} already exists; inspect or remove it before approving a new task"
+                );
+            }
+            if reuse == DeliveryReuse::ExactBase
+                && self.resolve_commit(&format!("refs/heads/{branch}"))? != base_sha
+            {
+                bail!(
+                    "Factory branch {branch} does not match the reserved base; refusing stale or unowned recovery state"
+                );
+            }
+            // Preserve an owned recovery branch exactly as it is.
+            self.git_os([
+                OsStr::new("worktree"),
+                OsStr::new("add"),
+                path.as_os_str(),
+                OsStr::new(&branch),
+            ])?;
+        } else {
+            self.git_os([
+                OsStr::new("worktree"),
+                OsStr::new("add"),
+                OsStr::new("-b"),
+                OsStr::new(&branch),
+                path.as_os_str(),
+                OsStr::new(&base_sha),
+            ])?;
+        }
+        Ok(Workspace {
+            kind: WorkspaceKind::Delivery,
+            path,
+            branch: Some(branch),
+            base_branch: base_branch.to_owned(),
+            base_sha,
+            disposition: WorkspaceDisposition::Created,
+        })
+    }
+
+    pub fn prepare_proposal(
+        &self,
+        run_id: i64,
+        base_branch: &str,
+        base_sha: &str,
+    ) -> Result<Workspace> {
+        if run_id <= 0 {
+            bail!("run id must be greater than zero");
+        }
+        self.validate_branch(base_branch)?;
+        let base_sha = self.resolve_commit(base_sha)?;
+        self.prune()?;
+        let path = self.workspace_root.join(format!("proposal-{run_id}"));
+        if let Some(existing) = self.registered_worktree(&path)? {
+            self.ensure_managed_path(&existing.path)?;
+            if existing.branch.is_some() {
+                bail!("proposal workspace {} is not detached", path.display());
+            }
+            return Ok(Workspace {
+                kind: WorkspaceKind::Proposal,
+                path: existing.path,
+                branch: None,
+                base_branch: base_branch.to_owned(),
+                base_sha,
+                disposition: WorkspaceDisposition::Reused,
+            });
+        }
+        self.ensure_available_target(&path)?;
+        self.git_os([
+            OsStr::new("worktree"),
+            OsStr::new("add"),
+            OsStr::new("--detach"),
+            path.as_os_str(),
+            OsStr::new(&base_sha),
+        ])?;
+        Ok(Workspace {
+            kind: WorkspaceKind::Proposal,
+            path,
+            branch: None,
+            base_branch: base_branch.to_owned(),
+            base_sha,
+            disposition: WorkspaceDisposition::Created,
+        })
+    }
+
+    pub fn preview_cleanup(&self, path: &Path) -> Result<CleanupPreview> {
+        self.ensure_managed_path(path)?;
+        let registered = self.registered_worktree(path)?.ok_or_else(|| {
+            anyhow::anyhow!("{} is not a registered Git worktree", path.display())
+        })?;
+        let dirty = !self
+            .git_in(&registered.path, ["status", "--porcelain"])?
+            .trim()
+            .is_empty();
+        Ok(CleanupPreview {
+            path: registered.path,
+            branch: registered.branch,
+            dirty,
+        })
+    }
+
+    pub fn cleanup(&self, path: &Path, confirm: bool) -> Result<(CleanupOutcome, CleanupPreview)> {
+        let preview = self.preview_cleanup(path)?;
+        if !confirm {
+            return Ok((CleanupOutcome::Previewed, preview));
+        }
+        if preview.dirty {
+            self.git_os([
+                OsStr::new("worktree"),
+                OsStr::new("remove"),
+                OsStr::new("--force"),
+                preview.path.as_os_str(),
+            ])?;
+        } else {
+            self.git_os([
+                OsStr::new("worktree"),
+                OsStr::new("remove"),
+                preview.path.as_os_str(),
+            ])?;
+        }
+        Ok((CleanupOutcome::Removed, preview))
+    }
+
+    pub fn cleanup_clean(&self, path: &Path) -> Result<CleanupPreview> {
+        let preview = self.preview_cleanup(path)?;
+        if preview.dirty {
+            bail!(
+                "refusing automatic cleanup of dirty delivery workspace {}",
+                preview.path.display()
+            );
+        }
+        self.git_os([
+            OsStr::new("worktree"),
+            OsStr::new("remove"),
+            preview.path.as_os_str(),
+        ])?;
+        Ok(preview)
+    }
+
+    pub fn cleanup_disposable(&self, path: &Path) -> Result<CleanupPreview> {
+        let preview = self.preview_cleanup(path)?;
+        self.git_os([
+            OsStr::new("worktree"),
+            OsStr::new("remove"),
+            OsStr::new("--force"),
+            preview.path.as_os_str(),
+        ])?;
+        Ok(preview)
+    }
+
+    pub fn branch_is_pushed(&self, branch: &str) -> Result<bool> {
+        self.validate_branch(branch)?;
+        let local = self.resolve_commit(&format!("refs/heads/{branch}"))?;
+        let remote_ref = format!("refs/heads/{branch}");
+        let output = self.git(["ls-remote", "--heads", "origin", &remote_ref])?;
+        let remote = output.split_whitespace().next();
+        Ok(remote == Some(local.as_str()))
+    }
+
+    pub fn retained_count(&self) -> Result<usize> {
+        let entries = fs::read_dir(&self.workspace_root)
+            .with_context(|| format!("failed to read {}", self.workspace_root.display()))?;
+        let mut count = 0;
+        for entry in entries {
+            let entry = entry?;
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            let is_delivery = name.strip_prefix("issue-").is_some_and(|issue| {
+                !issue.is_empty() && issue.bytes().all(|byte| byte.is_ascii_digit())
+            });
+            if is_delivery && entry.file_type()?.is_dir() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    fn worktree_for_branch(&self, branch: &str) -> Result<Option<PathBuf>> {
+        let mut found = self
+            .worktrees()?
+            .into_iter()
+            .filter(|item| item.branch.as_deref() == Some(branch));
+        let path = found.next().map(|item| item.path);
+        if found.next().is_some() {
+            bail!("branch {branch} is checked out in multiple worktrees");
+        }
+        Ok(path)
+    }
+
+    fn registered_worktree(&self, path: &Path) -> Result<Option<RegisteredWorktree>> {
+        let path = absolute_lexical(path)?;
+        Ok(self
+            .worktrees()?
+            .into_iter()
+            .find(|item| absolute_lexical(&item.path).is_ok_and(|candidate| candidate == path)))
+    }
+
+    fn worktrees(&self) -> Result<Vec<RegisteredWorktree>> {
+        parse_worktrees(&self.git(["worktree", "list", "--porcelain"])?)
+    }
+
+    fn ensure_managed_path(&self, path: &Path) -> Result<()> {
+        let path = absolute_lexical(path)?;
+        if path == self.repository {
+            bail!("refusing to target canonical checkout {}", path.display());
+        }
+        if path.parent() != Some(self.workspace_root.as_path()) {
+            bail!(
+                "workspace {} is outside managed root {}",
+                path.display(),
+                self.workspace_root.display()
+            );
+        }
+        Ok(())
+    }
+
+    fn ensure_available_target(&self, path: &Path) -> Result<()> {
+        self.ensure_managed_path(path)?;
+        if path.exists() {
+            bail!(
+                "workspace target {} exists but is not reusable; inspect it before cleanup",
+                path.display()
+            );
+        }
+        Ok(())
+    }
+
+    fn require_clean_exact_base(&self, path: &Path, base_sha: &str) -> Result<()> {
+        let head = self.resolve_commit_in(path, "HEAD")?;
+        let dirty = !self
+            .git_in(path, ["status", "--porcelain"])?
+            .trim()
+            .is_empty();
+        if head != base_sha || dirty {
+            bail!(
+                "preparing workspace {} is not a clean checkout of reserved base {}; refusing stale or unowned recovery state",
+                path.display(),
+                base_sha
+            );
+        }
+        Ok(())
+    }
+
+    fn require_capacity(&self) -> Result<()> {
+        let retained = self.retained_count()?;
+        if retained >= MAX_RETAINED_WORKSPACES {
+            bail!(
+                "workspace retention limit reached ({retained}/{MAX_RETAINED_WORKSPACES}); cleanup is required"
+            );
+        }
+        Ok(())
+    }
+
+    fn branch_exists(&self, branch: &str) -> Result<bool> {
+        let status = Command::new("git")
+            .current_dir(&self.repository)
+            .args(["show-ref", "--verify", "--quiet"])
+            .arg(format!("refs/heads/{branch}"))
+            .status()
+            .context("failed to inspect Git branch")?;
+        match status.code() {
+            Some(0) => Ok(true),
+            Some(1) => Ok(false),
+            _ => bail!("git show-ref failed with status {status}"),
+        }
+    }
+
+    fn resolve_commit(&self, sha: &str) -> Result<String> {
+        if sha.trim().is_empty() || sha.starts_with('-') {
+            bail!("base SHA must be a non-empty object name");
+        }
+        let expression = format!("{sha}^{{commit}}");
+        Ok(self
+            .git(["rev-parse", "--verify", &expression])?
+            .trim()
+            .to_owned())
+    }
+
+    fn resolve_commit_in(&self, directory: &Path, sha: &str) -> Result<String> {
+        if sha.trim().is_empty() || sha.starts_with('-') {
+            bail!("commit must be a non-empty object name");
+        }
+        let expression = format!("{sha}^{{commit}}");
+        Ok(self
+            .git_in(directory, ["rev-parse", "--verify", &expression])?
+            .trim()
+            .to_owned())
+    }
+
+    fn validate_branch(&self, branch: &str) -> Result<()> {
+        if branch.trim().is_empty() || branch.starts_with('-') {
+            bail!("base branch is invalid");
+        }
+        self.git(["check-ref-format", "--branch", branch])
+            .with_context(|| format!("invalid base branch {branch}"))?;
+        Ok(())
+    }
+
+    fn prune(&self) -> Result<()> {
+        self.git(["worktree", "prune"])?;
+        Ok(())
+    }
+
+    fn git<const N: usize>(&self, args: [&str; N]) -> Result<String> {
+        self.git_os(args.map(OsStr::new))
+    }
+
+    fn git_os<I, S>(&self, args: I) -> Result<String>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        git_output(&self.repository, args)
+    }
+
+    fn git_in<const N: usize>(&self, directory: &Path, args: [&str; N]) -> Result<String> {
+        git_output(directory, args.map(OsStr::new))
+    }
+}
+
+#[derive(Debug)]
+struct RegisteredWorktree {
+    path: PathBuf,
+    branch: Option<String>,
+}
+
+fn parse_worktrees(output: &str) -> Result<Vec<RegisteredWorktree>> {
+    let mut result = Vec::new();
+    let mut path = None;
+    let mut branch = None;
+    for line in output.lines().chain(std::iter::once("")) {
+        if line.is_empty() {
+            if let Some(path) = path.take() {
+                result.push(RegisteredWorktree {
+                    path,
+                    branch: branch.take(),
+                });
+            }
+        } else if let Some(value) = line.strip_prefix("worktree ") {
+            path = Some(PathBuf::from(value));
+        } else if let Some(value) = line.strip_prefix("branch refs/heads/") {
+            branch = Some(value.to_owned());
+        }
+    }
+    if result.is_empty() {
+        bail!("Git reported no worktrees");
+    }
+    Ok(result)
+}
+
+fn canonical_directory(name: &str, path: &Path) -> Result<PathBuf> {
+    if !path.is_absolute() || !path.is_dir() {
+        bail!(
+            "{name} must be an existing absolute directory: {}",
+            path.display()
+        );
+    }
+    path.canonicalize()
+        .with_context(|| format!("failed to canonicalize {name} {}", path.display()))
+}
+
+fn absolute_lexical(path: &Path) -> Result<PathBuf> {
+    if !path.is_absolute() {
+        bail!("workspace path must be absolute: {}", path.display());
+    }
+    if path
+        .components()
+        .any(|part| matches!(part, std::path::Component::ParentDir))
+    {
+        bail!("workspace path must not contain '..': {}", path.display());
+    }
+    Ok(path.to_owned())
+}
+
+fn slug(title: &str) -> String {
+    let mut result = String::new();
+    let mut separator = false;
+    for character in title.chars() {
+        if character.is_ascii_alphanumeric() {
+            if separator && !result.is_empty() && result.len() < 48 {
+                result.push('-');
+            }
+            separator = false;
+            if result.len() < 48 {
+                result.push(character.to_ascii_lowercase());
+            }
+        } else {
+            separator = true;
+        }
+    }
+    while result.ends_with('-') {
+        result.pop();
+    }
+    if result.is_empty() {
+        "task".to_owned()
+    } else {
+        result
+    }
+}
+
+fn git_output<I, S>(directory: &Path, args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let args = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_owned())
+        .collect::<Vec<OsString>>();
+    let output = Command::new("git")
+        .current_dir(directory)
+        .args(&args)
+        .output()
+        .with_context(|| format!("failed to run git in {}", directory.display()))?;
+    if !output.status.success() {
+        let command = args
+            .iter()
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        bail!(
+            "git {command} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    String::from_utf8(output.stdout).context("Git returned non-UTF-8 output")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    struct Fixture {
+        _temp: TempDir,
+        repository: PathBuf,
+        root: PathBuf,
+        head: String,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let temp = tempfile::tempdir().unwrap();
+            let repository = temp.path().join("repo");
+            let root = temp.path().join("workspaces");
+            fs::create_dir(&repository).unwrap();
+            fs::create_dir(&root).unwrap();
+            run(&repository, ["init", "-b", "main"]);
+            run(&repository, ["config", "user.email", "factory@example.com"]);
+            run(&repository, ["config", "user.name", "Factory"]);
+            fs::write(repository.join("README.md"), "factory\n").unwrap();
+            run(&repository, ["add", "README.md"]);
+            run(&repository, ["commit", "-m", "initial"]);
+            let head = run(&repository, ["rev-parse", "HEAD"]).trim().to_owned();
+            let remote = temp.path().join("origin.git");
+            let output = Command::new("git")
+                .current_dir(temp.path())
+                .args(["clone", "--bare"])
+                .arg(&repository)
+                .arg(&remote)
+                .output()
+                .unwrap();
+            assert!(output.status.success());
+            run(
+                &repository,
+                ["remote", "add", "origin", remote.to_str().unwrap()],
+            );
+            Self {
+                _temp: temp,
+                repository: repository.canonicalize().unwrap(),
+                root: root.canonicalize().unwrap(),
+                head,
+            }
+        }
+
+        fn manager(&self) -> WorkspaceManager {
+            WorkspaceManager::new(&self.repository, &self.root).unwrap()
+        }
+    }
+
+    #[test]
+    fn delivery_uses_sha_and_reuses_stable_issue_branch() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        let created = manager
+            .prepare_delivery(
+                39,
+                "Own worktrees safely!",
+                "main",
+                &fixture.head,
+                DeliveryReuse::Reject,
+            )
+            .unwrap();
+        assert_eq!(
+            created.branch.as_deref(),
+            Some("factory/39-own-worktrees-safely")
+        );
+        assert_eq!(
+            run(&created.path, ["rev-parse", "HEAD"]).trim(),
+            fixture.head
+        );
+        let reused = manager
+            .prepare_delivery(
+                39,
+                "Own worktrees safely!",
+                "main",
+                &fixture.head,
+                DeliveryReuse::Owned,
+            )
+            .unwrap();
+        assert_eq!(reused.path, created.path);
+        assert_eq!(reused.branch, created.branch);
+        assert_eq!(reused.disposition, WorkspaceDisposition::Reused);
+    }
+
+    #[test]
+    fn preparing_recovery_only_adopts_a_clean_exact_base() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        let workspace = manager
+            .prepare_delivery(
+                41,
+                "Crash before ready",
+                "main",
+                &fixture.head,
+                DeliveryReuse::Reject,
+            )
+            .unwrap();
+        assert_eq!(
+            manager
+                .prepare_delivery(
+                    41,
+                    "Crash before ready",
+                    "main",
+                    &fixture.head,
+                    DeliveryReuse::ExactBase,
+                )
+                .unwrap()
+                .path,
+            workspace.path
+        );
+        fs::write(workspace.path.join("unexpected.txt"), "unowned\n").unwrap();
+        assert!(
+            manager
+                .prepare_delivery(
+                    41,
+                    "Crash before ready",
+                    "main",
+                    &fixture.head,
+                    DeliveryReuse::ExactBase,
+                )
+                .unwrap_err()
+                .to_string()
+                .contains("not a clean checkout")
+        );
+    }
+
+    #[test]
+    fn fetch_default_branch_returns_exact_remote_commit() {
+        let fixture = Fixture::new();
+        assert_eq!(
+            fixture.manager().fetch_default_branch("main").unwrap(),
+            fixture.head
+        );
+    }
+
+    #[test]
+    fn delivery_ignores_operator_branch_and_stale_origin_head() {
+        let fixture = Fixture::new();
+        run(&fixture.repository, ["checkout", "-b", "operator-work"]);
+        fs::write(fixture.repository.join("operator.txt"), "local\n").unwrap();
+        run(&fixture.repository, ["add", "operator.txt"]);
+        run(&fixture.repository, ["commit", "-m", "operator work"]);
+        run(
+            &fixture.repository,
+            [
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/not-the-default",
+            ],
+        );
+        let manager = fixture.manager();
+        let fetched = manager.fetch_default_branch("main").unwrap();
+        let workspace = manager
+            .prepare_delivery(
+                40,
+                "Use remote default",
+                "main",
+                &fetched,
+                DeliveryReuse::Reject,
+            )
+            .unwrap();
+
+        assert_eq!(fetched, fixture.head);
+        assert_eq!(
+            run(&workspace.path, ["rev-parse", "HEAD"]).trim(),
+            fixture.head
+        );
+        assert_eq!(
+            run(&fixture.repository, ["branch", "--show-current"]).trim(),
+            "operator-work"
+        );
+        assert!(fixture.repository.join("operator.txt").exists());
+        assert!(!workspace.path.join("operator.txt").exists());
+    }
+
+    #[test]
+    fn dirty_cleanup_requires_confirmation() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        let workspace = manager
+            .prepare_delivery(
+                7,
+                "Keep changes",
+                "main",
+                &fixture.head,
+                DeliveryReuse::Reject,
+            )
+            .unwrap();
+        fs::write(workspace.path.join("new.txt"), "unpublished\n").unwrap();
+        let (outcome, preview) = manager.cleanup(&workspace.path, false).unwrap();
+        assert_eq!(outcome, CleanupOutcome::Previewed);
+        assert!(preview.dirty);
+        assert_eq!(
+            manager.cleanup(&workspace.path, true).unwrap().0,
+            CleanupOutcome::Removed
+        );
+        assert!(!workspace.path.exists());
+    }
+
+    #[test]
+    fn confirmed_cleanup_removes_clean_worktree_and_preserves_branch() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        let workspace = manager
+            .prepare_delivery(8, "Clean", "main", &fixture.head, DeliveryReuse::Reject)
+            .unwrap();
+        let branch = workspace.branch.clone().unwrap();
+        assert_eq!(
+            manager.cleanup(&workspace.path, true).unwrap().0,
+            CleanupOutcome::Removed
+        );
+        assert!(!workspace.path.exists());
+        assert!(manager.branch_exists(&branch).unwrap());
+    }
+
+    #[test]
+    fn new_task_cannot_adopt_a_preserved_branch_from_an_older_task() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        let first = manager
+            .prepare_delivery(
+                9,
+                "Stable task",
+                "main",
+                &fixture.head,
+                DeliveryReuse::Reject,
+            )
+            .unwrap();
+        manager.cleanup(&first.path, true).unwrap();
+        fs::write(fixture.repository.join("new-base.txt"), "new\n").unwrap();
+        run(&fixture.repository, ["add", "new-base.txt"]);
+        run(&fixture.repository, ["commit", "-m", "new default base"]);
+        run(&fixture.repository, ["push", "origin", "main"]);
+        let new_base = manager.fetch_default_branch("main").unwrap();
+
+        let error = manager
+            .prepare_delivery(9, "Stable task", "main", &new_base, DeliveryReuse::Reject)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("already exists"));
+        assert_ne!(new_base, fixture.head);
+        assert!(!first.path.exists());
+    }
+
+    #[test]
+    fn canonical_checkout_is_never_a_cleanup_target() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        assert!(manager.preview_cleanup(&fixture.repository).is_err());
+        assert!(fixture.repository.exists());
+    }
+
+    #[test]
+    fn retention_limit_blocks_new_but_allows_reuse() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        let existing = manager
+            .prepare_delivery(1, "Existing", "main", &fixture.head, DeliveryReuse::Reject)
+            .unwrap();
+        for index in 1..MAX_RETAINED_WORKSPACES {
+            fs::create_dir(fixture.root.join(format!("issue-{}", index + 10))).unwrap();
+        }
+        assert!(
+            manager
+                .prepare_delivery(2, "Blocked", "main", &fixture.head, DeliveryReuse::Reject,)
+                .is_err()
+        );
+        assert_eq!(
+            manager
+                .prepare_delivery(1, "Existing", "main", &fixture.head, DeliveryReuse::Owned,)
+                .unwrap()
+                .path,
+            existing.path
+        );
+        let proposal = manager.prepare_proposal(99, "main", &fixture.head).unwrap();
+        assert_eq!(proposal.kind, WorkspaceKind::Proposal);
+        manager.cleanup_disposable(&proposal.path).unwrap();
+    }
+
+    #[test]
+    fn proposal_is_detached_and_removable() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        let workspace = manager.prepare_proposal(91, "main", &fixture.head).unwrap();
+        assert_eq!(
+            run(&workspace.path, ["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
+            "HEAD"
+        );
+        manager.cleanup(&workspace.path, true).unwrap();
+        assert!(!workspace.path.exists());
+    }
+
+    fn run<const N: usize>(directory: &Path, args: [&str; N]) -> String {
+        let output = Command::new("git")
+            .current_dir(directory)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap()
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -191,6 +191,7 @@ impl WorkspaceManager {
         run_id: i64,
         base_branch: &str,
         base_sha: &str,
+        reuse: DeliveryReuse,
     ) -> Result<Workspace> {
         if run_id <= 0 {
             bail!("run id must be greater than zero");
@@ -200,9 +201,18 @@ impl WorkspaceManager {
         self.prune()?;
         let path = self.workspace_root.join(format!("proposal-{run_id}"));
         if let Some(existing) = self.registered_worktree(&path)? {
+            if reuse == DeliveryReuse::Reject {
+                bail!(
+                    "proposal workspace {} already exists; a new task cannot adopt prior or unowned Git state",
+                    path.display()
+                );
+            }
             self.ensure_managed_path(&existing.path)?;
             if existing.branch.is_some() {
                 bail!("proposal workspace {} is not detached", path.display());
+            }
+            if reuse == DeliveryReuse::ExactBase {
+                self.require_clean_exact_base(&existing.path, &base_sha)?;
             }
             return Ok(Workspace {
                 kind: WorkspaceKind::Proposal,
@@ -851,7 +861,9 @@ mod tests {
                 .path,
             existing.path
         );
-        let proposal = manager.prepare_proposal(99, "main", &fixture.head).unwrap();
+        let proposal = manager
+            .prepare_proposal(99, "main", &fixture.head, DeliveryReuse::Reject)
+            .unwrap();
         assert_eq!(proposal.kind, WorkspaceKind::Proposal);
         manager.cleanup_disposable(&proposal.path).unwrap();
     }
@@ -860,13 +872,38 @@ mod tests {
     fn proposal_is_detached_and_removable() {
         let fixture = Fixture::new();
         let manager = fixture.manager();
-        let workspace = manager.prepare_proposal(91, "main", &fixture.head).unwrap();
+        let workspace = manager
+            .prepare_proposal(91, "main", &fixture.head, DeliveryReuse::Reject)
+            .unwrap();
         assert_eq!(
             run(&workspace.path, ["rev-parse", "--abbrev-ref", "HEAD"]).trim(),
             "HEAD"
         );
         manager.cleanup(&workspace.path, true).unwrap();
         assert!(!workspace.path.exists());
+    }
+
+    #[test]
+    fn preparing_proposal_recovery_requires_a_clean_exact_base() {
+        let fixture = Fixture::new();
+        let manager = fixture.manager();
+        let workspace = manager
+            .prepare_proposal(92, "main", &fixture.head, DeliveryReuse::Reject)
+            .unwrap();
+        fs::write(workspace.path.join("unexpected.txt"), "stale state\n").unwrap();
+
+        let error = manager
+            .prepare_proposal(92, "main", &fixture.head, DeliveryReuse::ExactBase)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("not a clean checkout"));
+        assert_eq!(
+            manager
+                .prepare_proposal(92, "main", &fixture.head, DeliveryReuse::Owned)
+                .unwrap()
+                .path,
+            workspace.path
+        );
     }
 
     fn run<const N: usize>(directory: &Path, args: [&str; N]) -> String {

--- a/tests/cleanup_cli.rs
+++ b/tests/cleanup_cli.rs
@@ -148,20 +148,35 @@ fn cleanup_previews_then_removes_a_retained_worktree_and_preserves_its_branch() 
         "cleaned"
     );
 
-    let mut absent_preview =
-        cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
-    absent_preview.assert().success().stdout(
-        predicate::str::contains("workspace exists: false").and(predicate::str::contains(
-            "release the workspace reservation",
-        )),
+    git(
+        &repository,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "factory/7-new-revision",
+            prepared.path.to_str().unwrap(),
+            &base_sha,
+        ],
     );
-    let mut absent_confirm =
+    let mut old_run_preview =
         cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
-    absent_confirm
+    old_run_preview
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already cleaned; no changes made"));
+    let mut old_run_confirm =
+        cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
+    old_run_confirm
         .arg("--confirm")
         .assert()
         .success()
-        .stdout(predicate::str::contains("released workspace reservation"));
+        .stdout(predicate::str::contains("already cleaned; no changes made"));
+    assert!(prepared.path.exists());
+    assert_eq!(
+        run_git(&prepared.path, &["branch", "--show-current"]),
+        "factory/7-new-revision"
+    );
 }
 
 fn cleanup_command(
@@ -198,4 +213,14 @@ fn git(directory: &Path, arguments: &[&str]) {
         arguments.join(" "),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn run_git(directory: &Path, arguments: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(directory)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap().trim().to_owned()
 }

--- a/tests/cleanup_cli.rs
+++ b/tests/cleanup_cli.rs
@@ -1,0 +1,201 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use assert_cmd::Command as AssertCommand;
+use factory::storage::{Ledger, RunOutcome, TaskIdentity, TaskWorkspace};
+use factory::workspace::{DeliveryReuse, WorkspaceManager};
+use predicates::prelude::*;
+
+#[test]
+fn cleanup_previews_then_removes_a_retained_worktree_and_preserves_its_branch() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let remote = temp.path().join("origin.git");
+    let data_home = temp.path().join("factory-data");
+    let ledger_directory = temp.path().join("ledger");
+    fs::create_dir(&repository).unwrap();
+    git(&repository, &["init", "-b", "main"]);
+    git(
+        &repository,
+        &["config", "user.email", "factory@example.test"],
+    );
+    git(&repository, &["config", "user.name", "Factory Test"]);
+    fs::write(repository.join("README.md"), "fixture\n").unwrap();
+    git(&repository, &["add", "README.md"]);
+    git(&repository, &["commit", "-m", "fixture"]);
+    git(temp.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    let github_remote = "git@github.com:example/cleanup-fixture.git";
+    git(&repository, &["remote", "add", "origin", github_remote]);
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", &data_home)
+        .arg("init")
+        .assert()
+        .success();
+
+    let rewrite = format!("url.file://{}.insteadOf", remote.display());
+    git(&repository, &["config", &rewrite, github_remote]);
+    git(&repository, &["push", "-u", "origin", "main"]);
+    let repository = repository.canonicalize().unwrap();
+    let state_directory = fs::read_dir(&data_home)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let workspace_root = state_directory.join("worktrees").canonicalize().unwrap();
+    let manager = WorkspaceManager::new(&repository, &workspace_root).unwrap();
+    let base_sha = manager.fetch_default_branch("main").unwrap();
+
+    let mut ledger = Ledger::open_in(&ledger_directory).unwrap();
+    let task = ledger
+        .enqueue(
+            &TaskIdentity::ticket(
+                "example/cleanup-fixture",
+                "implement-ready-ticket",
+                "7",
+                "approved-revision",
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .task;
+    let claimed = ledger.claim_next().unwrap().unwrap();
+    assert_eq!(claimed.id, task.id);
+    let run = ledger.start_run(task.id, "codex").unwrap();
+    let prepared = manager
+        .prepare_delivery(
+            7,
+            "Retain this work",
+            "main",
+            &base_sha,
+            DeliveryReuse::Reject,
+        )
+        .unwrap();
+    ledger
+        .reserve_task_workspace(&TaskWorkspace {
+            task_id: task.id,
+            kind: "delivery".into(),
+            repository: task.repository.clone(),
+            base_branch: "main".into(),
+            base_sha: base_sha.clone(),
+            factory_branch: prepared.branch.clone(),
+            path: prepared.path.clone(),
+            state: "preparing".into(),
+            status_summary: None,
+            created_at: 0,
+            updated_at: 0,
+            cleaned_at: None,
+        })
+        .unwrap();
+    ledger
+        .record_run_workspace(
+            run.id,
+            &prepared.path,
+            "main",
+            &base_sha,
+            prepared.branch.as_deref(),
+            "delivery",
+        )
+        .unwrap();
+    ledger
+        .update_task_workspace_state(task.id, "retained", Some("test fixture"))
+        .unwrap();
+    ledger
+        .finish_run_and_task_terminal(
+            run.id,
+            RunOutcome::Failed,
+            None,
+            Some("retained for cleanup"),
+            None,
+        )
+        .unwrap();
+    drop(ledger);
+
+    let config = repository.join(".factory/config.toml");
+    let run_id = run.id.to_string();
+    let mut preview = cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
+    preview.assert().success().stdout(
+        predicate::str::contains("action: preview only")
+            .and(predicate::str::contains("branch preserved: true")),
+    );
+    assert!(prepared.path.exists());
+
+    let mut confirm = cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
+    confirm
+        .arg("--confirm")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("action: removed worktree"));
+    assert!(!prepared.path.exists());
+    let branch = prepared.branch.unwrap();
+    git(
+        &repository,
+        &["show-ref", "--verify", &format!("refs/heads/{branch}")],
+    );
+    assert_eq!(
+        Ledger::open_in(&ledger_directory)
+            .unwrap()
+            .task_workspace(task.id)
+            .unwrap()
+            .unwrap()
+            .state,
+        "cleaned"
+    );
+
+    let mut absent_preview =
+        cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
+    absent_preview.assert().success().stdout(
+        predicate::str::contains("workspace exists: false").and(predicate::str::contains(
+            "release the workspace reservation",
+        )),
+    );
+    let mut absent_confirm =
+        cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
+    absent_confirm
+        .arg("--confirm")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("released workspace reservation"));
+}
+
+fn cleanup_command(
+    repository: &Path,
+    data_home: &Path,
+    config: &Path,
+    ledger_directory: &Path,
+    run_id: &str,
+) -> AssertCommand {
+    let mut command = AssertCommand::cargo_bin("factory").unwrap();
+    command
+        .current_dir(repository)
+        .env("FACTORY_DATA_HOME", data_home)
+        .args([
+            "cleanup",
+            run_id,
+            "--config",
+            config.to_str().unwrap(),
+            "--data-directory",
+            ledger_directory.to_str().unwrap(),
+        ]);
+    command
+}
+
+fn git(directory: &Path, arguments: &[&str]) {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(directory)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        arguments.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -37,31 +37,57 @@ impl Fixture {
         let temp = tempfile::tempdir().unwrap();
         let runtime_dir = temp.path().join("runtime");
         fs::create_dir(&runtime_dir).unwrap();
+        let data_home = temp.path().join("factory-data");
         let mut repositories = Vec::new();
         for (index, issues) in issue_pages.iter().enumerate() {
             let repository = temp.path().join(format!("repo-{index}"));
             fs::create_dir_all(repository.join(".factory/workflows")).unwrap();
             assert!(
                 Command::new("git")
-                    .args(["init", "--quiet"])
+                    .args(["init", "--quiet", "-b", "main"])
                     .current_dir(&repository)
                     .status()
                     .unwrap()
                     .success()
             );
+            git(
+                &repository,
+                &["config", "user.email", "factory@example.test"],
+            );
+            git(&repository, &["config", "user.name", "Factory Tests"]);
+            fs::write(repository.join("README.md"), "fixture\n").unwrap();
+            git(&repository, &["add", "README.md"]);
+            git(&repository, &["commit", "-m", "fixture base"]);
+            let remote = temp.path().join(format!("remote-{index}.git"));
             assert!(
                 Command::new("git")
-                    .args([
-                        "remote",
-                        "add",
-                        "origin",
-                        &format!("git@github.com:example/repo-{index}.git")
-                    ])
+                    .args(["init", "--quiet", "--bare"])
+                    .arg(&remote)
+                    .status()
+                    .unwrap()
+                    .success()
+            );
+            let github_remote = format!("git@github.com:example/repo-{index}.git");
+            assert!(
+                Command::new("git")
+                    .args(["remote", "add", "origin", &github_remote])
                     .current_dir(&repository)
                     .status()
                     .unwrap()
                     .success()
             );
+            if index == 0 {
+                AssertCommand::cargo_bin("factory")
+                    .unwrap()
+                    .current_dir(&repository)
+                    .env("FACTORY_DATA_HOME", &data_home)
+                    .arg("init")
+                    .assert()
+                    .success();
+            }
+            let rewrite = format!("url.file://{}.insteadOf", remote.display());
+            git(&repository, &["config", &rewrite, &github_remote]);
+            git(&repository, &["push", "-u", "origin", "main"]);
             fs::write(
                 repository.join(".factory/workflows/implement-ready-ticket.md"),
                 "+++\nlabel = \"factory:ready\"\nruntime = \"codex\"\ntimeout = \"10s\"\n+++\n\nCUSTOM WORKFLOW: deliver a green draft PR and never merge it.\n",
@@ -81,15 +107,7 @@ impl Fixture {
         }
         let workspace = temp.path().join("worktrees");
         fs::create_dir(&workspace).unwrap();
-        let data_home = temp.path().join("factory-data");
         let config_path = repositories[0].join(".factory/config.toml");
-        AssertCommand::cargo_bin("factory")
-            .unwrap()
-            .current_dir(&repositories[0])
-            .env("FACTORY_DATA_HOME", &data_home)
-            .arg("init")
-            .assert()
-            .success();
         fs::write(
             &config_path,
             format!(
@@ -193,7 +211,10 @@ if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
   if [ -f "$0.auth-fail" ]; then echo "authentication expired" >&2; exit 1; fi
   echo "logged in"; exit 0
 fi
-if [ "$1" = "repo" ]; then cat .gh-name; exit 0; fi
+if [ "$1" = "repo" ]; then
+  case "$*" in *defaultBranchRef*) printf 'main\n' ;; *) cat .gh-name ;; esac
+  exit 0
+fi
 if [ "$1" = "issue" ] && [ "$2" = "edit" ]; then
   touch ".ready-removed-$3"
   exit 0
@@ -210,6 +231,7 @@ if [ "$1" = "api" ]; then
   fi
   case "$endpoint" in
     user|users/*) printf '{"id":42,"login":"owainlewis"}' ;;
+    repos/example/repo-[0-9]) printf '{"default_branch":"main"}' ;;
     */timeline*)
       number=$(printf '%s' "$endpoint" | sed -E 's#^.*/issues/([0-9]+)/timeline.*#\1#')
       cat ".timeline-$number.json"
@@ -448,6 +470,20 @@ fn write_executable(path: &Path, contents: &str) {
     fs::set_permissions(path, permissions).unwrap();
 }
 
+fn git(repository: &Path, arguments: &[&str]) {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(repository)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        arguments.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 async fn wait_for<F>(mut condition: F)
 where
     F: FnMut() -> bool,
@@ -567,8 +603,10 @@ async fn daemon_discovers_repository_from_nested_directory_and_restarts_cleanly(
             .spawn()
             .unwrap();
         wait_for(|| {
-            fs::read_to_string(&stderr_path)
-                .is_ok_and(|output| output.contains("Factory ready: watching 1 repositories"))
+            fs::read_to_string(&stderr_path).is_ok_and(|output| {
+                assert!(!output.contains("Error:"), "daemon failed:\n{output}");
+                output.contains("Factory ready: watching 1 repositories")
+            })
         })
         .await;
         interrupt(&child);
@@ -607,10 +645,8 @@ async fn cli_reports_ticket_and_runtime_lifecycle() {
     assert!(output.contains(
         "Factory task claimed: task=1 issue=#42 repository=example/repo-0 workflow=implement-ready-ticket run=1"
     ));
-    assert!(output.contains(&format!(
-        "Factory runtime delegated: run=1 runtime=codex cwd={} worktree=workflow-managed",
-        fixture.config.repositories[0].display()
-    )));
+    assert!(output.contains("Factory runtime delegated: run=1 runtime=codex cwd="));
+    assert!(output.contains("worktrees/issue-42 worktree=factory-owned"));
     assert!(output.contains("Factory run finished: run=1 outcome=succeeded duration="));
     assert!(!output.contains("Factory poll failed"));
 }
@@ -688,6 +724,25 @@ async fn discovers_claims_and_records_a_complete_codex_run() {
     assert_eq!(runs[0].outcome, "succeeded");
     assert_eq!(runs[0].session_id.as_deref(), Some("thread-1"));
     assert!(runs[0].result.as_deref().unwrap().contains("Draft PR"));
+    assert_eq!(runs[0].base_branch.as_deref(), Some("main"));
+    assert_eq!(
+        runs[0].factory_branch.as_deref(),
+        Some("factory/6-ticket-6")
+    );
+    assert_eq!(runs[0].workspace_kind.as_deref(), Some("delivery"));
+    assert_ne!(
+        runs[0].working_directory.as_deref(),
+        Some(fixture.config.repositories[0].to_str().unwrap())
+    );
+    assert_eq!(
+        Command::new("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&fixture.config.repositories[0])
+            .output()
+            .unwrap()
+            .stdout,
+        b"main\n"
+    );
     let prompt = fs::read_to_string(fixture.started_slots()[0].join("prompt")).unwrap();
     for expected in [
         "Factory-created software pull requests must remain for human merge",
@@ -1537,6 +1592,7 @@ async fn scheduled_tasks_use_the_same_worker_and_run_history() {
                 .success()
         );
     }
+    git(repository, &["push", "origin", "main"]);
     let inspected_commit = String::from_utf8(
         Command::new("git")
             .args(["rev-parse", "HEAD"])
@@ -1582,7 +1638,12 @@ async fn scheduled_tasks_use_the_same_worker_and_run_history() {
     let tasks = ledger.tasks().unwrap();
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks[0].state, TaskState::Succeeded);
-    assert_eq!(ledger.runs_for_task(tasks[0].id).unwrap().len(), 1);
+    let runs = ledger.runs_for_task(tasks[0].id).unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0].workspace_kind.as_deref(), Some("proposal"));
+    let workspace = ledger.task_workspace(tasks[0].id).unwrap().unwrap();
+    assert_eq!(workspace.state, "cleaned");
+    assert!(!workspace.path.exists());
     let prompt = fs::read_to_string(fixture.started_slots()[0].join("prompt")).unwrap();
     assert!(prompt.contains("Scheduled occurrence: 2026-07-18T12:00:00Z"));
     assert!(prompt.contains("You may use the authenticated gh CLI"));

--- a/tests/inspection_cli.rs
+++ b/tests/inspection_cli.rs
@@ -177,8 +177,11 @@ fn runs_filters_by_workflow_and_includes_bounded_summaries() {
     assert_eq!(
         keys,
         [
+            "base_branch",
+            "base_sha",
             "cancellation_requested_at",
             "duration_ms",
+            "factory_branch",
             "finished_at",
             "id",
             "last_activity_at",
@@ -198,6 +201,7 @@ fn runs_filters_by_workflow_and_includes_bounded_summaries() {
             "task_id",
             "workflow",
             "working_directory",
+            "workspace_kind",
         ]
     );
 }

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 
 use factory::storage::{
     ApprovalEvidence, CancellationRequest, Ledger, MAX_ERROR_BYTES, MAX_RESULT_BYTES,
-    ObservedTicket, RunOutcome, TaskIdentity, TaskState,
+    ObservedTicket, RunOutcome, TaskIdentity, TaskState, TaskWorkspace,
 };
 use rusqlite::Connection;
 
@@ -77,7 +77,7 @@ fn concurrent_first_open_converges_on_one_complete_schema() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 6);
+    assert_eq!(version, 7);
     let schedule_tables: i64 = connection
         .query_row(
             "SELECT COUNT(*) FROM sqlite_schema
@@ -87,6 +87,15 @@ fn concurrent_first_open_converges_on_one_complete_schema() {
         )
         .unwrap();
     assert_eq!(schedule_tables, 2);
+    let workspace_tables: i64 = connection
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_schema
+             WHERE type = 'table' AND name = 'task_workspaces'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(workspace_tables, 1);
 }
 
 #[test]
@@ -110,6 +119,111 @@ fn ticket_and_schedule_identities_deduplicate_exact_triggers() {
     assert!(first_schedule.created);
     assert!(!duplicate_schedule.created);
     assert_eq!(duplicate_schedule.task.id, first_schedule.task.id);
+}
+
+#[test]
+fn workspace_reservation_is_task_stable_and_rejects_reassignment() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    let task = ledger.enqueue(&ticket("workspace-owner")).unwrap().task;
+    let workspace = TaskWorkspace {
+        task_id: task.id,
+        kind: "delivery".into(),
+        repository: task.repository.clone(),
+        base_branch: "main".into(),
+        base_sha: "0123456789012345678901234567890123456789".into(),
+        factory_branch: Some("factory/3-own-workspace".into()),
+        path: temp.path().join("worktrees/issue-3"),
+        state: "preparing".into(),
+        status_summary: None,
+        created_at: 0,
+        updated_at: 0,
+        cleaned_at: None,
+    };
+
+    let reserved = ledger.reserve_task_workspace(&workspace).unwrap();
+    let repeated = ledger.reserve_task_workspace(&workspace).unwrap();
+    assert_eq!(reserved, repeated);
+    let mut conflicting = workspace;
+    conflicting.path = temp.path().join("worktrees/other");
+    assert!(
+        ledger
+            .reserve_task_workspace(&conflicting)
+            .unwrap_err()
+            .to_string()
+            .contains("different workspace")
+    );
+}
+
+#[test]
+fn delivery_workspace_reservations_are_bounded_to_ten_active_slots() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    let mut task_ids = Vec::new();
+    for number in 1..=11 {
+        let task = ledger
+            .enqueue(
+                &TaskIdentity::ticket(
+                    "owainlewis/factory",
+                    "implement-ready-ticket",
+                    number.to_string(),
+                    format!("approval-{number}"),
+                )
+                .unwrap(),
+            )
+            .unwrap()
+            .task;
+        task_ids.push(task.id);
+        let workspace = TaskWorkspace {
+            task_id: task.id,
+            kind: "delivery".into(),
+            repository: task.repository,
+            base_branch: "main".into(),
+            base_sha: "0123456789012345678901234567890123456789".into(),
+            factory_branch: Some(format!("factory/{number}-task")),
+            path: temp.path().join(format!("worktrees/issue-{number}")),
+            state: "preparing".into(),
+            status_summary: None,
+            created_at: 0,
+            updated_at: 0,
+            cleaned_at: None,
+        };
+        if number <= 10 {
+            ledger.reserve_task_workspace(&workspace).unwrap();
+        } else {
+            assert!(
+                ledger
+                    .reserve_task_workspace(&workspace)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("at most ten")
+            );
+            ledger
+                .update_task_workspace_state(task_ids[0], "cleaned", Some("released"))
+                .unwrap();
+            ledger.reserve_task_workspace(&workspace).unwrap();
+        }
+    }
+    assert_eq!(ledger.retained_delivery_workspace_count().unwrap(), 10);
+    ledger
+        .register_daemon_owner("workspace-cap-owner", std::process::id())
+        .unwrap();
+    let workdirs = HashMap::from([(
+        "owainlewis/factory".to_owned(),
+        "/canonical/repository".to_owned(),
+    )]);
+    let claimed = ledger
+        .claim_and_start_run_with_workdirs_filtered(
+            &["owainlewis/factory".to_owned()],
+            &ticket_runtimes(),
+            "workspace-cap-owner",
+            std::process::id(),
+            &workdirs,
+            false,
+        )
+        .unwrap()
+        .unwrap();
+    assert_eq!(claimed.task.id, task_ids[1]);
 }
 
 #[test]
@@ -868,7 +982,7 @@ fn migrates_a_version_one_ledger_without_losing_tasks() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 6);
+    assert_eq!(version, 7);
 }
 
 #[test]


### PR DESCRIPTION
Closes #39

## Summary
- create stable Factory-owned delivery branches and isolated worktrees before delegating to Codex
- persist workspace identity and reconcile interrupted runs, cleanup, proposals, and terminal reservations
- retain unsafe delivery worktrees with a ten-workspace cap and add `factory cleanup <run-id> [--confirm]`
- preserve the canonical checkout and update workflow guidance and operations documentation

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- `cargo test --test cleanup_cli`
- `git diff --check`
- independent diff review: approved with no important findings