### PR TITLE
Store runtime state under ~/.factory

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -35,7 +35,7 @@ the previous platform data directory, Factory refuses to select the new default
 while the previous ledger remains and reports the `FACTORY_DATA_HOME` value that
 continues using that state. Factory also refuses to start while the older global
 `~/.factory/factory.sqlite3` ledger remains, preventing overlap with work owned
-by an old Factory process.
+by an old Factory process, including when `FACTORY_DATA_HOME=~/.factory` is set.
 
 ## Worker boundary
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -35,7 +35,9 @@ the previous platform data directory, Factory refuses to select the new default
 while the previous ledger remains and reports the `FACTORY_DATA_HOME` value that
 continues using that state. Factory also refuses to start while the older global
 `~/.factory/factory.sqlite3` ledger remains, preventing overlap with work owned
-by an old Factory process, including when `FACTORY_DATA_HOME=~/.factory` is set.
+by an old Factory process regardless of the `FACTORY_DATA_HOME` setting. These
+overlap guards run when `factory run` starts; inspection and cleanup commands
+remain available.
 
 ## Worker boundary
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -28,6 +28,10 @@ another task while the issue remains in the same status or label entry. Leaving
 and re-entering creates one new task-scoped sandbox. The workflow tells the
 agent to find and continue an existing branch or pull request when appropriate.
 
+Factory stores durable state and managed worktrees below
+`~/.factory/<repository-hash>/`. Set `FACTORY_DATA_HOME` to override the
+`~/.factory` root.
+
 ## Worker boundary
 
 Worktree mode runs the host Codex CLI in a Factory-owned Git worktree. It is
@@ -70,12 +74,6 @@ The two task listings should show zero new tasks. In Docker mode, also run
 Factory container was created. This proves the empty poll persisted and
 launched nothing.
 
-Before first repository-local startup, Factory reads the old
-`~/.factory/factory.sqlite3` database without modifying it. If that database
-contains queued or running work for this repository, startup stops with
-instructions to stop the old daemon and finish or cancel the work. Terminal
-legacy history is not imported.
-
 ## Cancellation and recovery
 
 Request cancellation with:
@@ -117,7 +115,5 @@ disposable and are removed at a terminal outcome.
 - `factory run --once` proves polling without launching a model or worker.
 - `factory inspect RUN_ID` shows bounded task, workspace, optional container,
   branch, pull-request, and error evidence.
-- If old global Factory work is active, stop the old daemon and finish or cancel
-  it. Repository-local Factory never mutates or imports the legacy database.
 
 Scheduled workflows use the same configured worker as ticket workflows.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,7 +30,10 @@ agent to find and continue an existing branch or pull request when appropriate.
 
 Factory stores durable state and managed worktrees below
 `~/.factory/<repository-hash>/`. Set `FACTORY_DATA_HOME` to override the
-`~/.factory` root.
+`~/.factory` root. When upgrading an installation that already has state below
+the previous platform data directory, Factory refuses to select the new default
+while the previous ledger remains and reports the `FACTORY_DATA_HOME` value that
+continues using that state.
 
 ## Worker boundary
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -33,7 +33,9 @@ Factory stores durable state and managed worktrees below
 `~/.factory` root. When upgrading an installation that already has state below
 the previous platform data directory, Factory refuses to select the new default
 while the previous ledger remains and reports the `FACTORY_DATA_HOME` value that
-continues using that state.
+continues using that state. Factory also refuses to start while the older global
+`~/.factory/factory.sqlite3` ledger remains, preventing overlap with work owned
+by an old Factory process.
 
 ## Worker boundary
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -814,6 +814,13 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
     let base = dirs::home_dir()
         .map(|path| path.join(".factory"))
         .context("could not determine Factory data directory")?;
