### PR TITLE
feat(cli): run the continuous daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ resource-bounded execution. Factory does not use model API keys.
 5. Configure the GitHub Project, trusted users, and status names in
    `.factory/config.toml`.
 6. Review the generated triage and implementation workflows.
-7. Run `factory validate`, `factory workflows`, and `factory daemon`.
+7. Run `factory validate`, `factory workflows`, and `factory run`.
 
 For Docker execution, initialize with `factory init --execution-mode docker`,
 adapt the generated `.factory/Dockerfile`, and build the worker image:
@@ -83,7 +83,7 @@ prompt from standard input. Label-triggered workflows create their missing
 trigger label explicitly; scheduled workflows do not mutate labels during
 creation.
 
-`factory daemon` runs until Ctrl-C. `factory run --once` evaluates schedules
+`factory run` runs until Ctrl-C. `factory run --once` evaluates schedules
 and polls once, persists eligible tasks, and exits without launching Codex.
 If no schedule or issue matches, Factory launches no agent and uses no model
 tokens.

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -88,7 +88,7 @@ personal owner token safe.
 factory validate
 factory workflows
 factory run --once
-factory daemon
+factory run
 ```
 
 Validation checks the repository, all configured Project states, trusted users,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,7 +10,7 @@ Start from anywhere inside the configured repository:
 
 ```sh
 factory validate
-factory daemon
+factory run
 ```
 
 Startup validates the configured execution backend before claiming work.

--- a/docs/single-repository-v1/design.md
+++ b/docs/single-repository-v1/design.md
@@ -9,7 +9,7 @@
 Factory is a repo-local daemon that turns GitHub issues into agent-ready tasks
 and agent-ready tasks into reviewed pull requests.
 
-V1 manages one repository. Running `factory daemon` inside that repository
+V1 manages one repository. Running `factory run` inside that repository
 watches for tickets in two configured source states, then starts an agent only
 when useful work exists. The agent receives the ticket as a prompt, uses `gh`
 and `git` directly, follows the repository workflow, and moves the ticket to the
@@ -38,7 +38,7 @@ operator's whole machine.
 
 ## Requirements
 
-- `factory daemon` discovers the enclosing Git root and loads
+- `factory run` discovers the enclosing Git root and loads
   `.factory/config.toml`.
 - V1 manages exactly one GitHub repository and runs at most one agent at a time.
 - Factory polls cheaply and starts no agent when no issue matches a trigger.
@@ -479,7 +479,7 @@ CODEX_HOME="$HOME/.local/share/factory/codex" codex login
 
 export FACTORY_GITHUB_TOKEN="<dedicated-bot-token>"
 factory validate
-factory daemon
+factory run
 ```
 
 `factory validate` confirms the enclosing repository, Project and Status field,
