### PR TITLE
feat: add Docker Sandbox development template

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
 scope, and pull request guidance. Report security issues privately according to
 [SECURITY.md](SECURITY.md).
 
+To develop with Codex in an isolated environment, build and use the
+[Docker Sandbox template](docs/docker-sandbox-template.md). It includes the
+pinned Rust toolchain and a private Docker daemon.
+
 ```sh
 cargo fmt --all --check
 cargo clippy --locked --all-targets -- -D warnings

--- a/docker/sandbox-template/Dockerfile
+++ b/docker/sandbox-template/Dockerfile
@@ -1,0 +1,30 @@
+FROM docker/sandbox-templates:codex-docker
+
+LABEL org.opencontainers.image.title="Factory Codex sandbox"
+LABEL org.opencontainers.image.description="Rust development environment for Factory in Docker Sandboxes"
+
+USER root
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+USER agent
+
+ARG RUST_TOOLCHAIN=1.96.0
+ENV CARGO_HOME=/home/agent/.cargo
+ENV RUSTUP_HOME=/home/agent/.rustup
+ENV PATH=/home/agent/.cargo/bin:${PATH}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN curl --proto '=https' --tlsv1.2 --fail --silent --show-error \
+        https://sh.rustup.rs \
+        | sh -s -- -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}" \
+    && rustup component add clippy rustfmt \
+    && cargo --version \
+    && rustc --version

--- a/docs/docker-sandbox-template.md
+++ b/docs/docker-sandbox-template.md
@@ -1,0 +1,75 @@
+# Develop Factory in a Docker Sandbox
+
+Factory includes a custom Docker Sandbox template with the Rust toolchain and
+native build dependencies needed to format, lint, build, and test the project.
+It extends Docker's `codex-docker` template, so Codex and a private Docker
+daemon are available inside the sandbox.
+
+The template is separate from `.factory/Dockerfile`. The latter is the image
+used by Factory when `worker.sandbox = "docker"`; this template is the
+development environment used to work on Factory itself with `sbx`.
+
+## Build and load the template
+
+Docker Sandboxes has a separate image store from the host Docker daemon. Build
+the image, export it, and load it into `sbx`:
+
+```sh
+docker build \
+  --file docker/sandbox-template/Dockerfile \
+  --tag factory-sandbox:rust-1.96 \
+  docker/sandbox-template
+
+docker image save factory-sandbox:rust-1.96 --output /tmp/factory-sandbox.tar
+sbx template load /tmp/factory-sandbox.tar
+```
+
+The template pins the current development toolchain. To test another toolchain
+without editing the template, pass a build argument:
+
+```sh
+docker build \
+  --build-arg RUST_TOOLCHAIN=stable \
+  --file docker/sandbox-template/Dockerfile \
+  --tag factory-sandbox:rust-stable \
+  docker/sandbox-template
+```
+
+## Start Codex
+
+Use clone mode so Codex gets a complete Git repository and can create branches,
+commit, and push. Run this command from the repository's main checkout. Docker
+Sandboxes rejects clone mode from a linked Git worktree because its read-only
+source mount cannot resolve the worktree's `.git` pointer.
+
+```sh
+sbx run \
+  --clone \
+  --name factory-dev \
+  --template factory-sandbox:rust-1.96 \
+  codex .
+```
+
+The agent name must remain `codex` because the template extends Docker's Codex
+base image. Do not add credentials to the Dockerfile or saved template. Manage
+them through `sbx secret set` so Docker injects them at runtime.
+
+## Verify the environment
+
+Run the repository checks from Codex or from another terminal:
+
+```sh
+sbx exec factory-dev cargo fmt --all --check
+sbx exec factory-dev cargo clippy --locked --all-targets -- -D warnings
+sbx exec factory-dev cargo test --locked --all-targets
+sbx exec factory-dev docker version
+```
+
+Remove the sandbox when the work is complete:
+
+```sh
+sbx rm factory-dev
+```
+
+After changing the Dockerfile, rebuild and reload its tag. Docker Sandboxes
+caches templates until their tag is replaced or `sbx reset` clears the cache.


### PR DESCRIPTION
## Summary

- add a Codex Docker Sandbox template with Rust 1.96, Cargo, Clippy, rustfmt, native build dependencies, and a private Docker daemon
- document local build, template loading, clone-mode startup, verification, credentials, and cleanup
- link the development guide from the README

## Verification

- docker build --check --file docker/sandbox-template/Dockerfile docker/sandbox-template
- docker build --file docker/sandbox-template/Dockerfile --tag factory-sandbox:test docker/sandbox-template
- loaded the built image with sbx template load and created a Codex sandbox from it
- verified the sandbox runs as agent with Rust/Cargo 1.96 and Docker client/server 29.6.1
- cargo fmt --all --check
- cargo clippy --locked --all-targets -- -D warnings
- cargo test --locked --all-targets

All repository checks passed inside the real Docker Sandbox runtime. A fresh independent review approved the final diff with no findings.