### PR TITLE
feat: support configurable execution modes

### DIFF
--- a/.factory/config.toml
+++ b/.factory/config.toml
@@ -1,4 +1,5 @@
 version = 1
+execution_mode = "docker"
 poll_every = "30s"
 default_runtime = "codex"
 default_timeout = "2h"

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ runs triage. An item in the ready-to-implement state runs implementation and
 advances to review. Only items from configured trusted users can be claimed.
 All six status names are configurable.
 
-`execution_mode = "worktree"` runs every workflow with the host Codex CLI in a
-Factory-owned Git worktree. It is fast, but it is not a security boundary and
+`execution_mode = "worktree"` runs every daemon task with the host Codex CLI in
+a Factory-owned Git worktree. It is fast, but it is not a security boundary and
 should be used only for trusted local work. `execution_mode = "docker"` runs
-every workflow in a disposable container backed by a standalone clone. The
+every daemon task in a disposable container backed by a standalone clone. The
 container has a read-only root, no added Linux capabilities, bounded CPU,
 memory and processes, and no Docker socket or canonical repository mount.
 

--- a/README.md
+++ b/README.md
@@ -2,42 +2,45 @@
 
 Factory is a local-first daemon that turns trusted GitHub Project items into
 supervised Codex runs. Factory owns polling, durable claims, concurrency,
-Docker isolation, inspection, cancellation, cleanup, and recovery. Codex owns
-the adaptive workflow inside a standalone clone and uses `gh` and `git`
-directly. It leaves pull requests for human review and merge.
+workspace isolation, inspection, cancellation, cleanup, and recovery. Codex
+owns the adaptive workflow and uses `gh` and `git` directly. It leaves pull
+requests for human review and merge.
 
-Factory v1 manages one trusted repository on a Unix-like host. It uses Docker,
-the local `gh` CLI for polling, a dedicated GitHub token for workers, and a
-dedicated Codex login. It does not use model API keys.
+Factory v1 manages one trusted repository on a Unix-like host. Worktree mode is
+the fast default for trusted local development. Docker mode uses standalone
+clones, a dedicated GitHub token, and a dedicated Codex login for reproducible,
+resource-bounded execution. Factory does not use model API keys.
 
 ## Quick start
 
-1. Install Rust, Docker, `git`, `gh`, and Codex CLI.
+1. Install Rust, `git`, `gh`, and Codex CLI.
 2. Authenticate the host with `gh auth login`.
 3. Clone Factory and run `cargo install --path . --locked`.
 4. In a trusted target repository, run `factory init`.
 5. Configure the GitHub Project, trusted users, and status names in
    `.factory/config.toml`.
-6. Review the generated triage and implementation workflows and adapt the
-   generated `.factory/Dockerfile` to the repository toolchain.
-7. Build the worker image:
+6. Review the generated triage and implementation workflows.
+7. Run `factory validate`, `factory workflows`, and `factory daemon`.
 
-   ```sh
-   docker build --file .factory/Dockerfile --tag factory-codex:dev .
-   ```
+For Docker execution, initialize with `factory init --execution-mode docker`,
+adapt the generated `.factory/Dockerfile`, and build the worker image:
 
-8. Create the dedicated Codex login used by the worker:
+```sh
+docker build --file .factory/Dockerfile --tag factory-codex:dev .
+```
 
-   ```sh
-   mkdir -p "$HOME/.local/share/factory/codex"
-   CODEX_HOME="$HOME/.local/share/factory/codex" codex login
-   ```
+Create the dedicated Codex login used by the worker:
 
-   Set `worker.codex_auth` to
-   `~/.local/share/factory/codex/auth.json` in the config.
+```sh
+mkdir -p "$HOME/.local/share/factory/codex"
+CODEX_HOME="$HOME/.local/share/factory/codex" codex login
+```
 
-9. Export `FACTORY_GITHUB_TOKEN` for a dedicated GitHub identity, then run
-   `factory validate`, `factory workflows`, and `factory daemon`.
+Set `worker.codex_auth` to `~/.local/share/factory/codex/auth.json` in the
+config.
+
+Export `FACTORY_GITHUB_TOKEN` for a dedicated GitHub identity before starting
+Factory in Docker mode.
 
 Run the install command from the Factory repository, then verify the command:
 
@@ -62,8 +65,8 @@ cargo install --path . --locked --force
 
 `factory init --check` previews setup without writes. Initialization creates
 `.factory/config.toml`, external machine state and workspace storage, and the
-two workflows plus `.factory/Dockerfile`. Existing files are never overwritten.
-It does not alter the GitHub Project or start an agent.
+two workflows. Docker mode also creates `.factory/Dockerfile`. Existing files
+are never overwritten. It does not alter the GitHub Project or start an agent.
 
 Create a scheduled pull-request triage workflow without opening an editor:
 
@@ -86,16 +89,16 @@ If no schedule or issue matches, Factory launches no agent and uses no model
 tokens.
 
 The v1 loop has two reactions. An item in the configured ready-for-spec state
-runs triage in a read-only clone. An item in the ready-to-implement state runs
-implementation in a writable clone and advances to review. Only items from
-configured trusted users can be claimed. All six status names are configurable.
+runs triage. An item in the ready-to-implement state runs implementation and
+advances to review. Only items from configured trusted users can be claimed.
+All six status names are configurable.
 
-Each Project-triggered run gets one disposable Docker container and one
-standalone clone. Docker is the isolation boundary, so sandboxed runs do not
-use Git worktrees. The container has a read-only root, no added Linux
-capabilities, bounded CPU, memory and processes, and no Docker socket or
-canonical repository mount. Scheduled workflows remain a separate host-run
-feature in v1.
+`execution_mode = "worktree"` runs every workflow with the host Codex CLI in a
+Factory-owned Git worktree. It is fast, but it is not a security boundary and
+should be used only for trusted local work. `execution_mode = "docker"` runs
+every workflow in a disposable container backed by a standalone clone. The
+container has a read-only root, no added Linux capabilities, bounded CPU,
+memory and processes, and no Docker socket or canonical repository mount.
 
 See [`docs/single-repository-v1/design.md`](docs/single-repository-v1/design.md)
 for the setup, state machine, worker boundary, recovery model, and acceptance

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -1,14 +1,14 @@
 # Run the single-repository Factory v1
 
 Factory watches one GitHub Project and reacts only when trusted work enters one
