### PR TITLE
feat: show safe worker progress

### DIFF
--- a/.factory/workflows/implement/WORKFLOW.md
+++ b/.factory/workflows/implement/WORKFLOW.md
@@ -32,8 +32,13 @@ and report the conflict.
 
 Implement the smallest cohesive change that satisfies every acceptance
 criterion. Follow existing repository patterns and avoid unrelated cleanup. Add
-useful tests, then run the repository's formatting, linting, test, and build
-checks that cover the change.
+useful tests, then choose verification in proportion to the change. Always run
+the checks required by the ticket and repository. For documentation-only or
+other low-risk changes, prefer focused checks such as diff validation, link
+validation, rendering, and verification of any documented commands. For code,
+configuration, security-sensitive, shared-interface, or uncertain changes, run
+the wider formatting, linting, test, and build checks that cover the affected
+behavior. Do not run unrelated repository-wide checks solely by habit.
 
 If issue-specific product or technical specifications exist, compare the final
 implementation against them. If the repository provides a spec-validation
@@ -42,8 +47,15 @@ flow and capture useful screenshot, video, or equivalent evidence when the
 available environment supports it. If the repository provides a behavioural
 verification skill, follow it. Unit tests alone do not prove visible behaviour.
 
-Review the complete diff with a fresh agent. Fix valid correctness, security,
-regression, and maintainability findings, then rerun affected checks.
+Review the complete diff with a fresh agent. Give the reviewer the ticket,
+acceptance criteria, diff, and verification evidence. Keep the review scoped to
+the change and the surrounding behavior needed to prove it wrong. Do not ask
+the reviewer to repeat triage, audit the whole repository, or inspect unrelated
+history. Scale review depth to risk: low-risk documentation should receive
+focused accuracy, claim, link, and rendering checks, while code, configuration,
+security-sensitive, shared-interface, or uncertain changes require deeper
+correctness, security, regression, and maintainability analysis. Fix valid
+findings, then rerun affected checks.
 
 ## Publish and close the loop
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -14,8 +14,11 @@ factory run
 ```
 
 Startup validates the configured execution backend before claiming work.
-Lifecycle events report polls, claims, worker delegation, and terminal outcomes. Use
-the supported inspection commands instead of reading SQLite directly:
+Lifecycle events report polls, claims, worker delegation, safe Codex progress,
+and terminal outcomes. Progress distinguishes work such as reasoning, commands,
+file changes, web searches, and subtask coordination. Factory deliberately does
+not print prompts, reasoning content, command arguments, or raw tool output.
+Use the supported inspection commands instead of reading SQLite directly:
 
 ```sh
 factory tasks [--json]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1871,6 +1871,7 @@ async fn monitor_run(
     observations: &mut tokio::sync::watch::Receiver<RuntimeObservation>,
 ) -> Result<()> {
     let mut ledger = Ledger::open(ledger_path)?;
+    let mut last_reported_activity = None;
     let mut interval = tokio::time::interval(Duration::from_millis(50));
     interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
     loop {
@@ -1889,6 +1890,12 @@ async fn monitor_run(
                     observation.pull_request.as_deref(),
                     observation.activity.as_deref(),
                 )?;
+                if let Some(activity) = latest_worker_progress(observation.activity.as_deref())
+                    && last_reported_activity.as_deref() != Some(activity)
+                {
+                    eprintln!("Factory worker: run={run_id} {activity}");
+                    last_reported_activity = Some(activity.to_owned());
+                }
             }
             _ = interval.tick() => {
                 if ledger.cancellation_requested(run_id)? {
@@ -1898,6 +1905,13 @@ async fn monitor_run(
             }
         }
     }
+}
+
+fn latest_worker_progress(activity: Option<&str>) -> Option<&str> {
+    activity?
+        .lines()
+        .rev()
+        .find(|line| line.starts_with("Codex progress: "))
 }
 
 fn recovery_prompt(base: &str, previous: &Run, repository: &RepositoryTarget) -> String {
@@ -2300,6 +2314,21 @@ fn decrement_active(active: &mut HashMap<String, usize>, repository: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn latest_worker_progress_returns_only_the_last_safe_progress_line() {
+        assert_eq!(
+            latest_worker_progress(Some(
+                "Codex progress: working\nDocker stderr: SECRET\nCodex progress: files changed\n"
+            )),
+            Some("Codex progress: files changed")
+        );
+        assert_eq!(
+            latest_worker_progress(Some("Docker stderr: SECRET\n")),
+            None
+        );
+        assert_eq!(latest_worker_progress(None), None);
+    }
 
     fn utc(value: &str) -> DateTime<Utc> {
         DateTime::parse_from_rfc3339(value)

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -1231,6 +1231,39 @@ esac
         assert_eq!(receiver.borrow().sequence, sequence);
     }
 
+    #[test]
+    fn updated_plan_activity_is_safe_and_deduplicated() {
+        let (observations, mut receiver) = observation_channel();
+        let update = serde_json::json!({
+            "type": "item.updated",
+            "item": {
+                "type": "todo_list",
+                "items": [{ "text": "untrusted plan content" }]
+            }
+        });
+
+        observe_event(&observations, &update);
+        assert_eq!(
+            receiver.borrow().activity.as_deref(),
+            Some("Codex progress: plan updated\n")
+        );
+        assert!(
+            !receiver
+                .borrow()
+                .activity
+                .as_deref()
+                .unwrap()
+                .contains("untrusted")
+        );
+        receiver.borrow_and_update();
+        let sequence = receiver.borrow().sequence;
+
+        observe_event(&observations, &update);
+
+        assert!(!receiver.has_changed().unwrap());
+        assert_eq!(receiver.borrow().sequence, sequence);
+    }
+
     #[tokio::test]
     async fn bounds_and_rejects_malformed_activity_lines() {
         let (mut writer, reader) = tokio::io::duplex(1024);

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -16,9 +16,8 @@ use tokio::time::Instant as TokioInstant;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::WorkerConfig;
-use crate::inspection::sanitize_for_storage;
 use crate::runtime::{
-    ExecutionResult, RuntimeObservation, Termination, find_pull_request_url,
+    ExecutionResult, RuntimeObservation, Termination, find_pull_request_url, safe_activity_summary,
     write_stderr_best_effort, write_stdout_best_effort,
 };
 
@@ -753,9 +752,17 @@ async fn capture_pipe<R: AsyncRead + Unpin>(
     }
     let text = String::from_utf8_lossy(&bytes).into_owned();
     if !text.is_empty() {
-        observations.send_modify(|observation| {
-            observation.activity = Some(format!("Docker stderr: {}", sanitize_for_storage(&text)));
+        observations.send_if_modified(|observation| {
+            let stderr_activity = format!("Codex stderr activity: {} bytes\n", bytes.len());
+            let mut activity = observation.activity.take().unwrap_or_default();
+            if activity.lines().next_back() == stderr_activity.lines().next_back() {
+                observation.activity = Some(activity);
+                return false;
+            }
+            activity.push_str(&stderr_activity);
+            observation.activity = Some(truncate_tail(&activity, MAX_STREAM_BYTES));
             observation.sequence = observation.sequence.saturating_add(1);
+            true
         });
     }
     Ok(PipeCapture {
@@ -844,18 +851,32 @@ fn record_activity_line(
 }
 
 fn observe_event(observations: &watch::Sender<RuntimeObservation>, event: &Value) {
-    let kind = event
-        .get("type")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-    observations.send_modify(|observation| {
-        let mut activity = observation.activity.take().unwrap_or_default();
-        activity.push_str(&format!("Codex event: {}\n", sanitize_for_storage(kind)));
-        observation.activity = Some(truncate_tail(&activity, MAX_STREAM_BYTES));
-        if let Some(pull_request) = find_pull_request_url(event) {
-            observation.pull_request = Some(pull_request);
+    let summary = safe_activity_summary(event);
+    let pull_request = find_pull_request_url(event);
+    if summary.is_none() && pull_request.is_none() {
+        return;
+    }
+    observations.send_if_modified(|observation| {
+        let mut changed = false;
+        if let Some(summary) = summary {
+            let progress = format!("Codex progress: {summary}\n");
+            let mut activity = observation.activity.take().unwrap_or_default();
+            if activity.lines().next_back() != progress.lines().next_back() {
+                activity.push_str(&progress);
+                changed = true;
+            }
+            observation.activity = Some(truncate_tail(&activity, MAX_STREAM_BYTES));
         }
-        observation.sequence = observation.sequence.saturating_add(1);
+        if let Some(pull_request) = pull_request
+            && observation.pull_request.as_deref() != Some(&pull_request)
+        {
+            observation.pull_request = Some(pull_request);
+            changed = true;
+        }
+        if changed {
+            observation.sequence = observation.sequence.saturating_add(1);
+        }
+        changed
     });
 }
 
@@ -1130,11 +1151,84 @@ esac
                 .activity
                 .as_deref()
                 .unwrap()
-                .contains("turn.started")
+                .contains("Codex progress: working")
         );
 
         drop(writer);
         assert_eq!(capture.await.unwrap().unwrap().lines, 1);
+    }
+
+    #[tokio::test]
+    async fn stderr_activity_records_only_a_structural_byte_count() {
+        let secret = "unstructured-secret-value";
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let (observations, mut receiver) = observation_channel();
+        observations.send_modify(|observation| {
+            observation.activity = Some("Codex progress: working\n".to_owned());
+        });
+        receiver.borrow_and_update();
+        let capture = tokio::spawn(capture_pipe(reader, false, false, observations));
+
+        writer.write_all(secret.as_bytes()).await.unwrap();
+        drop(writer);
+        tokio::time::timeout(Duration::from_secs(1), receiver.changed())
+            .await
+            .expect("stderr activity was not observed")
+            .unwrap();
+
+        let activity = receiver.borrow().activity.clone().unwrap();
+        assert_eq!(
+            activity,
+            format!(
+                "Codex progress: working\nCodex stderr activity: {} bytes\n",
+                secret.len()
+            )
+        );
+        assert!(!activity.contains(secret));
+        assert_eq!(capture.await.unwrap().unwrap().text, secret);
+    }
+
+    #[test]
+    fn unknown_activity_without_a_pull_request_is_ignored() {
+        let (observations, receiver) = observation_channel();
+
+        observe_event(
+            &observations,
+            &serde_json::json!({
+                "type": "future.event",
+                "payload": "untrusted value"
+            }),
+        );
+
+        assert_eq!(receiver.borrow().sequence, 0);
+        assert_eq!(receiver.borrow().activity, None);
+        assert_eq!(receiver.borrow().pull_request, None);
+    }
+
+    #[test]
+    fn duplicate_and_unknown_item_activity_do_not_notify_or_advance_sequence() {
+        let (observations, mut receiver) = observation_channel();
+        let command = serde_json::json!({
+            "type": "item.started",
+            "item": { "type": "command_execution", "command": "untrusted" }
+        });
+
+        observe_event(&observations, &command);
+        assert!(receiver.has_changed().unwrap());
+        receiver.borrow_and_update();
+        let sequence = receiver.borrow().sequence;
+
+        observe_event(&observations, &command);
+        observe_event(
+            &observations,
+            &serde_json::json!({
+                "type": "item.started",
+                "item": { "type": "future_item", "payload": "untrusted" }
+            }),
+        );
+
+        assert!(!receiver.has_changed().unwrap());
+        assert_eq!(receiver.borrow().sequence, sequence);
     }
 
     #[tokio::test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -760,6 +760,17 @@ pub(crate) fn safe_activity_summary(event: &Value) -> Option<&'static str> {
             Some("agent_message") => Some("reporting progress"),
             _ => None,
         },
+        "item.updated" => match activity_item_type(event) {
+            Some("command_execution") => Some("command still running"),
+            Some("file_change") => Some("changing files"),
+            Some("mcp_tool_call") => Some("tool still running"),
+            Some("web_search") => Some("web search in progress"),
+            Some("collaboration_tool_call") => Some("subtask in progress"),
+            Some("todo_list") => Some("plan updated"),
+            Some("agent_message") => Some("reporting progress"),
+            Some("reasoning") => Some("reasoning"),
+            _ => None,
+        },
         "item.completed" => match activity_item_type(event) {
             Some("command_execution") => Some("command finished"),
             Some("file_change") => Some("files changed"),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -694,27 +694,23 @@ fn capture_activity_line(
     let line = line.strip_suffix(b"\r").unwrap_or(line);
     match serde_json::from_slice::<Value>(line) {
         Ok(event) => {
-            let event_type = event
-                .get("type")
-                .and_then(Value::as_str)
-                .filter(|value| {
-                    value.len() <= 80
-                        && value.bytes().all(|byte| {
-                            byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
-                        })
-                })
-                .unwrap_or("unknown");
-            update_observation(
-                observations,
-                None,
-                None,
-                None,
-                Some(format!("Codex event: {event_type}\n")),
-            );
+            if let Some(summary) = safe_activity_summary(&event) {
+                update_observation(
+                    observations,
+                    None,
+                    None,
+                    None,
+                    Some(format!("Codex progress: {summary}\n")),
+                );
+            }
             if let Some(pull_request) = find_pull_request_url(&event) {
-                observations.send_modify(|observation| {
-                    observation.pull_request = Some(pull_request);
+                observations.send_if_modified(|observation| {
+                    if observation.pull_request.as_deref() == Some(&pull_request) {
+                        return false;
+                    }
+                    observation.pull_request = Some(pull_request.clone());
                     observation.sequence = observation.sequence.saturating_add(1);
+                    true
                 });
             }
             if capture.thread_id.is_none()
@@ -734,6 +730,55 @@ fn capture_activity_line(
         }
         Err(_) => {}
     }
+}
+
+pub(crate) fn safe_activity_summary(event: &Value) -> Option<&'static str> {
+    let event_type = event
+        .get("type")
+        .and_then(Value::as_str)
+        .filter(|value| {
+            value.len() <= 80
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+        })
+        .unwrap_or("unknown");
+    match event_type {
+        "thread.started" => Some("worker started"),
+        "turn.started" => Some("working"),
+        "turn.completed" => Some("turn completed"),
+        "turn.failed" => Some("turn failed"),
+        "error" => Some("runtime error"),
+        "item.started" => match activity_item_type(event) {
+            Some("command_execution") => Some("running a command"),
+            Some("file_change") => Some("changing files"),
+            Some("mcp_tool_call") => Some("using a tool"),
+            Some("web_search") => Some("searching the web"),
+            Some("collaboration_tool_call") => Some("coordinating a subtask"),
+            Some("reasoning") => Some("reasoning"),
+            Some("todo_list") => Some("updating the plan"),
+            Some("agent_message") => Some("reporting progress"),
+            _ => None,
+        },
+        "item.completed" => match activity_item_type(event) {
+            Some("command_execution") => Some("command finished"),
+            Some("file_change") => Some("files changed"),
+            Some("web_search") => Some("web search finished"),
+            Some("todo_list") => Some("plan updated"),
+            Some("agent_message") => Some("progress reported"),
+            Some("reasoning" | "mcp_tool_call" | "collaboration_tool_call") => None,
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn activity_item_type(event: &Value) -> Option<&str> {
+    event
+        .get("item")
+        .and_then(Value::as_object)
+        .and_then(|item| item.get("type"))
+        .and_then(Value::as_str)
 }
 
 pub(crate) fn find_pull_request_url(value: &Value) -> Option<String> {
@@ -799,28 +844,45 @@ fn update_observation(
     session_id: Option<String>,
     activity: Option<String>,
 ) {
-    observations.send_modify(|observation| {
-        if let Some(process_id) = process_id {
+    observations.send_if_modified(|observation| {
+        let mut changed = false;
+        if let Some(process_id) = process_id
+            && observation.process_id != Some(process_id)
+        {
             observation.process_id = Some(process_id);
+            changed = true;
         }
-        if let Some(process_identity) = process_identity {
+        if let Some(process_identity) = process_identity
+            && observation.process_identity.as_deref() != Some(&process_identity)
+        {
             observation.process_identity = Some(process_identity);
+            changed = true;
         }
-        if let Some(session_id) = session_id {
+        if let Some(session_id) = session_id
+            && observation.session_id.as_deref() != Some(&session_id)
+        {
             observation.session_id = Some(session_id);
+            changed = true;
         }
         if let Some(activity) = activity {
+            let activity = crate::inspection::sanitize_for_storage(&activity);
             let observed = observation.activity.get_or_insert_with(String::new);
-            observed.push_str(&crate::inspection::sanitize_for_storage(&activity));
-            if observed.len() > MAX_OBSERVED_ACTIVITY_BYTES {
-                let mut start = observed.len() - MAX_OBSERVED_ACTIVITY_BYTES;
-                while !observed.is_char_boundary(start) {
-                    start += 1;
+            if observed.lines().next_back() != activity.lines().next_back() {
+                observed.push_str(&activity);
+                if observed.len() > MAX_OBSERVED_ACTIVITY_BYTES {
+                    let mut start = observed.len() - MAX_OBSERVED_ACTIVITY_BYTES;
+                    while !observed.is_char_boundary(start) {
+                        start += 1;
+                    }
+                    observed.drain(..start);
                 }
-                observed.drain(..start);
+                changed = true;
             }
         }
-        observation.sequence = observation.sequence.saturating_add(1);
+        if changed {
+            observation.sequence = observation.sequence.saturating_add(1);
+        }
+        changed
     });
 }
 
@@ -1232,4 +1294,40 @@ async fn stop_process_group_anchor(anchor: &mut Child, process_id: u32) -> Resul
         .await
         .context("failed to reap Codex process-group anchor")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod observation_tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_activity_does_not_notify_or_advance_the_sequence() {
+        let (observations, mut receiver) = observation_channel();
+        let activity = "Codex progress: working\n".to_owned();
+
+        update_observation(&observations, None, None, None, Some(activity.clone()));
+        assert!(receiver.has_changed().unwrap());
+        receiver.borrow_and_update();
+        let sequence = receiver.borrow().sequence;
+
+        update_observation(&observations, None, None, None, Some(activity));
+
+        assert!(!receiver.has_changed().unwrap());
+        assert_eq!(receiver.borrow().sequence, sequence);
+    }
+
+    #[test]
+    fn unknown_item_types_have_no_safe_activity_summary() {
+        assert_eq!(
+            safe_activity_summary(&serde_json::json!({
+                "type": "item.started",
+                "item": { "type": "future_item", "payload": "untrusted" }
+            })),
+            None
+        );
+        assert_eq!(
+            safe_activity_summary(&serde_json::json!({ "type": "item.completed" })),
+            None
+        );
+    }
 }

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -275,6 +275,9 @@ echo '{"type":"thread.started","thread_id":"progress-thread"}'
 echo '{"type":"turn.started","prompt":"SECRET prompt"}'
 echo '{"type":"item.started","item":{"type":"reasoning","text":"SECRET reasoning"}}'
 echo '{"type":"item.completed","item":{"type":"reasoning","text":"SECRET reasoning"}}'
+echo '{"type":"item.updated","item":{"type":"todo_list","items":[{"text":"SECRET plan"}]}}'
+echo '{"type":"item.updated","item":{"type":"todo_list","items":[{"text":"SECRET changed plan"}]}}'
+echo '{"type":"item.updated","item":{"type":"future_item","payload":"SECRET unknown item"}}'
 echo '{"type":"item.started","item":{"type":"command_execution","command":"echo SECRET"}}'
 echo '{"type":"future.event","payload":"SECRET unknown"}'
 echo '{"type":"item.completed","item":{"type":"command_execution","aggregated_output":"SECRET output"}}'
@@ -307,6 +310,7 @@ exit 0"#,
             "Codex progress: worker started\n",
             "Codex progress: working\n",
             "Codex progress: reasoning\n",
+            "Codex progress: plan updated\n",
             "Codex progress: running a command\n",
             "Codex progress: command finished\n",
             "Codex progress: changing files\n",

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -234,7 +234,7 @@ async fn persisted_activity_is_structural_and_never_contains_raw_secret_output()
         r#"cat >/dev/null
 printf '{"type":"item.completed","text":"TOKEN='
 awk 'BEGIN { for (i = 0; i < 70000; i++) printf "s" }'
-echo '","url":"https://github.com/owainlewis/factory/pull/123"}'
+echo '","item":{"type":"command_execution","command":"print TOKEN"},"url":"https://github.com/owainlewis/factory/pull/123"}'
 printf 'done' > "$output"
 exit 0"#,
     );
@@ -260,9 +260,63 @@ exit 0"#,
         Some("https://github.com/owainlewis/factory/pull/123")
     );
     let activity = observation.activity.unwrap();
-    assert_eq!(activity, "Codex event: item.completed\n");
+    assert_eq!(activity, "Codex progress: command finished\n");
     assert!(!activity.contains("TOKEN"));
-    assert!(!activity.contains('s'));
+    assert!(!activity.contains("ssssssss"));
+}
+
+#[tokio::test]
+async fn activity_reports_safe_progress_without_copying_event_payloads() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = fake_codex(
+        temp.path(),
+        r#"cat >/dev/null
+echo '{"type":"thread.started","thread_id":"progress-thread"}'
+echo '{"type":"turn.started","prompt":"SECRET prompt"}'
+echo '{"type":"item.started","item":{"type":"reasoning","text":"SECRET reasoning"}}'
+echo '{"type":"item.completed","item":{"type":"reasoning","text":"SECRET reasoning"}}'
+echo '{"type":"item.started","item":{"type":"command_execution","command":"echo SECRET"}}'
+echo '{"type":"future.event","payload":"SECRET unknown"}'
+echo '{"type":"item.completed","item":{"type":"command_execution","aggregated_output":"SECRET output"}}'
+echo '{"type":"item.started","item":{"type":"file_change","changes":[{"path":"SECRET-path"}]}}'
+echo '{"type":"item.completed","item":{"type":"file_change","changes":[{"path":"SECRET-path"}]}}'
+echo '{"type":"item.started","item":{"type":"collaboration_tool_call","prompt":"SECRET subtask"}}'
+echo '{"type":"item.completed","item":{"type":"collaboration_tool_call","result":"SECRET result"}}'
+printf 'done' > "$output"
+exit 0"#,
+    );
+    let (observations, receiver) = observation_channel();
+
+    CodexRuntime::new(executable)
+        .with_activity_streaming(false)
+        .run_with_session(
+            "Observe safe progress.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+            None,
+            observations,
+        )
+        .await
+        .unwrap();
+
+    let activity = receiver.borrow().activity.clone().unwrap();
+    assert_eq!(
+        activity,
+        concat!(
+            "Codex progress: worker started\n",
+            "Codex progress: working\n",
+            "Codex progress: reasoning\n",
+            "Codex progress: running a command\n",
+            "Codex progress: command finished\n",
+            "Codex progress: changing files\n",
+            "Codex progress: files changed\n",
+            "Codex progress: coordinating a subtask\n",
+        )
+    );
+    assert!(!activity.contains("SECRET"));
+    assert!(!activity.contains("echo"));
+    assert!(!activity.contains("SECRET-path"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- print allowlisted, human-readable Codex progress for worktree and Docker workers
- suppress duplicate and unknown events so they cannot fake liveness
- preserve the safety boundary around prompts, reasoning content, command arguments, raw output, and secrets
- make implementation verification and independent review proportional to change risk
- document the operator-visible progress behavior

Refs #78

## Verification

- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets`
- focused worktree and Docker activity, stderr concurrency, duplicate-event, unknown-event, and secret-exclusion regressions
- independent final review: Approve, no blocker or important findings

## Scope

This is the first observability slice from #78. It adds safe live progress to `factory run`; derived health states and `inspect --follow` remain separate follow-up work.