+    let global_database = base.join(DATABASE_NAME);
+    if global_database.exists() {
+        bail!(
+            "Factory found a global ledger at {} and refused to start repository-scoped state because old queued or running work could overlap; stop the old Factory process, finish or cancel its work, then archive the global ledger before using the new default",
+            global_database.display()
+        );
+    }
     let data_directory = base.join(digest);
     if let Some(previous_base) = dirs::data_local_dir().map(|path| path.join("factory")) {
         let previous_directory = previous_base.join(digest);

--- a/src/config.rs
+++ b/src/config.rs
@@ -814,13 +814,6 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
             .map(|path| path.join(".factory"))
             .context("could not determine Factory data directory")?,
     };
-    let global_database = base.join(DATABASE_NAME);
-    if global_database.exists() {
-        bail!(
-            "Factory found an unscoped ledger at {} and refused to start repository-scoped state because old queued or running work could overlap; stop the old Factory process, finish or cancel its work, then archive the unscoped ledger before using this data root",
-            global_database.display()
-        );
-    }
     let data_directory = base.join(digest);
     if configured_base.is_some() {
         return Ok(data_directory);

--- a/src/config.rs
+++ b/src/config.rs
@@ -806,7 +806,7 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
     let digest = format!("{:x}", hasher.finalize());
     let base = env::var_os("FACTORY_DATA_HOME")
         .map(PathBuf::from)
-        .or_else(|| dirs::data_local_dir().map(|path| path.join("factory")))
+        .or_else(|| dirs::home_dir().map(|path| path.join(".factory")))
         .context("could not determine Factory data directory")?;
     let base = if base.is_absolute() {
         base

--- a/src/config.rs
+++ b/src/config.rs
@@ -807,21 +807,24 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
     hasher.update(repository.as_os_str().as_encoded_bytes());
     let digest = format!("{:x}", hasher.finalize());
     let digest = &digest[..20];
-    if let Some(base) = env::var_os("FACTORY_DATA_HOME").map(PathBuf::from) {
-        return Ok(resolve_data_base(base)?.join(digest));
-    }
-
-    let base = dirs::home_dir()
-        .map(|path| path.join(".factory"))
-        .context("could not determine Factory data directory")?;
+    let configured_base = env::var_os("FACTORY_DATA_HOME").map(PathBuf::from);
+    let base = match configured_base.as_ref() {
+        Some(base) => resolve_data_base(base.clone())?,
+        None => dirs::home_dir()
+            .map(|path| path.join(".factory"))
+            .context("could not determine Factory data directory")?,
+    };
     let global_database = base.join(DATABASE_NAME);
     if global_database.exists() {
         bail!(
-            "Factory found a global ledger at {} and refused to start repository-scoped state because old queued or running work could overlap; stop the old Factory process, finish or cancel its work, then archive the global ledger before using the new default",
+            "Factory found an unscoped ledger at {} and refused to start repository-scoped state because old queued or running work could overlap; stop the old Factory process, finish or cancel its work, then archive the unscoped ledger before using this data root",
             global_database.display()
         );
     }
     let data_directory = base.join(digest);
+    if configured_base.is_some() {
+        return Ok(data_directory);
+    }
     if let Some(previous_base) = dirs::data_local_dir().map(|path| path.join("factory")) {
         let previous_directory = previous_base.join(digest);
         if previous_directory.join(DATABASE_NAME).exists() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::storage::DATABASE_NAME;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     pub repositories: Vec<PathBuf>,
@@ -804,10 +806,30 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
     hasher.update(b"\0");
     hasher.update(repository.as_os_str().as_encoded_bytes());
     let digest = format!("{:x}", hasher.finalize());
-    let base = env::var_os("FACTORY_DATA_HOME")
-        .map(PathBuf::from)
-        .or_else(|| dirs::home_dir().map(|path| path.join(".factory")))
+    let digest = &digest[..20];
+    if let Some(base) = env::var_os("FACTORY_DATA_HOME").map(PathBuf::from) {
+        return Ok(resolve_data_base(base)?.join(digest));
+    }
+
+    let base = dirs::home_dir()
+        .map(|path| path.join(".factory"))
         .context("could not determine Factory data directory")?;
+    let data_directory = base.join(digest);
+    if let Some(previous_base) = dirs::data_local_dir().map(|path| path.join("factory")) {
+        let previous_directory = previous_base.join(digest);
+        if previous_directory.join(DATABASE_NAME).exists() {
+            bail!(
+                "Factory found repository state at the previous default {} and refused to use {} because abandoning the previous ledger could repeat durable work; set FACTORY_DATA_HOME={} to keep using the existing state, or archive the previous ledger before choosing the new default",
+                previous_directory.display(),
+                data_directory.display(),
+                previous_base.display()
+            );
+        }
+    }
+    Ok(data_directory)
+}
+
+fn resolve_data_base(base: PathBuf) -> Result<PathBuf> {
     let base = if base.is_absolute() {
         base
     } else {
@@ -815,7 +837,7 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
             .context("failed to resolve current directory")?
             .join(base)
     };
-    Ok(base.join(&digest[..20]))
+    Ok(base)
 }
 
 pub fn repository_remote_identity(repository: &Path) -> Result<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use tokio_util::sync::CancellationToken;
 
 use factory::clone::CloneManager;
-use factory::config::{Config, ExecutionMode, repository_config_path, repository_remote_identity};
+use factory::config::{Config, ExecutionMode, repository_config_path};
 use factory::daemon::FactoryDaemon;
 use factory::docker::DockerWorker;
 use factory::execution::ResolvedWorkflow;
@@ -21,8 +21,7 @@ use factory::runtime::{
 };
 use factory::source::{PollReport, SourceClient};
 use factory::storage::{
-    CancellationRequest, DATABASE_NAME, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState,
-    validate_data_directory,
+    CancellationRequest, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState, validate_data_directory,
 };
 use factory::workflow::WorkflowCatalog;
 use factory::workspace::WorkspaceManager;
@@ -547,7 +546,6 @@ async fn run_poller(
     );
     let config = Config::load(&path)?;
     let data_directory = data_directory.unwrap_or_else(|| config.data_directory.clone());
-    ensure_legacy_cutover(&config, &data_directory)?;
     let catalog = WorkflowCatalog::load(&config)?;
     let ticket_validation = catalog.validate_ticket_workflows();
     if !once && ticket_validation.is_err() {
@@ -598,55 +596,6 @@ async fn run_poller(
     signal_task.abort();
     write_stderr_best_effort(b"Factory stopped.\n");
     Ok(0)
-}
-
-fn ensure_legacy_cutover(config: &Config, data_directory: &std::path::Path) -> Result<()> {
-    let legacy_directory = std::env::var_os("FACTORY_LEGACY_DATA_DIRECTORY")
-        .map(PathBuf::from)
-        .or_else(|| dirs::home_dir().map(|home| home.join(".factory")))
-        .context("could not determine legacy Factory data directory")?;
-    let legacy_database = legacy_directory.join(DATABASE_NAME);
-    if !legacy_database.is_file() {
-        return Ok(());
-    }
-    if data_directory
-        .components()
-        .any(|component| component == std::path::Component::ParentDir)
-    {
-        bail!(
-            "Factory data directory must not contain parent traversal: {}",
-            data_directory.display()
-        );
-    }
-    let legacy_directory = legacy_directory
-        .canonicalize()
-        .context("failed to resolve legacy Factory data directory")?;
-    let effective_data_directory = if data_directory.exists() {
-        data_directory
-            .canonicalize()
-            .context("failed to resolve Factory data directory")?
-    } else if data_directory.is_absolute() {
-        data_directory.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .context("failed to resolve current directory")?
-            .join(data_directory)
-    };
-    if effective_data_directory == legacy_directory {
-        bail!(
-            "repository-local Factory cannot use the legacy data directory {}; choose the derived repository state directory and leave legacy history untouched",
-            legacy_directory.display()
-        );
-    }
-    let repository = repository_remote_identity(&config.repositories[0])?;
-    let active = Ledger::existing_non_terminal_tasks_for_repository(&legacy_database, &repository)?;
-    if active > 0 {
-        bail!(
-            "legacy Factory has {active} non-terminal task(s) for {repository}; stop the old daemon and finish or cancel that work before starting repository-local Factory. The legacy database was left unchanged at {}",
-            legacy_database.display()
-        );
-    }
-    Ok(())
 }
 
 fn print_poll_report(report: &PollReport) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,8 @@ use factory::runtime::{
 };
 use factory::source::{PollReport, SourceClient};
 use factory::storage::{
-    CancellationRequest, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState, validate_data_directory,
+    CancellationRequest, DATABASE_NAME, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState,
+    validate_data_directory,
 };
 use factory::workflow::WorkflowCatalog;
 use factory::workspace::WorkspaceManager;
@@ -545,6 +546,7 @@ async fn run_poller(
         format!("Factory starting: mode={mode} config={}\n", path.display()).as_bytes(),
     );
     let config = Config::load(&path)?;
+    ensure_no_unscoped_ledger_overlap()?;
     let data_directory = data_directory.unwrap_or_else(|| config.data_directory.clone());
     let catalog = WorkflowCatalog::load(&config)?;
     let ticket_validation = catalog.validate_ticket_workflows();
@@ -596,6 +598,38 @@ async fn run_poller(
     signal_task.abort();
     write_stderr_best_effort(b"Factory stopped.\n");
     Ok(0)
+}
+
+fn ensure_no_unscoped_ledger_overlap() -> Result<()> {
+    let default_base = dirs::home_dir()
+        .map(|home| home.join(".factory"))
+        .context("could not determine Factory data directory")?;
+    let global_database = default_base.join(DATABASE_NAME);
+    if global_database.exists() {
+        bail!(
+            "Factory found a global ledger at {} and refused to start repository-scoped state because old queued or running work could overlap; stop the old Factory process, finish or cancel its work, then archive the global ledger before continuing",
+            global_database.display()
+        );
+    }
+
+    let Some(configured_base) = std::env::var_os("FACTORY_DATA_HOME").map(PathBuf::from) else {
+        return Ok(());
+    };
+    let configured_base = if configured_base.is_absolute() {
+        configured_base
+    } else {
+        std::env::current_dir()
+            .context("failed to resolve current directory")?
+            .join(configured_base)
+    };
+    let unscoped_database = configured_base.join(DATABASE_NAME);
+    if unscoped_database.exists() {
+        bail!(
+            "Factory found an unscoped ledger at {} and refused to start repository-scoped state because old queued or running work could overlap; stop the old Factory process, finish or cancel its work, then archive the unscoped ledger before using this data root",
+            unscoped_database.display()
+        );
+    }
+    Ok(())
 }
 
 fn print_poll_report(report: &PollReport) {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -672,24 +672,6 @@ impl Ledger {
             .context("failed to commit approval consumption")
     }
 
-    pub fn existing_non_terminal_tasks_for_repository(
-        path: &Path,
-        repository: &str,
-    ) -> Result<usize> {
-        let connection = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
-            .with_context(|| format!("failed to inspect legacy database {}", path.display()))?;
-        let count = connection
-            .query_row(
-                "SELECT COUNT(*) FROM tasks
-                 WHERE lower(repository) = lower(?1)
-                   AND state IN ('queued', 'running')",
-                [repository],
-                |row| row.get::<_, i64>(0),
-            )
-            .context("failed to inspect non-terminal legacy Factory tasks")?;
-        usize::try_from(count).context("legacy task count is outside the supported range")
-    }
-
     pub fn open_in(data_directory: &Path) -> Result<Self> {
         fs::create_dir_all(data_directory).with_context(|| {
             format!(

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -258,8 +258,10 @@ fn init_ignores_a_previous_default_without_a_ledger() {
 }
 
 #[test]
-fn init_refuses_to_overlap_a_global_ledger() {
+fn run_refuses_to_overlap_a_global_ledger() {
     let fixture = Fixture::new();
+    fixture.command().arg("init").assert().success();
+
     let global_database = fixture.home.join(".factory/factory.sqlite3");
     let mut global_ledger = Ledger::open(&global_database).unwrap();
     global_ledger
@@ -271,30 +273,32 @@ fn init_refuses_to_overlap_a_global_ledger() {
 
     fixture
         .command()
-        .env_remove("FACTORY_DATA_HOME")
-        .env_remove("XDG_DATA_HOME")
-        .arg("init")
+        .args(["run", "--once"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("unscoped ledger"))
+        .stderr(predicate::str::contains("global ledger"))
         .stderr(predicate::str::contains(global_database.to_str().unwrap()));
 }
 
 #[test]
-fn init_refuses_an_override_root_containing_an_unscoped_ledger() {
+fn run_refuses_an_override_root_containing_an_unscoped_ledger() {
     let fixture = Fixture::new();
-    let data_home = fixture.home.join(".factory");
-    let global_database = data_home.join("factory.sqlite3");
-    drop(Ledger::open(&global_database).unwrap());
+    let data_home = fixture.data_home.clone();
+    fixture.command().arg("init").assert().success();
+
+    let unscoped_database = data_home.join("factory.sqlite3");
+    drop(Ledger::open(&unscoped_database).unwrap());
 
     fixture
         .command()
         .env("FACTORY_DATA_HOME", data_home)
-        .arg("init")
+        .args(["run", "--once"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("unscoped ledger"))
-        .stderr(predicate::str::contains(global_database.to_str().unwrap()));
+        .stderr(predicate::str::contains(
+            unscoped_database.to_str().unwrap(),
+        ));
 }
 
 #[test]

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -258,6 +258,29 @@ fn init_ignores_a_previous_default_without_a_ledger() {
 }
 
 #[test]
+fn init_refuses_to_overlap_a_global_ledger() {
+    let fixture = Fixture::new();
+    let global_database = fixture.home.join(".factory/factory.sqlite3");
+    let mut global_ledger = Ledger::open(&global_database).unwrap();
+    global_ledger
+        .enqueue(
+            &TaskIdentity::ticket("example/repository", "implement", "1", "revision-1").unwrap(),
+        )
+        .unwrap();
+    drop(global_ledger);
+
+    fixture
+        .command()
+        .env_remove("FACTORY_DATA_HOME")
+        .env_remove("XDG_DATA_HOME")
+        .arg("init")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("global ledger"))
+        .stderr(predicate::str::contains(global_database.to_str().unwrap()));
+}
+
+#[test]
 fn init_docker_mode_creates_worker_configuration_and_dockerfile() {
     let fixture = Fixture::new();
 

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -276,7 +276,24 @@ fn init_refuses_to_overlap_a_global_ledger() {
         .arg("init")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("global ledger"))
+        .stderr(predicate::str::contains("unscoped ledger"))
+        .stderr(predicate::str::contains(global_database.to_str().unwrap()));
+}
+
+#[test]
+fn init_refuses_an_override_root_containing_an_unscoped_ledger() {
+    let fixture = Fixture::new();
+    let data_home = fixture.home.join(".factory");
+    let global_database = data_home.join("factory.sqlite3");
+    drop(Ledger::open(&global_database).unwrap());
+
+    fixture
+        .command()
+        .env("FACTORY_DATA_HOME", data_home)
+        .arg("init")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unscoped ledger"))
         .stderr(predicate::str::contains(global_database.to_str().unwrap()));
 }
 

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
 use assert_cmd::Command;
+use factory::storage::{Ledger, TaskIdentity};
 use predicates::prelude::*;
 
 struct Fixture {
@@ -56,6 +57,14 @@ impl Fixture {
 
     fn workflows(&self) -> PathBuf {
         self.repository.join(".factory/workflows")
+    }
+
+    fn previous_data_home(&self) -> PathBuf {
+        if cfg!(target_os = "macos") {
+            self.home.join("Library/Application Support/factory")
+        } else {
+            self.home.join(".local/share/factory")
+        }
     }
 }
 
@@ -169,6 +178,7 @@ fn init_uses_dot_factory_as_the_default_data_home() {
     fixture
         .command()
         .env_remove("FACTORY_DATA_HOME")
+        .env_remove("XDG_DATA_HOME")
         .arg("init")
         .assert()
         .success();
@@ -180,6 +190,71 @@ fn init_uses_dot_factory_as_the_default_data_home() {
         .collect::<Vec<_>>();
     assert_eq!(state_directories.len(), 1);
     assert!(state_directories[0].join("worktrees").is_dir());
+}
+
+#[test]
+fn init_refuses_to_abandon_state_at_the_previous_default() {
+    let fixture = Fixture::new();
+    let previous_data_home = fixture.previous_data_home();
+
+    fixture
+        .command()
+        .env("FACTORY_DATA_HOME", &previous_data_home)
+        .arg("init")
+        .assert()
+        .success();
+
+    let previous_state_directory = fs::read_dir(&previous_data_home)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let mut previous_ledger = Ledger::open_in(&previous_state_directory).unwrap();
+    previous_ledger
+        .enqueue(
+            &TaskIdentity::ticket("example/repository", "implement", "1", "revision-1").unwrap(),
+        )
+        .unwrap();
+    drop(previous_ledger);
+    let new_state_directory = fixture
+        .home
+        .join(".factory")
+        .join(previous_state_directory.file_name().unwrap());
+    drop(Ledger::open_in(&new_state_directory).unwrap());
+
+    fixture
+        .command()
+        .env_remove("FACTORY_DATA_HOME")
+        .env_remove("XDG_DATA_HOME")
+        .arg("init")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("refused to use"))
+        .stderr(predicate::str::contains(
+            previous_data_home.to_str().unwrap(),
+        ));
+}
+
+#[test]
+fn init_ignores_a_previous_default_without_a_ledger() {
+    let fixture = Fixture::new();
+    let previous_data_home = fixture.previous_data_home();
+
+    fixture
+        .command()
+        .env("FACTORY_DATA_HOME", previous_data_home)
+        .arg("init")
+        .assert()
+        .success();
+
+    fixture
+        .command()
+        .env_remove("FACTORY_DATA_HOME")
+        .env_remove("XDG_DATA_HOME")
+        .arg("init")
+        .assert()
+        .success();
 }
 
 #[test]

--- a/tests/init_cli.rs
+++ b/tests/init_cli.rs
@@ -163,6 +163,26 @@ fn init_creates_complete_repository_factory_without_overwriting() {
 }
 
 #[test]
+fn init_uses_dot_factory_as_the_default_data_home() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .env_remove("FACTORY_DATA_HOME")
+        .arg("init")
+        .assert()
+        .success();
+
+    let data_home = fixture.home.join(".factory");
+    let state_directories = fs::read_dir(&data_home)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect::<Vec<_>>();
+    assert_eq!(state_directories.len(), 1);
+    assert!(state_directories[0].join("worktrees").is_dir());
+}
+
+#[test]
 fn init_docker_mode_creates_worker_configuration_and_dockerfile() {
     let fixture = Fixture::new();
 


### PR DESCRIPTION
## Summary

- default repository state to `~/.factory/<repository-hash>/`
- preserve `FACTORY_DATA_HOME` overrides
- remove legacy database cutover queries and their storage helper
- refuse poller startup when platform-default, global, or configured-root ledgers could overlap durable work
- keep inspection and cleanup commands available during recovery
- document the current state layout and upgrade guards with integration coverage

## Verification

- `cargo test --all-targets` (145 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- final independent review: approved with no actionable findings