-of two configured states. Triage runs from a read-only clone. Implementation
-runs from a writable clone, pushes one stable issue branch, and leaves one pull
+of two configured states. It can run in fast local worktrees or isolated Docker
+clones. Implementation pushes one stable issue branch and leaves one pull
 request for human review and merge.
 
 ## Requirements
 
-Install Rust, Git, GitHub CLI, Docker, and Codex CLI on a Unix-like host. Docker
-must be running. Authenticate the host GitHub CLI:
+Install Rust, Git, GitHub CLI, and Codex CLI on a Unix-like host. Install and
+start Docker as well when using Docker mode. Authenticate the host GitHub CLI:
 
 ```sh
 gh auth login
@@ -35,7 +35,6 @@ This creates, only when missing:
 
 ```text
 .factory/config.toml
-.factory/Dockerfile
 .factory/workflows/triage-ticket.md
 .factory/workflows/implement-ready-ticket.md
 ```
@@ -44,14 +43,22 @@ It also creates the repository-specific Factory data directory outside the
 checkout. Re-running the command preserves every existing file. Preview missing
 resources without writing with `factory init --check`.
 
+This selects `execution_mode = "worktree"`. Worktrees are quick for trusted
+local development but are not a security boundary. To select Docker and create
+the worker Dockerfile instead, run:
+
+```sh
+factory init --execution-mode docker
+```
+
 Edit `.factory/config.toml` with the GitHub Project owner and number, the exact
 Status field values, and trusted issue authors. Status names are local policy,
 so Jira-style or team-specific names are valid when mapped to all six semantic
 states.
 
 Review the two workflow prompts. They are the adaptive part of the factory.
-Review `.factory/Dockerfile` and add the repository toolchain needed by tests
-and builds, then build the configured image:
+In Docker mode, review `.factory/Dockerfile` and add the repository toolchain
+needed by tests and builds, then build the configured image:
 
 ```sh
 docker build --file .factory/Dockerfile --tag factory-codex:dev .
@@ -85,10 +92,11 @@ factory daemon
 ```
 
 Validation checks the repository, all configured Project states, trusted users,
-Docker daemon, exact image, authenticated Codex session inside that image, live worker GitHub token, and
-writable Factory data path. `run --once` polls and records matching work but
-does not claim tasks or launch containers. With no matching Project item,
-Factory starts no container and invokes no model.
+and writable Factory data path. Worktree mode validates the host Codex CLI.
+Docker mode validates the Docker daemon, exact image, authenticated Codex
+session inside that image, and live worker GitHub token. `run --once` polls and
+records matching work but does not claim tasks or launch workers. With no
+matching Project item, Factory invokes no model.
 
 The continuous daemon reacts to two states:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,8 +1,8 @@
 # Operate Factory v1
 
 Factory is always watching, not always spending tokens. The daemon polls one
-configured GitHub Project and starts a Docker worker only for a trusted item in
-`ready_for_spec` or `ready_to_implement`.
+configured GitHub Project and starts a worker only for a trusted item in
+`ready_for_spec` or `ready_to_implement`, or when a scheduled workflow is due.
 
 ## Normal operation
 
@@ -13,8 +13,8 @@ factory validate
 factory daemon
 ```
 
-Startup validates all external dependencies before claiming work. Lifecycle
-events report polls, claims, container delegation, and terminal outcomes. Use
+Startup validates the configured execution backend before claiming work.
+Lifecycle events report polls, claims, worker delegation, and terminal outcomes. Use
 the supported inspection commands instead of reading SQLite directly:
 
 ```sh
@@ -30,9 +30,14 @@ title-independent `factory/<issue-number>` branch and linked pull request.
 
 ## Worker boundary
 
-Every Project task gets a disposable container and a standalone HTTPS clone.
-Triage mounts its clone read-only. Implementation mounts its clone read-write.
-The canonical checkout, Factory database, Docker socket, host credentials, and
+Worktree mode runs the host Codex CLI in a Factory-owned Git worktree. It is
+fast and uses the host user credentials and process boundary. It is not a
+security sandbox and should be used only for trusted local work.
+
+Docker mode gives every daemon task a disposable container and standalone HTTPS
+clone. Triage and scheduled workflows mount their clone read-only.
+Implementation and label-triggered delivery workflows mount it read-write. The
+canonical checkout, Factory database, Docker socket, host credentials, and
 unrelated repositories are not mounted.
 
 The worker runs as the clone owner with a read-only root filesystem, dropped
@@ -51,19 +56,18 @@ worker cannot merge or bypass review.
 ## Prove an idle poll
 
 When no configured Project item is ready and no scheduled workflow is due,
-capture the task list before and after one poll and list all Factory-managed
-containers:
+capture the task list before and after one poll:
 
 ```sh
 factory tasks --json
 factory run --once
 factory tasks --json
-docker ps --all --filter label=dev.factory.managed=true
 ```
 
-The two task listings should show zero new tasks, and the Docker listing should
-show zero Factory containers. This proves the empty poll persisted and launched
-nothing.
+The two task listings should show zero new tasks. In Docker mode, also run
+`docker ps --all --filter label=dev.factory.managed=true` and confirm that no
+Factory container was created. This proves the empty poll persisted and
+launched nothing.
 
 Before first repository-local startup, Factory reads the old
 `~/.factory/factory.sqlite3` database without modifying it. If that database
@@ -80,18 +84,18 @@ factory cancel RUN_ID
 ```
 
 Ctrl-C stops new polling and claims, cancels active workers, records terminal
-outcomes, and leaves queued work durable. On startup Factory reconciles durable
-container ownership before stopping or removing only containers labelled for
-that exact Factory instance. It captures the recovered logs and exit state,
-then permits bounded recovery. Repeated failure remains inspectable and never
-turns into an automatic merge.
+outcomes, and leaves queued work durable. Worktree mode supervises the host
+process group. Docker mode also reconciles durable container ownership before
+stopping or removing only containers labelled for that exact Factory instance.
+It captures recovered evidence, then permits bounded recovery. Repeated failure
+remains inspectable and never turns into an automatic merge.
 
-## Clone retention and cleanup
+## Workspace retention and cleanup
 
-Successful clean implementation clones are removed only after the branch is
-pushed and a pull-request handoff is recorded. Failed, cancelled, dirty,
-unpublished, or incomplete implementation clones are retained for recovery,
-up to ten.
+Successful clean implementation workspaces are removed only after the branch
+is pushed and a pull-request handoff is recorded. Failed, cancelled, dirty,
+unpublished, or incomplete implementation workspaces are retained for
+recovery, up to ten.
 
 Preview a retained clone before removal:
 
