### PR TITLE
feat(cli): format human-readable tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "toml_edit",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1122,6 +1123,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.47", features = ["io-util", "macros", "process", "rt-mult
 tokio-util = "0.7"
 toml = "0.9"
 toml_edit = "0.23"
+unicode-width = "0.2.2"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30", features = ["signal"] }

--- a/src/inspection.rs
+++ b/src/inspection.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 use serde::Serialize;
 
 use crate::storage::{Run, RunContainer, RunSandbox, Task, TaskState};
+use crate::table;
 
 const MAX_SUMMARY_BYTES: usize = 240;
 const MAX_DETAIL_BYTES: usize = 16 * 1024;
@@ -191,38 +192,73 @@ impl RunInspection {
 }
 
 pub fn print_tasks(tasks: &[Task]) {
-    println!("ID\tSTATE\tREPOSITORY\tWORKFLOW\tSOURCE\tCREATED\tUPDATED");
-    for task in tasks {
-        println!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            task.id,
-            task_state(task.state),
-            safe_column(&task.repository, 48),
-            safe_column(&task.workflow, 36),
-            safe_column(task.source_item.as_deref().unwrap_or("-"), 24),
-            task.created_at,
-            task.updated_at,
-        );
-    }
+    let rows = tasks
+        .iter()
+        .map(|task| {
+            [
+                task.id.to_string(),
+                task_state(task.state).to_owned(),
+                safe_column(&task.repository, 48),
+                safe_column(&task.workflow, 36),
+                safe_column(task.source_item.as_deref().unwrap_or("-"), 24),
+                task.created_at.to_string(),
+                task.updated_at.to_string(),
+            ]
+        })
+        .collect::<Vec<_>>();
+    print!(
+        "{}",
+        table::render(
+            [
+                "ID",
+                "STATE",
+                "REPOSITORY",
+                "WORKFLOW",
+                "SOURCE",
+                "CREATED",
+                "UPDATED",
+            ],
+            &rows,
+            &[0, 5, 6],
+        )
+    );
 }
 
 pub fn print_runs(runs: &[Run]) {
-    println!("ID\tOUTCOME\tRUNTIME\tWORKFLOW\tREPOSITORY\tSOURCE\tDURATION_MS\tSUMMARY");
-    for run in runs {
-        let view = RunView::from(run);
-        println!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            view.id,
-            safe_column(&view.outcome, 16),
-            safe_column(&view.runtime, 16),
-            safe_column(&view.workflow, 36),
-            safe_column(&view.repository, 48),
-            safe_column(view.source_item.as_deref().unwrap_or("-"), 24),
-            view.duration_ms
-                .map_or_else(|| "-".to_owned(), |value| value.to_string()),
-            safe_column(view.summary.as_deref().unwrap_or("-"), MAX_SUMMARY_BYTES),
-        );
-    }
+    let rows = runs
+        .iter()
+        .map(|run| {
+            let view = RunView::from(run);
+            [
+                view.id.to_string(),
+                safe_column(&view.outcome, 16),
+                safe_column(&view.runtime, 16),
+                safe_column(&view.workflow, 36),
+                safe_column(&view.repository, 48),
+                safe_column(view.source_item.as_deref().unwrap_or("-"), 24),
+                view.duration_ms
+                    .map_or_else(|| "-".to_owned(), |value| value.to_string()),
+                safe_column(view.summary.as_deref().unwrap_or("-"), MAX_SUMMARY_BYTES),
+            ]
+        })
+        .collect::<Vec<_>>();
+    print!(
+        "{}",
+        table::render(
+            [
+                "ID",
+                "OUTCOME",
+                "RUNTIME",
+                "WORKFLOW",
+                "REPOSITORY",
+                "SOURCE",
+                "DURATION_MS",
+                "SUMMARY",
+            ],
+            &rows,
+            &[0, 6],
+        )
+    );
 }
 
 pub fn print_inspection(inspection: &RunInspection) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,6 @@ pub mod runtime;
 pub mod sandbox;
 pub mod source;
 pub mod storage;
