### PR TITLE
docs: explain idle poll verification

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -77,6 +77,23 @@ persists eligible tasks, and exits without claiming or launching them. It is
 intended for setup checks and safe polling smoke tests. An empty evaluation
 does not invoke Codex.
 
+## Prove an idle poll
+
+When no configured Project item is ready and no scheduled workflow is due,
+capture the task list before and after one poll and list all Factory-managed
+containers:
+
+```sh
+factory tasks --json
+factory run --once
+factory tasks --json
+docker ps --all --filter label=dev.factory.managed=true
+```
+
+The two task listings should show zero new tasks, and the Docker listing should
+show zero Factory containers. This proves the empty poll persisted and launched
+nothing.
+
 Before first repository-local startup, Factory reads the old
 `~/.factory/factory.sqlite3` database without modifying it. If that database
 contains queued or running work for this repository, startup stops with


### PR DESCRIPTION
Closes #54

## Summary
- add a concise **Prove an idle poll** operations procedure
- compare JSON task listings around a one-shot poll
- list containers carrying the Factory-managed Docker label
- clarify that no Project item may be ready and no schedule may be due

## Verification
- `git diff --check`
- independent review completed; one schedule-trigger ambiguity found and fixed
- `cargo test`: all 51 library tests passed; the full suite was attempted, but four daemon integration tests failed due to process timing/SQLite I/O behavior on this container filesystem
- `cargo fmt --all -- --check` could not run because rustfmt is absent and the pinned toolchain directory is read-only; the change is Markdown-only

## Limitations
- The local environment could not provide a clean full integration-suite result; CI remains authoritative.