@@ -100,20 +104,21 @@ factory cleanup RUN_ID
 factory cleanup RUN_ID --confirm
 ```
 
-Confirmed cleanup removes only the recorded managed clone. The remote branch
-and pull request remain. Triage clones are disposable and are removed at a
-terminal outcome.
+Confirmed cleanup removes only the recorded managed worktree or standalone
+clone. The remote branch and pull request remain. Proposal workspaces are
+disposable and are removed at a terminal outcome.
 
 ## Troubleshooting
 
 - `factory init --check` reports missing repository assets without writing.
-- `factory validate` reports invalid state mappings, trusted users, worker
-  tokens, auth files, images, Docker availability, and data-path permissions.
-- `factory run --once` proves polling without launching a model or container.
-- `factory inspect RUN_ID` shows bounded task, container, branch, pull-request,
-  and error evidence.
+- `factory validate` reports invalid state mappings, trusted users, host Codex
+  availability in worktree mode, Docker prerequisites in Docker mode, and
+  data-path permissions.
+- `factory run --once` proves polling without launching a model or worker.
+- `factory inspect RUN_ID` shows bounded task, workspace, optional container,
+  branch, pull-request, and error evidence.
 - If old global Factory work is active, stop the old daemon and finish or cancel
   it. Repository-local Factory never mutates or imports the legacy database.
 
-Scheduled workflows remain a separate host-run feature in v1. They do not use
-the two-state Project pipeline or Docker worker path described here.
+Scheduled workflows remain outside the two-state Project pipeline but use the
+same configured worktree or Docker execution mode as ticket workflows.

--- a/docs/single-repository-v1/design.md
+++ b/docs/single-repository-v1/design.md
@@ -429,6 +429,7 @@ under a bounded cleanup policy.
 
 ```toml
 version = 1
+execution_mode = "docker"
 poll_every = "30s"
 max_concurrent_runs = 1
 default_runtime = "codex"
@@ -464,11 +465,12 @@ and workflows only from the canonical checkout, never from an agent branch.
 
 ### Bootstrap the local proof
 
-`factory init` creates `.factory/Dockerfile` and the two workflow files when
-they are missing and never overwrites them. The documented first run is:
+`factory init --execution-mode docker` creates `.factory/Dockerfile` and the
+two workflow files when they are missing and never overwrites them. The
+documented first run is:
 
 ```sh
-factory init
+factory init --execution-mode docker
 docker build --file .factory/Dockerfile --tag factory-codex:dev .
 
 mkdir -p "$HOME/.local/share/factory/codex"
@@ -498,7 +500,7 @@ dedicated bot plus repository rules.
 The existing CLI remains the user interface:
 
 ```text
-factory init
+factory init --execution-mode docker
 factory validate
 factory daemon
 factory run --once
@@ -575,8 +577,6 @@ and error.
 
 - Multiple repositories.
 - Jira, GitLab, and pull requests as first-class triggers.
-- Scheduled workflows. They can remain a separate subsystem and do not need to
-  share this issue pipeline in v1.
 - A general trigger language, workflow graph, effect model, or provider command
   abstraction.
 - Automatic merge, deployment, or production credentials.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,6 +1,7 @@
 # Copy this file to <repository>/.factory/config.toml.
 # Repository identity and external state paths are derived from the Git root.
 version = 1
+execution_mode = "docker"
 
 poll_every = "30s"
 default_runtime = "codex"

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -48,8 +48,8 @@ impl CloneManager {
         implementation: bool,
         github_token_env: &str,
     ) -> Result<StandaloneClone> {
-        if task_id <= 0 || issue == 0 {
-            bail!("clone task and issue IDs must be positive");
+        if task_id <= 0 || (implementation && issue == 0) {
+            bail!("clone task IDs and implementation issue IDs must be positive");
         }
         validate_repository(repository)?;
         validate_revision(base_sha)?;
@@ -191,6 +191,26 @@ impl CloneManager {
             base_branch: base_branch.to_owned(),
             base_sha: base_sha.to_owned(),
         })
+    }
+
+    pub fn prepare_proposal(
+        &self,
+        repository: &str,
+        task_id: i64,
+        base_branch: &str,
+        base_sha: &str,
+        github_token_env: &str,
+    ) -> Result<StandaloneClone> {
+        self.prepare(
+            repository,
+            task_id,
+            0,
+            "",
+            base_branch,
+            base_sha,
+            false,
+            github_token_env,
+        )
     }
 
     pub fn remove(&self, path: &Path) -> Result<()> {
@@ -415,16 +435,7 @@ esac
         };
 
         let triage = manager
