### PR TITLE
chore: prepare repository for open source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,62 @@
+name: Bug report
+description: Report a reproducible problem in Factory
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a problem. Remove secrets, credentials, and private repository data from all examples and logs.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What happened, and what did you expect instead?
+      placeholder: Describe the observed and expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Provide the smallest reliable sequence of commands or configuration that reproduces the problem.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Factory version
+      description: Provide a release version or commit SHA.
+      placeholder: 0.1.0 or abc1234
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the operating system and Rust, GitHub CLI, and Codex CLI versions when relevant.
+      placeholder: macOS 15, rustc 1.x, gh 2.x, codex 0.x
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Relevant logs or context
+      description: Paste sanitized logs or links that help explain the failure.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched for existing reports of this problem.
+          required: true
+        - label: I removed secrets, credentials, and private repository data.
+          required: true
+        - label: This is not a security vulnerability. I will use the private process in SECURITY.md for security reports.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/owainlewis/factory/security/policy
+    about: Read the private reporting instructions before sharing security details.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Propose a focused improvement to Factory
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or operational problem should Factory solve?
+      placeholder: Describe the current limitation and who it affects.
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the observable result without assuming a specific implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Possible approach
+      description: Share a design or API idea if you have one.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Explain any workarounds or simpler options you considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add sanitized examples, links, or constraints that would help evaluate the request.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched for existing requests that cover this outcome.
+          required: true
+        - label: I removed secrets, credentials, and private repository data.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Problem
+
+<!-- What problem does this pull request solve? Link an issue when one exists. -->
+
+## Changes
+
+<!-- Summarize the smallest important changes. -->
+
+## Verification
+
+<!-- List exact commands and manual checks, including relevant failure paths. -->
+
+## Risks
+
+<!-- Note security, compatibility, migration, or operational risks. Write "None" when there are none. -->
+
+- [ ] The change is focused and contains no unrelated cleanup.
+- [ ] Tests and documentation cover changed behavior.
+- [ ] Logs, fixtures, and screenshots contain no secrets or private repository data.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - name: Install Rust components
@@ -19,6 +20,6 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all --check
       - name: Run Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
       - name: Run tests
