### PR TITLE
feat: add repeatable Factory demo

### DIFF
--- a/.factory/config.toml
+++ b/.factory/config.toml
@@ -3,16 +3,10 @@ poll_every = "30s"
 
 [worker]
 runtime = "codex"
-sandbox = "docker"
+sandbox = "worktree"
 timeout = "2h"
 maximum_timeout = "8h"
 max_concurrent = 1
-image = "factory-codex:dev"
-memory = "8g"
-cpus = 4
-pids = 512
-codex_auth = "~/.codex/auth.json"
-github_token_env = "FACTORY_GITHUB_TOKEN"
 
 [source]
 type = "github"

--- a/.factory/workflows/triage/WORKFLOW.md
+++ b/.factory/workflows/triage/WORKFLOW.md
@@ -35,16 +35,18 @@ solves the stated problem.
 
 ## Route the ticket
 
-Move the item to `Ready To Implement` only when the desired behaviour is clear,
-the scope is bounded, every acceptance criterion is testable, and no material
-product or technical decision remains.
+Leave the item in `Creating Spec` when the specification is complete. Comment
+that it is ready for human approval and summarize the scope, acceptance
+criteria, verification plan, and any meaningful risks. A human owns the gate:
+only a human moves the item to `Ready To Implement` after reviewing the refined
+ticket.
 
-If information or a decision is missing, leave the item in `Creating Spec` and
-comment with the smallest set of focused questions needed to unblock it. If the
-issue is a duplicate, unsafe, already implemented, or inconsistent with the
-repository, leave it in `Creating Spec` and explain the evidence and recommended
-next action instead of forcing it forward.
+If information or a decision is missing, comment with the smallest set of
+focused questions needed to unblock it. If the issue is a duplicate, unsafe,
+already implemented, or inconsistent with the repository, explain the evidence
+and recommended next action instead of forcing it forward.
 
 Finish with one concise issue comment containing the routing decision, the
-evidence used, and the next action. Never claim that work is implementation-ready
-unless the refined ticket contains the specification described above.
+evidence used, and the next human action. Never move the item to
+`Ready To Implement`, implement the change, or open a pull request in this
+workflow.

--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ for implementation.
 A useful team workflow looks like this:
 
 ```text
-Ready For Spec -> Creating Spec -> Ready To Implement
-                                         |
-                                         v
-                              Implementing -> Reviewing -> Done
-                                                  |
-                                      CI and human feedback
-                                                  |
-                                      another agent pass if needed
+Ready For Spec -> Creating Spec
+                       |
+                  human approval
+                       |
+                       v
+              Ready To Implement -> Implementing -> Reviewing -> Done
+                                                        |
+                                            CI and human feedback
+                                                        |
+                                            another agent pass if needed
 ```
 
 These names are not built into Factory. They are ordinary GitHub Project status
@@ -188,6 +190,22 @@ factory run
 Factory will poll continuously, but it starts an agent only when work becomes
 eligible. Use `factory run --once` to poll and record eligible work without
 launching an agent.
+
+This repository includes a repeatable setup script for the complete two-flow
+demo. It creates a real issue, adds it to GitHub Project 16, and moves it to
+`Ready For Spec`:
+
+```sh
+./scripts/create-demo-issue.sh \
+  "Remove the unreachable legacy configuration test module" \
+  "src/config.rs contains a large test module guarded by cfg(all(test, any())), so it can never compile or run. Remove the unreachable module without changing active configuration behaviour."
+```
+
+Then run `cargo run -- run`. The specification agent refines the idea and stops
+in `Creating Spec`. Review the ticket on the board and move it to
+`Ready To Implement`. The same Factory process starts the implementation agent,
+which writes the code, opens a pull request, waits for CI and review, and moves
+the ticket to `Reviewing`. Use a fresh idea each time you repeat the demo.
 
 Inspect and operate the durable queue with:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -142,22 +142,24 @@ it:
 New idea or bug
       |
       v
