### PR TITLE
chore: configure Factory for its own repository

### DIFF
--- a/.factory/config.toml
+++ b/.factory/config.toml
@@ -1,0 +1,29 @@
+version = 1
+poll_every = "30s"
+default_runtime = "codex"
+default_timeout = "2h"
+maximum_timeout = "8h"
+max_concurrent_runs = 1
+
+[worker]
+kind = "docker"
+image = "factory-codex:dev"
+memory = "8g"
+cpus = 4
+pids = 512
+codex_auth = "~/.local/share/factory/codex/auth.json"
+
+[source]
+kind = "github_project"
+owner = "owainlewis"
+project_number = 16
+status_field = "Status"
+trusted_users = ["owainlewis"]
+
+[source.states]
+ready_for_spec = "Ready For Spec"
+creating_spec = "Creating Spec"
+ready_to_implement = "Ready To Implement"
+implementing = "Implementing"
+ready_to_review = "Reviewing"
+done = "Done"


### PR DESCRIPTION
## Summary

- check in the repo-scoped Factory configuration
- connect Factory to GitHub Project 16 and its six configurable lifecycle states
- use the Docker worker and documented dedicated Codex authentication path

## Verification

- cargo fmt --all --check
- cargo test --all-targets --no-fail-fast
- git diff --check
- live factory init and factory validate from a clean standalone clone
- independent config review approved with no findings

The file contains no secrets. Runtime credentials and the Docker image remain machine-local prerequisites.