@@ -502,7 +502,7 @@ The existing CLI remains the user interface:
 ```text
 factory init --execution-mode docker
 factory validate
-factory daemon
+factory run
 factory run --once
 factory workflows
 factory tasks

--- a/src/init.rs
+++ b/src/init.rs
@@ -117,7 +117,7 @@ impl fmt::Display for InitReport {
                 )?;
             }
             writeln!(formatter, "  factory validate")?;
-            writeln!(formatter, "  factory daemon")
+            writeln!(formatter, "  factory run")
         } else {
             writeln!(
                 formatter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,21 +49,12 @@ enum Command {
         #[arg(long, value_enum, default_value_t = ExecutionMode::Worktree)]
         execution_mode: ExecutionMode,
     },
-    /// Poll this repository once and persist eligible tasks without executing them.
+    /// Continuously evaluate work and execute tasks, or poll once without executing.
     Run {
-        /// Required safety flag confirming this is a non-executing single evaluation.
-        #[arg(long, required = true)]
+        /// Evaluate schedules and poll once without executing eligible tasks.
+        #[arg(long)]
         once: bool,
         /// Path to the Factory configuration file.
-        #[arg(long)]
-        config: Option<PathBuf>,
-        /// Directory containing the durable Factory database.
-        #[arg(long)]
-        data_directory: Option<PathBuf>,
-    },
-    /// Continuously evaluate schedules, poll for work, and execute eligible tasks.
-    Daemon {
-        /// Path to the repository-local Factory configuration file.
         #[arg(long)]
         config: Option<PathBuf>,
         /// Directory containing the durable Factory database.
@@ -273,14 +264,7 @@ async fn run_cli() -> Result<u8> {
             config,
             data_directory,
         } => {
-            debug_assert!(once);
-            return run_poller(config, data_directory, true).await;
-        }
-        Command::Daemon {
-            config,
-            data_directory,
-        } => {
-            return run_poller(config, data_directory, false).await;
+            return run_poller(config, data_directory, once).await;
         }
         Command::Approve {
             issue,

--- a/src/workflow_create.rs
+++ b/src/workflow_create.rs
@@ -53,7 +53,7 @@ impl fmt::Display for CreateWorkflowReport {
             )
         )?;
         writeln!(formatter, "  factory workflows")?;
-        writeln!(formatter, "  factory daemon")
+        writeln!(formatter, "  factory run")
     }
 }
 

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -17,6 +17,7 @@ use factory::storage::{Ledger, TaskIdentity, TaskState};
 use factory::workflow::{
     Trigger, WorkflowCatalog, scheduled_workflow_fingerprint, workflow_content_hash,
 };
+use predicates::prelude::PredicateBooleanExt;
 use rusqlite::Connection;
 use tokio_util::sync::CancellationToken;
 
@@ -30,6 +31,26 @@ struct Fixture {
     codex: PathBuf,
     runtime_dir: PathBuf,
     data_home: PathBuf,
+}
+
+#[test]
+fn help_advertises_run_and_rejects_the_removed_daemon_command() {
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("\n  run "))
+        .stdout(predicates::str::contains("\n  daemon ").not());
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .arg("daemon")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "unrecognized subcommand 'daemon'",
+        ));
 }
 
 impl Fixture {
@@ -519,7 +540,7 @@ fn spawn_daemon_cli(fixture: &Fixture, stderr_path: &Path) -> std::process::Chil
     let mut command = Command::new(env!("CARGO_BIN_EXE_factory"));
     command
         .args([
-            "daemon",
+            "run",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
@@ -597,7 +618,7 @@ async fn daemon_discovers_repository_from_nested_directory_and_restarts_cleanly(
             .path()
             .join(format!("nested-{attempt}.stderr"));
         let mut child = Command::new(env!("CARGO_BIN_EXE_factory"))
-            .arg("daemon")
+            .arg("run")
             .current_dir(&nested)
             .env("FACTORY_DATA_HOME", &fixture.data_home)
             .env("FACTORY_LEGACY_DATA_DIRECTORY", &legacy)
@@ -1147,7 +1168,7 @@ async fn subprocess_restart_kills_the_surviving_anchored_process_tree() {
     let mut first = Command::new(env!("CARGO_BIN_EXE_factory"));
     first
         .args([
-            "daemon",
+            "run",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
@@ -1199,7 +1220,7 @@ async fn subprocess_restart_kills_the_surviving_anchored_process_tree() {
     let mut second = Command::new(env!("CARGO_BIN_EXE_factory"));
     second
         .args([
-            "daemon",
+            "run",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
@@ -1742,7 +1763,7 @@ async fn invalid_scheduled_workflow_does_not_block_valid_ticket_workflow() {
     let mut daemon = Command::new(env!("CARGO_BIN_EXE_factory"));
     daemon
         .args([
-            "daemon",
+            "run",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
@@ -1797,7 +1818,7 @@ fn invalid_label_workflow_fails_daemon_startup() {
     AssertCommand::cargo_bin("factory")
         .unwrap()
         .args([
-            "daemon",
+            "run",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",
@@ -1841,7 +1862,7 @@ fn ambiguous_schedule_and_label_workflow_fails_daemon_startup() {
     AssertCommand::cargo_bin("factory")
         .unwrap()
         .args([
-            "daemon",
+            "run",
             "--config",
             fixture.config_path.to_str().unwrap(),
             "--data-directory",


### PR DESCRIPTION
## Summary

- make `factory run` start continuous polling and execution
- preserve `factory run --once` as a non-executing single evaluation
- remove the separate `factory daemon` command
- update generated guidance, docs, and lifecycle fixtures

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --no-fail-fast`
- focused continuous lifecycle and one-shot polling tests
- CLI help and removed-command rejection test
- independent review approved