### PR TITLE
feat: prove sandboxed Factory v1 end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ dedicated Codex login. It does not use model API keys.
 4. In a trusted target repository, run `factory init`.
 5. Configure the GitHub Project, trusted users, and status names in
    `.factory/config.toml`.
-6. Add the triage and implementation workflows under `.factory/workflows/`
-   and a repository-specific `.factory/Dockerfile` with the real toolchain.
-7. Build the repository worker image:
+6. Review the generated triage and implementation workflows and adapt the
+   generated `.factory/Dockerfile` to the repository toolchain.
+7. Build the worker image:
 
    ```sh
    docker build --file .factory/Dockerfile --tag factory-codex:dev .
@@ -41,8 +41,8 @@ dedicated Codex login. It does not use model API keys.
 
 `factory init --check` previews setup without writes. Initialization creates
 `.factory/config.toml`, external machine state and workspace storage, and the
-repository's workflow directory. It does not alter the GitHub Project or
-install opinionated workflows.
+two workflows plus `.factory/Dockerfile`. Existing files are never overwritten.
+It does not alter the GitHub Project or start an agent.
 
 Create a scheduled pull-request triage workflow without opening an editor:
 
@@ -78,7 +78,8 @@ feature in v1.
 
 See [`docs/single-repository-v1/design.md`](docs/single-repository-v1/design.md)
 for the setup, state machine, worker boundary, recovery model, and acceptance
-checks.
+checks. See [`docs/local-v1.md`](docs/local-v1.md) for the runnable setup and
+[`docs/operations.md`](docs/operations.md) for day-two operation.
 
 ## Development checks
 

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -85,7 +85,7 @@ factory daemon
 ```
 
 Validation checks the repository, all configured Project states, trusted users,
-Docker daemon, exact image, writable Codex auth, live worker GitHub token, and
+Docker daemon, exact image, authenticated Codex session inside that image, live worker GitHub token, and
 writable Factory data path. `run --once` polls and records matching work but
 does not claim tasks or launch containers. With no matching Project item,
 Factory starts no container and invokes no model.
@@ -130,7 +130,8 @@ the missing repository config without changing the checked-in workflows or
 Dockerfile. The image built as `factory-codex:dev` with digest
 `sha256:af5b2c31afc1e06d809a96d8c675bd7470532a4f1e30b0de118cab046fd3a52e`.
 `factory validate` resolved all six Project states, the trusted user, live
-worker token, Docker daemon and image, and dedicated writable Codex auth.
+worker token, Docker daemon and image, and a dedicated Codex login verified
+inside the hardened worker container.
 
 Before adding ready work, `factory run --once` saw seven repository issues and
 created zero tasks. `factory tasks --json` returned `[]`, and Docker listed no

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -120,3 +120,53 @@ poll to confirm the task, branch, and pull-request counts remain unchanged.
 
 See [operations.md](operations.md) for cancellation, recovery, cleanup, trust,
 and Docker limitations.
