### PR TITLE
feat: run project tasks in Docker sandboxes

### DIFF
--- a/.factory/Dockerfile
+++ b/.factory/Dockerfile
@@ -1,0 +1,32 @@
+FROM rust:1.88-bookworm
+
+ARG CODEX_VERSION=0.145.0
+ARG GH_VERSION=2.94.0
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        nodejs \
+        npm \
+        openssh-client \
+        pkg-config \
+        libssl-dev \
+    && npm install --global "@openai/codex@${CODEX_VERSION}" \
+    && architecture="$(dpkg --print-architecture)" \
+    && case "$architecture" in amd64) gh_architecture=amd64 ;; arm64) gh_architecture=arm64 ;; *) exit 1 ;; esac \
+    && curl --fail --silent --show-error --location \
+        "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${gh_architecture}.tar.gz" \
+        --output /tmp/gh.tar.gz \
+    && tar --extract --gzip --file /tmp/gh.tar.gz --directory /tmp \
+    && install "/tmp/gh_${GH_VERSION}_linux_${gh_architecture}/bin/gh" /usr/local/bin/gh \
+    && find /usr/local/cargo/bin -maxdepth 1 \( -type f -o -type l \) \
+        -exec ln -s {} /usr/local/bin/ \; \
+    && rm -rf /var/lib/apt/lists/* /root/.npm /tmp/gh.tar.gz /tmp/gh_*
+
+RUN groupadd --gid 1000 agent \
+    && useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash agent
+
+USER 1000:1000
+WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -1,31 +1,48 @@
 # Factory
 
-Factory is a local-first daemon that turns trusted GitHub issues and scheduled
-prompts into supervised Codex runs. Factory owns durable scheduling, task
-claims, concurrency, Factory-created branches and worktrees, process
-supervision, inspection, cancellation, cleanup, and recovery. Codex owns the
-adaptive development procedure inside the supplied worktree and leaves
-software pull requests for human merge.
+Factory is a local-first daemon that turns trusted GitHub Project items into
+supervised Codex runs. Factory owns polling, durable claims, concurrency,
+Docker isolation, inspection, cancellation, cleanup, and recovery. Codex owns
+the adaptive workflow inside a standalone clone and uses `gh` and `git`
+directly. It leaves pull requests for human review and merge.
 
-Factory v1 supports Unix-like systems and uses the authenticated local `gh`
-and Codex CLIs. It does not use model API keys.
+Factory v1 manages one trusted repository on a Unix-like host. It uses Docker,
+the local `gh` CLI for polling, a dedicated GitHub token for workers, and a
+dedicated Codex login. It does not use model API keys.
 
 ## Quick start
 
-1. Install Rust, `git`, `gh`, and Codex CLI.
-2. Authenticate with `gh auth login` and `codex login`.
+1. Install Rust, Docker, `git`, `gh`, and Codex CLI.
+2. Authenticate the host with `gh auth login`.
 3. Clone Factory and run `cargo install --path .`.
 4. In a trusted target repository, run `factory init`.
-5. Create a workflow with `factory workflow create`.
-6. Review and commit the new file under `.factory/workflows/`.
-7. Set `[github].trusted_approvers` to trusted GitHub logins.
-8. Run `factory validate`, `factory workflows`, then `factory daemon`.
-9. Authorize a complete issue with `factory approve ISSUE_NUMBER`.
+5. Configure the GitHub Project, trusted users, and status names in
+   `.factory/config.toml`.
+6. Add the triage and implementation workflows under `.factory/workflows/`
+   and a repository-specific `.factory/Dockerfile` with the real toolchain.
+7. Build the repository worker image:
+
+   ```sh
+   docker build --file .factory/Dockerfile --tag factory-codex:dev .
+   ```
+
+8. Create the dedicated Codex login used by the worker:
+
+   ```sh
+   mkdir -p "$HOME/.local/share/factory/codex"
+   CODEX_HOME="$HOME/.local/share/factory/codex" codex login
+   ```
+
+   Set `worker.codex_auth` to
+   `~/.local/share/factory/codex/auth.json` in the config.
+
+9. Export `FACTORY_GITHUB_TOKEN` for a dedicated GitHub identity, then run
+   `factory validate`, `factory workflows`, and `factory daemon`.
 
 `factory init --check` previews setup without writes. Initialization creates
-`.factory/config.toml`, external machine state and worktree storage, and the
-repository's workflow directory. It does not install an
-opinionated workflow or create GitHub labels.
+`.factory/config.toml`, external machine state and workspace storage, and the
+repository's workflow directory. It does not alter the GitHub Project or
+install opinionated workflows.
 
 Create a scheduled pull-request triage workflow without opening an editor:
 
@@ -47,15 +64,21 @@ and polls once, persists eligible tasks, and exits without launching Codex.
 If no schedule or issue matches, Factory launches no agent and uses no model
 tokens.
 
-The `factory:ready` label is only a wake signal. Adding it directly never
-authorizes work. `factory approve ISSUE_NUMBER` records the exact issue title,
-body, workflow revision, trusted GitHub user ID, and new label event that the
-daemon must verify again immediately before Codex starts.
+The v1 loop has two reactions. An item in the configured ready-for-spec state
+runs triage in a read-only clone. An item in the ready-to-implement state runs
+implementation in a writable clone and advances to review. Only items from
+configured trusted users can be claimed. All six status names are configurable.
 
-See [`docs/local-v1.md`](docs/local-v1.md) for the current implementation's
-installation, setup, operation, recovery, and acceptance instructions. The
-repo-local architecture and product boundary are documented in
-[`docs/single-repository-v1/design.md`](docs/single-repository-v1/design.md).
+Each Project-triggered run gets one disposable Docker container and one
+standalone clone. Docker is the isolation boundary, so sandboxed runs do not
+use Git worktrees. The container has a read-only root, no added Linux
+capabilities, bounded CPU, memory and processes, and no Docker socket or
+canonical repository mount. Scheduled workflows remain a separate host-run
+feature in v1.
+
+See [`docs/single-repository-v1/design.md`](docs/single-repository-v1/design.md)
+for the setup, state machine, worker boundary, recovery model, and acceptance
+checks.
 
 ## Development checks
 

--- a/docs/single-repository-v1/design.md
+++ b/docs/single-repository-v1/design.md
@@ -252,7 +252,7 @@ Factory instance and run ID.
 Factory starts it with these minimum controls:
 
 ```text
---user 1000:1000
+--user <host-clone-uid>:<host-clone-gid>
 --read-only
 --cap-drop ALL
 --security-opt no-new-privileges
@@ -260,10 +260,14 @@ Factory starts it with these minimum controls:
 --memory 8g
 --cpus 4
 --tmpfs /tmp:rw,size=1g
---tmpfs /home/agent/.codex:rw,uid=1000,gid=1000,mode=700
+--tmpfs /home/agent/.codex:rw,uid=<uid>,gid=<gid>,mode=700
 --mount <factory-auth.json>:/home/agent/.codex/auth.json:rw
 --mount <standalone-clone>:/workspace:ro|rw
 ```
+
+Factory derives the numeric UID and GID from the host clone. This keeps the
+bind mount writable on native Linux while still running the container without
+root privileges.
 
 It never mounts `/var/run/docker.sock`, SSH keys, the host `gh` configuration,
 the canonical checkout, or Factory's data directory. Network remains enabled in

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -6,7 +6,16 @@ poll_every = "30s"
 default_runtime = "codex"
 default_timeout = "2h"
 maximum_timeout = "8h"
-max_concurrent_runs = 2
+max_concurrent_runs = 1
+
+[worker]
+kind = "docker"
+image = "factory-codex:dev"
+memory = "8g"
+cpus = 4
+pids = 512
+codex_auth = "~/.local/share/factory/codex/auth.json"
+github_token_env = "FACTORY_GITHUB_TOKEN"
 
 [source]
 kind = "github_project"

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -1,0 +1,516 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+use crate::workspace::{CleanupPreview, WorkspaceManager};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StandaloneClone {
+    pub path: PathBuf,
+    pub branch: Option<String>,
+    pub base_branch: String,
+    pub base_sha: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct CloneManager {
+    root: PathBuf,
+    gh_executable: PathBuf,
+    git_executable: PathBuf,
+}
+
+impl CloneManager {
+    pub fn new(root: &Path) -> Result<Self> {
+        let root = root
+            .canonicalize()
+            .with_context(|| format!("failed to resolve clone root {}", root.display()))?;
+        if !root.is_dir() {
+            bail!("clone root {} is not a directory", root.display());
+        }
+        Ok(Self {
+            root,
+            gh_executable: PathBuf::from("gh"),
+            git_executable: PathBuf::from("git"),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn prepare(
+        &self,
+        repository: &str,
+        task_id: i64,
+        issue: u64,
+        title: &str,
+        base_branch: &str,
+        base_sha: &str,
+        implementation: bool,
+        github_token_env: &str,
+    ) -> Result<StandaloneClone> {
+        if task_id <= 0 || issue == 0 {
+            bail!("clone task and issue IDs must be positive");
+        }
+        validate_repository(repository)?;
+        validate_revision(base_sha)?;
+        let path = if implementation {
+            self.root.join(format!("issue-{issue}"))
+        } else {
+            self.root.join(format!("triage-{task_id}"))
+        };
+        self.ensure_managed_path(&path)?;
+        let token = std::env::var(github_token_env)
+            .with_context(|| format!("GitHub token environment {github_token_env:?} is missing"))?;
+        if token.trim().is_empty() {
+            bail!("GitHub token environment {github_token_env:?} is empty");
+        }
+        if !path.exists() {
+            let staging = tempfile::Builder::new()
+                .prefix(".factory-clone-")
+                .tempdir_in(&self.root)
+                .context("failed to create clone staging directory")?;
+            let staged_clone = staging.path().join("repository");
+            let clone_url = format!("https://github.com/{repository}.git");
+            let status = Command::new(&self.gh_executable)
+                .args(["repo", "clone", &clone_url])
+                .arg(&staged_clone)
+                .args(["--", "--no-checkout", "--no-tags"])
+                .env("GH_TOKEN", &token)
+                .status()
+                .context("failed to start gh repo clone")?;
+            if !status.success() {
+                bail!("gh repo clone failed with {status}");
+            }
+            if !staged_clone.join(".git").is_dir() {
+                bail!("gh repo clone did not produce standalone Git metadata");
+            }
+            fs::rename(&staged_clone, &path).with_context(|| {
+                format!("failed to publish completed clone at {}", path.display())
+            })?;
+        }
+        self.require_standalone_clone(&path, repository)?;
+        git(
+            &self.git_executable,
+            &path,
+            [
+                "config",
+                "credential.https://github.com.helper",
+                "!gh auth git-credential",
+            ],
+            &token,
+        )?;
+        let remote_ref = format!("refs/remotes/origin/{base_branch}");
+        let refspec = format!("+refs/heads/{base_branch}:{remote_ref}");
+        git(
+            &self.git_executable,
+            &path,
+            ["fetch", "--no-tags", "origin", &refspec],
+            &token,
+        )?;
+        let revision = format!("{base_sha}^{{commit}}");
+        let resolved = git_output(
+            &self.git_executable,
+            &path,
+            ["rev-parse", "--verify", &revision],
+            &token,
+        )?;
+        if resolved.trim() != base_sha {
+            bail!("clone base commit does not match the reserved source commit");
+        }
+        let branch = implementation.then(|| WorkspaceManager::delivery_branch(issue, title));
+        if let Some(branch) = &branch {
+            let remote_branch = format!("refs/remotes/origin/{branch}");
+            let source_branch = format!("refs/heads/{branch}");
+            let local_branch = Command::new(&self.git_executable)
+                .args(["show-ref", "--verify", "--quiet", &source_branch])
+                .current_dir(&path)
+                .env("GH_TOKEN", &token)
+                .status()
+                .context("failed to inspect local implementation branch")?
+                .code();
+            if local_branch == Some(0) {
+                git(&self.git_executable, &path, ["checkout", branch], &token)?;
+                return Ok(StandaloneClone {
+                    path,
+                    branch: Some(branch.clone()),
+                    base_branch: base_branch.to_owned(),
+                    base_sha: base_sha.to_owned(),
+                });
+            }
+            if local_branch != Some(1) {
+                bail!("failed to inspect local implementation branch");
+            }
+            let remote = Command::new(&self.git_executable)
+                .args([
+                    "ls-remote",
+                    "--exit-code",
+                    "--heads",
+                    "origin",
+                    &source_branch,
+                ])
+                .current_dir(&path)
+                .env("GH_TOKEN", &token)
+                .status()
+                .context("failed to inspect implementation branch")?
+                .code();
+            if remote == Some(0) {
+                let branch_refspec = format!("+refs/heads/{branch}:{remote_branch}");
+                git(
+                    &self.git_executable,
+                    &path,
+                    ["fetch", "--no-tags", "origin", &branch_refspec],
+                    &token,
+                )?;
+                git(
+                    &self.git_executable,
+                    &path,
+                    ["checkout", "-B", branch, &remote_branch],
+                    &token,
+                )?;
+            } else if remote == Some(2) {
+                git(
+                    &self.git_executable,
+                    &path,
+                    ["checkout", "-B", branch, base_sha],
+                    &token,
+                )?;
+            } else {
+                bail!("failed to inspect remote implementation branch");
+            }
+        } else {
+            git(
+                &self.git_executable,
+                &path,
+                ["checkout", "--detach", base_sha],
+                &token,
+            )?;
+        }
+        Ok(StandaloneClone {
+            path,
+            branch,
+            base_branch: base_branch.to_owned(),
+            base_sha: base_sha.to_owned(),
+        })
+    }
+
+    pub fn remove(&self, path: &Path) -> Result<()> {
+        self.ensure_managed_path(path)?;
+        if path.exists() {
+            fs::remove_dir_all(path)
+                .with_context(|| format!("failed to remove clone {}", path.display()))?;
+        }
+        Ok(())
+    }
+
+    pub fn preview_cleanup(&self, path: &Path) -> Result<CleanupPreview> {
+        self.ensure_managed_path(path)?;
+        if !path.join(".git").is_dir() {
+            bail!("{} is not a standalone Git clone", path.display());
+        }
+        let dirty = !git_output(&self.git_executable, path, ["status", "--porcelain"], "")?
+            .trim()
+            .is_empty();
+        let branch = git_output(&self.git_executable, path, ["branch", "--show-current"], "")?;
+        Ok(CleanupPreview {
+            path: path.to_owned(),
+            branch: (!branch.trim().is_empty()).then(|| branch.trim().to_owned()),
+            dirty,
+        })
+    }
+
+    pub fn branch_is_pushed(
+        &self,
+        path: &Path,
+        branch: &str,
+        github_token_env: &str,
+    ) -> Result<bool> {
+        self.ensure_managed_path(path)?;
+        let token = std::env::var(github_token_env)
+            .with_context(|| format!("GitHub token environment {github_token_env:?} is missing"))?;
+        let local = git_output(&self.git_executable, path, ["rev-parse", "HEAD"], &token)?;
+        let remote_ref = format!("refs/heads/{branch}");
+        let remote = git_output(
+            &self.git_executable,
+            path,
+            ["ls-remote", "--heads", "origin", &remote_ref],
+            &token,
+        )?;
+        Ok(remote.split_whitespace().next() == Some(local.trim()))
+    }
+
+    fn ensure_managed_path(&self, path: &Path) -> Result<()> {
+        let parent = path
+            .parent()
+            .context("clone path has no parent")?
+            .canonicalize()
+            .context("failed to resolve clone parent")?;
+        if parent != self.root || path == self.root {
+            bail!(
+                "clone path {} is outside {}",
+                path.display(),
+                self.root.display()
+            );
+        }
+        if let Ok(metadata) = fs::symlink_metadata(path)
+            && metadata.file_type().is_symlink()
+        {
+            bail!("clone path {} must not be a symlink", path.display());
+        }
+        Ok(())
+    }
+
+    fn require_standalone_clone(&self, path: &Path, repository: &str) -> Result<()> {
+        if !path.join(".git").is_dir() {
+            bail!(
+                "clone {} does not contain standalone Git metadata",
+                path.display()
+            );
+        }
+        let origin = git_output(
+            &self.git_executable,
+            path,
+            ["remote", "get-url", "origin"],
+            "",
+        )?;
+        let expected_suffix = format!("/{repository}.git");
+        if !origin
+            .trim()
+            .trim_end_matches('/')
+            .ends_with(&expected_suffix)
+        {
+            bail!(
+                "clone origin {:?} does not match {repository}",
+                origin.trim()
+            );
+        }
+        Ok(())
+    }
+}
+
+fn validate_repository(repository: &str) -> Result<()> {
+    let mut parts = repository.split('/');
+    if !matches!(
+        (parts.next(), parts.next(), parts.next()),
+        (Some(owner), Some(repo), None) if !owner.is_empty() && !repo.is_empty()
+    ) {
+        bail!("invalid GitHub repository identity {repository:?}");
+    }
+    Ok(())
+}
+
+fn validate_revision(revision: &str) -> Result<()> {
+    if revision.len() != 40 || !revision.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("base commit must be a full Git SHA");
+    }
+    Ok(())
+}
+
+fn git<const N: usize>(
+    executable: &Path,
+    repository: &Path,
+    arguments: [&str; N],
+    token: &str,
+) -> Result<()> {
+    let status = Command::new(executable)
+        .args(arguments)
+        .current_dir(repository)
+        .env("GH_TOKEN", token)
+        .status()
+        .context("failed to start Git")?;
+    if !status.success() {
+        bail!("Git command failed with {status}");
+    }
+    Ok(())
+}
+
+fn git_output<const N: usize>(
+    executable: &Path,
+    repository: &Path,
+    arguments: [&str; N],
+    token: &str,
+) -> Result<String> {
+    let output = Command::new(executable)
+        .args(arguments)
+        .current_dir(repository)
+        .env("GH_TOKEN", token)
+        .output()
+        .context("failed to start Git")?;
+    if !output.status.success() {
+        bail!(
+            "Git command failed with {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    String::from_utf8(output.stdout).context("Git output was not UTF-8")
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    const BASE_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+    const TOKEN_ENV: &str = "FACTORY_CLONE_TEST_TOKEN";
+
+    fn executable(path: &Path, contents: &str) {
+        fs::write(path, contents).unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[test]
+    fn prepares_standalone_triage_and_stable_implementation_clones() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("clones");
+        fs::create_dir(&root).unwrap();
+        let root = root.canonicalize().unwrap();
+        let log = temp.path().join("commands.log");
+        let gh = temp.path().join("gh");
+        let git = temp.path().join("git");
+        executable(
+            &gh,
+            &format!(
+                r#"#!/bin/sh
+set -eu
+printf 'gh|%s\n' "$*" >> '{}'
+test "$GH_TOKEN" = 'clone-test-token'
+test "$1 $2" = 'repo clone'
+mkdir -p "$4/.git"
+"#,
+                log.display()
+            ),
+        );
+        executable(
+            &git,
+            &format!(
+                r#"#!/bin/sh
+set -eu
+printf '%s|%s\n' "$PWD" "$*" >> '{}'
+case "$1 ${{2:-}}" in
+  'remote get-url') printf '%s\n' 'https://github.com/acme/widgets.git' ;;
+  'rev-parse --verify') printf '%s\n' '{}' ;;
+  'show-ref --verify')
+    if test -f .fake-local-branch && test "$(cat .fake-local-branch)" = "${{4#refs/heads/}}"; then exit 0; else exit 1; fi
+    ;;
+  'ls-remote --exit-code') exit 2 ;;
+  'checkout -B') printf '%s' "$3" > .fake-local-branch ;;
+  'checkout factory/'*) printf '%s' "$2" > .fake-local-branch ;;
+esac
+"#,
+                log.display(),
+                BASE_SHA
+            ),
+        );
+        // SAFETY: this test uses a process-unique environment variable name and
+        // no other test in this crate reads or writes it.
+        unsafe { std::env::set_var(TOKEN_ENV, "clone-test-token") };
+        let manager = CloneManager {
+            root: root.clone(),
+            gh_executable: gh,
+            git_executable: git,
+        };
+
+        let triage = manager
+            .prepare(
+                "acme/widgets",
+                7,
+                42,
+                "Fix login timeout",
+                "main",
+                BASE_SHA,
+                false,
+                TOKEN_ENV,
+            )
+            .unwrap();
+        assert_eq!(triage.path, root.join("triage-7"));
+        assert_eq!(triage.branch, None);
+        assert!(triage.path.join(".git").is_dir());
+
+        let implementation = manager
+            .prepare(
+                "acme/widgets",
+                8,
+                42,
+                "Fix login timeout",
+                "main",
+                BASE_SHA,
+                true,
+                TOKEN_ENV,
+            )
+            .unwrap();
+        assert_eq!(implementation.path, root.join("issue-42"));
+        assert_eq!(
+            implementation.branch.as_deref(),
+            Some("factory/42-fix-login-timeout")
+        );
+        assert!(implementation.path.join(".git").is_dir());
+
+        fs::write(implementation.path.join("local-work"), "preserve me").unwrap();
+        manager
+            .prepare(
+                "acme/widgets",
+                9,
+                42,
+                "Fix login timeout",
+                "main",
+                BASE_SHA,
+                true,
+                TOKEN_ENV,
+            )
+            .unwrap();
+        assert_eq!(
+            fs::read_to_string(implementation.path.join("local-work")).unwrap(),
+            "preserve me"
+        );
+
+        let commands = fs::read_to_string(log).unwrap();
+        assert!(commands.contains("gh|repo clone https://github.com/acme/widgets.git"));
+        assert!(commands.contains("checkout --detach"));
+        assert_eq!(
+            commands
+                .matches("checkout -B factory/42-fix-login-timeout")
+                .count(),
+            1
+        );
+        assert!(commands.contains("checkout factory/42-fix-login-timeout"));
+        assert!(!commands.contains("clone-test-token"));
+    }
+
+    #[test]
+    fn failed_initial_clone_does_not_poison_the_stable_destination() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("clones");
+        fs::create_dir(&root).unwrap();
+        let gh = temp.path().join("gh");
+        let git = temp.path().join("git");
+        executable(&gh, "#!/bin/sh\nmkdir -p \"$4/.git\"\nexit 1\n");
+        executable(&git, "#!/bin/sh\nexit 64\n");
+        unsafe { std::env::set_var(TOKEN_ENV, "clone-test-token") };
+        let manager = CloneManager {
+            root: root.canonicalize().unwrap(),
+            gh_executable: gh,
+            git_executable: git,
+        };
+
+        assert!(
+            manager
+                .prepare(
+                    "acme/widgets",
+                    99,
+                    42,
+                    "Fix login timeout",
+                    "main",
+                    BASE_SHA,
+                    true,
+                    TOKEN_ENV,
+                )
+                .is_err()
+        );
+        assert!(!root.join("issue-42").exists());
+        assert_eq!(fs::read_dir(root).unwrap().count(), 0);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,8 +20,19 @@ pub struct Config {
     pub max_concurrent_runs_per_repository: usize,
     pub workspace_root: PathBuf,
     pub data_directory: PathBuf,
+    pub worker: Option<WorkerConfig>,
     pub source: Option<SourceConfig>,
     pub github: GitHubConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerConfig {
+    pub image: String,
+    pub memory: String,
+    pub cpus: u32,
+    pub pids: u32,
+    pub codex_auth: PathBuf,
+    pub github_token_env: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -106,8 +117,21 @@ struct RawConfig {
     default_timeout: String,
     maximum_timeout: String,
     max_concurrent_runs: usize,
+    worker: Option<RawWorkerConfig>,
     source: Option<RawSourceConfig>,
     github: Option<RawGitHubConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawWorkerConfig {
+    kind: String,
+    image: String,
+    memory: String,
+    cpus: u32,
+    pids: u32,
+    codex_auth: Option<String>,
+    github_token_env: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -220,6 +244,9 @@ impl Config {
         if raw.max_concurrent_runs == 0 {
             bail!("max_concurrent_runs must be greater than zero");
         }
+        if raw.worker.is_some() && raw.max_concurrent_runs != 1 {
+            bail!("Docker workers require max_concurrent_runs = 1");
+        }
         if raw.source.is_some() && raw.github.is_some() {
             bail!("configure [source] or legacy [github], not both");
         }
@@ -252,6 +279,10 @@ impl Config {
 
         let repository = canonical_directory("repository", repository, repository)?;
         let data_directory = repository_data_directory(&repository)?;
+        let worker = raw
+            .worker
+            .map(|worker| resolve_worker(worker, &repository, &data_directory))
+            .transpose()?;
         let workspace_candidate = data_directory.join("worktrees");
         let workspace_root = if allow_missing_workspace {
             canonical_directory_or_missing("workspace_root", &workspace_candidate, &repository)?
@@ -276,6 +307,7 @@ impl Config {
             max_concurrent_runs_per_repository: raw.max_concurrent_runs,
             workspace_root,
             data_directory,
+            worker,
             source,
             github,
         })
@@ -320,6 +352,23 @@ impl fmt::Display for Config {
             "max_concurrent_runs: {}",
             self.max_concurrent_runs
         )?;
+        if let Some(worker) = &self.worker {
+            writeln!(formatter, "worker: docker")?;
+            writeln!(formatter, "worker.image: {}", worker.image)?;
+            writeln!(formatter, "worker.memory: {}", worker.memory)?;
+            writeln!(formatter, "worker.cpus: {}", worker.cpus)?;
+            writeln!(formatter, "worker.pids: {}", worker.pids)?;
+            writeln!(
+                formatter,
+                "worker.codex_auth: {}",
+                worker.codex_auth.display()
+            )?;
+            writeln!(
+                formatter,
+                "worker.github_token_env: {}",
+                worker.github_token_env
+            )?;
+        }
         if let Some(source) = &self.source {
             writeln!(
                 formatter,
@@ -344,6 +393,118 @@ impl fmt::Display for Config {
             self.data_directory.display()
         )?;
         writeln!(formatter, "worktrees: {}", self.workspace_root.display())
+    }
+}
+
+fn resolve_worker(
+    raw: RawWorkerConfig,
+    repository: &Path,
+    data_directory: &Path,
+) -> Result<WorkerConfig> {
+    if raw.kind != "docker" {
+        bail!("worker.kind must be \"docker\"");
+    }
+
+    let image = raw.image.trim();
+    if image.is_empty()
+        || image.chars().count() > 255
+        || !image.chars().all(|character| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, '.' | '_' | '/' | ':' | '@' | '-')
+        })
+        || !image
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_alphanumeric())
+        || (!image.rsplit('/').next().unwrap_or(image).contains(':') && !image.contains('@'))
+    {
+        bail!("worker.image must be a valid, explicitly tagged Docker image reference");
+    }
+
+    let memory = raw.memory.trim().to_ascii_lowercase();
+    let suffix_start = memory
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(memory.len());
+    let (amount, suffix) = memory.split_at(suffix_start);
+    if amount.is_empty()
+        || amount.starts_with('0')
+        || !amount.chars().all(|character| character.is_ascii_digit())
+        || !matches!(
+            suffix,
+            "" | "b" | "k" | "kb" | "m" | "mb" | "g" | "gb" | "t" | "tb"
+        )
+    {
+        bail!("worker.memory must be a positive Docker memory limit such as \"8g\"");
+    }
+    if raw.cpus == 0 {
+        bail!("worker.cpus must be greater than zero");
+    }
+    if raw.pids == 0 {
+        bail!("worker.pids must be greater than zero");
+    }
+
+    let codex_auth = match raw.codex_auth {
+        Some(path) => expand_path(Path::new(path.trim()), repository)?,
+        None => data_directory.join("codex/auth.json"),
+    };
+    if codex_auth.file_name().and_then(|name| name.to_str()) != Some("auth.json") {
+        bail!("worker.codex_auth must name an auth.json file");
+    }
+    let codex_auth = resolve_file_or_missing("worker.codex_auth", &codex_auth)?;
+    if codex_auth.starts_with(repository) {
+        bail!("worker.codex_auth must be outside the repository");
+    }
+    if let Some(home) = dirs::home_dir()
+        && codex_auth == home.join(".codex/auth.json")
+    {
+        bail!("worker.codex_auth must use a dedicated Factory credential, not ~/.codex/auth.json");
+    }
+
+    let github_token_env = raw
+        .github_token_env
+        .unwrap_or_else(|| "FACTORY_GITHUB_TOKEN".to_owned());
+    let github_token_env = github_token_env.trim();
+    if github_token_env.is_empty()
+        || !github_token_env
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+        || !github_token_env
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+    {
+        bail!("worker.github_token_env must be a valid environment variable name");
+    }
+
+    Ok(WorkerConfig {
+        image: image.to_owned(),
+        memory,
+        cpus: raw.cpus,
+        pids: raw.pids,
+        codex_auth,
+        github_token_env: github_token_env.to_owned(),
+    })
+}
+
+fn resolve_file_or_missing(name: &str, path: &Path) -> Result<PathBuf> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                bail!("{name} must be a regular file: {}", path.display());
+            }
+            path.canonicalize()
+                .with_context(|| format!("failed to resolve {name}: {}", path.display()))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let parent = path
+                .parent()
+                .with_context(|| format!("{name} has no parent directory"))?;
+            let parent = canonical_directory_or_missing(name, parent, parent)?;
+            Ok(parent.join("auth.json"))
+        }
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to inspect {name}: {}", path.display()))
+        }
     }
 }
 
@@ -819,6 +980,7 @@ mod tests {
             default_timeout: "2h".into(),
             maximum_timeout: "8h".into(),
             max_concurrent_runs: 2,
+            worker: None,
             source: None,
             github: Some(RawGitHubConfig {
                 trusted_approvers: vec!["owainlewis".into()],
@@ -826,6 +988,18 @@ mod tests {
                 proposed_label: "factory:proposed".into(),
                 needs_review_label: "factory:needs-review".into(),
             }),
+        }
+    }
+
+    fn docker_worker() -> RawWorkerConfig {
+        RawWorkerConfig {
+            kind: "docker".into(),
+            image: "factory-codex:dev".into(),
+            memory: "8g".into(),
+            cpus: 4,
+            pids: 512,
+            codex_auth: None,
+            github_token_env: None,
         }
     }
 
@@ -875,6 +1049,89 @@ mod tests {
         assert_eq!(source.trusted_users, ["OwainLewis"]);
         assert_eq!(config.github.trusted_approvers, ["OwainLewis"]);
         assert_eq!(config.github.ready_label, "factory:ready");
+    }
+
+    #[test]
+    fn resolves_docker_worker_with_dedicated_default_credentials() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repo");
+        let workspace = temp.path().join("worktrees");
+        let mut input = raw(&repository, &workspace);
+        input.max_concurrent_runs = 1;
+        input.worker = Some(docker_worker());
+
+        let config = Config::resolve(input, &repository).unwrap();
+        let worker = config.worker.unwrap();
+
+        assert_eq!(worker.image, "factory-codex:dev");
+        assert_eq!(worker.memory, "8g");
+        assert_eq!(worker.cpus, 4);
+        assert_eq!(worker.pids, 512);
+        assert_eq!(worker.github_token_env, "FACTORY_GITHUB_TOKEN");
+        assert_eq!(
+            worker.codex_auth,
+            config.data_directory.join("codex/auth.json")
+        );
+    }
+
+    #[test]
+    fn docker_worker_requires_one_concurrent_run() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repo");
+        let workspace = temp.path().join("worktrees");
+        let mut input = raw(&repository, &workspace);
+        input.worker = Some(docker_worker());
+
+        let error = Config::resolve(input, &repository).unwrap_err();
+
+        assert!(error.to_string().contains("max_concurrent_runs = 1"));
+    }
+
+    #[test]
+    fn rejects_unsafe_docker_worker_values() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repo");
+        let workspace = temp.path().join("worktrees");
+
+        for (field, change) in [
+            ("tagged image", 0_u8),
+            ("memory limit", 1),
+            ("CPU limit", 2),
+            ("process limit", 3),
+            ("token environment", 4),
+        ] {
+            let mut input = raw(&repository, &workspace);
+            input.max_concurrent_runs = 1;
+            let mut worker = docker_worker();
+            match change {
+                0 => worker.image = "factory-codex".into(),
+                1 => worker.memory = "0g".into(),
+                2 => worker.cpus = 0,
+                3 => worker.pids = 0,
+                4 => worker.github_token_env = Some("BAD-NAME".into()),
+                _ => unreachable!(),
+            }
+            input.worker = Some(worker);
+
+            let error = Config::resolve(input, &repository).unwrap_err();
+            assert!(!error.to_string().is_empty(), "accepted invalid {field}");
+        }
+    }
+
+    #[test]
+    fn rejects_repository_owned_codex_auth() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repo");
+        let workspace = temp.path().join("worktrees");
+        let mut input = raw(&repository, &workspace);
+        input.max_concurrent_runs = 1;
+        let mut worker = docker_worker();
+        worker.codex_auth = Some(".factory/auth.json".into());
+        input.worker = Some(worker);
+
+        let error = Config::resolve(input, &repository).unwrap_err();
+
+        assert!(error.to_string().contains("outside the repository"));
     }
 
     #[test]
@@ -962,6 +1219,7 @@ mod tests {
             default_timeout: "2h".into(),
             maximum_timeout: "8h".into(),
             max_concurrent_runs: 1,
+            worker: None,
             source: None,
             github: Some(RawGitHubConfig {
                 trusted_approvers: vec!["owainlewis".into()],

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,19 +9,22 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, SecondsFormat, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
+use sha2::{Digest, Sha256};
 use tokio::task::JoinSet;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
+use crate::clone::CloneManager;
 use crate::config::{Config, PipelineState, SourceConfig};
+use crate::docker::{CloneMount, DockerRunFailure, DockerWorker};
 use crate::github::{GitHubClient, PollReport, ProjectTicketContext, TicketContext};
 use crate::runtime::{
     CodexRuntime, ExecutionResult, RuntimeCancelled, RuntimeObservation, Termination,
     observation_channel,
 };
 use crate::storage::{
-    AUTOMATIC_DELIVERY_CLEANUP, Ledger, OPERATOR_CONFIRMED_CLEANUP, Run, RunOutcome, Task,
-    TaskIdentity, TaskState, TaskWorkspace,
+    AUTOMATIC_DELIVERY_CLEANUP, Ledger, OPERATOR_CONFIRMED_CLEANUP, Run, RunContainer, RunOutcome,
+    Task, TaskIdentity, TaskState, TaskWorkspace,
 };
 use crate::workflow::{
     Trigger, WorkflowCatalog, WorkflowEntry, scheduled_workflow_fingerprint, workflow_content_hash,
@@ -83,6 +86,7 @@ pub struct FactoryDaemon {
     ledger_path: PathBuf,
     github: GitHubClient,
     codex: CodexRuntime,
+    docker: Option<DockerWorker>,
 }
 
 pub struct OneShotReport {
@@ -108,12 +112,17 @@ impl FactoryDaemon {
         github: GitHubClient,
         codex: CodexRuntime,
     ) -> Self {
+        let docker = config.worker.clone().map(|worker| {
+            DockerWorker::new(worker, docker_instance_id(&config.data_directory))
+                .with_activity_streaming(false)
+        });
         Self {
             config,
             catalog,
             ledger_path: ledger_path.into(),
             github,
             codex: codex.with_activity_streaming(false),
+            docker,
         }
     }
 
@@ -131,11 +140,15 @@ impl FactoryDaemon {
             Err(error) => return Err(error),
         };
         let mut ledger = Ledger::open(&self.ledger_path)?;
+        if let Some(docker) = &self.docker {
+            reconcile_docker_workers(docker, &mut ledger, &cancellation).await?;
+        }
         if let Err(error) = reconcile_recovery_state(
             &mut ledger,
             &self.ledger_path,
             &self.config.repositories[0],
             &self.config.workspace_root,
+            self.docker.as_ref().map(DockerWorker::github_token_env),
         ) {
             eprintln!("Factory workspace startup reconciliation failed: {error:#}");
             return Err(error);
@@ -213,6 +226,7 @@ impl FactoryDaemon {
                     self.config.max_concurrent_runs_per_repository,
                     &self.ledger_path,
                     &self.codex,
+                    self.docker.as_ref(),
                     &self.github,
                     &self.config.github,
                     self.config.source.as_ref(),
@@ -231,6 +245,7 @@ impl FactoryDaemon {
                             &self.ledger_path,
                             &self.config.repositories[0],
                             &self.config.workspace_root,
+                            self.docker.as_ref().map(DockerWorker::github_token_env),
                         )?;
                     }
                     _ = schedule_interval.tick() => {
@@ -357,6 +372,20 @@ impl FactoryDaemon {
         }
         self.catalog.validate_ticket_workflows()?;
         self.github.validate_global(cancellation).await?;
+        if let Some(docker) = &self.docker {
+            docker.validate(cancellation).await?;
+        }
+        let needs_host_codex = self.docker.is_none()
+            || self.catalog.entries.iter().any(|entry| {
+                entry.errors.is_empty()
+                    && entry
+                        .trigger
+                        .as_ref()
+                        .is_some_and(|trigger| !matches!(trigger, Trigger::State(_)))
+            });
+        if !needs_host_codex {
+            return Ok(());
+        }
         match self
             .codex
             .health_check_with_cancellation(cancellation.clone())
@@ -409,18 +438,91 @@ fn reconcile_recovery_state(
     ledger_path: &Path,
     canonical_repository: &Path,
     workspace_root: &Path,
+    clone_token_env: Option<&str>,
 ) -> Result<()> {
     report_recovery(ledger.recover_orphaned_runs()?);
-    reconcile_pending_cleanup(ledger, canonical_repository, workspace_root)?;
-    reconcile_terminal_workspaces(ledger, ledger_path, canonical_repository, workspace_root)
+    reconcile_pending_cleanup(
+        ledger,
+        canonical_repository,
+        workspace_root,
+        clone_token_env,
+    )?;
+    reconcile_terminal_workspaces(
+        ledger,
+        ledger_path,
+        canonical_repository,
+        workspace_root,
+        clone_token_env,
+    )
+}
+
+async fn reconcile_docker_workers(
+    docker: &DockerWorker,
+    ledger: &mut Ledger,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    for identity in docker.owned_containers(cancellation).await? {
+        let Some(recorded) = ledger.run_container(identity.run_id)? else {
+            bail!(
+                "owned container {} has no durable Factory record",
+                identity.id
+            );
+        };
+        if recorded.container_id != identity.id
+            || recorded.instance_id != identity.instance_id
+            || recorded.image_id != identity.image_id
+        {
+            bail!("owned Docker container does not match its durable record");
+        }
+        let recovered = docker.recover_container(&identity, cancellation).await?;
+        if ledger
+            .run(recovered.identity.run_id)?
+            .is_some_and(|run| run.outcome == "running")
+        {
+            ledger.observe_run(
+                recovered.identity.run_id,
+                None,
+                None,
+                None,
+                None,
+                Some(&format!(
+                    "Recovered Docker container state={}: {}",
+                    recovered.state, recovered.logs
+                )),
+            )?;
+        }
+        ledger.finish_run_container(
+            recovered.identity.run_id,
+            "recovered",
+            recovered.exit_code,
+            Some(&recovered.logs),
+            false,
+        )?;
+        docker.remove_container(&recovered.identity.id).await?;
+        ledger.finish_run_container(
+            recovered.identity.run_id,
+            "recovered",
+            recovered.exit_code,
+            Some(&recovered.logs),
+            true,
+        )?;
+    }
+    Ok(())
+}
+
+fn docker_instance_id(data_directory: &Path) -> String {
+    let digest = Sha256::digest(data_directory.as_os_str().as_encoded_bytes());
+    format!("{:x}", digest)[..20].to_owned()
 }
 
 fn reconcile_pending_cleanup(
     ledger: &Ledger,
     canonical_repository: &Path,
     workspace_root: &Path,
+    clone_token_env: Option<&str>,
 ) -> Result<()> {
     let manager = WorkspaceManager::new(canonical_repository, workspace_root)?;
+    let clone_manager = CloneManager::new(workspace_root)?;
     manager.reconcile_startup()?;
     for workspace in ledger.task_workspaces_in_state("cleanup_pending")? {
         if !workspace.path.exists() {
@@ -432,11 +534,20 @@ fn reconcile_pending_cleanup(
             continue;
         }
         let cleanup = if workspace.kind == "proposal" {
-            manager.cleanup_disposable(&workspace.path).map(|_| ())
+            if workspace.backend == "clone" {
+                clone_manager.remove(&workspace.path)
+            } else {
+                manager.cleanup_disposable(&workspace.path).map(|_| ())
+            }
         } else if workspace.status_summary.as_deref() == Some(OPERATOR_CONFIRMED_CLEANUP) {
-            manager.cleanup(&workspace.path, true).map(|_| ())
+            if workspace.backend == "clone" {
+                clone_manager.remove(&workspace.path)
+            } else {
+                manager.cleanup(&workspace.path, true).map(|_| ())
+            }
         } else if workspace.status_summary.as_deref() == Some(AUTOMATIC_DELIVERY_CLEANUP) {
-            match automatic_cleanup_is_still_safe(ledger, &manager, &workspace) {
+            match automatic_cleanup_is_still_safe(ledger, &manager, &workspace, clone_token_env) {
+                Ok(true) if workspace.backend == "clone" => clone_manager.remove(&workspace.path),
                 Ok(true) => manager.cleanup_clean(&workspace.path).map(|_| ()),
                 Ok(false) => {
                     ledger.update_task_workspace_state(
@@ -486,6 +597,7 @@ fn automatic_cleanup_is_still_safe(
     ledger: &Ledger,
     manager: &WorkspaceManager,
     workspace: &TaskWorkspace,
+    clone_token_env: Option<&str>,
 ) -> Result<bool> {
     let task = ledger
         .task(workspace.task_id)?
@@ -503,8 +615,23 @@ fn automatic_cleanup_is_still_safe(
         .as_deref()
         .is_some_and(|result| !result.trim().is_empty())
         && run.pull_request.is_some();
-    let clean = !manager.preview_cleanup(&workspace.path)?.dirty;
+    let clone_manager = CloneManager::new(
+        workspace
+            .path
+            .parent()
+            .context("workspace clone has no managed root")?,
+    )?;
+    let clean = if workspace.backend == "clone" {
+        !clone_manager.preview_cleanup(&workspace.path)?.dirty
+    } else {
+        !manager.preview_cleanup(&workspace.path)?.dirty
+    };
     let published = match workspace.factory_branch.as_deref() {
+        Some(branch) if workspace.backend == "clone" => clone_manager.branch_is_pushed(
+            &workspace.path,
+            branch,
+            clone_token_env.context("clone cleanup has no GitHub token source")?,
+        )?,
         Some(branch) => manager.branch_is_pushed(branch)?,
         None => false,
     };
@@ -516,6 +643,7 @@ fn reconcile_terminal_workspaces(
     ledger_path: &Path,
     canonical_repository: &Path,
     workspace_root: &Path,
+    clone_token_env: Option<&str>,
 ) -> Result<()> {
     for workspace in ledger.active_task_workspaces()? {
         if matches!(workspace.state.as_str(), "cleanup_pending" | "retained") {
@@ -541,6 +669,7 @@ fn reconcile_terminal_workspaces(
             workspace_root,
             task.id,
             run.id,
+            clone_token_env,
         ) {
             eprintln!(
                 "Factory retained terminal workspace for task {} during startup reconciliation: {error:#}",
@@ -601,6 +730,7 @@ fn dispatch_available(
     repository_limit: usize,
     ledger_path: &Path,
     codex: &CodexRuntime,
+    docker: Option<&DockerWorker>,
     github: &GitHubClient,
     github_config: &crate::config::GitHubConfig,
     source_config: Option<&SourceConfig>,
@@ -721,6 +851,7 @@ fn dispatch_available(
         );
         *active.entry(repository.clone()).or_default() += 1;
         let codex = codex.clone();
+        let docker = docker.cloned();
         let github = github.clone();
         let github_config = github_config.clone();
         let source_config = source_config.cloned();
@@ -782,6 +913,7 @@ fn dispatch_available(
                 );
                 return (repository, Ok(()));
             }
+            let sandboxed = docker.is_some() && matches!(workflow.trigger, Trigger::State(_));
             let execution_target = match prepare_task_workspace(
                 &mut worker_ledger,
                 &github,
@@ -789,6 +921,8 @@ fn dispatch_available(
                 &workspace_root,
                 &task,
                 run_id,
+                sandboxed,
+                docker.as_ref().map(|worker| worker.github_token_env()),
                 &cancellation,
             )
             .await
@@ -813,7 +947,11 @@ fn dispatch_available(
                 run_id,
                 &execution_target,
                 &workflow,
-                prior_session.as_deref(),
+                if sandboxed {
+                    None
+                } else {
+                    prior_session.as_deref()
+                },
                 prior_successful_run_at,
             )
             .map(|prompt| {
@@ -832,28 +970,60 @@ fn dispatch_available(
                     return (repository, Ok(()));
                 }
             };
-            eprintln!(
-                "Factory runtime delegated: run={run_id} runtime={} cwd={} worktree=factory-owned",
-                workflow.runtime,
-                execution_target.path.display()
-            );
-            let result = execute_task(
-                worker_ledger,
-                &execution_target,
-                &workflow,
-                &codex,
-                run_id,
-                prompt,
-                cancellation,
-                recovery_source.and_then(|previous| previous.session_id),
-            )
-            .await;
+            if sandboxed {
+                eprintln!(
+                    "Factory runtime delegated: run={run_id} runtime={} cwd={} backend=docker-clone",
+                    workflow.runtime,
+                    execution_target.path.display(),
+                );
+            } else {
+                eprintln!(
+                    "Factory runtime delegated: run={run_id} runtime={} cwd={} worktree=factory-owned",
+                    workflow.runtime,
+                    execution_target.path.display(),
+                );
+            }
+            let result = if sandboxed {
+                let docker = docker.as_ref().expect("sandboxed tasks have Docker worker");
+                let mount = if matches!(
+                    workflow.trigger,
+                    Trigger::State(PipelineState::ReadyForSpec)
+                ) {
+                    CloneMount::ReadOnly
+                } else {
+                    CloneMount::ReadWrite
+                };
+                execute_docker_task(
+                    worker_ledger,
+                    &execution_target,
+                    &workflow,
+                    docker,
+                    mount,
+                    run_id,
+                    prompt,
+                    cancellation,
+                )
+                .await
+            } else {
+                execute_task(
+                    worker_ledger,
+                    &execution_target,
+                    &workflow,
+                    &codex,
+                    run_id,
+                    prompt,
+                    cancellation,
+                    recovery_source.and_then(|previous| previous.session_id),
+                )
+                .await
+            };
             if let Err(error) = finalize_task_workspace(
                 &finalization_ledger_path,
                 &target.path,
                 &workspace_root,
                 task.id,
                 run_id,
+                docker.as_ref().map(DockerWorker::github_token_env),
             ) {
                 eprintln!("Factory workspace finalization failed for run {run_id}: {error:#}");
             }
@@ -863,6 +1033,7 @@ fn dispatch_available(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn prepare_task_workspace(
     ledger: &mut Ledger,
     github: &GitHubClient,
@@ -870,6 +1041,8 @@ async fn prepare_task_workspace(
     workspace_root: &Path,
     task: &Task,
     run_id: i64,
+    sandboxed: bool,
+    github_token_env: Option<&str>,
     cancellation: &CancellationToken,
 ) -> Result<RepositoryTarget> {
     let workspace_root = workspace_root
@@ -906,6 +1079,7 @@ async fn prepare_task_workspace(
             TaskWorkspace {
                 task_id: task.id,
                 kind: "delivery".to_owned(),
+                backend: if sandboxed { "clone" } else { "worktree" }.to_owned(),
                 repository: task.repository.clone(),
                 base_branch,
                 base_sha,
@@ -924,11 +1098,16 @@ async fn prepare_task_workspace(
             TaskWorkspace {
                 task_id: task.id,
                 kind: "proposal".to_owned(),
+                backend: if sandboxed { "clone" } else { "worktree" }.to_owned(),
                 repository: task.repository.clone(),
                 base_branch,
                 base_sha,
                 factory_branch: None,
-                path: workspace_root.join(format!("proposal-{}", task.id)),
+                path: workspace_root.join(if sandboxed {
+                    format!("triage-{}", task.id)
+                } else {
+                    format!("proposal-{}", task.id)
+                }),
                 state: "preparing".to_owned(),
                 status_summary: None,
                 created_at: now,
@@ -938,6 +1117,49 @@ async fn prepare_task_workspace(
         };
         ledger.reserve_task_workspace(&candidate)?
     };
+    if sandboxed {
+        if workspace.backend != "clone" {
+            bail!("sandboxed task {} owns a non-clone workspace", task.id);
+        }
+        let ticket = ticket_summary(task)?;
+        let clone = CloneManager::new(&workspace_root)?.prepare(
+            &task.repository,
+            task.id,
+            ticket.number,
+            &ticket.title,
+            &workspace.base_branch,
+            &workspace.base_sha,
+            workspace.kind == "delivery",
+            github_token_env.context("sandboxed clone has no GitHub token source")?,
+        )?;
+        if clone.path != workspace.path
+            || clone.branch != workspace.factory_branch
+            || clone.base_branch != workspace.base_branch
+            || clone.base_sha != workspace.base_sha
+        {
+            bail!(
+                "standalone clone does not match task {} durable reservation",
+                task.id
+            );
+        }
+        ledger.update_task_workspace_state(task.id, "ready", None)?;
+        ledger.record_run_workspace(
+            run_id,
+            &clone.path,
+            &clone.base_branch,
+            &clone.base_sha,
+            clone.branch.as_deref(),
+            if workspace.kind == "delivery" {
+                "delivery"
+            } else {
+                "proposal"
+            },
+        )?;
+        return Ok(RepositoryTarget {
+            path: clone.path,
+            workflows: canonical_target.workflows.clone(),
+        });
+    }
     let prepared = if workspace.kind == "delivery" {
         let ticket = ticket_summary(task)?;
         manager.prepare_delivery(
@@ -1022,6 +1244,7 @@ fn finalize_task_workspace(
     workspace_root: &Path,
     task_id: i64,
     run_id: i64,
+    clone_token_env: Option<&str>,
 ) -> Result<()> {
     let ledger = Ledger::open(ledger_path)?;
     let task = ledger
@@ -1034,6 +1257,7 @@ fn finalize_task_workspace(
         return Ok(());
     }
     let manager = WorkspaceManager::new(canonical_repository, workspace_root)?;
+    let clone_manager = CloneManager::new(workspace_root)?;
     if workspace.kind == "proposal" {
         ledger.update_task_workspace_state(
             task_id,
@@ -1048,7 +1272,13 @@ fn finalize_task_workspace(
             )?;
             return Ok(());
         }
-        let preview = manager.cleanup_disposable(&workspace.path)?;
+        let preview = if workspace.backend == "clone" {
+            let preview = clone_manager.preview_cleanup(&workspace.path)?;
+            clone_manager.remove(&workspace.path)?;
+            preview
+        } else {
+            manager.cleanup_disposable(&workspace.path)?
+        };
         let summary = if preview.dirty {
             "discarded terminal proposal workspace with uncommitted changes"
         } else {
@@ -1068,7 +1298,11 @@ fn finalize_task_workspace(
     let run = ledger
         .run(run_id)?
         .with_context(|| format!("run {run_id} disappeared during workspace finalization"))?;
-    let preview = match manager.preview_cleanup(&workspace.path) {
+    let preview = match if workspace.backend == "clone" {
+        clone_manager.preview_cleanup(&workspace.path)
+    } else {
+        manager.preview_cleanup(&workspace.path)
+    } {
         Ok(preview) => preview,
         Err(error) => {
             ledger.update_task_workspace_state(
@@ -1080,7 +1314,15 @@ fn finalize_task_workspace(
         }
     };
     let published = match workspace.factory_branch.as_deref() {
-        Some(branch) => match manager.branch_is_pushed(branch) {
+        Some(branch) => match if workspace.backend == "clone" {
+            clone_manager.branch_is_pushed(
+                &workspace.path,
+                branch,
+                clone_token_env.context("clone cleanup has no GitHub token source")?,
+            )
+        } else {
+            manager.branch_is_pushed(branch)
+        } {
             Ok(published) => published,
             Err(error) => {
                 ledger.update_task_workspace_state(
@@ -1104,11 +1346,15 @@ fn finalize_task_workspace(
             "cleanup_pending",
             Some(AUTOMATIC_DELIVERY_CLEANUP),
         )?;
-        manager.cleanup_clean(&workspace.path)?;
+        if workspace.backend == "clone" {
+            clone_manager.remove(&workspace.path)?;
+        } else {
+            manager.cleanup_clean(&workspace.path)?;
+        }
         ledger.update_task_workspace_state(
             task_id,
             "cleaned",
-            Some("delivery worktree removed"),
+            Some("delivery workspace removed"),
         )?;
     } else {
         let summary = format!(
@@ -1149,6 +1395,163 @@ async fn execute_task(
         humantime::format_duration(started.elapsed())
     );
     execution.map(|_| ())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_docker_task(
+    mut ledger: Ledger,
+    repository: &RepositoryTarget,
+    workflow: &WorkflowTarget,
+    docker: &DockerWorker,
+    mount: CloneMount,
+    run_id: i64,
+    prompt: String,
+    cancellation: CancellationToken,
+) -> Result<()> {
+    let started = Instant::now();
+    let run_cancellation = cancellation.child_token();
+    let ledger_path = ledger.path().to_owned();
+    let (observations, observation_receiver) = observation_channel();
+    let cancellation_monitor = spawn_run_monitor(
+        ledger_path.clone(),
+        run_id,
+        run_cancellation.clone(),
+        observation_receiver,
+    );
+    let image_ref = docker.image().to_owned();
+    let limits_json = docker.limits_json(&repository.path)?;
+    let execution = docker
+        .run(
+            run_id,
+            &repository.path,
+            mount,
+            &prompt,
+            workflow.timeout,
+            run_cancellation,
+            observations.clone(),
+            move |identity| {
+                let ledger = Ledger::open(&ledger_path)?;
+                ledger.record_run_container(&RunContainer {
+                    run_id,
+                    container_id: identity.id.clone(),
+                    instance_id: identity.instance_id.clone(),
+                    image_ref,
+                    image_id: identity.image_id.clone(),
+                    limits_json,
+                    state: "created".to_owned(),
+                    exit_code: None,
+                    logs: None,
+                    created_at: Utc::now().timestamp_millis(),
+                    updated_at: Utc::now().timestamp_millis(),
+                    removed_at: None,
+                })
+            },
+        )
+        .await;
+    cancellation_monitor.abort();
+    let _ = cancellation_monitor.await;
+    let observation = observations.borrow().clone();
+    if observation.sequence > 0 {
+        ledger.observe_run(
+            run_id,
+            None,
+            None,
+            None,
+            observation.pull_request.as_deref(),
+            observation.activity.as_deref(),
+        )?;
+    }
+    match execution {
+        Ok((result, identity)) => {
+            let container_state = match result.termination {
+                Termination::Exited => "exited",
+                Termination::TimedOut => "timed_out",
+                Termination::Cancelled => "cancelled",
+            };
+            let container_logs = docker
+                .container_logs(&identity.id)
+                .await
+                .unwrap_or_default();
+            ledger.finish_run_container(
+                run_id,
+                container_state,
+                result.status.code(),
+                Some(&container_logs),
+                false,
+            )?;
+            record_execution(&mut ledger, run_id, &result)?;
+            docker
+                .remove_container(&identity.id)
+                .await
+                .context("completed Docker worker could not be removed")?;
+            ledger.finish_run_container(
+                run_id,
+                container_state,
+                result.status.code(),
+                Some(&container_logs),
+                true,
+            )?;
+            eprintln!(
+                "Factory run finished: run={run_id} outcome={} duration={}",
+                if result.succeeded() {
+                    "succeeded"
+                } else {
+                    "failed"
+                },
+                humantime::format_duration(started.elapsed())
+            );
+            Ok(())
+        }
+        Err(error) => {
+            let identity = error
+                .downcast_ref::<DockerRunFailure>()
+                .map(|failure| failure.identity.clone());
+            let mut cleanup_error = None;
+            if ledger.run_container(run_id)?.is_some() {
+                let logs = if let Some(identity) = &identity {
+                    docker
+                        .container_logs(&identity.id)
+                        .await
+                        .unwrap_or_default()
+                } else {
+                    String::new()
+                };
+                let container_evidence = if logs.is_empty() {
+                    format!("{error:#}")
+                } else {
+                    logs
+                };
+                ledger.finish_run_container(
+                    run_id,
+                    "error",
+                    None,
+                    Some(&container_evidence),
+                    false,
+                )?;
+                if let Some(identity) = &identity {
+                    match docker.remove_container(&identity.id).await {
+                        Ok(()) => ledger.finish_run_container(
+                            run_id,
+                            "error",
+                            None,
+                            Some(&container_evidence),
+                            true,
+                        )?,
+                        Err(remove_error) => cleanup_error = Some(remove_error),
+                    }
+                }
+            }
+            let detail = cleanup_error.as_ref().map_or_else(
+                || format!("{error:#}"),
+                |cleanup| format!("{error:#}; container cleanup failed: {cleanup:#}"),
+            );
+            ledger.finish_run_and_task(run_id, RunOutcome::Failed, None, Some(&detail), None)?;
+            match cleanup_error {
+                Some(cleanup) => Err(cleanup.context(detail)),
+                None => Err(error),
+            }
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1738,6 +2141,13 @@ fn record_execution(ledger: &mut Ledger, run_id: i64, result: &ExecutionResult) 
             RunOutcome::Failed,
             Some("Codex execution timed out".to_owned()),
         ),
+        Termination::Exited if result.status.success() && result.activity_error.is_some() => (
+            RunOutcome::Failed,
+            Some(format!(
+                "Codex emitted malformed JSON activity: {}",
+                result.activity_error.as_deref().unwrap_or("unknown error")
+            )),
+        ),
         Termination::Exited if result.status.success() => (RunOutcome::Succeeded, None),
         Termination::Exited => (
             RunOutcome::Failed,
@@ -2165,6 +2575,7 @@ mod tests {
             .reserve_task_workspace(&TaskWorkspace {
                 task_id: task.id,
                 kind: "delivery".into(),
+                backend: "worktree".into(),
                 repository: task.repository,
                 base_branch: "main".into(),
                 base_sha: base_sha.clone(),
@@ -2215,7 +2626,7 @@ mod tests {
             .unwrap();
         std::fs::write(prepared.path.join("late-change.txt"), "keep me\n").unwrap();
 
-        reconcile_pending_cleanup(&ledger, &repository, &workspace_root).unwrap();
+        reconcile_pending_cleanup(&ledger, &repository, &workspace_root, None).unwrap();
 
         assert!(prepared.path.join("late-change.txt").exists());
         assert_eq!(
@@ -2223,7 +2634,7 @@ mod tests {
             "retained"
         );
         std::fs::rename(&remote, temp.path().join("origin-unavailable.git")).unwrap();
-        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root)
+        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root, None)
             .unwrap();
         assert_eq!(
             ledger.task_workspace(task.id).unwrap().unwrap().state,
@@ -2245,6 +2656,7 @@ mod tests {
             .reserve_task_workspace(&TaskWorkspace {
                 task_id: proposal_task.id,
                 kind: "proposal".into(),
+                backend: "worktree".into(),
                 repository: proposal_task.repository,
                 base_branch: "main".into(),
                 base_sha: base_sha.clone(),
@@ -2280,7 +2692,7 @@ mod tests {
             )
             .unwrap();
 
-        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root)
+        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root, None)
             .unwrap();
 
         assert!(!proposal.path.exists());
@@ -2304,6 +2716,7 @@ mod tests {
             .reserve_task_workspace(&TaskWorkspace {
                 task_id: absent_task.id,
                 kind: "delivery".into(),
+                backend: "worktree".into(),
                 repository: absent_task.repository,
                 base_branch: "main".into(),
                 base_sha: base_sha.clone(),
@@ -2336,7 +2749,7 @@ mod tests {
             )
             .unwrap();
 
-        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root)
+        reconcile_terminal_workspaces(&ledger, ledger.path(), &repository, &workspace_root, None)
             .unwrap();
 
         assert!(!absent_path.exists());

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1,0 +1,1039 @@
+use std::ffi::OsString;
+use std::fmt;
+use std::path::{Path, PathBuf};
+use std::process::{ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+use anyhow::{Context, Result, bail};
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tokio::sync::watch;
+use tokio::time::Instant as TokioInstant;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::WorkerConfig;
+use crate::inspection::sanitize_for_storage;
+use crate::runtime::{
+    ExecutionResult, RuntimeObservation, Termination, find_pull_request_url,
+    write_stderr_best_effort, write_stdout_best_effort,
+};
+
+const MAX_STREAM_BYTES: usize = 256 * 1024;
+const MAX_STDERR_BYTES: usize = 64 * 1024;
+const MAX_FINAL_BYTES: usize = 256 * 1024;
+const STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloneMount {
+    ReadOnly,
+    ReadWrite,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainerIdentity {
+    pub id: String,
+    pub image_id: String,
+    pub instance_id: String,
+    pub run_id: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveredContainer {
+    pub identity: ContainerIdentity,
+    pub state: String,
+    pub exit_code: Option<i32>,
+    pub logs: String,
+}
+
+#[derive(Debug)]
+pub struct DockerRunFailure {
+    pub identity: ContainerIdentity,
+    source: anyhow::Error,
+}
+
+impl fmt::Display for DockerRunFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "Docker worker {} failed: {:#}",
+            self.identity.id, self.source
+        )
+    }
+}
+
+impl std::error::Error for DockerRunFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DockerWorker {
+    executable: PathBuf,
+    config: WorkerConfig,
+    instance_id: String,
+    stream_activity: bool,
+}
+
+impl DockerWorker {
+    pub fn new(config: WorkerConfig, instance_id: impl Into<String>) -> Self {
+        Self {
+            executable: PathBuf::from("docker"),
+            config,
+            instance_id: instance_id.into(),
+            stream_activity: true,
+        }
+    }
+
+    pub fn with_executable(mut self, executable: impl Into<PathBuf>) -> Self {
+        self.executable = executable.into();
+        self
+    }
+
+    pub fn with_activity_streaming(mut self, enabled: bool) -> Self {
+        self.stream_activity = enabled;
+        self
+    }
+
+    pub fn image(&self) -> &str {
+        &self.config.image
+    }
+
+    pub fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+
+    pub fn github_token_env(&self) -> &str {
+        &self.config.github_token_env
+    }
+
+    pub fn limits_json(&self, clone: &Path) -> Result<String> {
+        let (uid, gid) = host_owner(clone)?;
+        Ok(serde_json::json!({
+            "memory": self.config.memory,
+            "cpus": self.config.cpus,
+            "pids": self.config.pids,
+            "read_only_root": true,
+            "user": format!("{uid}:{gid}"),
+        })
+        .to_string())
+    }
+
+    pub async fn validate(&self, cancellation: &CancellationToken) -> Result<String> {
+        self.command_output(
+            &["version", "--format", "{{.Server.Version}}"],
+            cancellation,
+        )
+        .await
+        .context("Docker daemon is unavailable; start Docker and retry")?;
+        let image_id = self.image_id(cancellation).await?;
+        let metadata = std::fs::symlink_metadata(&self.config.codex_auth).with_context(|| {
+            format!(
+                "dedicated Codex auth file is missing: {}",
+                self.config.codex_auth.display()
+            )
+        })?;
+        if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+            bail!("dedicated Codex auth path must be a regular non-symlink file");
+        }
+        std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&self.config.codex_auth)
+            .with_context(|| {
+                format!(
+                    "dedicated Codex auth file must be writable for OAuth refresh: {}",
+                    self.config.codex_auth.display()
+                )
+            })?;
+        let token = std::env::var(&self.config.github_token_env).with_context(|| {
+            format!(
+                "GitHub token is missing; export {} for the dedicated Factory identity",
+                self.config.github_token_env
+            )
+        })?;
+        if token.trim().is_empty() {
+            bail!("{} must not be empty", self.config.github_token_env);
+        }
+        eprintln!(
+            "Warning: Factory cannot prove that {} is a least-privilege bot token. A personal token may allow the agent to merge or bypass review; use a dedicated identity and protected branches.",
+            self.config.github_token_env
+        );
+        Ok(image_id)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn run<F>(
+        &self,
+        run_id: i64,
+        clone: &Path,
+        mount: CloneMount,
+        prompt: &str,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+        observations: watch::Sender<RuntimeObservation>,
+        before_start: F,
+    ) -> Result<(ExecutionResult, ContainerIdentity)>
+    where
+        F: FnOnce(&ContainerIdentity) -> Result<()> + Send,
+    {
+        let started = Instant::now();
+        let image_id = self.image_id(&cancellation).await?;
+        let identity = self
+            .create(run_id, clone, mount, &image_id, &cancellation)
+            .await?;
+        if let Err(error) = before_start(&identity) {
+            let _ = self.remove(&identity.id, &CancellationToken::new()).await;
+            return Err(error);
+        }
+        let result = self
+            .start_and_wait(
+                &identity,
+                prompt,
+                run_timeout,
+                cancellation,
+                observations,
+                started,
+            )
+            .await;
+        let result = match result {
+            Ok(result) => result,
+            Err(error) => {
+                let _ = self.stop(&identity.id, &CancellationToken::new()).await;
+                return Err(DockerRunFailure {
+                    identity,
+                    source: error,
+                }
+                .into());
+            }
+        };
+        Ok((result, identity))
+    }
+
+    pub async fn remove_container(&self, id: &str) -> Result<()> {
+        self.remove(id, &CancellationToken::new()).await
+    }
+
+    pub async fn container_logs(&self, id: &str) -> Result<String> {
+        self.logs(id, &CancellationToken::new()).await
+    }
+
+    pub async fn owned_containers(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> Result<Vec<ContainerIdentity>> {
+        let filter = format!("label=dev.factory.instance={}", self.instance_id);
+        let output = self
+            .command_output(
+                &[
+                    "ps",
+                    "-a",
+                    "--filter",
+                    "label=dev.factory.managed=true",
+                    "--filter",
+                    &filter,
+                    "--format",
+                    "{{.ID}}\t{{.Label \"dev.factory.run\"}}",
+                ],
+                cancellation,
+            )
+            .await?;
+        let mut containers = Vec::new();
+        for line in output.lines().filter(|line| !line.trim().is_empty()) {
+            let mut fields = line.split('\t');
+            let id = fields.next().unwrap_or_default().trim();
+            let run_id = fields
+                .next()
+                .context("owned container has no run label")?
+                .parse::<i64>()
+                .context("owned container has invalid run label")?;
+            if id.is_empty() || run_id <= 0 {
+                bail!("Docker returned an invalid owned container record");
+            }
+            containers.push(ContainerIdentity {
+                id: id.to_owned(),
+                image_id: self.inspect_image(id, cancellation).await?,
+                instance_id: self.instance_id.clone(),
+                run_id,
+            });
+        }
+        Ok(containers)
+    }
+
+    pub async fn recover_container(
+        &self,
+        identity: &ContainerIdentity,
+        cancellation: &CancellationToken,
+    ) -> Result<RecoveredContainer> {
+        let (state, _) = self.inspect_state(&identity.id, cancellation).await?;
+        if state == "running" {
+            self.stop(&identity.id, cancellation).await?;
+        }
+        let (state, exit_code) = self.inspect_state(&identity.id, cancellation).await?;
+        let logs = self
+            .logs(&identity.id, cancellation)
+            .await
+            .unwrap_or_default();
+        Ok(RecoveredContainer {
+            identity: identity.clone(),
+            state,
+            exit_code,
+            logs,
+        })
+    }
+
+    async fn image_id(&self, cancellation: &CancellationToken) -> Result<String> {
+        let output = self
+            .command_output(
+                &[
+                    "image",
+                    "inspect",
+                    &self.config.image,
+                    "--format",
+                    "{{.Id}}",
+                ],
+                cancellation,
+            )
+            .await
+            .with_context(|| format!("Docker image {:?} is unavailable", self.config.image))?;
+        let image_id = output.trim();
+        if !image_id.starts_with("sha256:") {
+            bail!("Docker returned invalid image ID {image_id:?}");
+        }
+        Ok(image_id.to_owned())
+    }
+
+    async fn create(
+        &self,
+        run_id: i64,
+        clone: &Path,
+        mount: CloneMount,
+        image_id: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<ContainerIdentity> {
+        let clone = clone
+            .canonicalize()
+            .with_context(|| format!("failed to resolve clone {}", clone.display()))?;
+        let auth = self.config.codex_auth.canonicalize().with_context(|| {
+            format!(
+                "failed to resolve auth file {}",
+                self.config.codex_auth.display()
+            )
+        })?;
+        let (uid, gid) = host_owner(&clone)?;
+        let mut clone_mount = format!("type=bind,src={},dst=/workspace", docker_path(&clone)?);
+        if mount == CloneMount::ReadOnly {
+            clone_mount.push_str(",readonly");
+        }
+        let auth_mount = format!(
+            "type=bind,src={},dst=/home/agent/.codex/auth.json",
+            docker_path(&auth)?
+        );
+        let name = format!("factory-{}-{run_id}", self.instance_id);
+        let run_label = format!("dev.factory.run={run_id}");
+        let instance_label = format!("dev.factory.instance={}", self.instance_id);
+        let memory = self.config.memory.clone();
+        let cpus = self.config.cpus.to_string();
+        let pids = self.config.pids.to_string();
+        let arguments = vec![
+            OsString::from("create"),
+            OsString::from("--interactive"),
+            OsString::from("--name"),
+            OsString::from(name),
+            OsString::from("--label"),
+            OsString::from("dev.factory.managed=true"),
+            OsString::from("--label"),
+            OsString::from(run_label),
+            OsString::from("--label"),
+            OsString::from(instance_label),
+            OsString::from("--user"),
+            OsString::from(format!("{uid}:{gid}")),
+            OsString::from("--read-only"),
+            OsString::from("--cap-drop"),
+            OsString::from("ALL"),
+            OsString::from("--security-opt"),
+            OsString::from("no-new-privileges"),
+            OsString::from("--pids-limit"),
+            OsString::from(pids),
+            OsString::from("--memory"),
+            OsString::from(memory),
+            OsString::from("--cpus"),
+            OsString::from(cpus),
+            OsString::from("--log-opt"),
+            OsString::from("max-size=10m"),
+            OsString::from("--log-opt"),
+            OsString::from("max-file=1"),
+            OsString::from("--tmpfs"),
+            OsString::from(format!("/tmp:rw,size=1g,uid={uid},gid={gid},mode=1777")),
+            OsString::from("--tmpfs"),
+            OsString::from(format!(
+                "/home/agent/.codex:rw,size=64m,uid={uid},gid={gid},mode=700"
+            )),
+            OsString::from("--mount"),
+            OsString::from(clone_mount),
+            OsString::from("--mount"),
+            OsString::from(auth_mount),
+            OsString::from("--env"),
+            OsString::from("GH_TOKEN"),
+            OsString::from("--env"),
+            OsString::from("HOME=/home/agent"),
+            OsString::from("--env"),
+            OsString::from("CODEX_HOME=/home/agent/.codex"),
+            OsString::from("--workdir"),
+            OsString::from("/workspace"),
+            OsString::from(image_id),
+            OsString::from("codex"),
+            OsString::from("exec"),
+            OsString::from("--ephemeral"),
+            OsString::from("--ignore-user-config"),
+            OsString::from("--sandbox"),
+            OsString::from("danger-full-access"),
+            OsString::from("--json"),
+            OsString::from("--color"),
+            OsString::from("never"),
+            OsString::from("--output-last-message"),
+            OsString::from("/tmp/factory-last-message"),
+            OsString::from("-"),
+        ];
+        let output = self
+            .command_output_os(&arguments, cancellation)
+            .await
+            .context("failed to create Docker worker")?;
+        let id = output.trim();
+        if id.is_empty() || !id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            bail!("Docker create returned invalid container ID {id:?}");
+        }
+        Ok(ContainerIdentity {
+            id: id.to_owned(),
+            image_id: image_id.to_owned(),
+            instance_id: self.instance_id.clone(),
+            run_id,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn start_and_wait(
+        &self,
+        identity: &ContainerIdentity,
+        prompt: &str,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+        observations: watch::Sender<RuntimeObservation>,
+        started: Instant,
+    ) -> Result<ExecutionResult> {
+        let mut command = Command::new(&self.executable);
+        command
+            .args(["start", "--attach", "--interactive", &identity.id])
+            .env(
+                &self.config.github_token_env,
+                std::env::var(&self.config.github_token_env)?,
+            )
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = command.spawn().context("failed to start Docker worker")?;
+        let mut stdin = child.stdin.take().context("Docker attach has no stdin")?;
+        let stdout = child.stdout.take().context("Docker attach has no stdout")?;
+        let stderr = child.stderr.take().context("Docker attach has no stderr")?;
+        let stream = self.stream_activity;
+        let stdout_task = tokio::spawn(capture_pipe(stdout, true, stream, observations.clone()));
+        let stderr_task = tokio::spawn(capture_pipe(stderr, false, stream, observations));
+        stdin.write_all(prompt.as_bytes()).await?;
+        stdin.shutdown().await?;
+        drop(stdin);
+        let deadline = TokioInstant::now() + run_timeout;
+        let termination = tokio::select! {
+            () = cancellation.cancelled() => {
+                self.stop(&identity.id, &CancellationToken::new()).await?;
+                Termination::Cancelled
+            }
+            () = tokio::time::sleep_until(deadline) => {
+                self.stop(&identity.id, &CancellationToken::new()).await?;
+                Termination::TimedOut
+            }
+            status = child.wait() => {
+                status.context("failed to wait for Docker attach")?;
+                Termination::Exited
+            }
+        };
+        if termination != Termination::Exited
+            && tokio::time::timeout(STOP_TIMEOUT, child.wait())
+                .await
+                .is_err()
+        {
+            child.kill().await.ok();
+            child.wait().await.ok();
+        }
+        let stdout = await_capture(stdout_task, "stdout").await?;
+        let stderr = await_capture(stderr_task, "stderr").await?;
+        let (_, exit_code) = self
+            .inspect_state(&identity.id, &CancellationToken::new())
+            .await?;
+        let exit_code = exit_code.unwrap_or(1);
+        let final_response = self
+            .copy_final_response(&identity.id)
+            .await
+            .unwrap_or_default();
+        Ok(ExecutionResult {
+            status: exit_status(exit_code),
+            termination,
+            final_response,
+            final_response_truncated: false,
+            thread_id: None,
+            duration: started.elapsed(),
+            activity_lines: stdout.lines,
+            activity_error: stdout.malformed,
+            stderr_tail: stderr.text,
+        })
+    }
+
+    async fn stop(&self, id: &str, cancellation: &CancellationToken) -> Result<()> {
+        if self
+            .command_output(&["stop", "--time", "2", id], cancellation)
+            .await
+            .is_err()
+        {
+            self.command_output(&["kill", id], cancellation).await?;
+        }
+        Ok(())
+    }
+
+    async fn remove(&self, id: &str, cancellation: &CancellationToken) -> Result<()> {
+        self.command_output(&["rm", "--force", id], cancellation)
+            .await?;
+        Ok(())
+    }
+
+    async fn inspect_state(
+        &self,
+        id: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<(String, Option<i32>)> {
+        let output = self
+            .command_output(
+                &[
+                    "inspect",
+                    "--format",
+                    "{{.State.Status}}\t{{.State.ExitCode}}",
+                    id,
+                ],
+                cancellation,
+            )
+            .await?;
+        let mut fields = output.trim().split('\t');
+        let state = fields.next().unwrap_or_default().to_owned();
+        let exit_code = fields.next().and_then(|value| value.parse().ok());
+        Ok((state, exit_code))
+    }
+
+    async fn inspect_image(&self, id: &str, cancellation: &CancellationToken) -> Result<String> {
+        let image = self
+            .command_output(&["inspect", "--format", "{{.Image}}", id], cancellation)
+            .await?;
+        let image = image.trim();
+        if !image.starts_with("sha256:") {
+            bail!("Docker returned invalid container image ID {image:?}");
+        }
+        Ok(image.to_owned())
+    }
+
+    async fn logs(&self, id: &str, cancellation: &CancellationToken) -> Result<String> {
+        let mut command = Command::new(&self.executable);
+        command
+            .args(["logs", "--tail", "500", id])
+            .env(
+                "GH_TOKEN",
+                std::env::var(&self.config.github_token_env).unwrap_or_default(),
+            )
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let child = command.spawn().context("failed to start Docker logs")?;
+        let output = tokio::select! {
+            () = cancellation.cancelled() => bail!("Docker logs cancelled"),
+            output = tokio::time::timeout(Duration::from_secs(30), child.wait_with_output()) => {
+                output.context("Docker logs timed out")??
+            }
+        };
+        if !output.status.success() {
+            bail!(
+                "Docker logs failed with {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        let mut combined = output.stdout;
+        if !combined.is_empty() && !output.stderr.is_empty() {
+            combined.push(b'\n');
+        }
+        combined.extend_from_slice(&output.stderr);
+        Ok(truncate_tail(
+            &String::from_utf8_lossy(&combined),
+            MAX_STREAM_BYTES,
+        ))
+    }
+
+    async fn copy_final_response(&self, id: &str) -> Result<String> {
+        let temp = tempfile::NamedTempFile::new()?;
+        let source = format!("{id}:/tmp/factory-last-message");
+        let destination = temp.path().to_string_lossy().into_owned();
+        self.command_output(&["cp", &source, &destination], &CancellationToken::new())
+            .await?;
+        let bytes = std::fs::read(temp.path())?;
+        Ok(String::from_utf8_lossy(&bytes[..bytes.len().min(MAX_FINAL_BYTES)]).into_owned())
+    }
+
+    async fn command_output(
+        &self,
+        arguments: &[&str],
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
+        let arguments = arguments.iter().map(OsString::from).collect::<Vec<_>>();
+        self.command_output_os(&arguments, cancellation).await
+    }
+
+    async fn command_output_os(
+        &self,
+        arguments: &[OsString],
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
+        let mut command = Command::new(&self.executable);
+        command
+            .args(arguments)
+            .env(
+                &self.config.github_token_env,
+                std::env::var(&self.config.github_token_env).unwrap_or_default(),
+            )
+            .env(
+                "GH_TOKEN",
+                std::env::var(&self.config.github_token_env).unwrap_or_default(),
+            )
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let child = command.spawn().with_context(|| {
+            format!(
+                "failed to start Docker CLI at {}",
+                self.executable.display()
+            )
+        })?;
+        let output = tokio::select! {
+            () = cancellation.cancelled() => bail!("Docker command cancelled"),
+            output = tokio::time::timeout(Duration::from_secs(30), child.wait_with_output()) => {
+                output.context("Docker command timed out")??
+            }
+        };
+        if !output.status.success() {
+            bail!(
+                "Docker command failed with {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        String::from_utf8(output.stdout).context("Docker output was not UTF-8")
+    }
+}
+
+async fn await_capture(
+    mut task: tokio::task::JoinHandle<Result<PipeCapture>>,
+    stream: &str,
+) -> Result<PipeCapture> {
+    match tokio::time::timeout(STOP_TIMEOUT, &mut task).await {
+        Ok(result) => result.with_context(|| format!("Docker {stream} task panicked"))?,
+        Err(_) => {
+            task.abort();
+            let _ = task.await;
+            bail!("Docker {stream} did not close after worker termination")
+        }
+    }
+}
+
+#[cfg(unix)]
+fn host_owner(path: &Path) -> Result<(u32, u32)> {
+    let metadata = std::fs::metadata(path).with_context(|| {
+        format!(
+            "failed to inspect workspace ownership for {}",
+            path.display()
+        )
+    })?;
+    Ok((metadata.uid(), metadata.gid()))
+}
+
+#[derive(Debug)]
+struct PipeCapture {
+    text: String,
+    lines: usize,
+    malformed: Option<String>,
+}
+
+async fn capture_pipe<R: AsyncRead + Unpin>(
+    reader: R,
+    json_activity: bool,
+    stream: bool,
+    observations: watch::Sender<RuntimeObservation>,
+) -> Result<PipeCapture> {
+    if json_activity {
+        return capture_json_activity(reader, stream, observations).await;
+    }
+    let mut reader = reader;
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        if stream {
+            write_stderr_best_effort(&chunk[..read]);
+        }
+        append_bounded(&mut bytes, &chunk[..read], MAX_STDERR_BYTES);
+    }
+    let text = String::from_utf8_lossy(&bytes).into_owned();
+    if !text.is_empty() {
+        observations.send_modify(|observation| {
+            observation.activity = Some(format!("Docker stderr: {}", sanitize_for_storage(&text)));
+            observation.sequence = observation.sequence.saturating_add(1);
+        });
+    }
+    Ok(PipeCapture {
+        text,
+        lines: 0,
+        malformed: None,
+    })
+}
+
+async fn capture_json_activity<R: AsyncRead + Unpin>(
+    mut reader: R,
+    stream: bool,
+    observations: watch::Sender<RuntimeObservation>,
+) -> Result<PipeCapture> {
+    let mut bytes = Vec::new();
+    let mut pending = Vec::new();
+    let mut oversized = false;
+    let mut malformed = None;
+    let mut lines = 0;
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut chunk).await?;
+        if read == 0 {
+            break;
+        }
+        if stream {
+            write_stdout_best_effort(&chunk[..read]);
+        }
+        append_bounded(&mut bytes, &chunk[..read], MAX_STREAM_BYTES);
+        for byte in &chunk[..read] {
+            if *byte == b'\n' {
+                record_activity_line(
+                    &pending,
+                    oversized,
+                    &observations,
+                    &mut lines,
+                    &mut malformed,
+                );
+                pending.clear();
+                oversized = false;
+            } else if pending.len() < MAX_STREAM_BYTES {
+                pending.push(*byte);
+            } else {
+                oversized = true;
+            }
+        }
+    }
+    if !pending.is_empty() || oversized {
+        record_activity_line(
+            &pending,
+            oversized,
+            &observations,
+            &mut lines,
+            &mut malformed,
+        );
+    }
+    Ok(PipeCapture {
+        text: String::from_utf8_lossy(&bytes).into_owned(),
+        lines,
+        malformed,
+    })
+}
+
+fn record_activity_line(
+    line: &[u8],
+    oversized: bool,
+    observations: &watch::Sender<RuntimeObservation>,
+    lines: &mut usize,
+    malformed: &mut Option<String>,
+) {
+    if line.iter().all(u8::is_ascii_whitespace) && !oversized {
+        return;
+    }
+    *lines += 1;
+    if oversized {
+        malformed.get_or_insert_with(|| {
+            format!("Codex activity line exceeded {MAX_STREAM_BYTES} bytes")
+        });
+        return;
+    }
+    match serde_json::from_slice::<Value>(line) {
+        Ok(event) => observe_event(observations, &event),
+        Err(error) if malformed.is_none() => *malformed = Some(error.to_string()),
+        Err(_) => {}
+    }
+}
+
+fn observe_event(observations: &watch::Sender<RuntimeObservation>, event: &Value) {
+    let kind = event
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    observations.send_modify(|observation| {
+        let mut activity = observation.activity.take().unwrap_or_default();
+        activity.push_str(&format!("Codex event: {}\n", sanitize_for_storage(kind)));
+        observation.activity = Some(truncate_tail(&activity, MAX_STREAM_BYTES));
+        if let Some(pull_request) = find_pull_request_url(event) {
+            observation.pull_request = Some(pull_request);
+        }
+        observation.sequence = observation.sequence.saturating_add(1);
+    });
+}
+
+fn docker_path(path: &Path) -> Result<String> {
+    let value = path
+        .to_str()
+        .context("Docker mount path is not valid UTF-8")?;
+    if value.contains(',') || value.contains('\n') || value.contains('\r') {
+        bail!("Docker mount path contains unsupported characters");
+    }
+    Ok(value.to_owned())
+}
+
+fn append_bounded(target: &mut Vec<u8>, chunk: &[u8], maximum: usize) {
+    target.extend_from_slice(chunk);
+    if target.len() > maximum {
+        target.drain(..target.len() - maximum);
+    }
+}
+
+fn truncate_tail(value: &str, maximum: usize) -> String {
+    if value.len() <= maximum {
+        return value.to_owned();
+    }
+    let mut start = value.len() - maximum;
+    while !value.is_char_boundary(start) {
+        start += 1;
+    }
+    value[start..].to_owned()
+}
+
+#[cfg(unix)]
+fn exit_status(code: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(code << 8)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::fs;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+    use crate::runtime::observation_channel;
+
+    const TOKEN_ENV: &str = "FACTORY_DOCKER_TEST_TOKEN";
+
+    fn executable(path: &Path, contents: &str) {
+        fs::write(path, contents).unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[tokio::test]
+    async fn creates_hardened_read_only_and_read_write_workers_after_persistence() {
+        let temp = tempfile::tempdir().unwrap();
+        let log = temp.path().join("docker.log");
+        let docker = temp.path().join("docker");
+        let auth = temp.path().join("auth.json");
+        let read_only_clone = temp.path().join("triage");
+        let read_write_clone = temp.path().join("implementation");
+        fs::write(&auth, "{}").unwrap();
+        fs::create_dir(&read_only_clone).unwrap();
+        fs::create_dir(&read_write_clone).unwrap();
+        executable(
+            &docker,
+            &format!(
+                r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> '{}'
+case "$1 ${{2:-}}" in
+  'image inspect') printf '%s\n' 'sha256:abcdef0123456789' ;;
+  'create --interactive') printf '%s\n' 'abcdef0123456789' ;;
+  'start --attach')
+    cat >/dev/null
+    printf '%s\n' '{{"type":"item.completed"}}'
+    ;;
+  'inspect --format') printf 'exited\t0\n' ;;
+  'logs --tail') printf 'container stdout'; printf 'container stderr' >&2 ;;
+  'cp '*) printf '%s' 'finished' > "$3" ;;
+  'rm --force') ;;
+  *) printf 'unexpected fake docker command: %s\n' "$*" >&2; exit 1 ;;
+esac
+"#,
+                log.display()
+            ),
+        );
+        // SAFETY: this test uses a process-unique environment variable name and
+        // no other test in this crate reads or writes it.
+        unsafe { std::env::set_var(TOKEN_ENV, "super-secret-docker-token") };
+        let worker = DockerWorker::new(
+            WorkerConfig {
+                image: "factory-codex:test".to_owned(),
+                memory: "4g".to_owned(),
+                cpus: 2,
+                pids: 128,
+                codex_auth: auth.clone(),
+                github_token_env: TOKEN_ENV.to_owned(),
+            },
+            "test-instance",
+        )
+        .with_executable(&docker)
+        .with_activity_streaming(false);
+
+        for (run_id, clone, mount) in [
+            (11, read_only_clone.as_path(), CloneMount::ReadOnly),
+            (12, read_write_clone.as_path(), CloneMount::ReadWrite),
+        ] {
+            let (observations, _) = observation_channel();
+            let callback_log = log.clone();
+            let (result, identity) = worker
+                .run(
+                    run_id,
+                    clone,
+                    mount,
+                    "work on the issue",
+                    Duration::from_secs(5),
+                    CancellationToken::new(),
+                    observations,
+                    move |identity| {
+                        let commands = fs::read_to_string(&callback_log)?;
+                        let latest_create = commands.rfind("create --interactive").unwrap();
+                        assert!(
+                            !commands[latest_create..]
+                                .contains(&format!("start --attach --interactive {}", identity.id))
+                        );
+                        writeln!(
+                            fs::OpenOptions::new().append(true).open(&callback_log)?,
+                            "persisted {}",
+                            identity.run_id
+                        )?;
+                        Ok(())
+                    },
+                )
+                .await
+                .unwrap();
+            assert!(result.succeeded());
+            assert_eq!(result.final_response, "finished");
+            assert_eq!(identity.run_id, run_id);
+            let logs = worker.container_logs(&identity.id).await.unwrap();
+            assert!(logs.contains("container stdout"));
+            assert!(logs.contains("container stderr"));
+            worker.remove_container(&identity.id).await.unwrap();
+        }
+
+        let commands = fs::read_to_string(log).unwrap();
+        let create = commands
+            .lines()
+            .filter(|line| line.starts_with("create --interactive"))
+            .collect::<Vec<_>>();
+        assert_eq!(create.len(), 2);
+        for line in &create {
+            assert!(line.contains("--read-only"));
+            assert!(line.contains("--cap-drop ALL"));
+            assert!(line.contains("--security-opt no-new-privileges"));
+            assert!(line.contains("--pids-limit 128"));
+            assert!(line.contains("--memory 4g"));
+            assert!(line.contains("--cpus 2"));
+            assert!(line.contains("--env GH_TOKEN"));
+            assert!(line.contains("--sandbox danger-full-access"));
+            assert!(line.contains("--ephemeral --ignore-user-config"));
+            assert!(!line.contains("super-secret-docker-token"));
+            assert!(!line.contains("docker.sock"));
+        }
+        let read_only_path = read_only_clone.canonicalize().unwrap();
+        assert!(create[0].contains(&format!(
+            "type=bind,src={},dst=/workspace,readonly",
+            read_only_path.display()
+        )));
+        let read_write_path = read_write_clone.canonicalize().unwrap();
+        assert!(create[1].contains(&format!(
+            "type=bind,src={},dst=/workspace",
+            read_write_path.display()
+        )));
+        assert!(!create[1].contains("dst=/workspace,readonly"));
+        assert!(create[0].contains(&format!(
+            "type=bind,src={},dst=/home/agent/.codex/auth.json",
+            auth.canonicalize().unwrap().display()
+        )));
+
+        for run_id in [11, 12] {
+            let persisted = commands.find(&format!("persisted {run_id}")).unwrap();
+            let started = commands[persisted..]
+                .find("start --attach --interactive")
+                .map(|offset| offset + persisted)
+                .unwrap();
+            assert!(persisted < started);
+        }
+    }
+
+    #[tokio::test]
+    async fn streams_complete_activity_lines_before_eof() {
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let (observations, mut receiver) = observation_channel();
+        let capture = tokio::spawn(capture_pipe(reader, true, false, observations));
+
+        writer
+            .write_all(b"{\"type\":\"turn.started\"}\n")
+            .await
+            .unwrap();
+        writer.flush().await.unwrap();
+        tokio::time::timeout(Duration::from_secs(1), receiver.changed())
+            .await
+            .expect("activity was not streamed before EOF")
+            .unwrap();
+        assert!(
+            receiver
+                .borrow()
+                .activity
+                .as_deref()
+                .unwrap()
+                .contains("turn.started")
+        );
+
+        drop(writer);
+        assert_eq!(capture.await.unwrap().unwrap().lines, 1);
+    }
+
+    #[tokio::test]
+    async fn bounds_and_rejects_malformed_activity_lines() {
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let (observations, _) = observation_channel();
+        let capture = tokio::spawn(capture_pipe(reader, true, false, observations));
+        let writer_task = tokio::spawn(async move {
+            let mut oversized = vec![b'x'; MAX_STREAM_BYTES + 1];
+            oversized.push(b'\n');
+            writer.write_all(&oversized).await.unwrap();
+            writer.write_all(b"not-json\n").await.unwrap();
+        });
+
+        writer_task.await.unwrap();
+        let captured = capture.await.unwrap().unwrap();
+        assert_eq!(captured.lines, 2);
+        assert!(captured.malformed.as_deref().unwrap().contains("exceeded"));
+        assert!(captured.text.len() <= MAX_STREAM_BYTES);
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -424,6 +424,12 @@ fn default_config() -> String {
     document["default_timeout"] = value("2h");
     document["maximum_timeout"] = value("8h");
     document["max_concurrent_runs"] = value(1);
+    document["worker"] = Item::Table(Table::new());
+    document["worker"]["kind"] = value("docker");
+    document["worker"]["image"] = value("factory-codex:dev");
+    document["worker"]["memory"] = value("8g");
+    document["worker"]["cpus"] = value(4);
+    document["worker"]["pids"] = value(512);
     document["source"] = Item::Table(Table::new());
     document["source"]["kind"] = value("github_project");
     document["source"]["owner"] = value("owainlewis");

--- a/src/inspection.rs
+++ b/src/inspection.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use regex::Regex;
 use serde::Serialize;
 
-use crate::storage::{Run, Task, TaskState};
+use crate::storage::{Run, RunContainer, Task, TaskState};
 
 const MAX_SUMMARY_BYTES: usize = 240;
 const MAX_DETAIL_BYTES: usize = 16 * 1024;
@@ -124,10 +124,23 @@ pub struct RunInspection {
     pub result: Option<BoundedText>,
     pub error: Option<BoundedText>,
     pub activity: Option<BoundedText>,
+    pub container: Option<ContainerView>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContainerView {
+    pub id: String,
+    pub instance_id: String,
+    pub image_ref: String,
+    pub image_id: String,
+    pub limits: String,
+    pub state: String,
+    pub exit_code: Option<i32>,
+    pub removed_at: Option<i64>,
 }
 
 impl RunInspection {
-    pub fn new(run: &Run, task: &Task) -> Self {
+    pub fn new(run: &Run, task: &Task, container: Option<&RunContainer>) -> Self {
         Self {
             run: RunView::from(run),
             task: TaskView::from(task),
@@ -135,6 +148,16 @@ impl RunInspection {
             result: run.result.as_deref().map(BoundedText::new),
             error: run.error.as_deref().map(BoundedText::new),
             activity: run.activity.as_deref().map(BoundedText::new),
+            container: container.map(|container| ContainerView {
+                id: container.container_id.clone(),
+                instance_id: container.instance_id.clone(),
+                image_ref: container.image_ref.clone(),
+                image_id: container.image_id.clone(),
+                limits: container.limits_json.clone(),
+                state: container.state.clone(),
+                exit_code: container.exit_code,
+                removed_at: container.removed_at,
+            }),
         }
     }
 }
@@ -245,6 +268,12 @@ pub fn print_inspection(inspection: &RunInspection) {
         "Session: {}",
         safe_text(inspection.session_id.as_deref().unwrap_or("-"))
     );
+    if let Some(container) = &inspection.container {
+        println!("Container: {}", safe_text(&container.id));
+        println!("Container state: {}", safe_text(&container.state));
+        println!("Container image: {}", safe_text(&container.image_id));
+        println!("Container limits: {}", safe_text(&container.limits));
+    }
     print_detail("Result", inspection.result.as_ref());
     print_detail("Error", inspection.error.as_ref());
     print_detail("Activity", inspection.activity.as_ref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@ compile_error!("Factory v1 supports Unix-like operating systems only");
 
 pub mod approval;
 pub mod approve;
+pub mod clone;
 pub mod config;
 pub mod daemon;
+pub mod docker;
 pub mod execution;
 pub mod github;
 pub mod init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,10 @@ use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
 use factory::approve::approve_issue;
+use factory::clone::CloneManager;
 use factory::config::{Config, repository_config_path, repository_remote_identity};
 use factory::daemon::FactoryDaemon;
+use factory::docker::DockerWorker;
 use factory::execution::ResolvedWorkflow;
 use factory::github::{GitHubClient, PollReport};
 use factory::init::{InitOptions, initialize};
@@ -307,6 +309,11 @@ async fn run_cli() -> Result<u8> {
                         .await?;
                 }
             }
+            if let Some(worker) = &config.worker {
+                DockerWorker::new(worker.clone(), "validate")
+                    .validate(&CancellationToken::new())
+                    .await?;
+            }
             print!("{config}");
         }
         Command::Workflows { config } => {
@@ -411,7 +418,8 @@ async fn run_cli() -> Result<u8> {
             let task = ledger
                 .task(run.task_id)?
                 .with_context(|| format!("task {} for run {run_id} does not exist", run.task_id))?;
-            let inspection = RunInspection::new(&run, &task);
+            let container = ledger.run_container(run_id)?;
+            let inspection = RunInspection::new(&run, &task, container.as_ref());
             if json {
                 print_json(&inspection)?;
             } else {
@@ -496,6 +504,7 @@ async fn run_cli() -> Result<u8> {
                 return Ok(0);
             }
             let manager = WorkspaceManager::new(&config.repositories[0], &config.workspace_root)?;
+            let clone_manager = CloneManager::new(&config.workspace_root)?;
             if !workspace.path.exists() {
                 println!("run: {run_id}");
                 println!("workspace: {}", workspace.path.display());
@@ -526,7 +535,11 @@ async fn run_cli() -> Result<u8> {
                 }
                 return Ok(0);
             }
-            let preview = manager.preview_cleanup(&workspace.path)?;
+            let preview = if workspace.backend == "clone" {
+                clone_manager.preview_cleanup(&workspace.path)?
+            } else {
+                manager.preview_cleanup(&workspace.path)?
+            };
             println!("run: {run_id}");
             println!("workspace: {}", preview.path.display());
             println!(
@@ -536,7 +549,7 @@ async fn run_cli() -> Result<u8> {
             println!("dirty: {}", preview.dirty);
             println!("branch preserved: true");
             if !confirm {
-                println!("action: preview only; rerun with --confirm to remove the worktree");
+                println!("action: preview only; rerun with --confirm to remove the workspace");
             } else {
                 if matches!(task.state, TaskState::Queued | TaskState::Running) {
                     bail!(
@@ -550,13 +563,21 @@ async fn run_cli() -> Result<u8> {
                     "cleanup_pending",
                     Some(OPERATOR_CONFIRMED_CLEANUP),
                 )?;
-                manager.cleanup(&workspace.path, true)?;
+                if workspace.backend == "clone" {
+                    clone_manager.remove(&workspace.path)?;
+                } else {
+                    manager.cleanup(&workspace.path, true)?;
+                }
                 ledger.update_task_workspace_state(
                     task.id,
                     "cleaned",
                     Some("operator-confirmed cleanup completed"),
                 )?;
-                println!("action: removed worktree; local branch preserved");
+                if workspace.backend == "clone" {
+                    println!("action: removed clone; remote branch preserved");
+                } else {
+                    println!("action: removed worktree; local branch preserved");
+                }
             }
         }
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -736,7 +736,7 @@ fn capture_activity_line(
     }
 }
 
-fn find_pull_request_url(value: &Value) -> Option<String> {
+pub(crate) fn find_pull_request_url(value: &Value) -> Option<String> {
     match value {
         Value::String(value) => value.split_whitespace().find_map(|word| {
             let candidate = word.trim_matches(|character: char| {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, bail};
 use rusqlite::{Connection, OpenFlags, OptionalExtension, TransactionBehavior, params};
 
 pub const DATABASE_NAME: &str = "factory.sqlite3";
-const SCHEMA_VERSION: i64 = 9;
+const SCHEMA_VERSION: i64 = 10;
 pub const MAX_RESULT_BYTES: usize = 256 * 1024;
 pub const MAX_ERROR_BYTES: usize = 64 * 1024;
 pub const MAX_SESSION_ID_BYTES: usize = 1024;
@@ -251,6 +251,7 @@ pub struct ProjectClaimEvidence<'a> {
 pub struct TaskWorkspace {
     pub task_id: i64,
     pub kind: String,
+    pub backend: String,
     pub repository: String,
     pub base_branch: String,
     pub base_sha: String,
@@ -261,6 +262,22 @@ pub struct TaskWorkspace {
     pub created_at: i64,
     pub updated_at: i64,
     pub cleaned_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunContainer {
+    pub run_id: i64,
+    pub container_id: String,
+    pub instance_id: String,
+    pub image_ref: String,
+    pub image_id: String,
+    pub limits_json: String,
+    pub state: String,
+    pub exit_code: Option<i32>,
+    pub logs: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub removed_at: Option<i64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -856,7 +873,7 @@ impl Ledger {
     pub fn task_workspace(&self, task_id: i64) -> Result<Option<TaskWorkspace>> {
         self.connection
             .query_row(
-                "SELECT task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+                "SELECT task_id, kind, backend, repository, base_branch, base_sha, factory_branch, path,
                         state, status_summary, created_at, updated_at, cleaned_at
                  FROM task_workspaces WHERE task_id = ?1",
                 [task_id],
@@ -864,16 +881,17 @@ impl Ledger {
                     Ok(TaskWorkspace {
                         task_id: row.get(0)?,
                         kind: row.get(1)?,
-                        repository: row.get(2)?,
-                        base_branch: row.get(3)?,
-                        base_sha: row.get(4)?,
-                        factory_branch: row.get(5)?,
-                        path: PathBuf::from(row.get::<_, String>(6)?),
-                        state: row.get(7)?,
-                        status_summary: row.get(8)?,
-                        created_at: row.get(9)?,
-                        updated_at: row.get(10)?,
-                        cleaned_at: row.get(11)?,
+                        backend: row.get(2)?,
+                        repository: row.get(3)?,
+                        base_branch: row.get(4)?,
+                        base_sha: row.get(5)?,
+                        factory_branch: row.get(6)?,
+                        path: PathBuf::from(row.get::<_, String>(7)?),
+                        state: row.get(8)?,
+                        status_summary: row.get(9)?,
+                        created_at: row.get(10)?,
+                        updated_at: row.get(11)?,
+                        cleaned_at: row.get(12)?,
                     })
                 },
             )
@@ -914,12 +932,13 @@ impl Ledger {
         transaction
             .execute(
                 "INSERT INTO task_workspaces
-                 (task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+                 (task_id, kind, backend, repository, base_branch, base_sha, factory_branch, path,
                   state, status_summary, created_at, updated_at, cleaned_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'preparing', NULL, ?8, ?8, NULL)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'preparing', NULL, ?9, ?9, NULL)",
                 params![
                     workspace.task_id,
                     workspace.kind,
+                    workspace.backend,
                     workspace.repository,
                     workspace.base_branch,
                     workspace.base_sha,
@@ -963,6 +982,93 @@ impl Ledger {
         Ok(())
     }
 
+    pub fn record_run_container(&self, container: &RunContainer) -> Result<()> {
+        let running = self.connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM runs WHERE id = ?1 AND outcome = 'running')",
+            [container.run_id],
+            |row| row.get::<_, bool>(0),
+        )?;
+        if !running {
+            bail!(
+                "run {} must be running before container persistence",
+                container.run_id
+            );
+        }
+        self.connection
+            .execute(
+                "INSERT INTO run_containers
+                 (run_id, container_id, instance_id, image_ref, image_id, limits_json,
+                  state, exit_code, logs, created_at, updated_at, removed_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10, ?11)",
+                params![
+                    container.run_id,
+                    container.container_id,
+                    container.instance_id,
+                    container.image_ref,
+                    container.image_id,
+                    container.limits_json,
+                    container.state,
+                    container.exit_code,
+                    container.logs,
+                    container.created_at,
+                    container.removed_at,
+                ],
+            )
+            .context("failed to persist run container")?;
+        Ok(())
+    }
+
+    pub fn finish_run_container(
+        &self,
+        run_id: i64,
+        state: &str,
+        exit_code: Option<i32>,
+        logs: Option<&str>,
+        removed: bool,
+    ) -> Result<()> {
+        let logs = logs.map(|value| truncate_tail_utf8(value, MAX_ACTIVITY_BYTES));
+        let now = now_millis()?;
+        let changed = self.connection.execute(
+            "UPDATE run_containers SET state = ?1, exit_code = ?2,
+                    logs = COALESCE(?3, logs), updated_at = ?4,
+                    removed_at = CASE WHEN ?5 THEN ?4 ELSE removed_at END
+             WHERE run_id = ?6",
+            params![state, exit_code, logs, now, removed, run_id],
+        )?;
+        if changed != 1 {
+            bail!("run {run_id} has no persisted container");
+        }
+        Ok(())
+    }
+
+    pub fn run_container(&self, run_id: i64) -> Result<Option<RunContainer>> {
+        self.connection
+            .query_row(
+                "SELECT run_id, container_id, instance_id, image_ref, image_id, limits_json,
+                        state, exit_code, logs, created_at, updated_at, removed_at
+                 FROM run_containers WHERE run_id = ?1",
+                [run_id],
+                |row| {
+                    Ok(RunContainer {
+                        run_id: row.get(0)?,
+                        container_id: row.get(1)?,
+                        instance_id: row.get(2)?,
+                        image_ref: row.get(3)?,
+                        image_id: row.get(4)?,
+                        limits_json: row.get(5)?,
+                        state: row.get(6)?,
+                        exit_code: row.get(7)?,
+                        logs: row.get(8)?,
+                        created_at: row.get(9)?,
+                        updated_at: row.get(10)?,
+                        removed_at: row.get(11)?,
+                    })
+                },
+            )
+            .optional()
+            .context("failed to read run container")
+    }
+
     pub fn retained_delivery_workspace_count(&self) -> Result<usize> {
         let count = self.connection.query_row(
             "SELECT COUNT(*) FROM task_workspaces
@@ -991,7 +1097,7 @@ impl Ledger {
 
     pub fn task_workspaces_in_state(&self, state: &str) -> Result<Vec<TaskWorkspace>> {
         let mut statement = self.connection.prepare(
-            "SELECT task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+            "SELECT task_id, kind, backend, repository, base_branch, base_sha, factory_branch, path,
                     state, status_summary, created_at, updated_at, cleaned_at
              FROM task_workspaces WHERE state = ?1 ORDER BY task_id",
         )?;
@@ -1000,16 +1106,17 @@ impl Ledger {
                 Ok(TaskWorkspace {
                     task_id: row.get(0)?,
                     kind: row.get(1)?,
-                    repository: row.get(2)?,
-                    base_branch: row.get(3)?,
-                    base_sha: row.get(4)?,
-                    factory_branch: row.get(5)?,
-                    path: PathBuf::from(row.get::<_, String>(6)?),
-                    state: row.get(7)?,
-                    status_summary: row.get(8)?,
-                    created_at: row.get(9)?,
-                    updated_at: row.get(10)?,
-                    cleaned_at: row.get(11)?,
+                    backend: row.get(2)?,
+                    repository: row.get(3)?,
+                    base_branch: row.get(4)?,
+                    base_sha: row.get(5)?,
+                    factory_branch: row.get(6)?,
+                    path: PathBuf::from(row.get::<_, String>(7)?),
+                    state: row.get(8)?,
+                    status_summary: row.get(9)?,
+                    created_at: row.get(10)?,
+                    updated_at: row.get(11)?,
+                    cleaned_at: row.get(12)?,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()
@@ -1018,7 +1125,7 @@ impl Ledger {
 
     pub fn active_task_workspaces(&self) -> Result<Vec<TaskWorkspace>> {
         let mut statement = self.connection.prepare(
-            "SELECT task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+            "SELECT task_id, kind, backend, repository, base_branch, base_sha, factory_branch, path,
                     state, status_summary, created_at, updated_at, cleaned_at
              FROM task_workspaces WHERE state != 'cleaned' ORDER BY task_id",
         )?;
@@ -1027,16 +1134,17 @@ impl Ledger {
                 Ok(TaskWorkspace {
                     task_id: row.get(0)?,
                     kind: row.get(1)?,
-                    repository: row.get(2)?,
-                    base_branch: row.get(3)?,
-                    base_sha: row.get(4)?,
-                    factory_branch: row.get(5)?,
-                    path: PathBuf::from(row.get::<_, String>(6)?),
-                    state: row.get(7)?,
-                    status_summary: row.get(8)?,
-                    created_at: row.get(9)?,
-                    updated_at: row.get(10)?,
-                    cleaned_at: row.get(11)?,
+                    backend: row.get(2)?,
+                    repository: row.get(3)?,
+                    base_branch: row.get(4)?,
+                    base_sha: row.get(5)?,
+                    factory_branch: row.get(6)?,
+                    path: PathBuf::from(row.get::<_, String>(7)?),
+                    state: row.get(8)?,
+                    status_summary: row.get(9)?,
+                    created_at: row.get(10)?,
+                    updated_at: row.get(11)?,
+                    cleaned_at: row.get(12)?,
                 })
             })?
             .collect::<rusqlite::Result<Vec<_>>>()
@@ -2233,6 +2341,9 @@ fn migrate(connection: &Connection) -> Result<()> {
         if version < 9 {
             migrate_v9(connection)?;
         }
+        if version < 10 {
+            migrate_v10(connection)?;
+        }
         Ok(())
     })();
     match result {
@@ -2499,6 +2610,35 @@ fn migrate_v9(connection: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn migrate_v10(connection: &Connection) -> Result<()> {
+    connection
+        .execute_batch(
+            "ALTER TABLE task_workspaces ADD COLUMN backend TEXT NOT NULL DEFAULT 'worktree'
+                 CHECK (backend IN ('worktree', 'clone'));
+             CREATE TABLE run_containers (
+                 run_id INTEGER PRIMARY KEY REFERENCES runs(id),
+                 container_id TEXT NOT NULL UNIQUE,
+                 instance_id TEXT NOT NULL,
+                 image_ref TEXT NOT NULL,
+                 image_id TEXT NOT NULL,
+                 limits_json TEXT NOT NULL,
+                 state TEXT NOT NULL,
+                 exit_code INTEGER,
+                 logs TEXT,
+                 created_at INTEGER NOT NULL,
+                 updated_at INTEGER NOT NULL,
+                 removed_at INTEGER
+             );
+             CREATE INDEX run_containers_instance_state_idx
+                 ON run_containers(instance_id, state, run_id);
+             INSERT INTO schema_migrations(version, applied_at)
+                 VALUES (10, unixepoch('subsec') * 1000);
+             PRAGMA user_version = 10;",
+        )
+        .context("failed to migrate SQLite ledger to version 10")?;
+    Ok(())
+}
+
 fn query_task(connection: &Connection, id: i64) -> Result<Option<Task>> {
     connection
         .query_row("SELECT * FROM tasks WHERE id = ?1", [id], row_to_task)
@@ -2509,7 +2649,7 @@ fn query_task(connection: &Connection, id: i64) -> Result<Option<Task>> {
 fn query_task_workspace(connection: &Connection, task_id: i64) -> Result<Option<TaskWorkspace>> {
     connection
         .query_row(
-            "SELECT task_id, kind, repository, base_branch, base_sha, factory_branch, path,
+            "SELECT task_id, kind, backend, repository, base_branch, base_sha, factory_branch, path,
                     state, status_summary, created_at, updated_at, cleaned_at
              FROM task_workspaces WHERE task_id = ?1",
             [task_id],
@@ -2517,16 +2657,17 @@ fn query_task_workspace(connection: &Connection, task_id: i64) -> Result<Option<
                 Ok(TaskWorkspace {
                     task_id: row.get(0)?,
                     kind: row.get(1)?,
-                    repository: row.get(2)?,
-                    base_branch: row.get(3)?,
-                    base_sha: row.get(4)?,
-                    factory_branch: row.get(5)?,
-                    path: PathBuf::from(row.get::<_, String>(6)?),
-                    state: row.get(7)?,
-                    status_summary: row.get(8)?,
-                    created_at: row.get(9)?,
-                    updated_at: row.get(10)?,
-                    cleaned_at: row.get(11)?,
+                    backend: row.get(2)?,
+                    repository: row.get(3)?,
+                    base_branch: row.get(4)?,
+                    base_sha: row.get(5)?,
+                    factory_branch: row.get(6)?,
+                    path: PathBuf::from(row.get::<_, String>(7)?),
+                    state: row.get(8)?,
+                    status_summary: row.get(9)?,
+                    created_at: row.get(10)?,
+                    updated_at: row.get(11)?,
+                    cleaned_at: row.get(12)?,
                 })
             },
         )
@@ -2536,6 +2677,7 @@ fn query_task_workspace(connection: &Connection, task_id: i64) -> Result<Option<
 
 fn ensure_same_workspace(existing: &TaskWorkspace, requested: &TaskWorkspace) -> Result<()> {
     if existing.kind != requested.kind
+        || existing.backend != requested.backend
         || existing.repository != requested.repository
         || existing.base_branch != requested.base_branch
         || existing.base_sha != requested.base_sha

--- a/tests/cleanup_cli.rs
+++ b/tests/cleanup_cli.rs
@@ -81,6 +81,7 @@ fn cleanup_previews_then_removes_a_retained_worktree_and_preserves_its_branch() 
         .reserve_task_workspace(&TaskWorkspace {
             task_id: task.id,
             kind: "delivery".into(),
+            backend: "worktree".into(),
             repository: task.repository.clone(),
             base_branch: "main".into(),
             base_sha: base_sha.clone(),

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -125,6 +125,7 @@ impl Fixture {
             max_concurrent_runs_per_repository: repository_limit,
             workspace_root: workspace,
             data_directory: temp.path().join("data"),
+            worker: None,
             source: None,
             github: GitHubConfig {
                 trusted_approvers: vec!["owainlewis".into()],

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -95,6 +95,7 @@ impl Fixture {
             max_concurrent_runs_per_repository: 2,
             workspace_root: workspace,
             data_directory: temp.path().join("data"),
+            worker: None,
             source: None,
             github: GitHubConfig {
                 trusted_approvers: vec!["owainlewis".into()],

--- a/tests/github_project_polling.rs
+++ b/tests/github_project_polling.rs
@@ -76,6 +76,7 @@ impl Fixture {
             max_concurrent_runs_per_repository: 1,
             workspace_root,
             data_directory: temp.path().join("data"),
+            worker: None,
             source: Some(source),
             github: GitHubConfig {
                 trusted_approvers: vec!["owainlewis".to_owned()],

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -110,6 +110,13 @@ fn init_creates_only_configuration_and_workflow_directory() {
     assert!(config.contains("[source]"));
     assert!(config.contains("kind = \"github_project\""));
     assert!(config.contains("project_number = 16"));
+    assert!(config.contains("[worker]"));
+    assert!(config.contains("kind = \"docker\""));
+    assert!(config.contains("image = \"factory-codex:dev\""));
+    assert!(config.contains("memory = \"8g\""));
+    assert!(config.contains("cpus = 4"));
+    assert!(config.contains("pids = 512"));
+    assert!(config.contains("max_concurrent_runs = 1"));
     assert!(config.contains("[source.states]"));
     assert!(!config.contains("[github]"));
     assert!(!config.contains("repositories"));

--- a/tests/inspection_cli.rs
+++ b/tests/inspection_cli.rs
@@ -261,7 +261,15 @@ fn inspect_resolves_task_context_bounds_detail_and_escapes_terminal_controls() {
         .collect::<Vec<_>>();
     assert_eq!(
         keys,
-        ["activity", "error", "result", "run", "session_id", "task"]
+        [
+            "activity",
+            "container",
+            "error",
+            "result",
+            "run",
+            "session_id",
+            "task",
+        ]
     );
 }
 

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 
 use factory::storage::{
     ApprovalEvidence, CancellationRequest, Ledger, MAX_ERROR_BYTES, MAX_RESULT_BYTES,
-    ObservedTicket, RunOutcome, TaskIdentity, TaskState, TaskWorkspace,
+    ObservedTicket, RunContainer, RunOutcome, TaskIdentity, TaskState, TaskWorkspace,
 };
 use rusqlite::Connection;
 
@@ -168,7 +168,7 @@ fn concurrent_first_open_converges_on_one_complete_schema() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 9);
+    assert_eq!(version, 10);
     let schedule_tables: i64 = connection
         .query_row(
             "SELECT COUNT(*) FROM sqlite_schema
@@ -220,6 +220,7 @@ fn workspace_reservation_is_task_stable_and_rejects_reassignment() {
     let workspace = TaskWorkspace {
         task_id: task.id,
         kind: "delivery".into(),
+        backend: "worktree".into(),
         repository: task.repository.clone(),
         base_branch: "main".into(),
         base_sha: "0123456789012345678901234567890123456789".into(),
@@ -247,6 +248,62 @@ fn workspace_reservation_is_task_stable_and_rejects_reassignment() {
 }
 
 #[test]
+fn container_identity_and_terminal_evidence_are_durable() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+    ledger
+        .register_daemon_owner("container-owner", std::process::id())
+        .unwrap();
+    ledger.enqueue(&ticket("container-run")).unwrap();
+    let claimed = ledger
+        .claim_and_start_run(
+            &["owainlewis/factory".to_owned()],
+            &ticket_runtimes(),
+            "container-owner",
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap();
+    let container = RunContainer {
+        run_id: claimed.run.id,
+        container_id: "0123456789abcdef".into(),
+        instance_id: "factory-instance".into(),
+        image_ref: "factory-codex:dev".into(),
+        image_id: format!("sha256:{}", "a".repeat(64)),
+        limits_json: r#"{"memory":"8g"}"#.into(),
+        state: "created".into(),
+        exit_code: None,
+        logs: None,
+        created_at: 100,
+        updated_at: 100,
+        removed_at: None,
+    };
+
+    ledger.record_run_container(&container).unwrap();
+    ledger
+        .finish_run_container(claimed.run.id, "exited", Some(0), Some("finished"), false)
+        .unwrap();
+    let persisted = ledger.run_container(claimed.run.id).unwrap().unwrap();
+    assert_eq!(persisted.container_id, container.container_id);
+    assert_eq!(persisted.state, "exited");
+    assert_eq!(persisted.exit_code, Some(0));
+    assert_eq!(persisted.logs.as_deref(), Some("finished"));
+    assert!(persisted.removed_at.is_none());
+
+    ledger
+        .finish_run_container(claimed.run.id, "exited", Some(0), None, true)
+        .unwrap();
+    assert!(
+        ledger
+            .run_container(claimed.run.id)
+            .unwrap()
+            .unwrap()
+            .removed_at
+            .is_some()
+    );
+}
+
+#[test]
 fn delivery_workspace_reservations_are_bounded_to_ten_active_slots() {
     let temp = tempfile::tempdir().unwrap();
     let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
@@ -268,6 +325,7 @@ fn delivery_workspace_reservations_are_bounded_to_ten_active_slots() {
         let workspace = TaskWorkspace {
             task_id: task.id,
             kind: "delivery".into(),
+            backend: "worktree".into(),
             repository: task.repository,
             base_branch: "main".into(),
             base_sha: "0123456789012345678901234567890123456789".into(),
@@ -1073,7 +1131,7 @@ fn migrates_a_version_one_ledger_without_losing_tasks() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 9);
+    assert_eq!(version, 10);
 }
 
 #[test]
@@ -1085,7 +1143,10 @@ fn opens_an_existing_version_eight_ledger() {
     let connection = Connection::open(&path).unwrap();
     connection
         .execute_batch(
-            "DROP TABLE project_claims;
+            "DROP TABLE run_containers;
+             ALTER TABLE task_workspaces DROP COLUMN backend;
+             DROP TABLE project_claims;
+             DELETE FROM schema_migrations WHERE version = 10;
              DELETE FROM schema_migrations WHERE version = 9;
              PRAGMA user_version = 8;",
         )
@@ -1101,7 +1162,7 @@ fn opens_an_existing_version_eight_ledger() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 9);
+    assert_eq!(version, 10);
 }
 
 #[test]

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -84,9 +84,17 @@ fn validates_configurable_github_project_states() {
     let (temp, path, repository, data_home) = valid_config();
     let contents =
         fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/examples/config.toml")).unwrap();
+    let auth = temp.path().join("codex/auth.json");
+    fs::create_dir_all(auth.parent().unwrap()).unwrap();
+    fs::write(&auth, "{}").unwrap();
     fs::write(
         &path,
-        contents.replace("Ready To Implement", "Queued for engineering"),
+        contents
+            .replace("Ready To Implement", "Queued for engineering")
+            .replace(
+                "~/.local/share/factory/codex/auth.json",
+                auth.to_str().unwrap(),
+            ),
     )
     .unwrap();
     fs::write(
@@ -121,6 +129,19 @@ exit 64
     let mut permissions = fs::metadata(&gh).unwrap().permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&gh, permissions).unwrap();
+    let docker = bin.join("docker");
+    fs::write(
+        &docker,
+        r#"#!/bin/sh
+if [ "$1" = "version" ]; then echo "27.0.0"; exit 0; fi
+if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then echo "sha256:abcdef"; exit 0; fi
+exit 64
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&docker).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&docker, permissions).unwrap();
     let path_value = format!(
         "{}:{}",
         bin.display(),
@@ -131,6 +152,7 @@ exit 64
         .unwrap()
         .args(["validate", "--config", path.to_str().unwrap()])
         .env("FACTORY_DATA_HOME", data_home)
+        .env("FACTORY_GITHUB_TOKEN", "dedicated-test-token")
         .env("PATH", path_value)
         .assert()
         .success()

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -89,6 +89,7 @@ fn test_config(repositories: Vec<PathBuf>, workspace: PathBuf, data: PathBuf) ->
         max_concurrent_runs_per_repository: 2,
         workspace_root: workspace,
         data_directory: data,
+        worker: None,
         source: None,
         github: GitHubConfig {
             trusted_approvers: vec!["owainlewis".into()],
@@ -599,6 +600,7 @@ fn catalog_output_escapes_control_characters_in_every_dynamic_cell() {
         max_concurrent_runs_per_repository: 1,
         workspace_root: workspace,
         data_directory: temp.path().join("data"),
+        worker: None,
         source: None,
         github: GitHubConfig {
             trusted_approvers: vec!["owainlewis".into()],


### PR DESCRIPTION
Closes #50

## Summary
- run GitHub Project triage and implementation workflows in hardened disposable Docker workers
- use standalone HTTPS clones, with read-only triage and writable stable issue branches for implementation
- persist container identity, limits, logs, exit state, cleanup, cancellation, and crash recovery in SQLite
- validate Docker, the exact image, dedicated writable Codex auth, and the dedicated GitHub token
- keep agents adaptive: they use `gh` and `git` directly and leave pull requests for human merge

## Verification
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --no-fail-fast`
- `docker build --file .factory/Dockerfile --tag factory-codex:dev .`
- real hardened-container Codex smoke run returned `FACTORY_SANDBOX_OK`
- independent review: approved with no remaining findings