### PR TITLE
test: isolate workflow fixture data home

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -167,21 +167,32 @@ enum RawTriggerConfig {
 
 impl Config {
     pub fn load(path: &Path) -> Result<Self> {
-        Self::load_with_workspace_probe(path, ensure_workspace_writable, false)
+        Self::load_with_workspace_probe(path, ensure_workspace_writable, false, None)
     }
 
     pub fn load_for_inspection(path: &Path) -> Result<Self> {
         Self::load_without_workspace_probe(path)
     }
 
+    #[doc(hidden)]
+    pub fn load_with_data_home(path: &Path, data_home: &Path) -> Result<Self> {
+        Self::load_with_workspace_probe(
+            path,
+            ensure_workspace_writable,
+            false,
+            Some(data_home.to_owned()),
+        )
+    }
+
     pub(crate) fn load_without_workspace_probe(path: &Path) -> Result<Self> {
-        Self::load_with_workspace_probe(path, |_| Ok(()), true)
+        Self::load_with_workspace_probe(path, |_| Ok(()), true, None)
     }
 
     fn load_with_workspace_probe<F>(
         path: &Path,
         workspace_probe: F,
         allow_missing_workspace: bool,
+        data_home: Option<PathBuf>,
     ) -> Result<Self>
     where
         F: FnOnce(&Path) -> Result<()>,
@@ -217,6 +228,7 @@ impl Config {
             repository,
             workspace_probe,
             allow_missing_workspace,
+            data_home,
         )
         .with_context(|| format!("invalid Factory configuration in {}", path.display()))
     }
@@ -224,7 +236,7 @@ impl Config {
     pub(crate) fn validate_candidate(contents: &str, repository: &Path) -> Result<Self> {
         let raw: RawConfig =
             toml::from_str(contents).context("failed to parse candidate config")?;
-        Self::resolve_with_workspace_probe(raw, repository, |_| Ok(()), true)
+        Self::resolve_with_workspace_probe(raw, repository, |_| Ok(()), true, None)
             .context("invalid candidate Factory configuration")
     }
 
@@ -233,6 +245,7 @@ impl Config {
         repository: &Path,
         workspace_probe: F,
         allow_missing_workspace: bool,
+        data_home: Option<PathBuf>,
     ) -> Result<Self>
     where
         F: FnOnce(&Path) -> Result<()>,
@@ -264,7 +277,10 @@ impl Config {
         let repository = canonical_directory("repository", repository, repository)?;
         let triggers =
             resolve_triggers(raw.triggers, &repository, default_timeout, maximum_timeout)?;
-        let data_directory = repository_data_directory(&repository)?;
+        let data_directory = match data_home {
+            Some(data_home) => repository_data_directory_with_base(&repository, Some(data_home))?,
+            None => repository_data_directory(&repository)?,
+        };
         let worker = match execution_mode {
             ExecutionMode::Worktree => {
                 reject_sandbox_options(&raw.worker)?;
@@ -740,6 +756,16 @@ pub fn repository_config_path(repository: &Path) -> PathBuf {
 }
 
 pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
+    repository_data_directory_with_base(
+        repository,
+        env::var_os("FACTORY_DATA_HOME").map(PathBuf::from),
+    )
+}
+
+fn repository_data_directory_with_base(
+    repository: &Path,
+    configured_base: Option<PathBuf>,
+) -> Result<PathBuf> {
     let repository = repository
         .canonicalize()
         .with_context(|| format!("failed to resolve repository {}", repository.display()))?;
@@ -751,7 +777,6 @@ pub fn repository_data_directory(repository: &Path) -> Result<PathBuf> {
     hasher.update(repository.as_os_str().as_encoded_bytes());
     let digest = encode_lower(hasher.finalize());
     let digest = &digest[..20];
-    let configured_base = env::var_os("FACTORY_DATA_HOME").map(PathBuf::from);
     let base = match configured_base.as_ref() {
         Some(base) => resolve_data_base(base.clone())?,
         None => dirs::home_dir()

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -8,12 +8,15 @@ use factory::workflow::{Trigger, WorkflowCatalog, WorkflowEntry};
 struct Fixture {
     _temp: tempfile::TempDir,
     repository: std::path::PathBuf,
+    data_home: std::path::PathBuf,
 }
 
 impl Fixture {
     fn new(config: &str) -> Self {
         let temp = tempfile::tempdir().unwrap();
-        let repository = temp.path().join("repository");
+        let temp_path = temp.path().canonicalize().unwrap();
+        let repository = temp_path.join("repository");
+        let data_home = temp_path.join("factory-data");
         fs::create_dir_all(repository.join(".factory/workflows")).unwrap();
         assert!(
             Command::new("git")
@@ -39,6 +42,7 @@ impl Fixture {
         assert_cmd::Command::cargo_bin("factory")
             .unwrap()
             .current_dir(&repository)
+            .env("FACTORY_DATA_HOME", &data_home)
             .arg("init")
             .assert()
             .success();
@@ -46,11 +50,15 @@ impl Fixture {
         Self {
             _temp: temp,
             repository,
+            data_home,
         }
     }
 
     fn config(&self) -> anyhow::Result<Config> {
-        Config::load(&self.repository.join(".factory/config.toml"))
+        Config::load_with_data_home(
+            &self.repository.join(".factory/config.toml"),
+            &self.data_home,
+        )
     }
 }
 


### PR DESCRIPTION
Closes #100

## Summary

- give the workflow integration fixture a TempDir-owned Factory data home
- pass that data home to every `factory init` spawned by `tests/workflows.rs`
- add a hidden explicit config loader for integration tests so workflow config loads stay hermetic without unsafe process-global env mutation

## Verification

- `cargo test --locked --test workflows`
- `cargo test --locked --test runtime aborting_a_run_reaps_its_process_group_anchor` after one transient full-suite runtime failure
- `cargo test --locked --all-targets`
- `HOME=<unwritable-temp> CARGO_HOME=<existing-cache> RUSTC=<resolved-rustc> cargo test --locked --test workflows`
- before/after `find "$HOME/.factory" -mindepth 1 -maxdepth 1` diff around `cargo test --locked --test workflows` produced no changes

## Review

- fresh independent review of final diff: no blocking findings