+
+## Project 16 self-hosting evidence
+
+Factory v1 was exercised against the public
+[Factory Project](https://github.com/users/owainlewis/projects/16) on 22 July
+2026 from a clean standalone clone of commit `f15a919`. `factory init` created
+the missing repository config without changing the checked-in workflows or
+Dockerfile. The image built as `factory-codex:dev` with digest
+`sha256:af5b2c31afc1e06d809a96d8c675bd7470532a4f1e30b0de118cab046fd3a52e`.
+`factory validate` resolved all six Project states, the trusted user, live
+worker token, Docker daemon and image, and dedicated writable Codex auth.
+
+Before adding ready work, `factory run --once` saw seven repository issues and
+created zero tasks. `factory tasks --json` returned `[]`, and Docker listed no
+container for the Factory instance. This is the no-work, no-model path.
+
+The implementation proof used [issue #54](https://github.com/owainlewis/factory/issues/54).
+Factory moved it from Ready To Implement to Implementing, created task 1 and
+run 1, cloned commit `eeb3858`, checked out `factory/54`, and launched container
+`1bb173253992` with a read-only root, 4 CPUs, 8 GB memory, and 512 PIDs. The
+agent used `gh` and `git`, changed only `docs/operations.md`, recorded review
+and verification limitations, pushed commit `5733d47`, and opened
+[PR #55](https://github.com/owainlewis/factory/pull/55). GitHub CI passed in
+1m37s. The agent marked the PR ready, moved the issue to Reviewing, posted the
+[handoff comment](https://github.com/owainlewis/factory/issues/54#issuecomment-5040193067),
+and left merge and auto-merge untouched. Run 1 succeeded in 463,624 ms, stored
+the PR link and exact image evidence, then removed its container and clean
+clone.
+
+After stopping and restarting the daemon, the ledger still contained one
+succeeded task and one succeeded run for issue #54. GitHub still contained one
+open `factory/54` branch and one PR, and Docker contained no Factory container.
+The restart created no duplicate work.
+
+The triage proof used [issue #56](https://github.com/owainlewis/factory/issues/56).
+Factory moved it from Ready For Spec to Creating Spec, created task 2 and run 2,
+and launched the same image against a separate read-only `triage-2` clone. The
+agent inspected the startup path and rewrote the vague issue into a bounded
+goal, scope, acceptance criteria, verification plan, and explicit exclusions,
+then moved it to Ready To Implement. Run 2 succeeded in 112,535 ms and produced
+no branch or pull request.
+
+Two limitations were recorded. The proof used the operator's broad GitHub token,
+so it demonstrated the warning and human workflow but not least-privilege bot
+enforcement. Also, the daemon observed issue #56 become ready immediately after
+triage and queued its implementation generation before shutdown. Shutdown
+cancelled authorization before any implementation container launched. This is
+expected pipeline behavior, and it shows why a demo operator should stop or
+park a triaged ticket before the next poll when only the triage phase is being
+demonstrated.

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -1,234 +1,122 @@
-# Reliable local v1
+# Run the single-repository Factory v1
 
-This guide takes a trusted GitHub issue from `factory:ready` to one green draft
-pull request through one authenticated local Codex run. Factory never merges
-the pull request.
+Factory watches one GitHub Project and reacts only when trusted work enters one
+of two configured states. Triage runs from a read-only clone. Implementation
+runs from a writable clone, pushes one stable issue branch, and leaves one pull
+request for human review and merge.
 
-## Supported environment
+## Requirements
 
-Factory v1 requires a Unix-like operating system because process supervision
-uses Unix process groups. Install:
-
-- Rust and Cargo on the current stable toolchain;
-- Git;
-- GitHub CLI (`gh`);
-- Codex CLI authenticated with a ChatGPT subscription.
-
-Confirm authentication before installing Factory:
+Install Rust, Git, GitHub CLI, Docker, and Codex CLI on a Unix-like host. Docker
+must be running. Authenticate the host GitHub CLI:
 
 ```sh
+gh auth login
 gh auth status
-codex --version
-codex login status
 ```
 
-Factory rejects API-key Codex authentication. Do not configure `OPENAI_API_KEY`
-for Factory runs.
-
-## Install from a clean checkout
+Install Factory from a clean checkout:
 
 ```sh
 git clone https://github.com/owainlewis/factory.git
 cd factory
 cargo install --path .
-factory --version
 ```
 
-Re-run `cargo install --path . --force` after updating the checkout.
+## Initialize one repository
 
-## Initialize a trusted repository
-
-Run the explicit initializer from the repository Factory should manage:
+Run Factory inside the trusted repository it will manage:
 
 ```sh
-cd /absolute/path/to/trusted/repository
 factory init
 ```
 
-The command creates `.factory/config.toml` and `.factory/workflows/` in the
-repository. It derives a stable state directory for this clone under the user
-data directory and creates its external worktree directory there. It does not
-install a workflow, inspect or mutate GitHub labels, commit files, start the
-daemon, launch Codex, or merge pull requests.
+This creates, only when missing:
 
-Initialization is idempotent. Preview it without writes with:
-
-```sh
-factory init --check
+```text
+.factory/config.toml
+.factory/Dockerfile
+.factory/workflows/triage-ticket.md
+.factory/workflows/implement-ready-ticket.md
 ```
 
-To initialize a repository without changing directory, pass its path:
+It also creates the repository-specific Factory data directory outside the
+checkout. Re-running the command preserves every existing file. Preview missing
+resources without writing with `factory init --check`.
+
+Edit `.factory/config.toml` with the GitHub Project owner and number, the exact
+Status field values, and trusted issue authors. Status names are local policy,
+so Jira-style or team-specific names are valid when mapped to all six semantic
+states.
+
+Review the two workflow prompts. They are the adaptive part of the factory.
+Review `.factory/Dockerfile` and add the repository toolchain needed by tests
+and builds, then build the configured image:
 
 ```sh
-factory init --repository /absolute/path/to/repository
+docker build --file .factory/Dockerfile --tag factory-codex:dev .
 ```
 
-Create an implementation workflow from explicit prompt input. For a substantial
-policy, put only the Markdown prompt body in a file and pass its path:
+Create a dedicated writable Codex login for the worker:
 
 ```sh
-factory workflow create implement-ready-ticket \
-  --label factory:ready \
-  --timeout 4h \
-  --prompt-file /absolute/path/to/implementation-policy.md
+mkdir -p "$HOME/.local/share/factory/codex"
+CODEX_HOME="$HOME/.local/share/factory/codex" codex login
 ```
 
-The command does not open `$EDITOR`. Use `--prompt` for short policies or
-`--prompt-file -` to read from standard input. A label-triggered workflow
-creates its missing trigger label. Create any additional labels referenced by
-the policy, such as `factory:needs-review`, separately.
-
-Review and commit the generated policy in the target repository:
+Set `worker.codex_auth` to that `auth.json` path. Export a dedicated GitHub
+token through the environment named by `worker.github_token_env`:
 
 ```sh
-git add .factory/workflows/implement-ready-ticket.md
-git commit -m "chore: configure Factory"
+export FACTORY_GITHUB_TOKEN='...'
 ```
 
-Validate the machine-specific configuration without runtime work:
+Use a bot or narrowly scoped identity that can read and write the repository
+and Project but cannot bypass protected-branch review. Factory does not make a
+personal owner token safe.
+
+## Validate and start
 
 ```sh
 factory validate
-```
-
-The workflow is versioned policy: Codex owns ticket updates, implementation,
-tests, diff review, draft pull-request creation, CI repair, and handoff inside
-the supplied worktree. Factory owns the base commit, branch and worktree,
-durable task, one claim, concurrency, supervision, cancellation, inspection,
-deduplication, cleanup, and recovery.
-
-Check the resolved workflow catalog:
-
-```sh
 factory workflows
-```
-
-## Start and prove one ticket
-
-Write one complete issue with a bounded outcome, acceptance criteria, and
-verification. Ensure there is no existing implementation or pull request.
-Confirm your GitHub login appears in `[github].trusted_approvers`, then approve
-the exact ticket and workflow revision:
-
-```sh
-factory approve ISSUE_NUMBER
+factory run --once
 factory daemon
 ```
 
-Keep the terminal open. The daemon polls GitHub, persists one task, atomically
-claims it, re-fetches the issue and approval evidence, consumes that approval
-once, removes the ready label, and launches the authenticated Codex CLI. A
-directly applied `factory:ready` label has no authority and launches nothing.
+Validation checks the repository, all configured Project states, trusted users,
+Docker daemon, exact image, writable Codex auth, live worker GitHub token, and
+writable Factory data path. `run --once` polls and records matching work but
+does not claim tasks or launch containers. With no matching Project item,
+Factory starts no container and invokes no model.
 
-Use a second terminal to inspect durable state:
+The continuous daemon reacts to two states:
+
+1. `ready_for_spec` moves to `creating_spec`. The triage agent investigates the
+   issue, improves its acceptance criteria, and either moves it to
+   `ready_to_implement` or posts a precise blocker.
+2. `ready_to_implement` moves to `implementing`. The implementation agent uses
+   normal `gh` and `git`, tests the change, obtains independent review, pushes
+   `factory/<issue-number>`, opens or updates one pull request, waits for CI,
+   and moves the item to `ready_to_review`.
+
+Humans review the specification and the pull request. Feedback is given through
+the issue, review, Project state, and CI. Moving reviewed work back to
+`ready_to_implement` creates one continuation run on the same branch and pull
+request. Factory never merges or enables auto-merge.
+
+## Observe a run
 
 ```sh
 factory tasks
-factory runs implement-ready-ticket
+factory runs
 factory inspect RUN_ID
 ```
 
-Exactly one task and run should represent the triggering issue revision. A
-normal daemon restart must not create another implementation or pull request.
-To exercise restart deduplication after the run is terminal, stop Factory with
-Ctrl-C, start `factory daemon` again, wait through at least one poll, and confirm
-the task/run counts and linked pull request remain unchanged.
+JSON output is available with `--json`. A successful implementation handoff
+records the issue, task, run, container, image, limits, clone, branch, pull
+request, bounded logs, and result. Restart the daemon and wait through another
+poll to confirm the task, branch, and pull-request counts remain unchanged.
 
-Success means:
-
-- one Codex run used the recorded Factory branch and worktree without changing
-  the canonical checkout;
-- one linked draft pull request contains a useful summary and verification;
-- required CI and automated review are complete with no actionable feedback;
-- the issue has `factory:needs-review` and a useful handoff comment;
-- the pull request remains open, draft, and unmerged for a human.
-
-## Inspect, cancel, and recover
-
-List and inspect work without reading raw SQLite state:
-
-```sh
-factory tasks --json
-factory runs --json
-factory inspect RUN_ID --json
-```
-
-Request cancellation of a running Factory-owned process tree:
-
-```sh
-factory cancel RUN_ID
-```
-
-Ctrl-C stops polling and claiming, cancels active Codex process groups, records
-cancelled outcomes, and leaves queued tasks durable. On restart Factory inspects
-non-terminal runs. It leaves live owned work alone, otherwise stops a matching
-orphan process group, closes the interrupted attempt, and permits at most two
-durable recovery attempts. Recovery first resumes the stored Codex session and
-falls back once to a fresh session with current issue, Git, worktree, pull
-request, CI, and bounded prior evidence. Repeated failure remains inspectable;
-Factory never merges as part of recovery.
-
-Use a non-executing smoke test before starting the daemon:
-
-```sh
-factory run --once
-```
-
-This evaluates one schedule tick, polls GitHub once, and persists matching
-tasks without claiming them or launching Codex. If nothing matches, it uses no
-model tokens.
-
-## Troubleshooting
-
-- Authentication errors: rerun `gh auth status` and `codex login status`.
-- Invalid configuration: run `factory validate` and correct the reported
-  repository-local policy or concurrency constraint.
-- Legacy cutover blocked: stop the old global daemon and finish or cancel its
-  queued or running work for this repository. Factory leaves the old database
-  untouched and does not import its history.
-- Missing setup: run `factory init --check`, then `factory init` to create only
-  the missing resources.
-- Invalid workflows: run `factory workflows`; ticket workflow errors fail fast,
-  while invalid scheduled workflows are reported and isolated.
-- No task: confirm the issue is open, has `factory:ready`, belongs to the
-  configured GitHub repository, and has changed since any earlier completed
-  trigger.
-- Failed run: use `factory inspect RUN_ID`; preserve the issue, branch, PR, and
-  worktree so recovery or a human can reconcile current state.
-
-## V1 acceptance evidence
-
-The M3 exercise ran on 18 July 2026 from a clean clone of commit
-`c0804e58e4159b7230116b8262ede837bb7973b2` on the pushed #10 branch. From that
-checkout, `cargo install --path .` installed `factory 0.1.0` into an isolated
-prefix. `factory validate` reported a valid configuration and `factory
-workflows` resolved `implement-ready-ticket` as a valid `factory:ready` Codex
-workflow with a four-hour timeout. Factory was started with local ChatGPT Codex
-authentication and with `OPENAI_API_KEY` removed from its environment.
-
-The real trigger was [issue #23](https://github.com/owainlewis/factory/issues/23).
-The ledger was empty before the label was applied. Factory created task 1 and
-run 1, with Codex session
-`019f76f8-577d-7313-b421-a8680b6eeda7`. The run succeeded in 552,487 ms and
-recorded [draft PR #24](https://github.com/owainlewis/factory/pull/24) at commit
-`68d0a2efeb7b416923d6cc6aa51d0350d6ae4ab8`. The PR remained open, draft, and
-unmerged. Its GitHub Actions `check` job passed, all requested local checks
-passed, and a fresh independent Codex subagent review reported no actionable
-findings. Issue #23 ended with only `factory:needs-review` and a handoff comment
-linking the PR, summary, checks, review state, and limitations.
-
-Restart deduplication was exercised after the terminal run. Before restart the
-ledger contained one succeeded task and one succeeded run linked to PR #24.
-After stopping the daemon, restarting it, and waiting through a five-second
-poll, those counts and the linked PR were unchanged. GitHub still contained
-one open PR for issue #23, so the restart created neither another Codex run nor
-another implementation.
-
-Observed limitations: the pre-merge proof necessarily checked out the pushed
-#10 branch rather than released `main`; the same commit became the candidate
-for the implementation PR. Isolated install, data, configuration, repository,
-and workspace paths lived under a temporary macOS directory whose canonical
-form was `/private/tmp`. GitHub had no submitted review on acceptance PR #24;
-the required automated diff review was the fresh Codex subagent inside the one
-supervised run. No model API key was used. PR #24 is intentionally left for a
-human and must not be merged as part of the milestone closeout.
+See [operations.md](operations.md) for cancellation, recovery, cleanup, trust,
+and Docker limitations.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,84 +1,96 @@
-# Factory operation
+# Operate Factory v1
 
-`factory daemon` discovers the enclosing Git root, loads
-`.factory/config.toml`, validates `gh` and Codex subscription authentication,
-evaluates scheduled workflows, polls that repository, and dispatches durable
-scheduled and ready-ticket tasks. `max_concurrent_runs` controls concurrency.
-Each clone has its own SQLite database and worktree directory outside the
-checkout.
+Factory is always watching, not always spending tokens. The daemon polls one
+configured GitHub Project and starts a Docker worker only for a trusted item in
+`ready_for_spec` or `ready_to_implement`.
 
-In continuous mode, Factory writes concise lifecycle events to standard error.
-It reports startup validation, polls that queue work, claimed tasks, runtime
-delegation, and terminal run outcomes. Runtime delegation includes the initial
-working directory and marks the worktree as Factory-owned. Before Codex starts,
-Factory queries GitHub's default branch, fetches its exact commit, reserves a
-stable `factory/<issue>-<slug>` branch and worktree, records them durably, and
-launches Codex there. The canonical checkout is never used for agent changes.
+## Normal operation
 
-The ready label is a wake signal, not authority. `factory approve ISSUE_NUMBER`
-binds the current title, body, delivery workflow hash, stable trusted GitHub
-user ID, and a fresh ready-label event into a versioned approval artifact. The
-daemon re-fetches and validates that evidence immediately before runtime
-delegation, atomically consumes it, removes the label, and posts a claim record.
-Changed, malformed, untrusted, or replayed evidence fails closed without
-starting Codex. Comments and attachments are never copied into the execution
-prompt. `factory workflow create --label LABEL` creates a missing label without
-changing an existing definition. `factory init` does not inspect or mutate
-GitHub labels.
+Start from anywhere inside the configured repository:
 
-Five-field cron schedules are evaluated in the IANA timezone declared by the
-workflow. Factory stores the next occurrence and atomically advances that
-cursor when it creates the durable task, so repeated ticks, restarts, and
-multiple daemon loops cannot duplicate one UTC scheduled instant. Startup moves
-an overdue cursor to the next future occurrence instead of replaying work missed
-while Factory was offline. Disabled workflows are not evaluated. Invalid or
-failing scheduled workflows are reported and isolated from ready-ticket
-polling. A scheduled prompt receives its UTC occurrence, repository path,
-inspected commit, and previous successful run time when available. The agent may
-use its authenticated `gh` CLI to create or update tickets; Factory does not
-hard-code those effects.
+```sh
+factory validate
+factory daemon
+```
 
-Every active run records the Factory owner, a durable supervisor anchor that
-owns the Codex process group, the anchor's process-start identity, Codex session
-ID as soon as it is observed, working
-directory, pull-request URL when safely recognized, start time, and latest
-structural runtime activity. Raw event text is not stored. A workflow timeout is
-the maximum deadline for one execution.
-There is no short fixed idle timeout, so an active agent can keep working until
-that configured deadline. Explicit cancellation and deadline expiry terminate
-the complete Codex process group.
+Startup validates all external dependencies before claiming work. Lifecycle
+events report polls, claims, container delegation, and terminal outcomes. Use
+the supported inspection commands instead of reading SQLite directly:
 
-At startup and periodically while running, Factory checks every database run
-still marked `running`. It leaves a run alone when its owning daemon lease and
-process are live. The supervisor anchor remains the group leader if Codex exits
-while descendants are still running. Otherwise Factory verifies the anchor's
-recorded process-start identity, stops the matching orphan process group, closes
-the interrupted run, and queues one recovery attempt. Recovery first resumes
-the stored Codex session. If that
-session cannot be resumed, Factory starts one fresh fallback within the same
-execution deadline. The recovery prompt includes the current ticket,
-repository, Git worktree and branch inventory, pull-request URL when found, and
-bounded previous evidence, and tells Codex to inspect current reality before continuing.
-Factory permits at most two durable recovery attempts. Repeated failure leaves
-the task failed and inspectable. Terminal runs are never recovered.
+```sh
+factory tasks [--json]
+factory runs [WORKFLOW] [--json]
+factory inspect RUN_ID [--json]
+```
 
-On Ctrl-C, Factory stops polling and claiming immediately, cancels active
-Codex process trees, waits for the workers to record `cancelled`, and exits.
-Queued tasks remain durable for the next start. Failed and cancelled runs keep
-their bounded output, error, session, ticket, branch, and pull-request context
-for inspection. Scheduled proposal workspaces are detached and removed at a
-terminal outcome. Failed, cancelled, dirty, or unpublished delivery worktrees
-are retained, up to ten. Preview cleanup with `factory cleanup RUN_ID`; removal
-requires `factory cleanup RUN_ID --confirm` and preserves the local branch.
-Factory never merges software pull requests.
+Each Project transition is level-triggered and durable. Repeated polls and
+normal restarts do not create another task for the same state generation. A
+review-to-implementation transition creates one new generation and reuses the
+title-independent `factory/<issue-number>` branch and linked pull request.
 
-`factory run --once` evaluates one schedule tick, performs one discovery poll,
-persists eligible tasks, and exits without claiming or launching them. It is
-intended for setup checks and safe polling smoke tests. An empty evaluation
-does not invoke Codex.
+## Worker boundary
 
-Before first repository-local startup, Factory reads the old
-`~/.factory/factory.sqlite3` database without modifying it. If that database
-contains queued or running work for this repository, startup stops with
-instructions to stop the old daemon and finish or cancel the work. Terminal
-legacy history is not imported.
+Every Project task gets a disposable container and a standalone HTTPS clone.
+Triage mounts its clone read-only. Implementation mounts its clone read-write.
+The canonical checkout, Factory database, Docker socket, host credentials, and
+unrelated repositories are not mounted.
+
+The worker runs as the clone owner with a read-only root filesystem, dropped
+Linux capabilities, bounded CPU, memory and processes, and a temporary `/tmp`.
+Only the dedicated Codex auth file and task clone are writable. Factory records
+the exact image ID and limits before starting the container and captures bounded
+stdout and stderr. Containers are removed after their terminal evidence is
+durable.
+
+Docker is not a VM. It shares the host kernel, permits outbound network access,
+and receives long-lived credentials for Codex and GitHub. Run only trusted
+authors' issues. Treat all issue, comment, attachment, and review text as
+untrusted input. Use a dedicated GitHub identity and protected branches so the
+worker cannot merge or bypass review.
+
+## Cancellation and recovery
+
+Request cancellation with:
+
+```sh
+factory cancel RUN_ID
+```
+
+Ctrl-C stops new polling and claims, cancels active workers, records terminal
+outcomes, and leaves queued work durable. On startup Factory reconciles durable
+container ownership before stopping or removing only containers labelled for
+that exact Factory instance. It captures the recovered logs and exit state,
+then permits bounded recovery. Repeated failure remains inspectable and never
+turns into an automatic merge.
+
+## Clone retention and cleanup
+
+Successful clean implementation clones are removed only after the branch is
+pushed and a pull-request handoff is recorded. Failed, cancelled, dirty,
+unpublished, or incomplete implementation clones are retained for recovery,
+up to ten.
+
+Preview a retained clone before removal:
+
+```sh
+factory cleanup RUN_ID
+factory cleanup RUN_ID --confirm
+```
+
+Confirmed cleanup removes only the recorded managed clone. The remote branch
+and pull request remain. Triage clones are disposable and are removed at a
+terminal outcome.
+
+## Troubleshooting
+
+- `factory init --check` reports missing repository assets without writing.
+- `factory validate` reports invalid state mappings, trusted users, worker
+  tokens, auth files, images, Docker availability, and data-path permissions.
+- `factory run --once` proves polling without launching a model or container.
+- `factory inspect RUN_ID` shows bounded task, container, branch, pull-request,
+  and error evidence.
+- If old global Factory work is active, stop the old daemon and finish or cancel
+  it. Repository-local Factory never mutates or imports the legacy database.
+
+Scheduled workflows remain a separate host-run feature in v1. They do not use
+the two-state Project pipeline or Docker worker path described here.

--- a/docs/single-repository-v1/design.md
+++ b/docs/single-repository-v1/design.md
@@ -464,10 +464,11 @@ and workflows only from the canonical checkout, never from an agent branch.
 
 ### Bootstrap the local proof
 
-The repository supplies `.factory/Dockerfile` and the two workflow files. The
-documented first run is:
+`factory init` creates `.factory/Dockerfile` and the two workflow files when
+they are missing and never overwrites them. The documented first run is:
 
 ```sh
+factory init
 docker build --file .factory/Dockerfile --tag factory-codex:dev .
 
 mkdir -p "$HOME/.local/share/factory/codex"

--- a/docs/single-repository-v1/design.md
+++ b/docs/single-repository-v1/design.md
@@ -482,7 +482,8 @@ factory daemon
 
 `factory validate` confirms the enclosing repository, Project and Status field,
 all six configured state values, trusted users, Docker daemon, exact image,
-Codex authentication file, GitHub token, and writable Factory data directory.
+Codex authentication status inside the configured worker image, GitHub token,
+and writable Factory data directory and existing SQLite database.
 It prints one actionable error for every missing prerequisite and starts no
 container.
 

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -150,6 +150,7 @@ impl DockerWorker {
                     self.config.codex_auth.display()
                 )
             })?;
+        self.validate_codex_auth(&image_id, cancellation).await?;
         let token = std::env::var(&self.config.github_token_env).with_context(|| {
             format!(
                 "GitHub token is missing; export {} for the dedicated Factory identity",
@@ -164,6 +165,63 @@ impl DockerWorker {
             self.config.github_token_env
         );
         Ok(image_id)
+    }
+
+    async fn validate_codex_auth(
+        &self,
+        image_id: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<()> {
+        let auth = self.config.codex_auth.canonicalize().with_context(|| {
+            format!(
+                "failed to resolve auth file {}",
+                self.config.codex_auth.display()
+            )
+        })?;
+        let (uid, gid) = host_owner(&auth)?;
+        let auth_mount = format!(
+            "type=bind,src={},dst=/home/agent/.codex/auth.json",
+            docker_path(&auth)?
+        );
+        let arguments = vec![
+            OsString::from("run"),
+            OsString::from("--rm"),
+            OsString::from("--user"),
+            OsString::from(format!("{uid}:{gid}")),
+            OsString::from("--read-only"),
+            OsString::from("--network"),
+            OsString::from("none"),
+            OsString::from("--cap-drop"),
+            OsString::from("ALL"),
+            OsString::from("--security-opt"),
+            OsString::from("no-new-privileges"),
+            OsString::from("--pids-limit"),
+            OsString::from(self.config.pids.to_string()),
+            OsString::from("--memory"),
+            OsString::from(self.config.memory.clone()),
+            OsString::from("--cpus"),
+            OsString::from(self.config.cpus.to_string()),
+            OsString::from("--tmpfs"),
+            OsString::from(format!(
+                "/home/agent/.codex:rw,size=64m,uid={uid},gid={gid},mode=700"
+            )),
+            OsString::from("--mount"),
+            OsString::from(auth_mount),
+            OsString::from("--env"),
+            OsString::from("HOME=/home/agent"),
+            OsString::from("--env"),
+            OsString::from("CODEX_HOME=/home/agent/.codex"),
+            OsString::from(image_id),
+            OsString::from("codex"),
+            OsString::from("login"),
+            OsString::from("status"),
+        ];
+        self.command_output_os(&arguments, cancellation)
+            .await
+            .context(
+                "Codex authentication is invalid in the configured worker image; refresh the dedicated login",
+            )?;
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -851,6 +909,67 @@ mod tests {
         let mut permissions = fs::metadata(path).unwrap().permissions();
         permissions.set_mode(0o700);
         fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[tokio::test]
+    async fn validates_codex_login_in_a_hardened_temporary_container() {
+        let temp = tempfile::tempdir().unwrap();
+        let log = temp.path().join("docker.log");
+        let docker = temp.path().join("docker");
+        let auth = temp.path().join("auth.json");
+        fs::write(&auth, "{}").unwrap();
+        executable(
+            &docker,
+            &format!(
+                r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> '{}'
+case "$1 ${{2:-}}" in
+  'version --format') printf '%s\n' '27.0.0' ;;
+  'image inspect') printf '%s\n' 'sha256:abcdef0123456789' ;;
+  'run --rm') printf '%s\n' 'Logged in using ChatGPT' ;;
+  *) printf 'unexpected fake docker command: %s\n' "$*" >&2; exit 1 ;;
+esac
+"#,
+                log.display()
+            ),
+        );
+        // SAFETY: all tests in this module use the same harmless test value.
+        unsafe { std::env::set_var(TOKEN_ENV, "super-secret-docker-token") };
+        let worker = DockerWorker::new(
+            WorkerConfig {
+                image: "factory-codex:test".to_owned(),
+                memory: "4g".to_owned(),
+                cpus: 2,
+                pids: 128,
+                codex_auth: auth.clone(),
+                github_token_env: TOKEN_ENV.to_owned(),
+            },
+            "validate-instance",
+        )
+        .with_executable(&docker);
+
+        let image = worker.validate(&CancellationToken::new()).await.unwrap();
+        assert_eq!(image, "sha256:abcdef0123456789");
+        let commands = fs::read_to_string(log).unwrap();
+        let login = commands
+            .lines()
+            .find(|line| line.starts_with("run --rm"))
+            .unwrap();
+        assert!(login.contains("--read-only"));
+        assert!(login.contains("--network none"));
+        assert!(login.contains("--cap-drop ALL"));
+        assert!(login.contains("--security-opt no-new-privileges"));
+        assert!(login.contains("--pids-limit 128"));
+        assert!(login.contains("--memory 4g"));
+        assert!(login.contains("--cpus 2"));
+        assert!(login.contains("codex login status"));
+        assert!(login.contains(&format!(
+            "type=bind,src={},dst=/home/agent/.codex/auth.json",
+            auth.canonicalize().unwrap().display()
+        )));
+        assert!(!login.contains("super-secret-docker-token"));
+        assert!(!login.contains("docker.sock"));
     }
 
     #[tokio::test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -152,6 +152,24 @@ impl GitHubClient {
         Ok(())
     }
 
+    pub async fn validate_token_env(
+        &self,
+        environment: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<GitHubUser> {
+        let token = std::env::var(environment)
+            .with_context(|| format!("GitHub token is missing; export {environment}"))?;
+        if token.trim().is_empty() {
+            bail!("{environment} must not be empty");
+        }
+        let output = self
+            .run_with_token(None, &["api", "user"], Some(&token), cancellation)
+            .await
+            .with_context(|| format!("GitHub token from {environment} is not valid"))?;
+        serde_json::from_str(&output)
+            .context("GitHub token validation returned malformed user JSON")
+    }
+
     pub async fn validate_repository(
         &self,
         repository: &Path,
@@ -1289,8 +1307,22 @@ impl GitHubClient {
         arguments: &[&str],
         cancellation: &CancellationToken,
     ) -> Result<String> {
+        self.run_with_token(repository, arguments, None, cancellation)
+            .await
+    }
+
+    async fn run_with_token(
+        &self,
+        repository: Option<&Path>,
+        arguments: &[&str],
+        token: Option<&str>,
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
         let mut command = Command::new(&self.executable);
         command.args(arguments).env_remove("GH_REPO");
+        if let Some(token) = token {
+            command.env("GH_TOKEN", token);
+        }
         if let Some(repository) = repository {
             command.current_dir(repository);
         }
@@ -1318,7 +1350,12 @@ impl GitHubClient {
             }
         };
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            let stderr = if let Some(secret) = token {
+                stderr.replace(secret, "[REDACTED]")
+            } else {
+                stderr
+            };
             bail!(
                 "gh {} failed with status {}: {}",
                 arguments.join(" "),
@@ -1770,6 +1807,11 @@ impl From<ApiIssue> for IssueSnapshot {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     use super::*;
     use crate::approval::{ClaimArtifact, render_claim};
 
@@ -1824,5 +1866,27 @@ mod tests {
             ticket_context_hash(&context, "deliver", "workflow").unwrap(),
             context.approval.approved_content_hash
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn worker_token_validation_redacts_a_rejected_secret() {
+        const TOKEN_ENV: &str = "FACTORY_GITHUB_VALIDATION_TEST_TOKEN";
+        let temp = tempfile::tempdir().unwrap();
+        let gh = temp.path().join("gh");
+        fs::write(&gh, "#!/bin/sh\nprintf '%s' \"$GH_TOKEN\" >&2\nexit 1\n").unwrap();
+        let mut permissions = fs::metadata(&gh).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&gh, permissions).unwrap();
+        unsafe { std::env::set_var(TOKEN_ENV, "worker-secret-value") };
+
+        let error = GitHubClient::new(gh)
+            .validate_token_env(TOKEN_ENV, &CancellationToken::new())
+            .await
+            .unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("is not valid"));
+        assert!(message.contains("[REDACTED]"));
+        assert!(!message.contains("worker-secret-value"));
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -4,7 +4,7 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
@@ -1524,6 +1524,7 @@ struct ProjectItem {
     #[allow(dead_code)]
     #[serde(rename = "updatedAt")]
     updated_at: String,
+    #[serde(default, deserialize_with = "deserialize_project_issue")]
     content: Option<ProjectIssue>,
     #[serde(rename = "fieldValueByName", alias = "fieldValue")]
     field_value: Option<ProjectStatusValue>,
@@ -1553,6 +1554,21 @@ struct ProjectAuthor {
 struct ProjectRepository {
     #[serde(rename = "nameWithOwner")]
     name_with_owner: String,
+}
+
+fn deserialize_project_issue<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<ProjectIssue>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        Some(value) if value.get("id").is_some() => serde_json::from_value(value)
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+        _ => Ok(None),
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1888,5 +1904,27 @@ mod tests {
         assert!(message.contains("is not valid"));
         assert!(message.contains("[REDACTED]"));
         assert!(!message.contains("worker-secret-value"));
+    }
+
+    #[test]
+    fn project_poll_ignores_non_issue_content() {
+        let response: ProjectItemsResponse = serde_json::from_value(serde_json::json!({
+            "data": {
+                "node": {
+                    "items": {
+                        "pageInfo": {"hasNextPage": false, "endCursor": null},
+                        "nodes": [{
+                            "id": "PVTI_pull_request",
+                            "updatedAt": "2026-07-21T00:00:00Z",
+                            "content": {},
+                            "fieldValueByName": null
+                        }]
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        assert!(response.data.node.unwrap().items.nodes[0].content.is_none());
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -10,6 +10,10 @@ use toml_edit::{DocumentMut, Item, Table, value};
 
 use crate::config::Config;
 
+const TRIAGE_WORKFLOW: &str = include_str!("../.factory/workflows/triage-ticket.md");
+const IMPLEMENT_WORKFLOW: &str = include_str!("../.factory/workflows/implement-ready-ticket.md");
+const WORKER_DOCKERFILE: &str = include_str!("../.factory/Dockerfile");
+
 #[derive(Debug, Clone)]
 pub struct InitOptions {
     pub repository: PathBuf,
@@ -103,7 +107,11 @@ impl fmt::Display for InitReport {
             }
         } else if self.exit_code() == 0 {
             writeln!(formatter, "Next:")?;
-            writeln!(formatter, "  factory workflow create <workflow-id> --help")?;
+            writeln!(formatter, "  edit .factory/config.toml for your Project")?;
+            writeln!(
+                formatter,
+                "  docker build -f .factory/Dockerfile -t factory-codex:dev ."
+            )?;
             writeln!(formatter, "  factory validate")?;
             writeln!(formatter, "  factory daemon")
         } else {
@@ -120,6 +128,13 @@ struct DirectoryPlan {
     action: PlannedAction,
 }
 
+struct FilePlan {
+    path: PathBuf,
+    action: PlannedAction,
+    contents: &'static str,
+    detail: &'static str,
+}
+
 struct ConfigPlan {
     path: PathBuf,
     workspace: PathBuf,
@@ -132,6 +147,7 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
     let repository = discover_repository(&options.repository)?;
     let workflows = plan_workflow_directory(&repository)?;
     let config = plan_config(&options.config_path, &repository)?;
+    let assets = plan_default_assets(&repository)?;
 
     if options.check {
         return Ok(InitReport {
@@ -144,7 +160,14 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
                     "workspace directory",
                 ),
                 planned_resource(workflows.action, &workflows.path, "workflow directory"),
-            ],
+            ]
+            .into_iter()
+            .chain(
+                assets
+                    .iter()
+                    .map(|asset| planned_resource(asset.action, &asset.path, asset.detail)),
+            )
+            .collect(),
             check: true,
         });
     }
@@ -202,6 +225,28 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
         resource: workflows.path.display().to_string(),
         detail: Some("workflow directory".to_owned()),
     });
+
+    for (index, asset) in assets.iter().enumerate() {
+        if let Err(error) = apply_file(asset) {
+            resources.push(failed_resource(asset.path.display().to_string(), error));
+            for skipped in &assets[index + 1..] {
+                resources.push(skipped_resource(
+                    skipped.path.display().to_string(),
+                    "an earlier setup file failed",
+                ));
+            }
+            return Ok(InitReport {
+                repository,
+                resources,
+                check: false,
+            });
+        }
+        resources.push(ResourceResult {
+            status: applied_status(asset.action),
+            resource: asset.path.display().to_string(),
+            detail: Some(asset.detail.to_owned()),
+        });
+    }
 
     Ok(InitReport {
         repository,
@@ -340,6 +385,46 @@ fn plan_workflow_directory(repository: &Path) -> Result<DirectoryPlan> {
             PlannedAction::Create
         },
         path,
+    })
+}
+
+fn plan_default_assets(repository: &Path) -> Result<Vec<FilePlan>> {
+    let factory = repository.join(".factory");
+    Ok(vec![
+        plan_file(
+            factory.join("workflows/triage-ticket.md"),
+            TRIAGE_WORKFLOW,
+            "triage workflow",
+        )?,
+        plan_file(
+            factory.join("workflows/implement-ready-ticket.md"),
+            IMPLEMENT_WORKFLOW,
+            "implementation workflow",
+        )?,
+        plan_file(
+            factory.join("Dockerfile"),
+            WORKER_DOCKERFILE,
+            "Docker worker image",
+        )?,
+    ])
+}
+
+fn plan_file(path: PathBuf, contents: &'static str, detail: &'static str) -> Result<FilePlan> {
+    let action = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            bail!("setup path must be a regular file: {}", path.display())
+        }
+        Ok(_) => PlannedAction::Unchanged,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => PlannedAction::Create,
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to inspect {}", path.display()));
+        }
+    };
+    Ok(FilePlan {
+        path,
+        action,
+        contents,
+        detail,
     })
 }
 
@@ -540,6 +625,27 @@ fn apply_directory(plan: &DirectoryPlan) -> Result<()> {
         )?;
     }
     Ok(())
+}
+
+fn apply_file(plan: &FilePlan) -> Result<()> {
+    if plan.action == PlannedAction::Unchanged {
+        return Ok(());
+    }
+    let parent = plan.path.parent().context("setup file has no parent")?;
+    let mut temporary = NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create temporary file in {}", parent.display()))?;
+    temporary
+        .write_all(plan.contents.as_bytes())
+        .with_context(|| format!("failed to write {}", plan.path.display()))?;
+    temporary
+        .as_file_mut()
+        .sync_all()
+        .with_context(|| format!("failed to sync {}", plan.path.display()))?;
+    temporary
+        .persist_noclobber(&plan.path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("refusing to overwrite {}", plan.path.display()))?;
+    sync_parent(parent)
 }
 
 #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use factory::runtime::{
 };
 use factory::storage::{
     CancellationRequest, DATABASE_NAME, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState,
+    validate_data_directory,
 };
 use factory::workflow::WorkflowCatalog;
 use factory::workflow_create::{CreateWorkflowOptions, create_workflow};
@@ -299,6 +300,7 @@ async fn run_cli() -> Result<u8> {
             let config = Config::load(&path)?;
             let catalog = WorkflowCatalog::load(&config)?;
             catalog.validate_ticket_workflows()?;
+            validate_data_directory(&config.data_directory)?;
             if let Some(source) = &config.source {
                 let github = GitHubClient::default();
                 let cancellation = CancellationToken::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,6 +310,9 @@ async fn run_cli() -> Result<u8> {
                 }
             }
             if let Some(worker) = &config.worker {
+                GitHubClient::default()
+                    .validate_token_env(&worker.github_token_env, &CancellationToken::new())
+                    .await?;
                 DockerWorker::new(worker.clone(), "validate")
                     .validate(&CancellationToken::new())
                     .await?;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,6 +20,59 @@ pub const OPERATOR_CONFIRMED_CLEANUP: &str = "operator-confirmed cleanup";
 const DAEMON_OWNER_LEASE_MILLIS: i64 = 10_000;
 const APPROVAL_RESERVATION_TTL_MILLIS: i64 = 10 * 60 * 1000;
 
+pub fn validate_data_directory(data_directory: &Path) -> Result<()> {
+    fs::create_dir_all(data_directory).with_context(|| {
+        format!(
+            "failed to create Factory data directory {}",
+            data_directory.display()
+        )
+    })?;
+    tempfile::NamedTempFile::new_in(data_directory).with_context(|| {
+        format!(
+            "Factory data directory is not writable: {}",
+            data_directory.display()
+        )
+    })?;
+
+    let database = data_directory.join(DATABASE_NAME);
+    if !database.exists() {
+        return Ok(());
+    }
+    let metadata = fs::symlink_metadata(&database)
+        .with_context(|| format!("failed to inspect Factory database {}", database.display()))?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        bail!(
+            "Factory database must be a regular non-symlink file: {}",
+            database.display()
+        );
+    }
+    if metadata.permissions().readonly() {
+        bail!(
+            "Factory database is read-only and cannot be opened read-write: {}",
+            database.display()
+        );
+    }
+    let connection = Connection::open_with_flags(
+        &database,
+        OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| {
+        format!(
+            "Factory database cannot be opened read-write: {}",
+            database.display()
+        )
+    })?;
+    connection
+        .execute_batch("BEGIN IMMEDIATE; ROLLBACK;")
+        .with_context(|| {
+            format!(
+                "Factory database cannot acquire a write transaction: {}",
+                database.display()
+            )
+        })?;
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskState {
     Queued,

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -84,6 +84,7 @@ impl Fixture {
                     .arg("init")
                     .assert()
                     .success();
+                fs::remove_file(repository.join(".factory/workflows/triage-ticket.md")).unwrap();
             }
             let rewrite = format!("url.file://{}.insteadOf", remote.display());
             git(&repository, &["config", &rewrite, &github_remote]);

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -80,6 +80,7 @@ impl Fixture {
             .arg("init")
             .assert()
             .success();
+        fs::remove_file(repositories[0].join(".factory/workflows/triage-ticket.md")).unwrap();
         fs::write(
             &config_path,
             "version = 1\npoll_every = \"20ms\"\ndefault_runtime = \"codex\"\ndefault_timeout = \"2h\"\nmaximum_timeout = \"8h\"\nmax_concurrent_runs = 2\n\n[github]\ntrusted_approvers = [\"owainlewis\"]\nready_label = \"factory:ready\"\nproposed_label = \"factory:proposed\"\nneeds_review_label = \"factory:needs-review\"\n",

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -91,7 +91,7 @@ fn set_origin(path: &Path, origin: &str) {
 }
 
 #[test]
-fn init_creates_only_configuration_and_workflow_directory() {
+fn init_creates_complete_repository_factory_without_overwriting() {
     let fixture = Fixture::new();
 
     fixture
@@ -101,9 +101,11 @@ fn init_creates_only_configuration_and_workflow_directory() {
         .success()
         .stdout(predicate::str::contains("repository configuration"))
         .stdout(predicate::str::contains("workflow directory"))
-        .stdout(predicate::str::contains("factory workflow create"))
+        .stdout(predicate::str::contains("triage-ticket.md"))
+        .stdout(predicate::str::contains("implement-ready-ticket.md"))
+        .stdout(predicate::str::contains("Dockerfile"))
         .stdout(predicate::str::contains("GitHub label").not())
-        .stdout(predicate::str::contains("implement-ready-ticket.md").not());
+        .stdout(predicate::str::contains("factory validate"));
 
     let config = fs::read_to_string(fixture.config_path()).unwrap();
     assert!(config.contains("version = 1"));
@@ -123,7 +125,19 @@ fn init_creates_only_configuration_and_workflow_directory() {
     assert!(!config.contains("workspace_root"));
     assert!(fixture.workspace().is_dir());
     assert!(fixture.workflows().is_dir());
-    assert_eq!(fs::read_dir(fixture.workflows()).unwrap().count(), 0);
+    assert_eq!(fs::read_dir(fixture.workflows()).unwrap().count(), 2);
+    assert_eq!(
+        fs::read_to_string(fixture.workflows().join("triage-ticket.md")).unwrap(),
+        include_str!("../.factory/workflows/triage-ticket.md")
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.workflows().join("implement-ready-ticket.md")).unwrap(),
+        include_str!("../.factory/workflows/implement-ready-ticket.md")
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.repository.join(".factory/Dockerfile")).unwrap(),
+        include_str!("../.factory/Dockerfile")
+    );
     assert!(!fixture.repository.join(".gh-calls").exists());
 
     fixture
@@ -147,7 +161,10 @@ fn check_reports_missing_resources_without_writes() {
         .stdout(predicate::str::contains("would create:"))
         .stdout(predicate::str::contains("repository configuration"))
         .stdout(predicate::str::contains("workspace directory"))
-        .stdout(predicate::str::contains("workflow directory"));
+        .stdout(predicate::str::contains("workflow directory"))
+        .stdout(predicate::str::contains("triage-ticket.md"))
+        .stdout(predicate::str::contains("implement-ready-ticket.md"))
+        .stdout(predicate::str::contains("Dockerfile"));
 
     assert!(!fixture.config_path().exists());
     assert!(!fixture.data_home.exists());
@@ -164,6 +181,65 @@ fn init_does_not_touch_existing_workflows() {
     fixture.command().arg("init").assert().success();
 
     assert_eq!(fs::read_to_string(workflow).unwrap(), "custom policy\n");
+    assert!(fixture.workflows().join("triage-ticket.md").is_file());
+    assert!(
+        fixture
+            .workflows()
+            .join("implement-ready-ticket.md")
+            .is_file()
+    );
+}
+
+#[test]
+fn init_preserves_existing_default_assets_byte_for_byte() {
+    let fixture = Fixture::new();
+    fs::create_dir_all(fixture.workflows()).unwrap();
+    let triage = fixture.workflows().join("triage-ticket.md");
+    let implement = fixture.workflows().join("implement-ready-ticket.md");
+    let dockerfile = fixture.repository.join(".factory/Dockerfile");
+    fs::write(&triage, "custom triage\n").unwrap();
+    fs::write(&implement, "custom implementation\n").unwrap();
+    fs::write(&dockerfile, "FROM custom-image\n").unwrap();
+
+    fixture.command().arg("init").assert().success();
+
+    assert_eq!(fs::read_to_string(triage).unwrap(), "custom triage\n");
+    assert_eq!(
+        fs::read_to_string(implement).unwrap(),
+        "custom implementation\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dockerfile).unwrap(),
+        "FROM custom-image\n"
+    );
+}
+
+#[test]
+fn init_rejects_symlinked_default_asset_without_touching_target() {
+    let fixture = Fixture::new();
+    fs::create_dir_all(fixture.workflows()).unwrap();
+    let outside = fixture._temp.path().join("outside-triage.md");
+    fs::write(&outside, "outside policy\n").unwrap();
+    symlink(&outside, fixture.workflows().join("triage-ticket.md")).unwrap();
+
+    fixture
+        .command()
+        .arg("init")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "setup path must be a regular file",
+        ));
+
+    assert_eq!(fs::read_to_string(outside).unwrap(), "outside policy\n");
+    assert!(!fixture.config_path().exists());
+    assert!(
+        !fixture
+            .workflows()
+            .join("implement-ready-ticket.md")
+            .exists()
+    );
+    assert!(!fixture.repository.join(".factory/Dockerfile").exists());
 }
 
 #[test]

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -40,6 +40,8 @@ fn initialize_repository(repository: &std::path::Path, data_home: &std::path::Pa
         .arg("init")
         .assert()
         .success();
+    fs::remove_file(repository.join(".factory/workflows/triage-ticket.md")).unwrap();
+    fs::remove_file(repository.join(".factory/workflows/implement-ready-ticket.md")).unwrap();
 }
 
 #[test]

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -44,6 +44,8 @@ fn valid_config() -> (
         .arg("init")
         .assert()
         .success();
+    fs::remove_dir_all(repository.join(".factory/workflows")).unwrap();
+    fs::create_dir(repository.join(".factory/workflows")).unwrap();
     let path = repository.join(".factory/config.toml");
     fs::write(
         &path,
@@ -116,6 +118,7 @@ fn validates_configurable_github_project_states() {
 if [ "$1" = "--version" ]; then echo "gh version 2.80.0"; exit 0; fi
 if [ "$1" = "auth" ]; then exit 0; fi
 if [ "$1" = "repo" ]; then echo "example/repository"; exit 0; fi
+if [ "$1" = "api" ] && [ "$2" = "user" ] && [ "$GH_TOKEN" = "dedicated-test-token" ]; then echo '{"id":99,"login":"factory-bot"}'; exit 0; fi
 if [ "$1" = "api" ] && [ "$2" = "users/owainlewis" ]; then echo '{"id":1,"login":"owainlewis","node_id":"U_1"}'; exit 0; fi
 if [ "$1" = "project" ] && [ "$2" = "view" ]; then echo '{"id":"PVT_16"}'; exit 0; fi
 if [ "$1" = "project" ] && [ "$2" = "field-list" ]; then

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -81,6 +81,44 @@ fn validates_explicit_config() {
         .stdout(predicate::str::contains("default_runtime: codex"));
 }
 
+#[cfg(unix)]
+#[test]
+fn rejects_an_existing_database_that_is_not_writable() {
+    let (_temp, path, _repository, data_home) = valid_config();
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["validate", "--config", path.to_str().unwrap()])
+        .env("FACTORY_DATA_HOME", &data_home)
+        .assert()
+        .success();
+    let state_directory = fs::read_dir(&data_home)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let database = state_directory.join("factory.sqlite3");
+    rusqlite::Connection::open(&database)
+        .unwrap()
+        .execute_batch("CREATE TABLE proof (id INTEGER);")
+        .unwrap();
+    let mut permissions = fs::metadata(&database).unwrap().permissions();
+    permissions.set_mode(0o400);
+    fs::set_permissions(&database, permissions).unwrap();
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["validate", "--config", path.to_str().unwrap()])
+        .env("FACTORY_DATA_HOME", &data_home)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Factory database is read-only"));
+
+    let mut permissions = fs::metadata(&database).unwrap().permissions();
+    permissions.set_mode(0o600);
+    fs::set_permissions(database, permissions).unwrap();
+}
+
 #[test]
 fn validates_configurable_github_project_states() {
     let (temp, path, repository, data_home) = valid_config();
@@ -138,6 +176,7 @@ exit 64
         r#"#!/bin/sh
 if [ "$1" = "version" ]; then echo "27.0.0"; exit 0; fi
 if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then echo "sha256:abcdef"; exit 0; fi
+if [ "$1" = "run" ] && [ "$2" = "--rm" ]; then echo "Logged in using ChatGPT"; exit 0; fi
 exit 64
 "#,
     )

--- a/tests/workflow_create_cli.rs
+++ b/tests/workflow_create_cli.rs
@@ -83,6 +83,8 @@ exit 64
             executable_path,
         };
         fixture.command().arg("init").assert().success();
+        fs::remove_file(fixture.workflow("triage-ticket")).unwrap();
+        fs::remove_file(fixture.workflow("implement-ready-ticket")).unwrap();
         fs::write(
             fixture.repository.join(".factory/config.toml"),
             r#"version = 1

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -52,6 +52,8 @@ impl Fixture {
             .arg("init")
             .assert()
             .success();
+        fs::remove_dir_all(repository.join(".factory/workflows")).unwrap();
+        fs::create_dir(repository.join(".factory/workflows")).unwrap();
         let config_path = repository.join(".factory/config.toml");
         let config = test_config(
             vec![repository.canonicalize().unwrap()],


### PR DESCRIPTION
Closes #43

## What changed

- bootstrap a complete repo-scoped Factory with config, workflows, and Dockerfile
- validate GitHub Project states, dedicated worker identity, Docker, Codex login, and writable state before claiming work
- ignore non-issue GitHub Project items safely
- document and prove the two-phase triage and implementation flow
- use clean standalone Docker clones, never Git worktrees, with the agent owning git, gh, PR, review, and CI work

## Live proof

- no-work poll created no tasks and launched no model
- issue #56 was triaged from Ready For Spec to Ready To Implement without a branch or PR
- issue #54 produced branch factory/54 and PR #55, passed CI, received independent review, moved to Reviewing, and stopped at the human merge boundary
- restart inspection found one durable completed task and no duplicate run or container

## Checks

- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --no-fail-fast
- git diff --check
- live factory validate against GitHub Project 16 and factory-codex:dev

## Known boundary

The proof used the repository owner token, so least-privilege merge prevention remains an operational setup requirement enforced by a dedicated bot identity and protected branches.