### PR TITLE
feat: add safe state reset command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "clap",
  "cron",
  "dirs",
+ "fs2",
  "humantime",
  "nix",
  "predicates",
@@ -380,6 +381,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures-core"
@@ -1126,6 +1137,28 @@ checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4"
 chrono-tz = "0.10"
 cron = "0.15"
 dirs = "6.0"
+fs2 = "0.4"
 humantime = "2.2"
 regex = "1.13"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -273,12 +273,18 @@ factory runs
 factory inspect RUN_ID
 factory cancel RUN_ID
 factory cleanup RUN_ID
+factory reset
 ```
 
 Run a schedule-triggered workflow immediately with `factory run ID`. This form
 rejects source-triggered workflows because the loop is what binds the issue
 identity and live source state to the task. The explicit `factory workflow run
 ID` command remains available for manual repository-only workflow runs.
+
+`factory reset` previews the repository ledger and any legacy global ledger.
+After retained runs have been cleaned, use `factory reset --confirm` to remove
+durable task history and start fresh. Configuration, workflows, branches, and
+worktree directories are preserved.
 
 ## Sandboxes and trust
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -113,6 +113,24 @@ Confirmed cleanup removes only the recorded managed worktree or standalone
 clone. The remote branch and pull request remain. Proposal workspaces are
 disposable and are removed at a terminal outcome.
 
+## Reset durable state
+
+Preview a fresh start before removing task history:
+
+```sh
+factory reset
+factory reset --confirm
+```
+
+Reset includes the current repository ledger and the older global ledger when
+it exists. Confirmation is refused while either ledger has queued or running
+work, a live daemon lease, an unremoved managed container, or retained workspace
+ownership. Stop Factory and use `factory cleanup RUN_ID --confirm` for retained
+work before retrying.
+
+Reset removes only SQLite state. Repository configuration, workflows, branches,
+and worktree directories are preserved.
+
 ## Troubleshooting
 
 - `factory init --check` reports missing repository assets without writing.

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,6 +173,10 @@ impl Config {
         Self::load_with_workspace_probe(path, ensure_workspace_writable, false)
     }
 
+    pub fn load_for_inspection(path: &Path) -> Result<Self> {
+        Self::load_without_workspace_probe(path)
+    }
+
     pub(crate) fn load_without_workspace_probe(path: &Path) -> Result<Self> {
         Self::load_with_workspace_probe(path, |_| Ok(()), true)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result, bail};
@@ -22,7 +23,7 @@ use factory::runtime::{
 use factory::source::{PollReport, SourceClient};
 use factory::storage::{
     CancellationRequest, DATABASE_NAME, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState,
-    validate_data_directory,
+    acquire_state_reset_lock, inspect_reset_state, validate_data_directory,
 };
 use factory::workflow::{Trigger, WorkflowCatalog};
 use factory::workspace::WorkspaceManager;
@@ -141,6 +142,18 @@ enum Command {
         #[arg(long)]
         config: Option<PathBuf>,
         /// Directory containing the durable Factory database.
+        #[arg(long)]
+        data_directory: Option<PathBuf>,
+    },
+    /// Preview or confirm removal of durable state for the current repository.
+    Reset {
+        /// Remove state after reviewing the preview.
+        #[arg(long)]
+        confirm: bool,
+        /// Path to the repository-local Factory configuration file.
+        #[arg(long)]
+        config: Option<PathBuf>,
+        /// Directory containing the repository-scoped Factory database.
         #[arg(long)]
         data_directory: Option<PathBuf>,
     },
@@ -514,9 +527,157 @@ async fn run_cli() -> Result<u8> {
                 }
             }
         }
+        Command::Reset {
+            confirm,
+            config,
+            data_directory,
+        } => {
+            let path = resolve_config_path(config)?;
+            let config = Config::load_for_inspection(&path)?;
+            let data_directory = data_directory.unwrap_or_else(|| config.data_directory.clone());
+            let mut databases = vec![("repository", data_directory.join(DATABASE_NAME))];
+            let global = dirs::home_dir()
+                .context("could not determine Factory data directory")?
+                .join(".factory")
+                .join(DATABASE_NAME);
+            push_reset_target(&mut databases, "legacy-global", global);
+            if let Some(configured_global) = configured_unscoped_database_path()? {
+                push_reset_target(&mut databases, "configured-global", configured_global);
+            }
+            let _reset_locks = confirm
+                .then(|| {
+                    databases
+                        .iter()
+                        .map(|(_, database)| acquire_state_reset_lock(database))
+                        .collect::<Result<Vec<_>>>()
+                })
+                .transpose()?;
+            let mut existing = Vec::new();
+            for (kind, database) in databases {
+                if database_has_state(&database)? {
+                    existing.push((kind, database));
+                }
+            }
+            if existing.is_empty() {
+                println!("action: no Factory state exists; no changes made");
+                return Ok(0);
+            }
+            for (kind, database) in &existing {
+                for artifact in database_state_files(database) {
+                    if state_file_exists(&artifact)? {
+                        validate_regular_state_file(&artifact)?;
+                    }
+                }
+                let summary = if state_file_exists(database)? {
+                    inspect_reset_state(database)?
+                } else {
+                    Default::default()
+                };
+                println!("target: {kind}");
+                println!("database: {}", database.display());
+                println!("tasks: {}", summary.tasks);
+                println!("runs: {}", summary.runs);
+                println!("active tasks: {}", summary.active_tasks);
+                println!("active runs: {}", summary.active_runs);
+                println!("managed containers: {}", summary.managed_containers);
+                println!("live daemons: {}", summary.live_daemons);
+                for repository in &summary.repositories {
+                    println!("repository: {repository}");
+                }
+                println!("retained workspaces: {}", summary.retained_workspaces.len());
+                for workspace in &summary.retained_workspaces {
+                    println!("retained workspace: {}", workspace.display());
+                }
+                if confirm
+                    && (summary.active_tasks > 0
+                        || summary.active_runs > 0
+                        || summary.managed_containers > 0
+                        || summary.live_daemons > 0
+                        || !summary.retained_workspaces.is_empty())
+                {
+                    bail!(
+                        "refusing to reset {kind} state while it owns active work or retained resources; stop Factory, finish or cancel active work, and clean retained runs first"
+                    );
+                }
+            }
+            if !confirm {
+                println!("action: preview only; rerun with --confirm to remove durable state");
+                return Ok(0);
+            }
+            for (_, database) in existing {
+                remove_database_files(&database)?;
+            }
+            println!("action: removed durable state; configuration and worktrees preserved");
+        }
     }
 
     Ok(0)
+}
+
+fn remove_database_files(database: &Path) -> Result<()> {
+    for path in database_state_files(database) {
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to remove Factory state file {}", path.display())
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn database_state_files(database: &Path) -> [PathBuf; 4] {
+    let with_suffix = |suffix: &str| {
+        let mut value = database.as_os_str().to_os_string();
+        value.push(suffix);
+        PathBuf::from(value)
+    };
+    [
+        database.to_path_buf(),
+        with_suffix("-wal"),
+        with_suffix("-shm"),
+        with_suffix("-journal"),
+    ]
+}
+
+fn database_has_state(database: &Path) -> Result<bool> {
+    database_state_files(database)
+        .iter()
+        .try_fold(false, |found, path| Ok(found || state_file_exists(path)?))
+}
+
+fn state_file_exists(path: &Path) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to inspect Factory state {}", path.display())),
+    }
+}
+
+fn push_reset_target(
+    databases: &mut Vec<(&'static str, PathBuf)>,
+    kind: &'static str,
+    database: PathBuf,
+) {
+    if !databases.iter().any(|(_, existing)| existing == &database) {
+        databases.push((kind, database));
+    }
+}
+
+fn validate_regular_state_file(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect Factory state file {}", path.display()))?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        bail!(
+            "refusing to use non-regular Factory state file {}",
+            path.display()
+        );
+    }
+    Ok(())
 }
 
 fn open_data_ledger(
@@ -625,8 +786,21 @@ fn ensure_no_unscoped_ledger_overlap() -> Result<()> {
         );
     }
 
-    let Some(configured_base) = std::env::var_os("FACTORY_DATA_HOME").map(PathBuf::from) else {
+    let Some(unscoped_database) = configured_unscoped_database_path()? else {
         return Ok(());
+    };
+    if unscoped_database.exists() {
+        bail!(
+            "Factory found an unscoped ledger at {} and refused to start repository-scoped state because old queued or running work could overlap; stop the old Factory process, finish or cancel its work, then archive the unscoped ledger before using this data root",
+            unscoped_database.display()
+        );
+    }
+    Ok(())
+}
+
+fn configured_unscoped_database_path() -> Result<Option<PathBuf>> {
+    let Some(configured_base) = std::env::var_os("FACTORY_DATA_HOME").map(PathBuf::from) else {
+        return Ok(None);
     };
     let configured_base = if configured_base.is_absolute() {
         configured_base
@@ -635,14 +809,7 @@ fn ensure_no_unscoped_ledger_overlap() -> Result<()> {
             .context("failed to resolve current directory")?
             .join(configured_base)
     };
-    let unscoped_database = configured_base.join(DATABASE_NAME);
-    if unscoped_database.exists() {
-        bail!(
-            "Factory found an unscoped ledger at {} and refused to start repository-scoped state because old queued or running work could overlap; stop the old Factory process, finish or cancel its work, then archive the unscoped ledger before using this data root",
-            unscoped_database.display()
-        );
-    }
-    Ok(())
+    Ok(Some(configured_base.join(DATABASE_NAME)))
 }
 
 fn print_poll_report(report: &PollReport) {
@@ -673,6 +840,38 @@ fn print_poll_report(report: &PollReport) {
 enum WorkflowRunMode {
     Any,
     ScheduledOnly,
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::path::PathBuf;
+
+    use super::database_state_files;
+
+    #[test]
+    fn sqlite_sidecar_paths_preserve_non_utf8_database_bytes() {
+        let database = PathBuf::from(OsString::from_vec(b"/tmp/factory-\xFF.sqlite3".to_vec()));
+        let files = database_state_files(&database);
+
+        assert_eq!(
+            files[0].as_os_str().as_bytes(),
+            database.as_os_str().as_bytes()
+        );
+        assert_eq!(
+            files[1].as_os_str().as_bytes(),
+            b"/tmp/factory-\xFF.sqlite3-wal"
+        );
+        assert_eq!(
+            files[2].as_os_str().as_bytes(),
+            b"/tmp/factory-\xFF.sqlite3-shm"
+        );
+        assert_eq!(
+            files[3].as_os_str().as_bytes(),
+            b"/tmp/factory-\xFF.sqlite3-journal"
+        );
+    }
 }
 
 async fn run_workflow(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,10 +1,11 @@
-use std::collections::HashMap;
-use std::fs;
+use std::collections::{BTreeSet, HashMap};
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
+use fs2::FileExt;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, TransactionBehavior, params};
 
 pub const DATABASE_NAME: &str = "factory.sqlite3";
@@ -19,6 +20,207 @@ pub const AUTOMATIC_DELIVERY_CLEANUP: &str =
 pub const OPERATOR_CONFIRMED_CLEANUP: &str = "operator-confirmed cleanup";
 const DAEMON_OWNER_LEASE_MILLIS: i64 = 10_000;
 const APPROVAL_RESERVATION_TTL_MILLIS: i64 = 10 * 60 * 1000;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResetSummary {
+    pub tasks: usize,
+    pub runs: usize,
+    pub active_tasks: usize,
+    pub active_runs: usize,
+    pub managed_containers: usize,
+    pub live_daemons: usize,
+    pub repositories: Vec<String>,
+    pub retained_workspaces: Vec<PathBuf>,
+}
+
+pub fn inspect_reset_state(database: &Path) -> Result<ResetSummary> {
+    let connection = Connection::open_with_flags(
+        database,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| {
+        format!(
+            "failed to open Factory database read-only {}",
+            database.display()
+        )
+    })?;
+    connection
+        .busy_timeout(std::time::Duration::from_secs(5))
+        .context("failed to configure reset inspection timeout")?;
+    let version: i64 = connection
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .context("failed to inspect Factory schema version")?;
+    if version > SCHEMA_VERSION {
+        bail!(
+            "Factory database schema version {version} is newer than supported version {SCHEMA_VERSION}"
+        );
+    }
+    let count = |table: &str, condition: &str| -> Result<usize> {
+        if !table_exists(&connection, table)? {
+            return Ok(0);
+        }
+        connection
+            .query_row(
+                &format!("SELECT COUNT(*) FROM {table} {condition}"),
+                [],
+                |row| row.get(0),
+            )
+            .with_context(|| format!("failed to inspect Factory reset table {table}"))
+    };
+    let lease_cutoff = now_millis()?.saturating_sub(DAEMON_OWNER_LEASE_MILLIS);
+    let live_daemons = if table_exists(&connection, "daemon_owners")? {
+        let mut statement = connection
+            .prepare("SELECT pid, heartbeat_at FROM daemon_owners")
+            .context("failed to prepare Factory daemon inspection")?;
+        statement
+            .query_map([], |row| Ok((row.get::<_, u32>(0)?, row.get::<_, i64>(1)?)))
+            .context("failed to inspect Factory daemons")?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("failed to read Factory daemons")?
+            .into_iter()
+            .filter(|(pid, heartbeat)| *heartbeat >= lease_cutoff || process_is_alive(*pid))
+            .count()
+    } else {
+        0
+    };
+    let retained_workspaces = if table_exists(&connection, "task_workspaces")? {
+        let mut statement = connection
+            .prepare(
+                "SELECT path FROM task_workspaces
+                 WHERE state != 'cleaned' ORDER BY created_at, task_id",
+            )
+            .context("failed to prepare retained workspace inspection")?;
+        statement
+            .query_map([], |row| row.get::<_, String>(0).map(PathBuf::from))
+            .context("failed to inspect retained workspaces")?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("failed to read retained workspaces")?
+    } else {
+        Vec::new()
+    };
+    let mut repositories = BTreeSet::new();
+    for table in [
+        "tasks",
+        "runs",
+        "trigger_observations",
+        "schedule_cursors",
+        "task_workspaces",
+    ] {
+        if !table_exists(&connection, table)? {
+            continue;
+        }
+        let mut statement = connection
+            .prepare(&format!("SELECT DISTINCT repository FROM {table}"))
+            .with_context(|| format!("failed to prepare repository inspection for {table}"))?;
+        repositories.extend(
+            statement
+                .query_map([], |row| row.get::<_, String>(0))
+                .with_context(|| format!("failed to inspect repositories in {table}"))?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .with_context(|| format!("failed to read repositories in {table}"))?,
+        );
+    }
+    Ok(ResetSummary {
+        tasks: count("tasks", "")?,
+        runs: count("runs", "")?,
+        active_tasks: count("tasks", "WHERE state IN ('queued', 'running')")?,
+        active_runs: count("runs", "WHERE outcome = 'running'")?,
+        managed_containers: count("run_containers", "WHERE removed_at IS NULL")?,
+        live_daemons,
+        repositories: repositories.into_iter().collect(),
+        retained_workspaces,
+    })
+}
+
+fn table_exists(connection: &Connection, table: &str) -> Result<bool> {
+    connection
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?1
+             )",
+            [table],
+            |row| row.get(0),
+        )
+        .context("failed to inspect Factory database schema")
+}
+
+pub fn acquire_state_reset_lock(database: &Path) -> Result<StateLockGuard> {
+    let file = open_state_lock(database)?;
+    file.try_lock_exclusive().with_context(|| {
+        format!(
+            "Factory state is in use and cannot be reset: {}",
+            database.display()
+        )
+    })?;
+    Ok(StateLockGuard { _file: file })
+}
+
+fn acquire_shared_state_lock(database: &Path) -> Result<File> {
+    let file = open_state_lock(database)?;
+    file.lock_shared()
+        .with_context(|| format!("failed to lock Factory state {}", database.display()))?;
+    Ok(file)
+}
+
+fn open_state_lock(database: &Path) -> Result<File> {
+    let path = path_with_suffix(database, ".lock");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create Factory state directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            bail!(
+                "Factory state lock must not be a symlink: {}",
+                path.display()
+            );
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed to inspect Factory state lock {}", path.display())
+            });
+        }
+    }
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("failed to open Factory state lock {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("failed to inspect Factory state lock {}", path.display()))?;
+    if !metadata.is_file() {
+        bail!(
+            "Factory state lock is not a regular file: {}",
+            path.display()
+        );
+    }
+    if fs::symlink_metadata(&path)
+        .with_context(|| format!("failed to inspect Factory state lock {}", path.display()))?
+        .file_type()
+        .is_symlink()
+    {
+        bail!(
+            "Factory state lock must not be a symlink: {}",
+            path.display()
+        );
+    }
+    Ok(file)
+}
+
+fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(suffix);
+    PathBuf::from(value)
+}
 
 pub fn validate_data_directory(data_directory: &Path) -> Result<()> {
     fs::create_dir_all(data_directory).with_context(|| {
@@ -52,6 +254,7 @@ pub fn validate_data_directory(data_directory: &Path) -> Result<()> {
             database.display()
         );
     }
+    let _state_lock = acquire_shared_state_lock(&database)?;
     let connection = Connection::open_with_flags(
         &database,
         OpenFlags::SQLITE_OPEN_READ_WRITE | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -407,6 +610,11 @@ pub struct RecoveryReport {
 pub struct Ledger {
     connection: Connection,
     path: PathBuf,
+    _state_lock: File,
+}
+
+pub struct StateLockGuard {
+    _file: File,
 }
 
 impl Ledger {
@@ -688,6 +896,7 @@ impl Ledger {
                 format!("failed to create database directory {}", parent.display())
             })?;
         }
+        let state_lock = acquire_shared_state_lock(path)?;
         let connection = Connection::open(path)
             .with_context(|| format!("failed to open SQLite database {}", path.display()))?;
         connection
@@ -701,6 +910,7 @@ impl Ledger {
         Ok(Self {
             connection,
             path: path.to_owned(),
+            _state_lock: state_lock,
         })
     }
 

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -10,6 +10,7 @@ fn cli_exposes_the_small_v1_surface() {
         .success()
         .stdout(predicates::str::contains("\n  run "))
         .stdout(predicates::str::contains("\n  validate "))
+        .stdout(predicates::str::contains("\n  reset "))
         .stdout(predicates::str::contains("\n  daemon ").not())
         .stdout(predicates::str::contains("\n  approve ").not());
 

--- a/tests/reset_cli.rs
+++ b/tests/reset_cli.rs
@@ -1,0 +1,398 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use assert_cmd::Command as AssertCommand;
+use factory::storage::{Ledger, RunOutcome, TaskIdentity, TaskWorkspace};
+use predicates::prelude::*;
+
+#[test]
+fn reset_previews_then_removes_repository_and_legacy_state() {
+    let fixture = Fixture::new();
+    finish_task(&fixture.scoped_ledger, "scoped");
+    finish_task(&fixture.legacy_ledger, "legacy");
+    finish_task(&fixture.configured_legacy_ledger, "configured-legacy");
+
+    fixture.command().assert().success().stdout(
+        predicate::str::contains("target: repository")
+            .and(predicate::str::contains("target: legacy-global"))
+            .and(predicate::str::contains("target: configured-global"))
+            .and(predicate::str::contains("action: preview only")),
+    );
+    assert!(fixture.scoped_ledger.join("factory.sqlite3").exists());
+    assert!(fixture.legacy_ledger.join("factory.sqlite3").exists());
+    assert!(
+        fixture
+            .configured_legacy_ledger
+            .join("factory.sqlite3")
+            .exists()
+    );
+
+    fixture
+        .command()
+        .arg("--confirm")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("action: removed durable state"));
+    assert!(!fixture.scoped_ledger.join("factory.sqlite3").exists());
+    assert!(!fixture.legacy_ledger.join("factory.sqlite3").exists());
+    assert!(
+        !fixture
+            .configured_legacy_ledger
+            .join("factory.sqlite3")
+            .exists()
+    );
+    assert!(fixture.repository.join(".factory/config.toml").exists());
+    assert!(fixture.scoped_ledger.join("worktrees").is_dir());
+}
+
+#[test]
+fn reset_refuses_queued_work() {
+    let fixture = Fixture::new();
+    Ledger::open_in(&fixture.scoped_ledger)
+        .unwrap()
+        .enqueue(&ticket("queued"))
+        .unwrap();
+
+    fixture
+        .command()
+        .arg("--confirm")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "refusing to reset repository state",
+        ));
+    assert!(fixture.scoped_ledger.join("factory.sqlite3").exists());
+}
+
+#[test]
+fn reset_refuses_retained_workspace_ownership() {
+    let fixture = Fixture::new();
+    let workspace = fixture.scoped_ledger.join("worktrees/issue-7");
+    let mut ledger = Ledger::open_in(&fixture.scoped_ledger).unwrap();
+    let task = ledger.enqueue(&ticket("retained")).unwrap().task;
+    ledger
+        .reserve_task_workspace(&TaskWorkspace {
+            task_id: task.id,
+            kind: "delivery".into(),
+            backend: "worktree".into(),
+            repository: task.repository.clone(),
+            base_branch: "main".into(),
+            base_sha: "0123456789abcdef".into(),
+            factory_branch: Some("factory/7-retained".into()),
+            path: workspace.clone(),
+            state: "retained".into(),
+            status_summary: Some("uncommitted work".into()),
+            created_at: 0,
+            updated_at: 0,
+            cleaned_at: None,
+        })
+        .unwrap();
+    drop(ledger);
+
+    fixture
+        .command()
+        .arg("--confirm")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(workspace.to_str().unwrap()))
+        .stderr(predicate::str::contains("retained resources"));
+    assert!(fixture.scoped_ledger.join("factory.sqlite3").exists());
+}
+
+#[test]
+fn reset_refuses_a_live_daemon() {
+    let fixture = Fixture::new();
+    let mut ledger = Ledger::open_in(&fixture.scoped_ledger).unwrap();
+    ledger.register_daemon_owner("live-reset-test", 42).unwrap();
+    drop(ledger);
+
+    fixture
+        .command()
+        .arg("--confirm")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "refusing to reset repository state",
+        ));
+    assert!(fixture.scoped_ledger.join("factory.sqlite3").exists());
+}
+
+#[test]
+fn reset_refuses_a_stale_lease_when_the_recorded_pid_is_alive() {
+    let fixture = Fixture::new();
+    let mut ledger = Ledger::open_in(&fixture.scoped_ledger).unwrap();
+    ledger
+        .register_daemon_owner("stale-live-reset-test", std::process::id())
+        .unwrap();
+    drop(ledger);
+    let connection =
+        rusqlite::Connection::open(fixture.scoped_ledger.join("factory.sqlite3")).unwrap();
+    connection
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+            ["stale-live-reset-test"],
+        )
+        .unwrap();
+    drop(connection);
+
+    fixture
+        .command()
+        .arg("--confirm")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "refusing to reset repository state",
+        ));
+    assert!(fixture.scoped_ledger.join("factory.sqlite3").exists());
+}
+
+#[test]
+fn reset_preview_with_no_state_creates_no_lock_files() {
+    let fixture = Fixture::new();
+
+    fixture
+        .command()
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no Factory state exists"));
+
+    assert!(!fixture.scoped_ledger.join("factory.sqlite3.lock").exists());
+    assert!(!fixture.legacy_ledger.join("factory.sqlite3.lock").exists());
+    assert!(
+        !fixture
+            .configured_legacy_ledger
+            .join("factory.sqlite3.lock")
+            .exists()
+    );
+}
+
+#[test]
+fn reset_preview_does_not_require_or_recreate_the_workspace_directory() {
+    let fixture = Fixture::new();
+    let workspace = fixture.scoped_ledger.join("worktrees");
+    fs::remove_dir(&workspace).unwrap();
+
+    fixture
+        .command()
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no Factory state exists"));
+    assert!(!workspace.exists());
+}
+
+#[test]
+fn reset_refuses_while_another_command_holds_the_state_lock() {
+    let fixture = Fixture::new();
+    let ledger = Ledger::open_in(&fixture.scoped_ledger).unwrap();
+
+    fixture
+        .command()
+        .arg("--confirm")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("state is in use"));
+    drop(ledger);
+    assert!(fixture.scoped_ledger.join("factory.sqlite3").exists());
+}
+
+#[test]
+fn reset_preview_does_not_migrate_or_create_wal_state() {
+    let fixture = Fixture::new();
+    let database = fixture.scoped_ledger.join("factory.sqlite3");
+    let connection = rusqlite::Connection::open(&database).unwrap();
+    connection
+        .execute_batch(
+            "CREATE TABLE tasks (
+                 id INTEGER PRIMARY KEY,
+                 identity_key TEXT NOT NULL UNIQUE,
+                 kind TEXT NOT NULL,
+                 repository TEXT NOT NULL,
+                 workflow TEXT NOT NULL,
+                 source_item TEXT,
+                 state TEXT NOT NULL,
+                 created_at INTEGER NOT NULL,
+                 updated_at INTEGER NOT NULL
+             );
+             CREATE TABLE runs (
+                 id INTEGER PRIMARY KEY,
+                 task_id INTEGER NOT NULL,
+                 workflow TEXT NOT NULL,
+                 repository TEXT NOT NULL,
+                 source_item TEXT,
+                 runtime TEXT NOT NULL,
+                 started_at INTEGER NOT NULL,
+                 finished_at INTEGER,
+                 outcome TEXT NOT NULL,
+                 result TEXT,
+                 error TEXT,
+                 session_id TEXT
+             );
+             PRAGMA user_version = 1;",
+        )
+        .unwrap();
+    drop(connection);
+
+    fixture.command().assert().success();
+    let connection = rusqlite::Connection::open_with_flags(
+        &database,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    )
+    .unwrap();
+    assert_eq!(
+        connection
+            .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        1
+    );
+    assert!(!fixture.scoped_ledger.join("factory.sqlite3-wal").exists());
+}
+
+#[test]
+fn reset_discovers_and_removes_orphaned_rollback_journal_state() {
+    let fixture = Fixture::new();
+    let journal = fixture.scoped_ledger.join("factory.sqlite3-journal");
+    fs::write(&journal, "orphaned journal").unwrap();
+
+    fixture
+        .command()
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("target: repository"));
+    assert!(journal.exists());
+
+    fixture
+        .command()
+        .arg("--confirm")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("action: removed durable state"));
+    assert!(!journal.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn reset_rejects_a_symlinked_database_without_touching_its_target() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = Fixture::new();
+    drop(Ledger::open_in(&fixture.scoped_ledger).unwrap());
+    let database = fixture.scoped_ledger.join("factory.sqlite3");
+    let target = fixture.scoped_ledger.join("target.sqlite3");
+    fs::rename(&database, &target).unwrap();
+    symlink(&target, &database).unwrap();
+
+    fixture
+        .command()
+        .arg("--confirm")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("non-regular Factory state file"));
+    assert!(target.exists());
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    repository: PathBuf,
+    home: PathBuf,
+    data_home: PathBuf,
+    scoped_ledger: PathBuf,
+    legacy_ledger: PathBuf,
+    configured_legacy_ledger: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repository");
+        let home = temp.path().join("home");
+        let data_home = temp.path().join("factory-data");
+        fs::create_dir(&repository).unwrap();
+        fs::create_dir(&home).unwrap();
+        git(&repository, &["init", "-b", "main"]);
+        git(
+            &repository,
+            &["config", "user.email", "factory@example.test"],
+        );
+        git(&repository, &["config", "user.name", "Factory Test"]);
+        fs::write(repository.join("README.md"), "fixture\n").unwrap();
+        git(&repository, &["add", "README.md"]);
+        git(&repository, &["commit", "-m", "fixture"]);
+        git(
+            &repository,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:example/reset-fixture.git",
+            ],
+        );
+        AssertCommand::cargo_bin("factory")
+            .unwrap()
+            .current_dir(&repository)
+            .env("HOME", &home)
+            .env("FACTORY_DATA_HOME", &data_home)
+            .arg("init")
+            .assert()
+            .success();
+        let scoped_ledger = fs::read_dir(&data_home)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        let legacy_ledger = home.join(".factory");
+        let configured_legacy_ledger = data_home.clone();
+        fs::create_dir_all(scoped_ledger.join("worktrees")).unwrap();
+        Self {
+            _temp: temp,
+            repository,
+            home,
+            data_home,
+            scoped_ledger,
+            legacy_ledger,
+            configured_legacy_ledger,
+        }
+    }
+
+    fn command(&self) -> AssertCommand {
+        let mut command = AssertCommand::cargo_bin("factory").unwrap();
+        command
+            .current_dir(&self.repository)
+            .env("HOME", &self.home)
+            .env("FACTORY_DATA_HOME", &self.data_home)
+            .args(["reset", "--config", ".factory/config.toml"]);
+        command
+    }
+}
+
+fn finish_task(directory: &Path, revision: &str) {
+    let mut ledger = Ledger::open_in(directory).unwrap();
+    let task = ledger.enqueue(&ticket(revision)).unwrap().task;
+    let claimed = ledger.claim_next().unwrap().unwrap();
+    assert_eq!(claimed.id, task.id);
+    let run = ledger.start_run(task.id, "codex").unwrap();
+    ledger
+        .finish_run_and_task_terminal(run.id, RunOutcome::Succeeded, None, None, None)
+        .unwrap();
+}
+
+fn ticket(revision: &str) -> TaskIdentity {
+    TaskIdentity::ticket("example/reset-fixture", "implement", "7", revision).unwrap()
+}
+
+fn git(directory: &Path, arguments: &[&str]) {
+    let output = Command::new("git")
+        .args(arguments)
+        .current_dir(directory)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        arguments.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- add `factory reset` with read-only preview and explicit `--confirm`
- reset repository-scoped, home legacy, and `FACTORY_DATA_HOME` legacy ledgers
- refuse active work, live legacy processes, managed containers, retained workspaces, concurrent ledger users, and unsafe state paths
- preserve checked-in configuration, workflows, branches, and worktree directories
- document the workflow and add focused destructive-boundary coverage

## Acceptance criteria

- [x] preview reports exact database targets, repository identities, task/run counts, active resources, and retained workspace paths
- [x] preview does not migrate databases, create WAL or lock files, or require/recreate a workspace directory
- [x] confirmation is serialized against all new Factory ledger users
- [x] confirmation refuses queued/running tasks and runs, live daemon leases or PIDs, unremoved containers, and retained workspaces
- [x] legacy global state is handled for both default and configured data roots
- [x] SQLite WAL, SHM, rollback journal, non-UTF-8, symlink, and orphan-sidecar cases are handled safely
- [x] repository configuration and worktree directories remain untouched

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- fresh independent review: Approve, no blocker or important findings

## Limits

- Windows-specific behavior and hostile filesystem path replacement were not exercised.
- Batch worktree pruning remains a separate follow-up; reset preserves worktree directories.