+mod table;
 pub mod workflow;
 pub mod workspace;

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,0 +1,94 @@
+use unicode_width::UnicodeWidthStr;
+
+pub(crate) fn render<const COLUMNS: usize>(
+    headings: [&str; COLUMNS],
+    rows: &[[String; COLUMNS]],
+    right_aligned: &[usize],
+) -> String {
+    let widths = std::array::from_fn(|column| {
+        rows.iter()
+            .map(|row| display_width(&row[column]))
+            .chain([display_width(headings[column])])
+            .max()
+            .unwrap_or_default()
+    });
+    let mut output = String::new();
+
+    write_row(
+        &mut output,
+        headings.each_ref().map(|heading| *heading),
+        &widths,
+        right_aligned,
+    );
+    write_row(
+        &mut output,
+        std::array::from_fn(|column| "─".repeat(widths[column])),
+        &widths,
+        &[],
+    );
+    for row in rows {
+        write_row(&mut output, row.each_ref(), &widths, right_aligned);
+    }
+
+    output
+}
+
+fn write_row<T: AsRef<str>, const COLUMNS: usize>(
+    output: &mut String,
+    cells: [T; COLUMNS],
+    widths: &[usize; COLUMNS],
+    right_aligned: &[usize],
+) {
+    for (column, cell) in cells.iter().enumerate() {
+        if column > 0 {
+            output.push_str("  ");
+        }
+        let cell = cell.as_ref();
+        let padding = widths[column].saturating_sub(display_width(cell));
+        if right_aligned.contains(&column) {
+            output.extend(std::iter::repeat_n(' ', padding));
+            output.push_str(cell);
+        } else {
+            output.push_str(cell);
+            if column + 1 < COLUMNS {
+                output.extend(std::iter::repeat_n(' ', padding));
+            }
+        }
+    }
+    output.push('\n');
+}
+
+fn display_width(value: &str) -> usize {
+    value.width()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render;
+
+    #[test]
+    fn aligns_text_and_numeric_columns() {
+        let rows = [
+            ["queued".to_owned(), "2".to_owned()],
+            ["succeeded".to_owned(), "12".to_owned()],
+        ];
+
+        assert_eq!(
+            render(["STATE", "ID"], &rows, &[1]),
+            "STATE      ID\n─────────  ──\nqueued      2\nsucceeded  12\n"
+        );
+    }
+
+    #[test]
+    fn aligns_wide_and_combining_unicode_by_terminal_width() {
+        let rows = [
+            ["界".to_owned(), "1".to_owned()],
+            ["e\u{301}".to_owned(), "12".to_owned()],
+        ];
+
+        assert_eq!(
+            render(["NAME", "ID"], &rows, &[1]),
+            "NAME  ID\n────  ──\n界     1\né     12\n"
+        );
+    }
+}

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -3,12 +3,14 @@ use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use std::{collections::BTreeMap, fmt::Write};
 
 use anyhow::Result;
 use chrono_tz::Tz;
 
 use crate::config::{Config, TriggerKind};
 use crate::hash::sha256_hex;
