### PR TITLE
feat: run scheduled workflows directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,10 @@ factory cancel RUN_ID
 factory cleanup RUN_ID
 ```
 
-Run a repository-only workflow manually with `factory workflow run ID`. Ticket
-workflows normally run through their trigger because that is how Factory binds
-the issue identity and live source state to the task.
+Run a schedule-triggered workflow immediately with `factory run ID`. This form
+rejects source-triggered workflows because the loop is what binds the issue
+identity and live source state to the task. The explicit `factory workflow run
+ID` command remains available for manual repository-only workflow runs.
 
 ## Sandboxes and trust
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,16 +211,8 @@ async fn run_cli() -> Result<u8> {
             data_directory,
         } => {
             if let Some(workflow_id) = workflow_id {
-                let repository =
-                    std::env::current_dir().context("failed to resolve current directory")?;
-                let repository = factory::init::discover_repository(&repository)?;
-                return run_workflow(
-                    &workflow_id,
-                    &repository,
-                    config,
-                    WorkflowRunMode::ScheduledOnly,
-                )
-                .await;
+                return run_workflow(&workflow_id, None, config, WorkflowRunMode::ScheduledOnly)
+                    .await;
             }
             return run_poller(config, data_directory, once).await;
         }
@@ -310,7 +302,13 @@ async fn run_cli() -> Result<u8> {
             let repository = repository
                 .unwrap_or(std::env::current_dir().context("failed to resolve current directory")?);
             let repository = factory::init::discover_repository(&repository)?;
-            return run_workflow(&workflow_id, &repository, config, WorkflowRunMode::Any).await;
+            return run_workflow(
+                &workflow_id,
+                Some(&repository),
+                config,
+                WorkflowRunMode::Any,
+            )
+            .await;
         }
         Command::Tasks {
             json,
@@ -679,13 +677,16 @@ enum WorkflowRunMode {
 
 async fn run_workflow(
     workflow_id: &str,
-    repository: &std::path::Path,
+    repository: Option<&std::path::Path>,
     config_path: Option<PathBuf>,
     mode: WorkflowRunMode,
 ) -> Result<u8> {
     let path = resolve_config_path(config_path)?;
     let config = Config::load(&path)?;
     let catalog = WorkflowCatalog::load(&config)?;
+    let repository = repository
+        .or_else(|| config.repositories.first().map(PathBuf::as_path))
+        .context("Factory configuration has no repository")?;
     let workflow = ResolvedWorkflow::resolve(&config, &catalog, workflow_id, repository)?;
     if matches!(mode, WorkflowRunMode::ScheduledOnly) {
         let entry = catalog
@@ -696,6 +697,12 @@ async fn run_workflow(
         if !matches!(entry.trigger, Some(Trigger::Schedule { .. })) {
             bail!(
                 "workflow {:?} cannot be run directly with `factory run`; only schedule-triggered workflows are allowed",
+                workflow.id
+            );
+        }
+        if config.execution_mode == ExecutionMode::Docker {
+            bail!(
+                "workflow {:?} cannot be run directly when worker.sandbox is \"docker\"; start the `factory run` loop to preserve Docker isolation",
                 workflow.id
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use factory::storage::{
     CancellationRequest, DATABASE_NAME, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState,
     validate_data_directory,
 };
-use factory::workflow::WorkflowCatalog;
+use factory::workflow::{Trigger, WorkflowCatalog};
 use factory::workspace::WorkspaceManager;
 
 #[derive(Debug, Parser)]
@@ -50,14 +50,16 @@ enum Command {
     },
     /// Continuously evaluate work and execute tasks, or poll once without executing.
     Run {
+        /// Schedule-triggered workflow ID to run once instead of starting the loop.
+        workflow_id: Option<String>,
         /// Evaluate schedules and poll once without executing eligible tasks.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "workflow_id")]
         once: bool,
         /// Path to the Factory configuration file.
         #[arg(long)]
         config: Option<PathBuf>,
         /// Directory containing the durable Factory database.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "workflow_id")]
         data_directory: Option<PathBuf>,
     },
     /// Validate configuration, workflows, and configured GitHub Project IDs.
@@ -203,10 +205,23 @@ async fn run_cli() -> Result<u8> {
             return Ok(exit_code);
         }
         Command::Run {
+            workflow_id,
             once,
             config,
             data_directory,
         } => {
+            if let Some(workflow_id) = workflow_id {
+                let repository =
+                    std::env::current_dir().context("failed to resolve current directory")?;
+                let repository = factory::init::discover_repository(&repository)?;
+                return run_workflow(
+                    &workflow_id,
+                    &repository,
+                    config,
+                    WorkflowRunMode::ScheduledOnly,
+                )
+                .await;
+            }
             return run_poller(config, data_directory, once).await;
         }
         Command::Validate { config } => {
@@ -295,7 +310,7 @@ async fn run_cli() -> Result<u8> {
             let repository = repository
                 .unwrap_or(std::env::current_dir().context("failed to resolve current directory")?);
             let repository = factory::init::discover_repository(&repository)?;
-            return run_workflow(&workflow_id, &repository, config).await;
+            return run_workflow(&workflow_id, &repository, config, WorkflowRunMode::Any).await;
         }
         Command::Tasks {
             json,
@@ -656,15 +671,35 @@ fn print_poll_report(report: &PollReport) {
     }
 }
 
+#[derive(Clone, Copy)]
+enum WorkflowRunMode {
+    Any,
+    ScheduledOnly,
+}
+
 async fn run_workflow(
     workflow_id: &str,
     repository: &std::path::Path,
     config_path: Option<PathBuf>,
+    mode: WorkflowRunMode,
 ) -> Result<u8> {
     let path = resolve_config_path(config_path)?;
     let config = Config::load(&path)?;
     let catalog = WorkflowCatalog::load(&config)?;
     let workflow = ResolvedWorkflow::resolve(&config, &catalog, workflow_id, repository)?;
+    if matches!(mode, WorkflowRunMode::ScheduledOnly) {
+        let entry = catalog
+            .entries
+            .iter()
+            .find(|entry| entry.repository == workflow.repository && entry.id == workflow.id)
+            .context("resolved workflow disappeared from the workflow catalog")?;
+        if !matches!(entry.trigger, Some(Trigger::Schedule { .. })) {
+            bail!(
+                "workflow {:?} cannot be run directly with `factory run`; only schedule-triggered workflows are allowed",
+                workflow.id
+            );
+        }
+    }
     if workflow.runtime != "codex" {
         bail!(
             "workflow {:?} resolves to unsupported runtime {:?}; Factory v1 supports codex",

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -119,6 +119,114 @@ printf 'Read-only workflow complete.' > "$output"
 }
 
 #[test]
+fn run_executes_a_schedule_triggered_workflow_once() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let workflows = repository.join(".factory/workflows");
+    let data_home = temp.path().join("factory-data");
+    let binaries = temp.path().join("bin");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::create_dir(&binaries).unwrap();
+    initialize_repository(&repository, &data_home);
+    fs::create_dir(workflows.join("pr-review")).unwrap();
+    fs::write(
+        workflows.join("pr-review/WORKFLOW.md"),
+        "Review open pull requests.\n",
+    )
+    .unwrap();
+    let config_path = repository.join(".factory/config.toml");
+    let mut config = fs::read_to_string(&config_path).unwrap();
+    config.push_str(
+        r#"
+[trigger.pr-review]
+type = "schedule"
+schedule = "*/10 * * * *"
+timezone = "UTC"
+workflow = ".factory/workflows/pr-review/WORKFLOW.md"
+"#,
+    );
+    fs::write(config_path, config).unwrap();
+
+    let prompt_capture = temp.path().join("prompt.txt");
+    let executable = binaries.join("codex");
+    fs::write(
+        &executable,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 1.2.3"
+  exit 0
+fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+output=""
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "--output-last-message" ]; then
+    output="$argument"
+  fi
+  previous="$argument"
+done
+cat > "$FACTORY_PROMPT_CAPTURE"
+echo '{"type":"thread.started","thread_id":"scheduled-thread"}'
+printf 'Scheduled workflow complete.' > "$output"
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    let path = format!(
+        "{}:{}",
+        binaries.display(),
+        env::var("PATH").unwrap_or_default()
+    );
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["run", "pr-review"])
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", &data_home)
+        .env("PATH", path)
+        .env("FACTORY_PROMPT_CAPTURE", &prompt_capture)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Scheduled workflow complete."))
+        .stderr(predicate::str::contains("Running workflow \"pr-review\""));
+
+    let prompt = fs::read_to_string(prompt_capture).unwrap();
+    assert!(prompt.contains("Review open pull requests."));
+    assert!(prompt.contains("Workflow: pr-review"));
+}
+
+#[test]
+fn run_rejects_source_triggered_workflows_before_launch() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let workflows = repository.join(".factory/workflows");
+    let data_home = temp.path().join("factory-data");
+    fs::create_dir_all(&workflows).unwrap();
+    initialize_repository(&repository, &data_home);
+    fs::write(
+        workflows.join("triage/WORKFLOW.md"),
+        "Triage the supplied issue.\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["run", "triage"])
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", &data_home)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "only schedule-triggered workflows are allowed",
+        ));
+}
+
+#[test]
 fn concurrent_manual_runs_exit_when_shared_output_is_full_and_unread() {
     let temp = tempfile::tempdir().unwrap();
     let repository = temp.path().join("repository");

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -42,6 +42,24 @@ fn initialize_repository(repository: &std::path::Path, data_home: &std::path::Pa
         .success();
 }
 
+fn install_codex_invocation_sentinel(binaries: &std::path::Path) -> String {
+    fs::create_dir(binaries).unwrap();
+    let executable = binaries.join("codex");
+    fs::write(
+        &executable,
+        "#!/bin/sh\ntouch \"$FACTORY_CODEX_MARKER\"\nexit 99\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    format!(
+        "{}:{}",
+        binaries.display(),
+        env::var("PATH").unwrap_or_default()
+    )
+}
+
 #[test]
 fn manual_workflow_run_resolves_context_and_invokes_codex() {
     let temp = tempfile::tempdir().unwrap();
@@ -145,7 +163,7 @@ timezone = "UTC"
 workflow = ".factory/workflows/pr-review/WORKFLOW.md"
 "#,
     );
-    fs::write(config_path, config).unwrap();
+    fs::write(&config_path, config).unwrap();
 
     let prompt_capture = temp.path().join("prompt.txt");
     let executable = binaries.join("codex");
@@ -185,8 +203,13 @@ printf 'Scheduled workflow complete.' > "$output"
 
     Command::cargo_bin("factory")
         .unwrap()
-        .args(["run", "pr-review"])
-        .current_dir(&repository)
+        .args([
+            "run",
+            "pr-review",
+            "--config",
+            config_path.to_str().unwrap(),
+        ])
+        .current_dir(temp.path())
         .env("FACTORY_DATA_HOME", &data_home)
         .env("PATH", path)
         .env("FACTORY_PROMPT_CAPTURE", &prompt_capture)
@@ -201,11 +224,61 @@ printf 'Scheduled workflow complete.' > "$output"
 }
 
 #[test]
+fn run_rejects_a_direct_schedule_when_docker_is_configured() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let workflows = repository.join(".factory/workflows");
+    let data_home = temp.path().join("factory-data");
+    let binaries = temp.path().join("bin");
+    let codex_marker = temp.path().join("codex-invoked");
+    fs::create_dir_all(&workflows).unwrap();
+    initialize_repository(&repository, &data_home);
+    fs::create_dir(workflows.join("pr-review")).unwrap();
+    fs::write(
+        workflows.join("pr-review/WORKFLOW.md"),
+        "Review open pull requests.\n",
+    )
+    .unwrap();
+    let config_path = repository.join(".factory/config.toml");
+    let config = fs::read_to_string(&config_path)
+        .unwrap()
+        .replace("sandbox = \"worktree\"", "sandbox = \"docker\"")
+        .replace(
+            "max_concurrent = 1",
+            "max_concurrent = 1\nimage = \"factory-codex:test\"\nmemory = \"1g\"\ncpus = 1\npids = 64",
+        );
+    let config = format!(
+        "{config}\n[trigger.pr-review]\ntype = \"schedule\"\nschedule = \"*/10 * * * *\"\ntimezone = \"UTC\"\nworkflow = \".factory/workflows/pr-review/WORKFLOW.md\"\n"
+    );
+    fs::write(&config_path, config).unwrap();
+    let path = install_codex_invocation_sentinel(&binaries);
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["run", "pr-review"])
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", &data_home)
+        .env("FACTORY_CODEX_MARKER", &codex_marker)
+        .env("PATH", path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "cannot be run directly when worker.sandbox is \"docker\"",
+        ))
+        .stderr(predicate::str::contains(
+            "start the `factory run` loop to preserve Docker isolation",
+        ));
+    assert!(!codex_marker.exists());
+}
+
+#[test]
 fn run_rejects_source_triggered_workflows_before_launch() {
     let temp = tempfile::tempdir().unwrap();
     let repository = temp.path().join("repository");
     let workflows = repository.join(".factory/workflows");
     let data_home = temp.path().join("factory-data");
+    let binaries = temp.path().join("bin");
+    let codex_marker = temp.path().join("codex-invoked");
     fs::create_dir_all(&workflows).unwrap();
     initialize_repository(&repository, &data_home);
     fs::write(
@@ -213,17 +286,21 @@ fn run_rejects_source_triggered_workflows_before_launch() {
         "Triage the supplied issue.\n",
     )
     .unwrap();
+    let path = install_codex_invocation_sentinel(&binaries);
 
     Command::cargo_bin("factory")
         .unwrap()
         .args(["run", "triage"])
         .current_dir(&repository)
         .env("FACTORY_DATA_HOME", &data_home)
+        .env("FACTORY_CODEX_MARKER", &codex_marker)
+        .env("PATH", path)
         .assert()
         .failure()
         .stderr(predicate::str::contains(
             "only schedule-triggered workflows are allowed",
         ));
+    assert!(!codex_marker.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow `factory run <workflow-id>` for schedule-triggered workflows
- reject source-triggered workflows before launching Codex
- preserve the bare polling loop and explicit manual workflow command

## Verification
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- focused tests rerun after rebasing onto latest `origin/main`
- independent review: approved with no blocker or important findings