-Ready For Spec --triage prompt--> clear ticket / human question
-      |                                  |
-      +<---------------------------------+
-      |
-      v
-Ready To Implement --implementation prompt--> pull request
+Ready For Spec --triage prompt--> Creating Spec
+                                        |
+                                 human reviews ticket
+                                        |
+                                        v
+Ready To Implement --implementation prompt--> Reviewing
       ^                                             |
       |                                             v
       +-------- human review, CI, agent feedback ---+
 ```
 
 Triage turns vague work into an executable ticket with context, scope,
-acceptance criteria, constraints, and verification. Implementation treats that
-ticket as the spec, makes the change, and produces review evidence. Humans still
-choose work and remain accountable for quality. Their feedback goes through the
-issue, review, CI, or Project state so the next agent run can continue the loop.
+acceptance criteria, constraints, and verification, then stops. A human reviews
+the ticket and moves it to the implementation trigger. Implementation treats
+the approved ticket as the spec, makes the change, and produces review evidence.
+Humans still choose work and remain accountable for quality. Their feedback
+goes through the issue, review, CI, or Project state so the next agent run can
+continue the loop.
 
 The exact names and transitions belong to the team's GitHub Project and prompts.
 Another repository could use `Todo`, `Agent Ready`, or a label instead.

--- a/scripts/create-demo-issue.sh
+++ b/scripts/create-demo-issue.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository="owainlewis/factory"
+project_owner="owainlewis"
+project_number="16"
+status_field="Status"
+ready_status="Ready For Spec"
+trusted_user="owainlewis"
+
+usage() {
+  echo "Usage: $0 <idea-title> [idea-description]" >&2
+  echo "Creates a real demo issue in ${repository} and places it in ${ready_status}." >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 2
+fi
+
+title=$1
+body=${2:-"This is an early idea. Investigate the repository and turn it into a clear, bounded task with testable acceptance criteria."}
+
+if [[ -z ${title//[[:space:]]/} ]]; then
+  echo "The idea title must not be empty." >&2
+  exit 2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "GitHub CLI is required. Install gh and retry." >&2
+  exit 1
+fi
+
+gh auth status >/dev/null
+authenticated_user=$(gh api user --jq '.login')
+if [[ "$authenticated_user" != "$trusted_user" ]]; then
+  echo "The active GitHub user ${authenticated_user} is not trusted by this Factory demo. Log in as ${trusted_user}." >&2
+  exit 1
+fi
+
+project_id=$(gh project view "$project_number" \
+  --owner "$project_owner" \
+  --format json \
+  --jq '.id')
+
+field_and_option=$(gh project field-list "$project_number" \
+  --owner "$project_owner" \
+  --limit 1000 \
+  --format json \
+  --jq '.fields[] | select(.name == "Status") | [.id, (.options[] | select(.name == "Ready For Spec") | .id)] | @tsv')
+
+IFS=$'\t' read -r field_id option_id <<<"$field_and_option"
+if [[ -z ${project_id:-} || -z ${field_id:-} || -z ${option_id:-} ]]; then
+  echo "Could not resolve Project ${project_number}, field ${status_field}, or status ${ready_status}." >&2
+  exit 1
+fi
+
+issue_url=$(gh issue create \
+  --repo "$repository" \
+  --title "$title" \
+  --body "$body")
+
+if ! item_id=$(gh project item-add "$project_number" \
+  --owner "$project_owner" \
+  --url "$issue_url" \
+  --format json \
+  --jq '.id'); then
+  echo "The issue was created but could not be added to Project ${project_number}: ${issue_url}" >&2
+  exit 1
+fi
+
+if ! gh project item-edit \
+  --id "$item_id" \
+  --project-id "$project_id" \
+  --field-id "$field_id" \
+  --single-select-option-id "$option_id" >/dev/null; then
+  echo "The issue was added to the Project but its status could not be set: ${issue_url}" >&2
+  exit 1
+fi
+
+echo "Demo issue: ${issue_url}"
+echo "Project: https://github.com/users/${project_owner}/projects/${project_number}"
+echo "Status: ${ready_status}"
+echo
+echo "Next:"
+echo "  1. Run: cargo run -- run"
+echo "  2. Wait for the agent to refine the ticket and leave it in Creating Spec."
+echo "  3. Review the ticket and move it to Ready To Implement."
+echo "  4. Watch the implementation agent open a PR and move it to Reviewing."

--- a/tests/demo_script.rs
+++ b/tests/demo_script.rs
@@ -1,0 +1,107 @@
+#[cfg(unix)]
+mod unix {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+    use std::process::Command;
+
+    fn write_fake_gh(bin: &Path) {
+        let gh = bin.join("gh");
+        fs::write(
+            &gh,
+            r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$GH_LOG"
+case "$1 $2" in
+  "auth status") exit 0 ;;
+  "api user") printf '%s\n' "${GH_USER:-owainlewis}" ;;
+  "project view") printf '%s\n' 'PROJECT_ID' ;;
+  "project field-list") printf 'FIELD_ID\tOPTION_ID\n' ;;
+  "issue create") printf '%s\n' 'https://github.com/owainlewis/factory/issues/123' ;;
+  "project item-add") printf '%s\n' 'ITEM_ID' ;;
+  "project item-edit") exit 0 ;;
+  *) exit 64 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&gh).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(gh, permissions).unwrap();
+    }
+
+    #[test]
+    fn creates_and_routes_a_demo_issue() {
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("bin");
+        let log = temp.path().join("gh.log");
+        fs::create_dir(&bin).unwrap();
+        write_fake_gh(&bin);
+        let path = format!(
+            "{}:{}",
+            bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/create-demo-issue.sh");
+
+        let output = Command::new(script)
+            .arg("A rough idea")
+            .arg("Please turn this into a task.")
+            .env("PATH", path)
+            .env("GH_LOG", &log)
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("https://github.com/owainlewis/factory/issues/123"));
+        assert!(stdout.contains("Status: Ready For Spec"));
+        assert!(stdout.contains("cargo run -- run"));
+
+        let calls = fs::read_to_string(log).unwrap();
+        assert!(calls.contains("issue create --repo owainlewis/factory"));
+        assert!(calls.contains("project item-add 16 --owner owainlewis"));
+        assert!(calls.contains("project item-edit --id ITEM_ID --project-id PROJECT_ID"));
+    }
+
+    #[test]
+    fn rejects_a_missing_idea_without_calling_github() {
+        let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/create-demo-issue.sh");
+
+        let output = Command::new(script).output().unwrap();
+
+        assert_eq!(output.status.code(), Some(2));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("Usage:"));
+    }
+
+    #[test]
+    fn rejects_an_untrusted_github_user_before_creating_an_issue() {
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("bin");
+        let log = temp.path().join("gh.log");
+        fs::create_dir(&bin).unwrap();
+        write_fake_gh(&bin);
+        let path = format!(
+            "{}:{}",
+            bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/create-demo-issue.sh");
+
+        let output = Command::new(script)
+            .arg("A rough idea")
+            .env("PATH", path)
+            .env("GH_LOG", &log)
+            .env("GH_USER", "someone-else")
+            .output()
+            .unwrap();
+
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("is not trusted"));
+        assert!(!fs::read_to_string(log).unwrap().contains("issue create"));
+    }
+}


### PR DESCRIPTION
## Summary
- make the human specification gate explicit: triage stops in Creating Spec
- commit Factory itself to the simple trusted worktree demo mode
- add a repeatable script that creates an idea, adds it to Project 16, and sets Ready For Spec
- document the complete two-flow demonstration
- test GitHub command orchestration and trusted-user rejection with a fake gh CLI

## Demo flow
1. idea enters Ready For Spec
2. triage agent refines it and stops in Creating Spec
3. human reviews and moves it to Ready To Implement
4. implementation agent opens a green PR and moves it to Reviewing

## Verification
- `bash -n scripts/create-demo-issue.sh`
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `git diff --check`
- live read-only Project 16 field/status verification
- independent review: approved