+use crate::table;
 
 pub fn scheduled_workflow_fingerprint(
     expression: &str,
@@ -133,40 +135,56 @@ impl WorkflowCatalog {
 
 impl fmt::Display for WorkflowCatalog {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(
-            formatter,
-            "REPOSITORY\tWORKFLOW\tTRIGGER\tRUNTIME\tTIMEOUT\tVALIDITY"
-        )?;
+        let mut repositories = BTreeMap::<String, Vec<[String; 5]>>::new();
         for entry in &self.entries {
-            let trigger = entry
-                .trigger
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_else(|| "-".to_owned());
-            let runtime = entry.runtime.as_deref().unwrap_or("-");
-            let timeout = entry
-                .timeout
-                .map(humantime::format_duration)
-                .map(|duration| duration.to_string())
-                .unwrap_or_else(|| "-".to_owned());
-            let validity = if entry.errors.is_empty() {
-                "valid".to_owned()
-            } else {
-                format!("invalid: {}", entry.errors.join("; "))
-            };
-            let cells = [
-                entry.repository.display().to_string(),
-                entry.id.clone(),
-                trigger,
-                runtime.to_owned(),
-                timeout,
-                validity,
-            ]
-            .map(|cell| sanitize_catalog_cell(&cell));
-            writeln!(formatter, "{}", cells.join("\t"))?;
+            repositories
+                .entry(sanitize_catalog_cell(
+                    &entry.repository.display().to_string(),
+                ))
+                .or_default()
+                .push(workflow_row(entry));
+        }
+
+        for (index, (repository, rows)) in repositories.iter().enumerate() {
+            if index > 0 {
+                formatter.write_char('\n')?;
+            }
+            writeln!(formatter, "Repository: {repository}\n")?;
+            formatter.write_str(&table::render(
+                ["WORKFLOW", "TRIGGER", "RUNTIME", "TIMEOUT", "VALIDITY"],
+                rows,
+                &[],
+            ))?;
         }
         Ok(())
     }
+}
+
+fn workflow_row(entry: &WorkflowEntry) -> [String; 5] {
+    let trigger = entry
+        .trigger
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "-".to_owned());
+    let timeout = entry
+        .timeout
+        .map(humantime::format_duration)
+        .map(|duration| duration.to_string())
+        .unwrap_or_else(|| "-".to_owned());
+    let validity = if entry.errors.is_empty() {
+        "valid".to_owned()
+    } else {
+        format!("invalid: {}", entry.errors.join("; "))
+    };
+
+    [
+        entry.id.clone(),
+        trigger,
+        entry.runtime.clone().unwrap_or_else(|| "-".to_owned()),
+        timeout,
+        validity,
+    ]
+    .map(|cell| sanitize_catalog_cell(&cell))
 }
 
 impl fmt::Display for Trigger {

--- a/tests/inspection_cli.rs
+++ b/tests/inspection_cli.rs
@@ -351,5 +351,8 @@ fn empty_ledgers_have_stable_empty_outputs() {
         .arg(&data)
         .assert()
         .success()
-        .stdout("ID\tSTATE\tREPOSITORY\tWORKFLOW\tSOURCE\tCREATED\tUPDATED\n");
+        .stdout(
+            "ID  STATE  REPOSITORY  WORKFLOW  SOURCE  CREATED  UPDATED\n\
+             ──  ─────  ──────────  ────────  ──────  ───────  ───────\n",
+        );
 }

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -1,8 +1,9 @@
 use std::fs;
 use std::process::Command;
+use std::time::Duration;
 
 use factory::config::{Config, TriggerKind};
-use factory::workflow::{Trigger, WorkflowCatalog};
+use factory::workflow::{Trigger, WorkflowCatalog, WorkflowEntry};
 
 struct Fixture {
     _temp: tempfile::TempDir,
@@ -75,6 +76,49 @@ trusted_users = ["owainlewis"]
 {triggers}
 "#
     )
+}
+
+#[test]
+fn catalog_display_groups_the_repository_and_aligns_workflows() {
+    let repository = std::path::PathBuf::from("/tmp/a-long-repository-path");
+    let entries = vec![
+        WorkflowEntry {
+            repository: repository.clone(),
+            path: repository.join("implement.md"),
+            id: "implement".to_owned(),
+            trigger: Some(Trigger::Source {
+                state: "open".to_owned(),
+                labels: vec!["factory:ready-to-implement".to_owned()],
+            }),
+            runtime: Some("codex".to_owned()),
+            timeout: Some(Duration::from_secs(4 * 60 * 60)),
+            prompt: Some("Implement it.".to_owned()),
+            errors: Vec::new(),
+        },
+        WorkflowEntry {
+            repository,
+            path: std::path::PathBuf::from("/tmp/pr-review.md"),
+            id: "pr-review".to_owned(),
+            trigger: Some(Trigger::Schedule {
+                expression: "*/10 * * * *".to_owned(),
+                timezone: chrono_tz::Europe::London,
+            }),
+            runtime: Some("codex".to_owned()),
+            timeout: Some(Duration::from_secs(30 * 60)),
+            prompt: Some("Review it.".to_owned()),
+            errors: Vec::new(),
+        },
+    ];
+
+    assert_eq!(
+        WorkflowCatalog { entries }.to_string(),
+        "Repository: /tmp/a-long-repository-path\n\
+         \n\
+         WORKFLOW   TRIGGER                                                    RUNTIME  TIMEOUT  VALIDITY\n\
+         ─────────  ─────────────────────────────────────────────────────────  ───────  ───────  ────────\n\
+         implement  source state \"open\" labels [\"factory:ready-to-implement\"]  codex    4h       valid\n\
+         pr-review  schedule \"*/10 * * * *\" (Europe/London)                    codex    30m      valid\n"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace raw tab-separated CLI output with aligned human-readable tables
- group workflow rows under their repository instead of repeating long paths
- right-align numeric task and run columns
- measure Unicode terminal width so CJK, emoji, and combining marks stay aligned
- preserve stable JSON output for scripts

## Verification
- cargo test --lib
- cargo test --test inspection_cli
- cargo test --test workflows
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- real factory workflows output verified from the primary checkout
- independent review: approved with no findings