### PR TITLE
fix: support sha2 0.11 digest encoding

### DIFF
--- a/src/approval.rs
+++ b/src/approval.rs
@@ -3,7 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+
+use crate::hash::sha256_hex;
 
 const PREFIX: &str = "<!-- factory-approval:v1 ";
 const SUFFIX: &str = " -->";
@@ -46,7 +47,7 @@ pub fn approved_content_hash(
         workflow_id,
         workflow_hash,
     ))?;
-    Ok(format!("v1:{:x}", Sha256::digest(canonical)))
+    Ok(format!("v1:{}", sha256_hex(canonical)))
 }
 
 pub fn nonce(issue: u64, approver_id: u64) -> Result<String> {
@@ -56,7 +57,7 @@ pub fn nonce(issue: u64, approver_id: u64) -> Result<String> {
         .as_nanos();
     let sequence = NONCE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
     let value = serde_json::to_vec(&(now, std::process::id(), sequence, issue, approver_id))?;
-    Ok(format!("{:x}", Sha256::digest(value)))
+    Ok(sha256_hex(value))
 }
 
 pub fn render(artifact: &ApprovalArtifact) -> Result<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::hash::encode_lower;
 use crate::storage::DATABASE_NAME;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -809,7 +810,7 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
     hasher.update(identity.as_bytes());
     hasher.update(b"\0");
     hasher.update(repository.as_os_str().as_encoded_bytes());
-    let digest = format!("{:x}", hasher.finalize());
+    let digest = encode_lower(hasher.finalize());
     let digest = &digest[..20];
     let configured_base = env::var_os("FACTORY_DATA_HOME").map(PathBuf::from);
     let base = match configured_base.as_ref() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,7 +9,6 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, SecondsFormat, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
-use sha2::{Digest, Sha256};
 use tokio::task::JoinSet;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
@@ -18,6 +17,7 @@ use crate::clone::CloneManager;
 use crate::config::{Config, SourceConfig};
 use crate::docker::{CloneMount, DockerRunFailure, DockerWorker};
 use crate::github::{GitHubClient, LabelTicketContext, ProjectTicketContext, TicketContext};
+use crate::hash::sha256_hex_prefix;
 use crate::runtime::{
     CodexRuntime, ExecutionResult, RuntimeCancelled, RuntimeObservation, Termination,
     observation_channel,
@@ -568,8 +568,7 @@ async fn reconcile_docker_workers(
 }
 
 fn docker_instance_id(data_directory: &Path) -> String {
-    let digest = Sha256::digest(data_directory.as_os_str().as_encoded_bytes());
-    format!("{:x}", digest)[..20].to_owned()
+    sha256_hex_prefix(data_directory.as_os_str().as_encoded_bytes(), 20)
 }
 
 fn validate_workspace_backends(ledger: &Ledger, docker_mode: bool) -> Result<()> {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,0 +1,44 @@
+use sha2::{Digest, Sha256};
+
+const LOWER_HEX: &[u8; 16] = b"0123456789abcdef";
+
+pub(crate) fn encode_lower(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        encoded.push(LOWER_HEX[(byte >> 4) as usize] as char);
+        encoded.push(LOWER_HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+pub(crate) fn sha256_hex(data: impl AsRef<[u8]>) -> String {
+    encode_lower(Sha256::digest(data))
+}
+
+pub(crate) fn sha256_hex_prefix(data: impl AsRef<[u8]>, length: usize) -> String {
+    sha256_hex(data)[..length].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_hex_matches_known_vector() {
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn sha256_hex_prefix_preserves_leading_hash_characters() {
+        assert_eq!(sha256_hex_prefix(b"abc", 20), "ba7816bf8f01cfea4141");
+    }
+
+    #[test]
+    fn encode_lower_preserves_leading_zeroes_and_uses_lowercase() {
+        assert_eq!(encode_lower([0x00, 0x01, 0x0f, 0x10, 0xff]), "00010f10ff");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod daemon;
 pub mod docker;
 pub mod execution;
 pub mod github;
+mod hash;
 pub mod init;
 pub mod inspection;
 pub mod runtime;

--- a/src/source.rs
+++ b/src/source.rs
@@ -5,11 +5,11 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::{Config, SourceConfig, repository_remote_identity};
+use crate::hash::sha256_hex;
 use crate::storage::{Ledger, ObservedTicket, Task};
 use crate::workflow::{Trigger, WorkflowCatalog, WorkflowEntry};
 
@@ -343,8 +343,8 @@ fn observed_ticket(issue: SourceIssue, state: &str, labels: &[String]) -> Result
         let mut selected_labels = labels.to_vec();
         selected_labels.sort();
         format!(
-            "source:{:x}",
-            Sha256::digest(
+            "source:{}",
+            sha256_hex(
                 serde_json::to_vec(&(issue.key.as_str(), state, selected_labels))
                     .expect("source revision tuple is serializable")
             )

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -6,9 +6,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use chrono_tz::Tz;
-use sha2::{Digest, Sha256};
 
 use crate::config::{Config, TriggerKind};
+use crate::hash::sha256_hex;
 
 pub fn scheduled_workflow_fingerprint(
     expression: &str,
@@ -25,7 +25,7 @@ pub fn scheduled_workflow_fingerprint(
         timeout.subsec_nanos(),
         prompt,
     ))?;
-    Ok(format!("v2:{:x}", Sha256::digest(definition)))
+    Ok(format!("v2:{}", sha256_hex(definition)))
 }
 
 pub fn workflow_content_hash(entry: &WorkflowEntry) -> Result<String> {
@@ -38,7 +38,7 @@ pub fn workflow_content_hash(entry: &WorkflowEntry) -> Result<String> {
             .map(|timeout| (timeout.as_secs(), timeout.subsec_nanos())),
         entry.prompt.as_deref(),
     ))?;
-    Ok(format!("v1:{:x}", Sha256::digest(definition)))
+    Ok(format!("v1:{}", sha256_hex(definition)))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- replace seven `LowerHex` digest formatting sites with one shared lowercase encoder
- preserve existing SHA-256 strings, including leading zeroes and 20-character identifiers
- add known-vector, lowercase, leading-zero, and prefix tests

## Why

`sha2` 0.11 changes the digest output type, which no longer implements `LowerHex`. Dependabot PR #67 therefore fails to compile. This compatibility change works with both `sha2` 0.10.9 and 0.11.0, allowing #67 to be rebased and merged without changing persisted hash values.

## Validation

- `cargo fmt --all --check`
- `cargo test --locked --all-targets` with `sha2` 0.10.9
- `cargo clippy --locked --all-targets -- -D warnings` with `sha2` 0.10.9
- `cargo test --locked --all-targets` with `sha2` 0.11.0
- `cargo clippy --locked --all-targets -- -D warnings` with `sha2` 0.11.0
- independent review: approved with no blocker or important findings

The temporary 0.11 manifest and lockfile changes were restored before commit, so this PR adds no dependency changes.