-        run: cargo test
+        run: cargo test --locked --all-targets

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target/
+*.db
+*.db-shm
+*.db-wal
+.DS_Store

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,120 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to [owain@owainlewis.com](mailto:owain@owainlewis.com). All complaints
+will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][version].
+
+[homepage]: https://www.contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to Factory
+
+Thanks for helping improve Factory. Bug reports, design feedback, documentation
+fixes, and focused code changes are all welcome.
+
+## Before you start
+
+- Search the existing issues before opening a new one.
+- Use a feature request to discuss substantial behavior or architecture changes
+  before investing in an implementation.
+- Keep pull requests focused on one problem. Unrelated cleanup is easier to
+  review separately.
+- Do not include secrets, credentials, private repository data, or sensitive
+  ticket content in issues, logs, fixtures, or pull requests.
+
+Security vulnerabilities should be reported privately as described in
+[SECURITY.md](SECURITY.md), not through a public issue.
+
+## Development setup
+
+Factory requires a current stable Rust toolchain. Some integration tests also
+exercise local `git` and GitHub CLI behavior.
+
+```sh
+git clone https://github.com/owainlewis/factory.git
+cd factory
+cargo build --locked
+```
+
+To exercise Factory against GitHub, install and authenticate the GitHub CLI.
+Most unit and integration tests do not require live GitHub access.
+
+## Making a change
+
+1. Create a branch from `main`.
+2. Add or update tests for behavior changes.
+3. Update documentation when commands, configuration, or operational behavior
+   changes.
+4. Run the project checks:
+
+```sh
+cargo fmt --all --check
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked --all-targets
+```
+
+## Pull requests
+
+Explain the problem and the chosen solution, call out security or compatibility
+risks, and include the commands or manual steps used to verify the change. CI
+must pass before merge. Maintainers may ask for a smaller scope or additional
+evidence when a change affects trust boundaries, credentials, workspaces, or
+durable task state.
+
+By participating in this project, you agree to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md). Contributions are licensed under the
+project's [MIT License](LICENSE).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 description = "A local-first supervisor for agent workflows"
+repository = "https://github.com/owainlewis/factory"
+homepage = "https://github.com/owainlewis/factory"
+readme = "README.md"
+keywords = ["agents", "automation", "cli", "github", "workflow"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 anyhow = "1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Owain Lewis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Factory
 
+[![CI](https://github.com/owainlewis/factory/actions/workflows/ci.yml/badge.svg)](https://github.com/owainlewis/factory/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-2f6feb.svg)](LICENSE)
+
 Factory keeps coding agents working on a repository without making a human
 orchestrate every step from a terminal.
 
@@ -8,14 +11,7 @@ creates a durable task, prepares an isolated workspace, and gives one Markdown
 workflow to an agent. The agent uses normal tools such as `gh` and `git` to do
 the work. When nothing matches, Factory does nothing and spends no model tokens.
 
-```text
-ticket or schedule
-        |
-        v
-matching trigger -> durable task -> sandboxed agent -> issue / pull request
-        ^                                                |
-        +----------- CI and human feedback --------------+
-```
+![Factory turns trusted triggers into durable, reviewable agent work](docs/assets/readme/factory-loop.svg)
 
 ## Why Factory exists
 
@@ -51,18 +47,7 @@ for implementation.
 
 A useful team workflow looks like this:
 
-```text
-Ready For Spec -> Creating Spec
-                       |
-                  human approval
-                       |
-                       v
-              Ready To Implement -> Implementing -> Reviewing -> Done
-                                                        |
-                                            CI and human feedback
-                                                        |
-                                            another agent pass if needed
-```
+![A ticket moves from specification through implementation and review](docs/assets/readme/ticket-workflow.svg)
 
 These names are not built into Factory. They are ordinary GitHub Project status
 values and repository-owned prompts.
@@ -266,8 +251,16 @@ and [the operations guide](docs/operations.md).
 
 ## Development
 
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
+scope, and pull request guidance. Report security issues privately according to
+[SECURITY.md](SECURITY.md).
+
 ```sh
 cargo fmt --all --check
-cargo clippy --all-targets -- -D warnings
-cargo test --all-targets
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked --all-targets
 ```
+
+## License
+
+Factory is available under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+Factory launches coding agents with access to repositories, developer tools,
+and credentials. Treat its trust and isolation boundaries as security-sensitive.
+
+## Supported versions
+
+Factory is under active development and has not reached a stable release. Only
+the latest commit on `main` receives security fixes.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability. Email
+[owain@owainlewis.com](mailto:owain@owainlewis.com) with:
+
+- a clear description of the issue and its impact;
+- the affected revision and configuration;
+- reproduction steps or a proof of concept; and
+- any suggested mitigation, if known.
+
+Do not include real credentials or private repository data. You should receive
+an acknowledgement within seven days. Once the report is understood, the
+maintainer will coordinate remediation and disclosure with you. Please allow a
+reasonable period for a fix before publishing details.
+
+## Security model
+
+A managed worktree protects the canonical checkout, but it is not a security
+boundary. The worker still shares the host, network, processes, and credentials.
+Use Docker execution for stronger local isolation, narrow credentials, trusted
+ticket authors, and protected branches. See the
+[operations guide](docs/operations.md) for deployment guidance.

--- a/docs/assets/readme/factory-loop.svg
+++ b/docs/assets/readme/factory-loop.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="540" viewBox="0 0 1280 540" role="img" aria-labelledby="title desc">
+  <title id="title">Factory execution loop</title>
+  <desc id="desc">A trusted ticket or schedule enters a matching trigger, becomes a durable task, runs in a managed worker, and produces a reviewable pull request. CI and human feedback can re-enter the trigger to create a new bounded task.</desc>
+  <defs>
+    <filter id="shadow" x="-20%" y="-30%" width="140%" height="170%">
+      <feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#172033" flood-opacity=".09"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#71809d"/>
+    </marker>
+    <marker id="arrow-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#7457d6"/>
+    </marker>
+    <style>
+      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#172033}
+      .eyebrow{font-size:14px;font-weight:750;letter-spacing:1.2px;fill:#5f6c84}
+      .label{font-size:19px;font-weight:720}
+      .detail{font-size:15px;fill:#5f6c84}
+      .card{fill:#fff;stroke:#dce2ee;stroke-width:2}
+      .flow{fill:none;stroke:#71809d;stroke-width:3;marker-end:url(#arrow)}
+    </style>
+  </defs>
+  <rect width="1280" height="540" rx="28" fill="#f7f8fc"/>
+  <text class="text eyebrow" x="64" y="64">FROM INTENT TO EVIDENCE</text>
+  <text class="text label" x="64" y="101" font-size="28">A controlled loop keeps agent work moving</text>
+
+  <g filter="url(#shadow)">
+    <rect class="card" x="64" y="168" width="208" height="136" rx="20"/>
+    <rect class="card" x="310" y="168" width="208" height="136" rx="20"/>
+    <rect class="card" x="556" y="168" width="208" height="136" rx="20"/>
+    <rect class="card" x="802" y="168" width="208" height="136" rx="20"/>
+    <rect x="1048" y="168" width="168" height="136" rx="20" fill="#e5f6f1" stroke="#9dd9c8" stroke-width="2"/>
+  </g>
+
+  <g class="text" text-anchor="middle">
+    <circle cx="168" cy="205" r="16" fill="#eaf1ff"/><text x="168" y="211" font-size="15" font-weight="750" fill="#2e5cc2">1</text>
+    <text class="label" x="168" y="246">Trusted input</text><text class="detail" x="168" y="274">ticket or schedule</text>
+    <circle cx="414" cy="205" r="16" fill="#eaf1ff"/><text x="414" y="211" font-size="15" font-weight="750" fill="#2e5cc2">2</text>
+    <text class="label" x="414" y="246">Match trigger</text><text class="detail" x="414" y="274">status, label, or cron</text>
+    <circle cx="660" cy="205" r="16" fill="#eaf1ff"/><text x="660" y="211" font-size="15" font-weight="750" fill="#2e5cc2">3</text>
+    <text class="label" x="660" y="246">Durable task</text><text class="detail" x="660" y="274">claimed and recoverable</text>
+    <circle cx="906" cy="205" r="16" fill="#eaf1ff"/><text x="906" y="211" font-size="15" font-weight="750" fill="#2e5cc2">4</text>
+    <text class="label" x="906" y="246">Managed worker</text><text class="detail" x="906" y="274">workflow + agent + limits</text>
+    <circle cx="1132" cy="205" r="16" fill="#d5efe7"/><text x="1132" y="211" font-size="15" font-weight="750" fill="#087a5d">5</text>
+    <text class="label" x="1132" y="246">Review</text><text class="detail" x="1132" y="274">issue or PR</text>
+  </g>
+
+  <path class="flow" d="M272 236h38M518 236h38M764 236h38M1010 236h38"/>
+
+  <rect x="310" y="385" width="700" height="76" rx="18" fill="#f1ecff" stroke="#cec0f4" stroke-width="2"/>
+  <circle cx="354" cy="423" r="15" fill="#7457d6"/>
+  <path d="M347 423l5 5 10-12" fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <text class="text label" x="386" y="416">CI and human feedback</text>
+  <text class="text detail" x="386" y="441">Evidence closes the task, or re-enters the trigger for another bounded pass.</text>
+  <path d="M1132 304v119h-122" fill="none" stroke="#7457d6" stroke-width="3" marker-end="url(#arrow-purple)"/>
+  <path d="M414 385V304" fill="none" stroke="#7457d6" stroke-width="3" marker-end="url(#arrow-purple)"/>
+</svg>

--- a/docs/assets/readme/ticket-workflow.svg
+++ b/docs/assets/readme/ticket-workflow.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
+  <title id="title">Example ticket workflow</title>
+  <desc id="desc">A ticket moves from Ready For Spec to Creating Spec. Human approval moves it to Ready To Implement, then it moves through Implementing and Reviewing to Done. CI and human feedback can return the ticket through Ready To Implement for a new pass.</desc>
+  <defs>
+    <filter id="shadow" x="-20%" y="-30%" width="140%" height="170%">
+      <feDropShadow dx="0" dy="7" stdDeviation="9" flood-color="#172033" flood-opacity=".08"/>
+    </filter>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#71809d"/>
+    </marker>
+    <marker id="arrow-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#7457d6"/>
+    </marker>
+    <style>
+      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#172033}
+      .eyebrow{font-size:14px;font-weight:750;letter-spacing:1.2px}
+      .label{font-size:17px;font-weight:720}
+      .detail{font-size:14px;fill:#5f6c84}
+      .card{fill:#fff;stroke:#dce2ee;stroke-width:2}
+      .flow{fill:none;stroke:#71809d;stroke-width:3;marker-end:url(#arrow)}
+    </style>
+  </defs>
+  <rect width="1280" height="520" rx="28" fill="#f7f8fc"/>
+
+  <text class="text eyebrow" x="64" y="58" fill="#2e5cc2">DEFINE THE WORK</text>
+  <rect x="52" y="80" width="580" height="166" rx="22" fill="#eef4ff" stroke="#c5d5f7" stroke-width="2"/>
+  <g filter="url(#shadow)">
+    <rect class="card" x="72" y="112" width="126" height="102" rx="17"/>
+    <rect class="card" x="214" y="112" width="126" height="102" rx="17"/>
+    <rect x="356" y="112" width="126" height="102" rx="17" fill="#fff2de" stroke="#f0c982" stroke-width="2"/>
+    <rect x="498" y="112" width="126" height="102" rx="17" fill="#e5f6f1" stroke="#9dd9c8" stroke-width="2"/>
+  </g>
+  <g class="text" text-anchor="middle">
+    <text class="label" x="135" y="143">Ready For</text><text class="label" x="135" y="166">Spec</text><text class="detail" x="135" y="194">human intent</text>
+    <text class="label" x="277" y="143">Creating</text><text class="label" x="277" y="166">Spec</text><text class="detail" x="277" y="194">agent clarifies</text>
+    <text class="label" x="419" y="143">Human</text><text class="label" x="419" y="166">approval</text><text class="detail" x="419" y="194">review intent</text>
+    <text class="label" x="561" y="143">Ready To</text><text class="label" x="561" y="166">Implement</text><text class="detail" x="561" y="194">clear contract</text>
+  </g>
+  <path class="flow" d="M198 163h16M340 163h16M482 163h16"/>
+
+  <text class="text eyebrow" x="676" y="58" fill="#6042b4">BUILD AND PROVE</text>
+  <rect x="652" y="80" width="576" height="166" rx="22" fill="#f3efff" stroke="#d3c7f5" stroke-width="2"/>
+  <g filter="url(#shadow)">
+    <rect class="card" x="678" y="112" width="160" height="102" rx="17"/>
+    <rect class="card" x="862" y="112" width="160" height="102" rx="17"/>
+    <rect x="1046" y="112" width="156" height="102" rx="17" fill="#e5f6f1" stroke="#9dd9c8" stroke-width="2"/>
+  </g>
+  <g class="text" text-anchor="middle">
+    <text class="label" x="758" y="151">Implementing</text><text class="detail" x="758" y="180">change + tests</text>
+    <text class="label" x="942" y="151">Reviewing</text><text class="detail" x="942" y="180">CI + humans</text>
+    <text class="label" x="1124" y="151">Done</text><text class="detail" x="1124" y="180">human decision</text>
+  </g>
+  <path class="flow" d="M838 163h24M1022 163h24"/>
+  <path class="flow" d="M624 163h54"/>
+
+  <rect x="262" y="330" width="760" height="96" rx="20" fill="#fff" stroke="#dce2ee" stroke-width="2"/>
+  <circle cx="310" cy="378" r="18" fill="#7457d6"/>
+  <path d="M301 378h18M310 369v18" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
+  <text class="text label" x="346" y="369">Feedback can request another pass</text>
+  <text class="text detail" x="346" y="397">The ticket re-enters the configured trigger, creating a new bounded implementation task.</text>
+  <path d="M942 214v116" fill="none" stroke="#7457d6" stroke-width="3" marker-end="url(#arrow-purple)"/>
+  <path d="M561 330V214" fill="none" stroke="#7457d6" stroke-width="3" marker-end="url(#arrow-purple)"/>
+  <text class="text detail" x="640" y="474" text-anchor="middle">Status names are repository-owned policy, not hard-coded Factory behavior.</text>
+</svg>


### PR DESCRIPTION
## Summary

- add the canonical MIT license and complete Cargo package metadata
- add contributor, security, conduct, issue, pull request, and dependency-update guidance
- replace both README ASCII diagrams with accessible, browser-verified SVGs
- make CI reproducible with locked dependency resolution and a job timeout

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- `cargo package --locked --allow-dirty --list`
- parsed all GitHub YAML and both SVGs
- verified all local Markdown links
- rendered both SVGs in Chrome at native dimensions and inspected the results
- independent post-rebase review: Approve, no blocker or important findings

## Risks

Low. Runtime behavior is unchanged. GitHub-hosted issue-form, badge, and contact-link rendering will only be observable after publication.