-            .prepare(
-                "acme/widgets",
-                7,
-                42,
-                "Fix login timeout",
-                "main",
-                BASE_SHA,
-                false,
-                TOKEN_ENV,
-            )
+            .prepare_proposal("acme/widgets", 7, "main", BASE_SHA, TOKEN_ENV)
             .unwrap();
         assert_eq!(triage.path, root.join("triage-7"));
         assert_eq!(triage.branch, None);

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,9 +20,26 @@ pub struct Config {
     pub max_concurrent_runs_per_repository: usize,
     pub workspace_root: PathBuf,
     pub data_directory: PathBuf,
+    pub execution_mode: ExecutionMode,
     pub worker: Option<WorkerConfig>,
     pub source: Option<SourceConfig>,
     pub github: GitHubConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionMode {
+    Worktree,
+    Docker,
+}
+
+impl fmt::Display for ExecutionMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Worktree => "worktree",
+            Self::Docker => "docker",
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -112,6 +129,7 @@ pub struct GitHubConfig {
 #[serde(deny_unknown_fields)]
 struct RawConfig {
     version: u8,
+    execution_mode: Option<ExecutionMode>,
     poll_every: String,
     default_runtime: String,
     default_timeout: String,
@@ -244,7 +262,18 @@ impl Config {
         if raw.max_concurrent_runs == 0 {
             bail!("max_concurrent_runs must be greater than zero");
         }
-        if raw.worker.is_some() && raw.max_concurrent_runs != 1 {
+        let execution_mode = match (raw.execution_mode, raw.worker.is_some()) {
+            (Some(ExecutionMode::Worktree), true) => {
+                bail!("worktree execution_mode does not accept [worker] configuration")
+            }
+            (Some(ExecutionMode::Docker), false) => {
+                bail!("docker execution_mode requires [worker] configuration")
+            }
+            (Some(mode), _) => mode,
+            (None, true) => ExecutionMode::Docker,
+            (None, false) => ExecutionMode::Worktree,
+        };
+        if execution_mode == ExecutionMode::Docker && raw.max_concurrent_runs != 1 {
             bail!("Docker workers require max_concurrent_runs = 1");
         }
         if raw.source.is_some() && raw.github.is_some() {
@@ -307,6 +336,7 @@ impl Config {
             max_concurrent_runs_per_repository: raw.max_concurrent_runs,
             workspace_root,
             data_directory,
+            execution_mode,
             worker,
             source,
             github,
@@ -352,6 +382,7 @@ impl fmt::Display for Config {
             "max_concurrent_runs: {}",
             self.max_concurrent_runs
         )?;
+        writeln!(formatter, "execution_mode: {}", self.execution_mode)?;
         if let Some(worker) = &self.worker {
             writeln!(formatter, "worker: docker")?;
             writeln!(formatter, "worker.image: {}", worker.image)?;
@@ -975,6 +1006,7 @@ mod tests {
         }
         RawConfig {
             version: 1,
+            execution_mode: None,
             poll_every: "30s".into(),
             default_runtime: "codex".into(),
             default_timeout: "2h".into(),
@@ -1016,6 +1048,57 @@ mod tests {
         );
         assert!(config.workspace_root.ends_with("worktrees"));
         assert_eq!(config.poll_every, Duration::from_secs(30));
+        assert_eq!(config.execution_mode, ExecutionMode::Worktree);
+    }
+
+    #[test]
+    fn resolves_explicit_and_legacy_docker_modes() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repo");
+        let workspace = temp.path().join("worktrees");
+        let mut explicit = raw(&repository, &workspace);
+        explicit.execution_mode = Some(ExecutionMode::Docker);
+        explicit.max_concurrent_runs = 1;
+        explicit.worker = Some(docker_worker());
+        assert_eq!(
+            Config::resolve(explicit, &repository)
+                .unwrap()
+                .execution_mode,
+            ExecutionMode::Docker
+        );
+
+        let mut legacy = raw(&repository, &workspace);
+        legacy.max_concurrent_runs = 1;
+        legacy.worker = Some(docker_worker());
+        assert_eq!(
+            Config::resolve(legacy, &repository).unwrap().execution_mode,
+            ExecutionMode::Docker
+        );
+    }
+
+    #[test]
+    fn rejects_execution_mode_worker_mismatches() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repo");
+        let workspace = temp.path().join("worktrees");
+        let mut worktree = raw(&repository, &workspace);
+        worktree.execution_mode = Some(ExecutionMode::Worktree);
+        worktree.worker = Some(docker_worker());
+        assert!(
+            Config::resolve(worktree, &repository)
+                .unwrap_err()
+                .to_string()
+                .contains("worktree execution_mode does not accept [worker]")
+        );
+
+        let mut docker = raw(&repository, &workspace);
+        docker.execution_mode = Some(ExecutionMode::Docker);
+        assert!(
+            Config::resolve(docker, &repository)
+                .unwrap_err()
+                .to_string()
+                .contains("docker execution_mode requires [worker]")
+        );
     }
 
     #[test]
@@ -1214,6 +1297,7 @@ mod tests {
         fs::create_dir(&workspace).unwrap();
         let config = RawConfig {
             version: 1,
+            execution_mode: None,
             poll_every: "30s".into(),
             default_runtime: "codex".into(),
             default_timeout: "2h".into(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -375,15 +375,7 @@ impl FactoryDaemon {
         if let Some(docker) = &self.docker {
             docker.validate(cancellation).await?;
         }
-        let needs_host_codex = self.docker.is_none()
-            || self.catalog.entries.iter().any(|entry| {
-                entry.errors.is_empty()
-                    && entry
-                        .trigger
-                        .as_ref()
-                        .is_some_and(|trigger| !matches!(trigger, Trigger::State(_)))
-            });
-        if !needs_host_codex {
+        if self.docker.is_some() {
             return Ok(());
         }
         match self
@@ -720,6 +712,17 @@ fn resolve_workflow_target(entry: &WorkflowEntry) -> Option<(String, WorkflowTar
     ))
 }
 
+fn docker_clone_mount(trigger: &Trigger) -> CloneMount {
+    if matches!(
+        trigger,
+        Trigger::Label(_) | Trigger::State(PipelineState::ReadyToImplement)
+    ) {
+        CloneMount::ReadWrite
+    } else {
+        CloneMount::ReadOnly
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn dispatch_available(
     ledger: &mut Ledger,
@@ -913,7 +916,7 @@ fn dispatch_available(
                 );
                 return (repository, Ok(()));
             }
-            let sandboxed = docker.is_some() && matches!(workflow.trigger, Trigger::State(_));
+            let sandboxed = docker.is_some();
             let execution_target = match prepare_task_workspace(
                 &mut worker_ledger,
                 &github,
@@ -984,15 +987,8 @@ fn dispatch_available(
                 );
             }
             let result = if sandboxed {
-                let docker = docker.as_ref().expect("sandboxed tasks have Docker worker");
-                let mount = if matches!(
-                    workflow.trigger,
-                    Trigger::State(PipelineState::ReadyForSpec)
-                ) {
-                    CloneMount::ReadOnly
-                } else {
-                    CloneMount::ReadWrite
-                };
+                let docker = docker.as_ref().expect("Docker tasks have a Docker worker");
+                let mount = docker_clone_mount(&workflow.trigger);
                 execute_docker_task(
                     worker_ledger,
                     &execution_target,
@@ -1117,21 +1113,39 @@ async fn prepare_task_workspace(
         };
         ledger.reserve_task_workspace(&candidate)?
     };
-    if sandboxed {
-        if workspace.backend != "clone" {
-            bail!("sandboxed task {} owns a non-clone workspace", task.id);
-        }
-        let ticket = ticket_summary(task)?;
-        let clone = CloneManager::new(&workspace_root)?.prepare(
-            &task.repository,
+    let expected_backend = if sandboxed { "clone" } else { "worktree" };
+    if workspace.backend != expected_backend {
+        bail!(
+            "task {} owns a {} workspace but the configured execution mode requires {}; finish or clean up the task before changing execution_mode",
             task.id,
-            ticket.number,
-            &ticket.title,
-            &workspace.base_branch,
-            &workspace.base_sha,
-            workspace.kind == "delivery",
-            github_token_env.context("sandboxed clone has no GitHub token source")?,
-        )?;
+            workspace.backend,
+            expected_backend,
+        );
+    }
+    if sandboxed {
+        let token_env = github_token_env.context("sandboxed clone has no GitHub token source")?;
+        let clone_manager = CloneManager::new(&workspace_root)?;
+        let clone = if workspace.kind == "delivery" {
+            let ticket = ticket_summary(task)?;
+            clone_manager.prepare(
+                &task.repository,
+                task.id,
+                ticket.number,
+                &ticket.title,
+                &workspace.base_branch,
+                &workspace.base_sha,
+                true,
+                token_env,
+            )?
+        } else {
+            clone_manager.prepare_proposal(
+                &task.repository,
+                task.id,
+                &workspace.base_branch,
+                &workspace.base_sha,
+                token_env,
+            )?
+        };
         if clone.path != workspace.path
             || clone.branch != workspace.factory_branch
             || clone.base_branch != workspace.base_branch
@@ -2190,6 +2204,29 @@ mod tests {
         DateTime::parse_from_rfc3339(value)
             .unwrap()
             .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn docker_mounts_only_delivery_workflows_read_write() {
+        assert_eq!(
+            docker_clone_mount(&Trigger::State(PipelineState::ReadyForSpec)),
+            CloneMount::ReadOnly
+        );
+        assert_eq!(
+            docker_clone_mount(&Trigger::Schedule {
+                expression: "0 9 * * 1".to_owned(),
+                timezone: chrono_tz::UTC,
+            }),
+            CloneMount::ReadOnly
+        );
+        assert_eq!(
+            docker_clone_mount(&Trigger::State(PipelineState::ReadyToImplement)),
+            CloneMount::ReadWrite
+        );
+        assert_eq!(
+            docker_clone_mount(&Trigger::Label("factory:ready".to_owned())),
+            CloneMount::ReadWrite
+        );
     }
 
     fn scheduled_targets(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -140,6 +140,7 @@ impl FactoryDaemon {
             Err(error) => return Err(error),
         };
         let mut ledger = Ledger::open(&self.ledger_path)?;
+        validate_workspace_backends(&ledger, self.docker.is_some())?;
         if let Some(docker) = &self.docker {
             reconcile_docker_workers(docker, &mut ledger, &cancellation).await?;
         }
@@ -505,6 +506,23 @@ async fn reconcile_docker_workers(
 fn docker_instance_id(data_directory: &Path) -> String {
     let digest = Sha256::digest(data_directory.as_os_str().as_encoded_bytes());
     format!("{:x}", digest)[..20].to_owned()
+}
+
+fn validate_workspace_backends(ledger: &Ledger, docker_mode: bool) -> Result<()> {
+    let expected = if docker_mode { "clone" } else { "worktree" };
+    let incompatible = ledger
+        .active_task_workspaces()?
+        .into_iter()
+        .filter(|workspace| workspace.backend != expected)
+        .map(|workspace| format!("task {} ({})", workspace.task_id, workspace.backend))
+        .collect::<Vec<_>>();
+    if !incompatible.is_empty() {
+        bail!(
+            "configured execution mode requires {expected} workspaces, but active work uses {}; finish or clean up those tasks before changing execution_mode",
+            incompatible.join(", ")
+        );
+    }
+    Ok(())
 }
 
 fn reconcile_pending_cleanup(
@@ -2227,6 +2245,38 @@ mod tests {
             docker_clone_mount(&Trigger::Label("factory:ready".to_owned())),
             CloneMount::ReadWrite
         );
+    }
+
+    #[test]
+    fn startup_rejects_active_workspaces_from_another_execution_mode() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+        let task = ledger
+            .enqueue(&TaskIdentity::ticket("example/repo", "triage", "42", "approval").unwrap())
+            .unwrap()
+            .task;
+        ledger
+            .reserve_task_workspace(&TaskWorkspace {
+                task_id: task.id,
+                kind: "proposal".into(),
+                backend: "clone".into(),
+                repository: task.repository,
+                base_branch: "main".into(),
+                base_sha: "0123456789012345678901234567890123456789".into(),
+                factory_branch: None,
+                path: temp.path().join("triage-1"),
+                state: "ready".into(),
+                status_summary: None,
+                created_at: 0,
+                updated_at: 0,
+                cleaned_at: None,
+            })
+            .unwrap();
+
+        validate_workspace_backends(&ledger, true).unwrap();
+        let error = validate_workspace_backends(&ledger, false).unwrap_err();
+        assert!(error.to_string().contains("task 1 (clone)"));
+        assert!(error.to_string().contains("before changing execution_mode"));
     }
 
     fn scheduled_targets(

--- a/src/init.rs
+++ b/src/init.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result, bail};
 use tempfile::NamedTempFile;
 use toml_edit::{DocumentMut, Item, Table, value};
 
-use crate::config::Config;
+use crate::config::{Config, ExecutionMode};
 
 const TRIAGE_WORKFLOW: &str = include_str!("../.factory/workflows/triage-ticket.md");
 const IMPLEMENT_WORKFLOW: &str = include_str!("../.factory/workflows/implement-ready-ticket.md");
@@ -19,6 +19,7 @@ pub struct InitOptions {
     pub repository: PathBuf,
     pub config_path: PathBuf,
     pub check: bool,
+    pub execution_mode: ExecutionMode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,6 +61,7 @@ pub struct InitReport {
     repository: PathBuf,
     resources: Vec<ResourceResult>,
     check: bool,
+    execution_mode: ExecutionMode,
 }
 
 impl InitReport {
@@ -108,10 +110,12 @@ impl fmt::Display for InitReport {
         } else if self.exit_code() == 0 {
             writeln!(formatter, "Next:")?;
             writeln!(formatter, "  edit .factory/config.toml for your Project")?;
-            writeln!(
-                formatter,
-                "  docker build -f .factory/Dockerfile -t factory-codex:dev ."
-            )?;
+            if self.execution_mode == ExecutionMode::Docker {
+                writeln!(
+                    formatter,
+                    "  docker build -f .factory/Dockerfile -t factory-codex:dev ."
+                )?;
+            }
             writeln!(formatter, "  factory validate")?;
             writeln!(formatter, "  factory daemon")
         } else {
@@ -141,13 +145,14 @@ struct ConfigPlan {
     workspace_action: PlannedAction,
     action: PlannedAction,
     candidate: Option<String>,
+    execution_mode: ExecutionMode,
 }
 
 pub fn initialize(options: InitOptions) -> Result<InitReport> {
     let repository = discover_repository(&options.repository)?;
     let workflows = plan_workflow_directory(&repository)?;
-    let config = plan_config(&options.config_path, &repository)?;
-    let assets = plan_default_assets(&repository)?;
+    let config = plan_config(&options.config_path, &repository, options.execution_mode)?;
+    let assets = plan_default_assets(&repository, config.execution_mode)?;
 
     if options.check {
         return Ok(InitReport {
@@ -169,6 +174,7 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
             )
             .collect(),
             check: true,
+            execution_mode: config.execution_mode,
         });
     }
 
@@ -199,6 +205,7 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
             repository,
             resources,
             check: false,
+            execution_mode: config.execution_mode,
         });
     }
     resources.push(ResourceResult {
@@ -218,6 +225,7 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
             repository,
             resources,
             check: false,
+            execution_mode: config.execution_mode,
         });
     }
     resources.push(ResourceResult {
@@ -239,6 +247,7 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
                 repository,
                 resources,
                 check: false,
+                execution_mode: config.execution_mode,
             });
         }
         resources.push(ResourceResult {
@@ -252,6 +261,7 @@ pub fn initialize(options: InitOptions) -> Result<InitReport> {
         repository,
         resources,
         check: false,
+        execution_mode: config.execution_mode,
     })
 }
 
@@ -388,9 +398,9 @@ fn plan_workflow_directory(repository: &Path) -> Result<DirectoryPlan> {
     })
 }
 
-fn plan_default_assets(repository: &Path) -> Result<Vec<FilePlan>> {
+fn plan_default_assets(repository: &Path, execution_mode: ExecutionMode) -> Result<Vec<FilePlan>> {
     let factory = repository.join(".factory");
-    Ok(vec![
+    let mut assets = vec![
         plan_file(
             factory.join("workflows/triage-ticket.md"),
             TRIAGE_WORKFLOW,
@@ -401,12 +411,15 @@ fn plan_default_assets(repository: &Path) -> Result<Vec<FilePlan>> {
             IMPLEMENT_WORKFLOW,
             "implementation workflow",
         )?,
-        plan_file(
+    ];
+    if execution_mode == ExecutionMode::Docker {
+        assets.push(plan_file(
             factory.join("Dockerfile"),
             WORKER_DOCKERFILE,
             "Docker worker image",
-        )?,
-    ])
+        )?);
+    }
+    Ok(assets)
 }
 
 fn plan_file(path: PathBuf, contents: &'static str, detail: &'static str) -> Result<FilePlan> {
@@ -439,7 +452,11 @@ pub(crate) fn validate_optional_directory(path: &Path) -> Result<()> {
     }
 }
 
-fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
+fn plan_config(
+    path: &Path,
+    repository: &Path,
+    requested_mode: ExecutionMode,
+) -> Result<ConfigPlan> {
     let path = absolute_path(path)?;
     let expected = repository.join(".factory/config.toml");
     if path != expected {
@@ -466,10 +483,11 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
                 workspace_action,
                 action: PlannedAction::Unchanged,
                 candidate: None,
+                execution_mode: config.execution_mode,
             })
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            let candidate = default_config();
+            let candidate = default_config(requested_mode);
             let validated = Config::validate_candidate(&candidate, repository)
                 .context("generated configuration is invalid")?;
             let workspace = validated.workspace_root;
@@ -483,6 +501,7 @@ fn plan_config(path: &Path, repository: &Path) -> Result<ConfigPlan> {
                 },
                 action: PlannedAction::Create,
                 candidate: Some(candidate),
+                execution_mode: requested_mode,
             })
         }
         Err(error) => {
@@ -501,20 +520,23 @@ fn absolute_path(path: &Path) -> Result<PathBuf> {
     }
 }
 
-fn default_config() -> String {
+fn default_config(execution_mode: ExecutionMode) -> String {
     let mut document = DocumentMut::new();
     document["version"] = value(1);
+    document["execution_mode"] = value(execution_mode.to_string());
     document["poll_every"] = value("30s");
     document["default_runtime"] = value("codex");
     document["default_timeout"] = value("2h");
     document["maximum_timeout"] = value("8h");
     document["max_concurrent_runs"] = value(1);
-    document["worker"] = Item::Table(Table::new());
-    document["worker"]["kind"] = value("docker");
-    document["worker"]["image"] = value("factory-codex:dev");
-    document["worker"]["memory"] = value("8g");
-    document["worker"]["cpus"] = value(4);
-    document["worker"]["pids"] = value(512);
+    if execution_mode == ExecutionMode::Docker {
+        document["worker"] = Item::Table(Table::new());
+        document["worker"]["kind"] = value("docker");
+        document["worker"]["image"] = value("factory-codex:dev");
+        document["worker"]["memory"] = value("8g");
+        document["worker"]["cpus"] = value(4);
+        document["worker"]["pids"] = value(512);
+    }
     document["source"] = Item::Table(Table::new());
     document["source"]["kind"] = value("github_project");
     document["source"]["owner"] = value("owainlewis");

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,9 +309,9 @@ async fn run_cli() -> Result<u8> {
             let catalog = WorkflowCatalog::load(&config)?;
             catalog.validate_ticket_workflows()?;
             validate_data_directory(&config.data_directory)?;
+            let cancellation = CancellationToken::new();
             if let Some(source) = &config.source {
                 let github = GitHubClient::default();
-                let cancellation = CancellationToken::new();
                 github.validate_global(&cancellation).await?;
                 for repository in &config.repositories {
                     github
@@ -321,10 +321,14 @@ async fn run_cli() -> Result<u8> {
             }
             if let Some(worker) = &config.worker {
                 GitHubClient::default()
-                    .validate_token_env(&worker.github_token_env, &CancellationToken::new())
+                    .validate_token_env(&worker.github_token_env, &cancellation)
                     .await?;
                 DockerWorker::new(worker.clone(), "validate")
-                    .validate(&CancellationToken::new())
+                    .validate(&cancellation)
+                    .await?;
+            } else {
+                CodexRuntime::default()
+                    .health_check_with_cancellation(cancellation)
                     .await?;
             }
             print!("{config}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use factory::approve::approve_issue;
 use factory::clone::CloneManager;
-use factory::config::{Config, repository_config_path, repository_remote_identity};
+use factory::config::{Config, ExecutionMode, repository_config_path, repository_remote_identity};
 use factory::daemon::FactoryDaemon;
 use factory::docker::DockerWorker;
 use factory::execution::ResolvedWorkflow;
@@ -45,6 +45,9 @@ enum Command {
         /// Report required changes without writing anything.
         #[arg(long)]
         check: bool,
+        /// Execution backend for a new configuration.
+        #[arg(long, value_enum, default_value_t = ExecutionMode::Worktree)]
+        execution_mode: ExecutionMode,
     },
     /// Poll this repository once and persist eligible tasks without executing them.
     Run {
@@ -247,7 +250,11 @@ async fn run_cli() -> Result<u8> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Init { repository, check } => {
+        Command::Init {
+            repository,
+            check,
+            execution_mode,
+        } => {
             let repository = repository
                 .unwrap_or(std::env::current_dir().context("failed to resolve current directory")?);
             let repository = factory::init::discover_repository(&repository)?;
@@ -255,6 +262,7 @@ async fn run_cli() -> Result<u8> {
                 config_path: repository_config_path(&repository),
                 repository,
                 check,
+                execution_mode,
             })?;
             let exit_code = report.exit_code();
             print!("{report}");

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use assert_cmd::Command as AssertCommand;
 use factory::approval::{ApprovalArtifact, approved_content_hash, render};
-use factory::config::{Config, GitHubConfig};
+use factory::config::{Config, ExecutionMode, GitHubConfig};
 use factory::daemon::FactoryDaemon;
 use factory::github::GitHubClient;
 use factory::runtime::CodexRuntime;
@@ -126,6 +126,7 @@ impl Fixture {
             max_concurrent_runs_per_repository: repository_limit,
             workspace_root: workspace,
             data_directory: temp.path().join("data"),
+            execution_mode: ExecutionMode::Worktree,
             worker: None,
             source: None,
             github: GitHubConfig {

--- a/tests/github_polling.rs
+++ b/tests/github_polling.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use assert_cmd::Command as AssertCommand;
 use chrono::Utc;
 use factory::approval::{ApprovalArtifact, approved_content_hash, render};
-use factory::config::{Config, GitHubConfig};
+use factory::config::{Config, ExecutionMode, GitHubConfig};
 use factory::github::{GitHubClient, TicketContext};
 use factory::storage::{Ledger, RunOutcome, TaskIdentity};
 use factory::workflow::{
@@ -96,6 +96,7 @@ impl Fixture {
             max_concurrent_runs_per_repository: 2,
             workspace_root: workspace,
             data_directory: temp.path().join("data"),
+            execution_mode: ExecutionMode::Worktree,
             worker: None,
             source: None,
             github: GitHubConfig {

--- a/tests/github_project_polling.rs
+++ b/tests/github_project_polling.rs
@@ -7,7 +7,9 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
 
-use factory::config::{Config, GitHubConfig, PipelineState, SourceConfig, SourceStates};
+use factory::config::{
+    Config, ExecutionMode, GitHubConfig, PipelineState, SourceConfig, SourceStates,
+};
 use factory::github::{GitHubClient, ProjectTicketContext};
 use factory::storage::{Ledger, RunOutcome};
 use factory::workflow::WorkflowCatalog;
@@ -76,6 +78,7 @@ impl Fixture {
             max_concurrent_runs_per_repository: 1,
             workspace_root,
             data_directory: temp.path().join("data"),
+            execution_mode: ExecutionMode::Worktree,
             worker: None,
             source: Some(source),
             github: GitHubConfig {

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -103,21 +103,17 @@ fn init_creates_complete_repository_factory_without_overwriting() {
         .stdout(predicate::str::contains("workflow directory"))
         .stdout(predicate::str::contains("triage-ticket.md"))
         .stdout(predicate::str::contains("implement-ready-ticket.md"))
-        .stdout(predicate::str::contains("Dockerfile"))
+        .stdout(predicate::str::contains("Dockerfile").not())
         .stdout(predicate::str::contains("GitHub label").not())
         .stdout(predicate::str::contains("factory validate"));
 
     let config = fs::read_to_string(fixture.config_path()).unwrap();
     assert!(config.contains("version = 1"));
+    assert!(config.contains("execution_mode = \"worktree\""));
     assert!(config.contains("[source]"));
     assert!(config.contains("kind = \"github_project\""));
     assert!(config.contains("project_number = 16"));
-    assert!(config.contains("[worker]"));
-    assert!(config.contains("kind = \"docker\""));
-    assert!(config.contains("image = \"factory-codex:dev\""));
-    assert!(config.contains("memory = \"8g\""));
-    assert!(config.contains("cpus = 4"));
-    assert!(config.contains("pids = 512"));
+    assert!(!config.contains("[worker]"));
     assert!(config.contains("max_concurrent_runs = 1"));
     assert!(config.contains("[source.states]"));
     assert!(!config.contains("[github]"));
@@ -134,10 +130,7 @@ fn init_creates_complete_repository_factory_without_overwriting() {
         fs::read_to_string(fixture.workflows().join("implement-ready-ticket.md")).unwrap(),
         include_str!("../.factory/workflows/implement-ready-ticket.md")
     );
-    assert_eq!(
-        fs::read_to_string(fixture.repository.join(".factory/Dockerfile")).unwrap(),
-        include_str!("../.factory/Dockerfile")
-    );
+    assert!(!fixture.repository.join(".factory/Dockerfile").exists());
     assert!(!fixture.repository.join(".gh-calls").exists());
 
     fixture
@@ -147,6 +140,32 @@ fn init_creates_complete_repository_factory_without_overwriting() {
         .success()
         .stdout(predicate::str::contains("unchanged:"));
     assert_eq!(fs::read_to_string(fixture.config_path()).unwrap(), config);
+}
+
+#[test]
+fn init_docker_mode_creates_worker_configuration_and_dockerfile() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .args(["init", "--execution-mode", "docker"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Dockerfile"))
+        .stdout(predicate::str::contains("docker build"));
+
+    let config = fs::read_to_string(fixture.config_path()).unwrap();
+    assert!(config.contains("execution_mode = \"docker\""));
+    assert!(config.contains("[worker]"));
+    assert!(config.contains("kind = \"docker\""));
+    assert!(config.contains("image = \"factory-codex:dev\""));
+    assert!(config.contains("memory = \"8g\""));
+    assert!(config.contains("cpus = 4"));
+    assert!(config.contains("pids = 512"));
+    assert_eq!(
+        fs::read_to_string(fixture.repository.join(".factory/Dockerfile")).unwrap(),
+        include_str!("../.factory/Dockerfile")
+    );
 }
 
 #[test]
@@ -164,7 +183,7 @@ fn check_reports_missing_resources_without_writes() {
         .stdout(predicate::str::contains("workflow directory"))
         .stdout(predicate::str::contains("triage-ticket.md"))
         .stdout(predicate::str::contains("implement-ready-ticket.md"))
-        .stdout(predicate::str::contains("Dockerfile"));
+        .stdout(predicate::str::contains("Dockerfile").not());
 
     assert!(!fixture.config_path().exists());
     assert!(!fixture.data_home.exists());

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -67,12 +67,35 @@ needs_review_label = "factory:needs-review"
     (temp, path, repository, data_home)
 }
 
+#[cfg(unix)]
+fn command_with_healthy_codex(temp: &tempfile::TempDir) -> Command {
+    let bin = temp.path().join("healthy-bin");
+    fs::create_dir_all(&bin).unwrap();
+    let codex = bin.join("codex");
+    fs::write(
+        &codex,
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codex 1.0.0'; exit 0; fi\nif [ \"$1 $2\" = \"login status\" ]; then echo 'Logged in using ChatGPT'; exit 0; fi\nexit 64\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&codex).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(codex, permissions).unwrap();
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut command = Command::cargo_bin("factory").unwrap();
+    command.env("PATH", path);
+    command
+}
+
+#[cfg(unix)]
 #[test]
 fn validates_explicit_config() {
-    let (_temp, path, _repository, data_home) = valid_config();
+    let (temp, path, _repository, data_home) = valid_config();
 
-    Command::cargo_bin("factory")
-        .unwrap()
+    command_with_healthy_codex(&temp)
         .args(["validate", "--config", path.to_str().unwrap()])
         .env("FACTORY_DATA_HOME", data_home)
         .assert()
@@ -83,10 +106,36 @@ fn validates_explicit_config() {
 
 #[cfg(unix)]
 #[test]
-fn rejects_an_existing_database_that_is_not_writable() {
-    let (_temp, path, _repository, data_home) = valid_config();
+fn worktree_validation_requires_a_healthy_host_codex_cli() {
+    let (temp, path, _repository, data_home) = valid_config();
+    let bin = temp.path().join("bin");
+    fs::create_dir(&bin).unwrap();
+    let codex = bin.join("codex");
+    fs::write(&codex, "#!/bin/sh\necho broken codex >&2\nexit 64\n").unwrap();
+    let mut permissions = fs::metadata(&codex).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&codex, permissions).unwrap();
+    let path_value = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
     Command::cargo_bin("factory")
         .unwrap()
+        .args(["validate", "--config", path.to_str().unwrap()])
+        .env("FACTORY_DATA_HOME", data_home)
+        .env("PATH", path_value)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Codex CLI health check failed"));
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_an_existing_database_that_is_not_writable() {
+    let (temp, path, _repository, data_home) = valid_config();
+    command_with_healthy_codex(&temp)
         .args(["validate", "--config", path.to_str().unwrap()])
         .env("FACTORY_DATA_HOME", &data_home)
         .assert()
@@ -244,13 +293,13 @@ fn reports_specific_validation_failures() {
         ));
 }
 
+#[cfg(unix)]
 #[test]
 fn uses_default_config_path() {
-    let (_temp, _path, repository, data_home) = valid_config();
+    let (temp, _path, repository, data_home) = valid_config();
     fs::create_dir_all(repository.join("nested/directory")).unwrap();
 
-    Command::cargo_bin("factory")
-        .unwrap()
+    command_with_healthy_codex(&temp)
         .arg("validate")
         .current_dir(repository.join("nested/directory"))
         .env("FACTORY_DATA_HOME", data_home)
@@ -259,14 +308,14 @@ fn uses_default_config_path() {
         .stdout(predicate::str::contains("Configuration is valid."));
 }
 
+#[cfg(unix)]
 #[test]
 fn resolves_relative_paths_from_config_directory() {
-    let (_temp, path, repository, data_home) = valid_config();
+    let (temp, path, repository, data_home) = valid_config();
     let launch_dir = repository.join("nested");
     fs::create_dir(&launch_dir).unwrap();
 
-    Command::cargo_bin("factory")
-        .unwrap()
+    command_with_healthy_codex(&temp)
         .current_dir(launch_dir)
         .args(["validate", "--config", path.to_str().unwrap()])
         .env("FACTORY_DATA_HOME", &data_home)

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use assert_cmd::Command;
-use factory::config::{Config, GitHubConfig, PipelineState, SourceConfig, SourceStates};
+use factory::config::{
+    Config, ExecutionMode, GitHubConfig, PipelineState, SourceConfig, SourceStates,
+};
 use factory::workflow::{Trigger, WorkflowCatalog};
 use predicates::prelude::*;
 
@@ -91,6 +93,7 @@ fn test_config(repositories: Vec<PathBuf>, workspace: PathBuf, data: PathBuf) ->
         max_concurrent_runs_per_repository: 2,
         workspace_root: workspace,
         data_directory: data,
+        execution_mode: ExecutionMode::Worktree,
         worker: None,
         source: None,
         github: GitHubConfig {
@@ -605,6 +608,7 @@ fn catalog_output_escapes_control_characters_in_every_dynamic_cell() {
         max_concurrent_runs_per_repository: 1,
         workspace_root: workspace,
         data_directory: temp.path().join("data"),
+        execution_mode: ExecutionMode::Worktree,
         worker: None,
         source: None,
         github: GitHubConfig {


### PR DESCRIPTION
## Summary

- add explicit worktree and Docker execution modes
- make trusted-local worktrees the lightweight default for new repositories
- keep Docker sandboxes on standalone clones with no Git worktrees
- run scheduled, triage, and implementation daemon tasks through the selected backend
- fail closed when config, worker settings, credentials, or active workspace backends do not match
- make init assets and operations guidance mode-aware
- keep Factory itself explicitly configured for Docker

## Verification

- cargo fmt --all --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --no-fail-fast
- git diff --check origin/main
- independent review approved after one documentation finding was fixed

## Boundary

Worktree mode is trusted-local isolation, not a security sandbox. Docker mode uses disposable containers and standalone clones. Manual `factory workflow run` remains a direct host command; execution_mode controls daemon-dispatched tasks.