### PR TITLE
fix: keep daemon alive after host sleep

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -157,13 +158,23 @@ impl FactoryDaemon {
         let owner = DaemonOwner::new()?;
         ledger.register_daemon_owner(&owner.id, owner.pid)?;
         let owner_heartbeat_shutdown = CancellationToken::new();
+        let owner_resumed_after_pause = Arc::new(AtomicBool::new(false));
         let owner_heartbeat_task = {
             let ledger_path = self.ledger_path.clone();
             let owner_id = owner.id.clone();
+            let owner_pid = owner.pid;
+            let resumed_after_pause = owner_resumed_after_pause.clone();
             let shutdown = owner_heartbeat_shutdown.clone();
             let daemon_cancellation = cancellation.clone();
             tokio::spawn(async move {
-                let result = maintain_owner_lease(&ledger_path, &owner_id, shutdown).await;
+                let result = maintain_owner_lease(
+                    &ledger_path,
+                    &owner_id,
+                    owner_pid,
+                    resumed_after_pause,
+                    shutdown,
+                )
+                .await;
                 if let Err(error) = &result {
                     eprintln!("Factory daemon owner heartbeat failed: {error:#}");
                     daemon_cancellation.cancel();
@@ -236,6 +247,9 @@ impl FactoryDaemon {
 
         let loop_result: Result<()> = async {
             loop {
+                if renew_owner_lease(&mut ledger, &owner)? {
+                    owner_resumed_after_pause.store(true, Ordering::Release);
+                }
                 dispatch_available(
                     &mut ledger,
                     &targets,
@@ -253,27 +267,38 @@ impl FactoryDaemon {
                     &mut retention_warning_shown,
                     &cancellation,
                     &owner,
+                    &owner_resumed_after_pause,
                 )?;
 
                 tokio::select! {
                     _ = cancellation.cancelled() => return Ok(()),
                     _ = recovery_interval.tick() => {
-                        ledger.heartbeat_daemon_owner(&owner.id)?;
-                        reconcile_recovery_state(
+                        if reconcile_recovery_state_for_owner(
                             &mut ledger,
                             &self.ledger_path,
                             &self.config.repositories[0],
                             &self.config.workspace_root,
                             self.sandbox.as_ref().map(SandboxWorker::github_token_env),
-                        )?;
+                            &owner,
+                        )? {
+                            owner_resumed_after_pause.store(true, Ordering::Release);
+                        }
                     }
                     _ = schedule_interval.tick() => {
-                        schedules = initialize_schedules(
-                            &mut ledger,
-                            &targets,
-                            Utc::now(),
-                            &owner.id,
-                        );
+                        if renew_owner_lease(&mut ledger, &owner)? {
+                            owner_resumed_after_pause.store(true, Ordering::Release);
+                        }
+                        let now = Utc::now();
+                        schedules = if owner_resumed_after_pause.swap(false, Ordering::AcqRel) {
+                            initialize_schedules_after_pause(
+                                &mut ledger,
+                                &targets,
+                                now,
+                                &owner.id,
+                            )
+                        } else {
+                            initialize_schedules(&mut ledger, &targets, now, &owner.id)
+                        };
                         evaluate_schedules(&mut ledger, &mut schedules, Utc::now());
                     }
                     completed = source_polls.join_next(), if !source_polls.is_empty() => {
@@ -501,6 +526,49 @@ fn reconcile_recovery_state(
     clone_token_env: Option<&str>,
 ) -> Result<()> {
     report_recovery(ledger.recover_orphaned_runs()?);
+    reconcile_recovery_workspaces(
+        ledger,
+        ledger_path,
+        canonical_repository,
+        workspace_root,
+        clone_token_env,
+    )
+}
+
+fn reconcile_recovery_state_for_owner(
+    ledger: &mut Ledger,
+    ledger_path: &Path,
+    canonical_repository: &Path,
+    workspace_root: &Path,
+    clone_token_env: Option<&str>,
+    owner: &DaemonOwner,
+) -> Result<bool> {
+    let (resumed_after_pause, report) = ledger
+        .renew_daemon_owner_and_recover_orphaned_runs(&owner.id, owner.pid)
+        .with_context(|| {
+            format!(
+                "failed to renew daemon owner {:?} for PID {} during recovery",
+                owner.id, owner.pid
+            )
+        })?;
+    report_recovery(report);
+    reconcile_recovery_workspaces(
+        ledger,
+        ledger_path,
+        canonical_repository,
+        workspace_root,
+        clone_token_env,
+    )?;
+    Ok(resumed_after_pause)
+}
+
+fn reconcile_recovery_workspaces(
+    ledger: &mut Ledger,
+    ledger_path: &Path,
+    canonical_repository: &Path,
+    workspace_root: &Path,
+    clone_token_env: Option<&str>,
+) -> Result<()> {
     reconcile_pending_cleanup(
         ledger,
         canonical_repository,
@@ -806,6 +874,8 @@ fn report_recovery(report: crate::storage::RecoveryReport) {
 async fn maintain_owner_lease(
     ledger_path: &Path,
     owner_id: &str,
+    owner_pid: u32,
+    resumed_after_pause: Arc<AtomicBool>,
     shutdown: CancellationToken,
 ) -> Result<()> {
     let mut ledger = Ledger::open(ledger_path)?;
@@ -814,9 +884,29 @@ async fn maintain_owner_lease(
     loop {
         tokio::select! {
             _ = shutdown.cancelled() => return Ok(()),
-            _ = interval.tick() => ledger.heartbeat_daemon_owner(owner_id)?,
+            _ = interval.tick() => {
+                let resumed = ledger
+                    .renew_daemon_owner(owner_id, owner_pid)
+                    .with_context(|| format!(
+                    "failed to renew daemon owner {owner_id:?} for PID {owner_pid}"
+                    ))?;
+                if resumed {
+                    resumed_after_pause.store(true, Ordering::Release);
+                }
+            }
         }
     }
+}
+
+fn renew_owner_lease(ledger: &mut Ledger, owner: &DaemonOwner) -> Result<bool> {
+    ledger
+        .renew_daemon_owner(&owner.id, owner.pid)
+        .with_context(|| {
+            format!(
+                "failed to renew daemon owner {:?} for PID {}",
+                owner.id, owner.pid
+            )
+        })
 }
 
 fn resolve_workflow_target(entry: &WorkflowEntry) -> Option<(String, WorkflowTarget)> {
@@ -849,6 +939,7 @@ fn dispatch_available(
     retention_warning_shown: &mut bool,
     cancellation: &CancellationToken,
     owner: &DaemonOwner,
+    owner_resumed_after_pause: &AtomicBool,
 ) -> Result<()> {
     while runs.len() < global_limit && !cancellation.is_cancelled() {
         let available = targets
@@ -891,15 +982,19 @@ fn dispatch_available(
             *retention_warning_shown = false;
         }
         let mut worker_ledger = Ledger::open(ledger_path)?;
-        let Some(claimed) = ledger.claim_and_start_run_with_workdirs_filtered(
-            &available,
-            &workflow_runtimes,
-            &owner.id,
-            owner.pid,
-            &working_directories,
-            delivery_slots_available,
-        )?
-        else {
+        let (resumed_after_pause, claimed) = ledger
+            .renew_daemon_owner_and_claim_with_workdirs_filtered(
+                &available,
+                &workflow_runtimes,
+                &owner.id,
+                owner.pid,
+                &working_directories,
+                delivery_slots_available,
+            )?;
+        if resumed_after_pause {
+            owner_resumed_after_pause.store(true, Ordering::Release);
+        }
+        let Some(claimed) = claimed else {
             break;
         };
         let task = claimed.task;
@@ -2198,12 +2293,48 @@ fn initialize_schedules_preserving_due(
     initialize_schedules_with_policy(ledger, targets, startup_at, owner_id, true)
 }
 
+fn initialize_schedules_after_pause(
+    ledger: &mut Ledger,
+    targets: &HashMap<String, RepositoryTarget>,
+    startup_at: DateTime<Utc>,
+    owner_id: &str,
+) -> Vec<ScheduledTarget> {
+    initialize_schedules_with_policy_after_pause(ledger, targets, startup_at, owner_id)
+}
+
 fn initialize_schedules_with_policy(
     ledger: &mut Ledger,
     targets: &HashMap<String, RepositoryTarget>,
     startup_at: DateTime<Utc>,
     owner_id: &str,
     preserve_existing_due: bool,
+) -> Vec<ScheduledTarget> {
+    initialize_schedules_with_options(
+        ledger,
+        targets,
+        startup_at,
+        owner_id,
+        preserve_existing_due,
+        false,
+    )
+}
+
+fn initialize_schedules_with_policy_after_pause(
+    ledger: &mut Ledger,
+    targets: &HashMap<String, RepositoryTarget>,
+    startup_at: DateTime<Utc>,
+    owner_id: &str,
+) -> Vec<ScheduledTarget> {
+    initialize_schedules_with_options(ledger, targets, startup_at, owner_id, false, true)
+}
+
+fn initialize_schedules_with_options(
+    ledger: &mut Ledger,
+    targets: &HashMap<String, RepositoryTarget>,
+    startup_at: DateTime<Utc>,
+    owner_id: &str,
+    preserve_existing_due: bool,
+    resumed_after_pause: bool,
 ) -> Vec<ScheduledTarget> {
     let mut schedules = Vec::new();
     for (repository, target) in targets {
@@ -2226,7 +2357,13 @@ fn initialize_schedules_with_policy(
                     target.timeout,
                     &target.prompt,
                 )?;
-                let cursor = ledger.initialize_schedule_cursor(
+                let initialize_cursor = if resumed_after_pause {
+                    Ledger::initialize_schedule_cursor_after_pause
+                } else {
+                    Ledger::initialize_schedule_cursor
+                };
+                let cursor = initialize_cursor(
+                    ledger,
                     repository,
                     workflow,
                     &fingerprint,
@@ -2526,6 +2663,396 @@ mod tests {
                 )]),
             },
         )])
+    }
+
+    #[test]
+    fn resumed_daemon_reconciles_and_claims_without_cancelling_active_work() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("ledger.db");
+        let targets = scheduled_targets(temp.path(), "* * * * *", chrono_tz::UTC);
+        let owner = DaemonOwner {
+            id: "resumed-owner".to_owned(),
+            pid: std::process::id(),
+        };
+        let mut ledger = Ledger::open(&path).unwrap();
+        ledger.register_daemon_owner(&owner.id, owner.pid).unwrap();
+        let schedules = initialize_schedules(
+            &mut ledger,
+            &targets,
+            utc("2026-07-18T12:00:10Z"),
+            &owner.id,
+        );
+        assert_eq!(schedules[0].next_due, utc("2026-07-18T12:01:00Z"));
+
+        ledger
+            .enqueue(
+                &TaskIdentity::ticket("example/repo", "active-work", "#1", "revision-1").unwrap(),
+            )
+            .unwrap();
+        let runtimes = HashMap::from([
+            (
+                (
+                    "example/repo".to_owned(),
+                    "active-work".to_owned(),
+                    "ticket".to_owned(),
+                ),
+                "codex".to_owned(),
+            ),
+            (
+                (
+                    "example/repo".to_owned(),
+                    "next-work".to_owned(),
+                    "ticket".to_owned(),
+                ),
+                "codex".to_owned(),
+            ),
+        ]);
+        let active_run = ledger
+            .claim_and_start_run(
+                &["example/repo".to_owned()],
+                &runtimes,
+                &owner.id,
+                owner.pid,
+            )
+            .unwrap()
+            .unwrap()
+            .run;
+        ledger
+            .enqueue(
+                &TaskIdentity::ticket("example/repo", "next-work", "#2", "revision-2").unwrap(),
+            )
+            .unwrap();
+        rusqlite::Connection::open(&path)
+            .unwrap()
+            .execute(
+                "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+                [&owner.id],
+            )
+            .unwrap();
+
+        let (resumed_after_pause, recovery) = ledger
+            .renew_daemon_owner_and_recover_orphaned_runs(&owner.id, owner.pid)
+            .unwrap();
+        assert!(resumed_after_pause);
+        assert!(recovery.recovered_run_ids.is_empty());
+        assert_eq!(
+            ledger.run(active_run.id).unwrap().unwrap().outcome,
+            "running"
+        );
+
+        let mut resumed = initialize_schedules_after_pause(
+            &mut ledger,
+            &targets,
+            utc("2026-07-18T12:02:10Z"),
+            &owner.id,
+        );
+        assert_eq!(resumed[0].next_due, utc("2026-07-18T12:03:00Z"));
+        evaluate_schedules(&mut ledger, &mut resumed, utc("2026-07-18T12:02:10Z"));
+        assert_eq!(
+            ledger
+                .tasks()
+                .unwrap()
+                .iter()
+                .filter(|task| task.kind == "scheduled")
+                .count(),
+            0
+        );
+
+        rusqlite::Connection::open(&path)
+            .unwrap()
+            .execute(
+                "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+                [&owner.id],
+            )
+            .unwrap();
+        let (claim_resumed_after_pause, claimed) = ledger
+            .renew_daemon_owner_and_claim_with_workdirs_filtered(
+                &["example/repo".to_owned()],
+                &runtimes,
+                &owner.id,
+                owner.pid,
+                &HashMap::from([("example/repo".to_owned(), temp.path().display().to_string())]),
+                true,
+            )
+            .unwrap();
+        assert!(claim_resumed_after_pause);
+        let claimed = claimed.unwrap();
+        assert_eq!(claimed.task.workflow, "next-work");
+        assert_eq!(
+            ledger.run(active_run.id).unwrap().unwrap().outcome,
+            "running"
+        );
+        let after_claim_pause = initialize_schedules_after_pause(
+            &mut ledger,
+            &targets,
+            utc("2026-07-18T12:04:10Z"),
+            &owner.id,
+        );
+        assert_eq!(after_claim_pause[0].next_due, utc("2026-07-18T12:05:00Z"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn daemon_run_keeps_an_active_worker_and_claims_later_work_after_a_stale_heartbeat() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        use std::process::Command;
+
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("repository");
+        let remote = temp.path().join("origin.git");
+        let workspace_root = temp.path().join("worktrees");
+        let data_directory = temp.path().join("data");
+        fs::create_dir_all(repository.join(".factory/workflows")).unwrap();
+        fs::create_dir(&workspace_root).unwrap();
+        let git = |directory: &Path, arguments: &[&str]| {
+            let output = Command::new("git")
+                .args(arguments)
+                .current_dir(directory)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {} failed: {}",
+                arguments.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&repository, &["init", "-q", "-b", "main"]);
+        git(
+            &repository,
+            &["config", "user.email", "factory@example.test"],
+        );
+        git(&repository, &["config", "user.name", "Factory Test"]);
+        fs::write(repository.join("README.md"), "fixture\n").unwrap();
+        git(&repository, &["add", "README.md"]);
+        git(&repository, &["commit", "-q", "-m", "fixture"]);
+        git(
+            temp.path(),
+            &[
+                "clone",
+                "-q",
+                "--bare",
+                repository.to_str().unwrap(),
+                remote.to_str().unwrap(),
+            ],
+        );
+        git(
+            &repository,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:example/repository.git",
+            ],
+        );
+        git(
+            &repository,
+            &[
+                "config",
+                &format!("url.file://{}.insteadOf", remote.display()),
+                "git@github.com:example/repository.git",
+            ],
+        );
+        let repository = repository.canonicalize().unwrap();
+
+        let workflow = repository.join(".factory/workflows/implement.md");
+        fs::write(&workflow, "Implement the source ticket.\n").unwrap();
+        let source_mode = temp.path().join("source-mode");
+        fs::write(&source_mode, "one\n").unwrap();
+        let source = temp.path().join("source");
+        fs::write(
+            &source,
+            format!(
+                r#"#!/bin/sh
+first='{{"key":"1","title":"First","state":"ready","labels":["factory"],"url":"https://example.test/1","revision":"one"}}'
+if [ "$(cat '{}')" = "two" ]; then
+  second='{{"key":"2","title":"Second","state":"ready","labels":["factory"],"url":"https://example.test/2","revision":"two"}}'
+  printf '{{"issues":[%s,%s]}}\n' "$first" "$second"
+else
+  printf '{{"issues":[%s]}}\n' "$first"
+fi
+"#,
+                source_mode.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&source).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&source, permissions).unwrap();
+
+        let invocation_count = temp.path().join("codex-count");
+        let first_started = temp.path().join("first-started");
+        let release_first = temp.path().join("release-first");
+        let codex = temp.path().join("codex");
+        fs::write(
+            &codex,
+            format!(
+                r#"#!/bin/sh
+if [ "$1" = "--version" ]; then echo "codex-cli 1.2.3"; exit 0; fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then echo "Logged in using ChatGPT"; exit 0; fi
+count=0
+if [ -f '{count}' ]; then count=$(cat '{count}'); fi
+count=$((count + 1))
+printf '%s\n' "$count" > '{count}'
+output=''
+previous=''
+for argument in "$@"; do
+  if [ "$previous" = "--output-last-message" ]; then output="$argument"; fi
+  previous="$argument"
+done
+cat >/dev/null
+if [ "$count" -eq 1 ]; then
+  touch '{started}'
+  while [ ! -f '{release}' ]; do sleep 0.02; done
+fi
+printf 'completed %s' "$count" > "$output"
+printf '{{"type":"thread.started","thread_id":"thread-%s"}}\n' "$count"
+"#,
+                count = invocation_count.display(),
+                started = first_started.display(),
+                release = release_first.display(),
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&codex).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&codex, permissions).unwrap();
+
+        let gh = temp.path().join("gh");
+        fs::write(
+            &gh,
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then echo "gh version 2.80.0"; exit 0; fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then echo authenticated; exit 0; fi
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  case "$*" in
+    *defaultBranchRef*) echo "main" ;;
+    *) echo "example/repository" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "repos/example/repository" ]; then
+  printf '{"default_branch":"main"}'
+  exit 0
+fi
+echo "unexpected gh command: $*" >&2
+exit 1
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&gh).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&gh, permissions).unwrap();
+
+        let config = Config {
+            repositories: vec![repository.clone()],
+            poll_every: Duration::from_millis(25),
+            default_runtime: "codex".to_owned(),
+            default_timeout: Duration::from_secs(60),
+            maximum_timeout: Duration::from_secs(120),
+            max_concurrent_runs: 1,
+            max_concurrent_runs_per_repository: 1,
+            workspace_root,
+            data_directory: data_directory.clone(),
+            execution_mode: crate::config::ExecutionMode::Worktree,
+            worker: None,
+            triggers: vec![crate::config::TriggerConfig {
+                id: "implement".to_owned(),
+                workflow,
+                timeout: Duration::from_secs(60),
+                kind: crate::config::TriggerKind::Source {
+                    state: "ready".to_owned(),
+                    labels: vec!["factory".to_owned()],
+                },
+            }],
+            source: Some(SourceConfig {
+                command: vec![source.display().to_string()],
+                owner: String::new(),
+                project_number: 0,
+                status_field: String::new(),
+                trusted_users: Vec::new(),
+            }),
+        };
+        let catalog = WorkflowCatalog::load(&config).unwrap();
+        let ledger_path = data_directory.join("factory.db");
+        let daemon = FactoryDaemon::with_clients(
+            config,
+            catalog,
+            &ledger_path,
+            GitHubClient::new(gh),
+            CodexRuntime::new(codex),
+        );
+        let cancellation = CancellationToken::new();
+        let daemon_cancellation = cancellation.clone();
+        let daemon_task = tokio::spawn(async move { daemon.run(daemon_cancellation).await });
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while !first_started.exists() {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap();
+        rusqlite::Connection::open(&ledger_path)
+            .unwrap()
+            .execute("UPDATE daemon_owners SET heartbeat_at = 0", [])
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                let heartbeat: i64 = rusqlite::Connection::open(&ledger_path)
+                    .unwrap()
+                    .query_row("SELECT MAX(heartbeat_at) FROM daemon_owners", [], |row| {
+                        row.get(0)
+                    })
+                    .unwrap();
+                if heartbeat > 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(!daemon_task.is_finished());
+
+        fs::write(&source_mode, "two\n").unwrap();
+        fs::write(&release_first, "release\n").unwrap();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let ledger = Ledger::open(&ledger_path).unwrap();
+                let second_succeeded = ledger.runs(None).unwrap().iter().any(|run| {
+                    run.source_item.as_deref() == Some("2") && run.outcome == "succeeded"
+                });
+                if fs::read_to_string(&invocation_count).is_ok_and(|count| count.trim() == "2")
+                    && second_succeeded
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .unwrap();
+
+        cancellation.cancel();
+        daemon_task.await.unwrap().unwrap();
+        let ledger = Ledger::open(&ledger_path).unwrap();
+        let runs = ledger.runs(None).unwrap();
+        assert_eq!(
+            runs.iter()
+                .find(|run| run.source_item.as_deref() == Some("1"))
+                .unwrap()
+                .outcome,
+            "succeeded"
+        );
+        assert_eq!(
+            runs.iter()
+                .find(|run| run.source_item.as_deref() == Some("2"))
+                .unwrap()
+                .outcome,
+            "succeeded"
+        );
     }
 
     #[test]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1562,6 +1562,48 @@ impl Ledger {
         startup_at: i64,
         owner_id: &str,
     ) -> Result<ScheduleCursor> {
+        self.initialize_schedule_cursor_with_policy(
+            repository,
+            workflow,
+            fingerprint,
+            next_due_at,
+            startup_at,
+            owner_id,
+            false,
+        )
+    }
+
+    pub fn initialize_schedule_cursor_after_pause(
+        &mut self,
+        repository: &str,
+        workflow: &str,
+        fingerprint: &str,
+        next_due_at: i64,
+        startup_at: i64,
+        owner_id: &str,
+    ) -> Result<ScheduleCursor> {
+        self.initialize_schedule_cursor_with_policy(
+            repository,
+            workflow,
+            fingerprint,
+            next_due_at,
+            startup_at,
+            owner_id,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn initialize_schedule_cursor_with_policy(
+        &mut self,
+        repository: &str,
+        workflow: &str,
+        fingerprint: &str,
+        next_due_at: i64,
+        startup_at: i64,
+        owner_id: &str,
+        resumed_after_pause: bool,
+    ) -> Result<ScheduleCursor> {
         if repository.trim().is_empty()
             || workflow.trim().is_empty()
             || fingerprint.trim().is_empty()
@@ -1639,7 +1681,7 @@ impl Ledger {
                 if prior_fingerprint == fingerprint
                     && (prior_due > startup_at
                         || other_matching_owner
-                        || current_owner_matches) =>
+                        || (current_owner_matches && !resumed_after_pause)) =>
             {
                 prior_due
             }
@@ -1817,8 +1859,51 @@ impl Ledger {
         working_directories: &HashMap<String, String>,
         allow_new_ticket_tasks: bool,
     ) -> Result<Option<ClaimedRun>> {
+        self.claim_and_start_run_with_workdirs_filtered_inner(
+            available_repositories,
+            workflow_runtimes,
+            owner_id,
+            owner_pid,
+            working_directories,
+            allow_new_ticket_tasks,
+            false,
+        )
+        .map(|(_, claimed)| claimed)
+    }
+
+    pub fn renew_daemon_owner_and_claim_with_workdirs_filtered(
+        &mut self,
+        available_repositories: &[String],
+        workflow_runtimes: &HashMap<(String, String, String), String>,
+        owner_id: &str,
+        owner_pid: u32,
+        working_directories: &HashMap<String, String>,
+        allow_new_ticket_tasks: bool,
+    ) -> Result<(bool, Option<ClaimedRun>)> {
+        self.claim_and_start_run_with_workdirs_filtered_inner(
+            available_repositories,
+            workflow_runtimes,
+            owner_id,
+            owner_pid,
+            working_directories,
+            allow_new_ticket_tasks,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn claim_and_start_run_with_workdirs_filtered_inner(
+        &mut self,
+        available_repositories: &[String],
+        workflow_runtimes: &HashMap<(String, String, String), String>,
+        owner_id: &str,
+        owner_pid: u32,
+        working_directories: &HashMap<String, String>,
+        allow_new_ticket_tasks: bool,
+        renew_owner: bool,
+    ) -> Result<(bool, Option<ClaimedRun>)> {
         if available_repositories.is_empty() {
-            return Ok(None);
+            return Ok((false, None));
         }
         let available = available_repositories
             .iter()
@@ -1828,6 +1913,37 @@ impl Ledger {
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("failed to begin atomic task and run claim")?;
         let now = now_millis()?;
+        let resumed_after_pause = if renew_owner {
+            let previous_heartbeat = transaction
+                .query_row(
+                    "SELECT heartbeat_at FROM daemon_owners
+                     WHERE owner_id = ?1 AND pid = ?2",
+                    params![owner_id, owner_pid],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()
+                .context("failed to inspect daemon owner during task claim")?
+                .with_context(|| {
+                    format!(
+                        "daemon owner {owner_id:?} is missing, fenced, or belongs to a different PID"
+                    )
+                })?;
+            let changed = transaction
+                .execute(
+                    "UPDATE daemon_owners SET heartbeat_at = ?1
+                     WHERE owner_id = ?2 AND pid = ?3",
+                    params![now, owner_id, owner_pid],
+                )
+                .context("failed to renew daemon owner during task claim")?;
+            if changed != 1 {
+                bail!(
+                    "daemon owner {owner_id:?} is missing, fenced, or belongs to a different PID"
+                );
+            }
+            previous_heartbeat < now.saturating_sub(DAEMON_OWNER_LEASE_MILLIS)
+        } else {
+            false
+        };
         let owner_is_live = transaction
             .query_row(
                 "SELECT EXISTS(
@@ -1954,7 +2070,7 @@ impl Ledger {
             transaction
                 .commit()
                 .context("failed to finish empty task claim")?;
-            return Ok(None);
+            return Ok((resumed_after_pause, None));
         };
         let runtime = workflow_runtimes
             .get(&(
@@ -2021,7 +2137,7 @@ impl Ledger {
         transaction
             .commit()
             .context("failed to commit atomic task and run claim")?;
-        Ok(Some(ClaimedRun { task, run }))
+        Ok((resumed_after_pause, Some(ClaimedRun { task, run })))
     }
 
     fn claim_next_matching(&mut self, repositories: Option<&str>) -> Result<Option<Task>> {
@@ -2513,10 +2629,85 @@ impl Ledger {
     }
 
     pub fn recover_orphaned_runs(&mut self) -> Result<RecoveryReport> {
+        self.recover_orphaned_runs_inner(None)
+            .map(|(_, report)| report)
+    }
+
+    pub fn renew_daemon_owner_and_recover_orphaned_runs(
+        &mut self,
+        owner_id: &str,
+        owner_pid: u32,
+    ) -> Result<(bool, RecoveryReport)> {
+        self.recover_orphaned_runs_inner(Some((owner_id, owner_pid)))
+    }
+
+    fn recover_orphaned_runs_inner(
+        &mut self,
+        renewing_owner: Option<(&str, u32)>,
+    ) -> Result<(bool, RecoveryReport)> {
         let transaction = self
             .connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
             .context("failed to begin orphan recovery transaction")?;
+        let recovery_now = now_millis()?;
+        let lease_cutoff = recovery_now.saturating_sub(DAEMON_OWNER_LEASE_MILLIS);
+        let resumed_after_pause = if let Some((owner_id, owner_pid)) = renewing_owner {
+            let registered = transaction
+                .query_row(
+                    "SELECT pid, heartbeat_at FROM daemon_owners WHERE owner_id = ?1",
+                    [owner_id],
+                    |row| Ok((row.get::<_, u32>(0)?, row.get::<_, i64>(1)?)),
+                )
+                .optional()
+                .context("failed to inspect daemon owner during orphan recovery")?;
+            let previous_heartbeat = match registered {
+                Some((registered_pid, _)) if registered_pid != owner_pid => bail!(
+                    "daemon owner {owner_id:?} belongs to PID {registered_pid}, not recovering as PID {owner_pid}"
+                ),
+                Some((_, previous_heartbeat)) => previous_heartbeat,
+                None => bail!("daemon owner {owner_id:?} is fenced or not registered"),
+            };
+            let changed = transaction
+                .execute(
+                    "UPDATE daemon_owners SET heartbeat_at = ?1
+                     WHERE owner_id = ?2 AND pid = ?3",
+                    params![recovery_now, owner_id, owner_pid],
+                )
+                .context("failed to renew daemon owner during orphan recovery")?;
+            if changed != 1 {
+                bail!("daemon owner {owner_id:?} changed while recovery renewed its lease");
+            }
+            previous_heartbeat < lease_cutoff
+        } else {
+            false
+        };
+        let owners = {
+            let mut statement = transaction
+                .prepare("SELECT owner_id, pid, heartbeat_at FROM daemon_owners")
+                .context("failed to prepare daemon owner fencing query")?;
+            statement
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, u32>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                })
+                .context("failed to query daemon owners for fencing")?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .context("failed to read daemon owners for fencing")?
+        };
+        for (owner_id, owner_pid, heartbeat_at) in owners {
+            if heartbeat_at >= lease_cutoff && process_is_alive(owner_pid) {
+                continue;
+            }
+            transaction
+                .execute(
+                    "DELETE FROM daemon_owners WHERE owner_id = ?1 AND pid = ?2",
+                    params![owner_id, owner_pid],
+                )
+                .context("failed to fence stale daemon owner during orphan recovery")?;
+        }
         let active = {
             let mut statement = transaction
                 .prepare("SELECT * FROM runs WHERE outcome = 'running' ORDER BY id")
@@ -2529,7 +2720,6 @@ impl Ledger {
         };
         let mut recovered_run_ids = Vec::new();
         let mut exhausted_run_ids = Vec::new();
-        let lease_cutoff = now_millis()?.saturating_sub(DAEMON_OWNER_LEASE_MILLIS);
         for run in active {
             let owner_is_live = match (&run.owner_id, run.owner_pid) {
                 (Some(owner_id), Some(owner_pid)) => {
@@ -2547,6 +2737,15 @@ impl Ledger {
             };
             if owner_is_live {
                 continue;
+            }
+            if let (Some(owner_id), Some(owner_pid)) = (&run.owner_id, run.owner_pid) {
+                transaction
+                    .execute(
+                        "DELETE FROM daemon_owners
+                         WHERE owner_id = ?1 AND pid = ?2",
+                        params![owner_id, owner_pid],
+                    )
+                    .context("failed to fence stale daemon owner during orphan recovery")?;
             }
             if let (Some(process_id), Some(recorded_identity)) =
                 (run.process_id, run.process_identity.as_deref())
@@ -2608,10 +2807,13 @@ impl Ledger {
         transaction
             .commit()
             .context("failed to commit orphan recovery")?;
-        Ok(RecoveryReport {
-            recovered_run_ids,
-            exhausted_run_ids,
-        })
+        Ok((
+            resumed_after_pause,
+            RecoveryReport {
+                recovered_run_ids,
+                exhausted_run_ids,
+            },
+        ))
     }
 
     pub fn register_daemon_owner(&mut self, owner_id: &str, pid: u32) -> Result<()> {
@@ -2631,20 +2833,36 @@ impl Ledger {
         Ok(())
     }
 
-    pub fn heartbeat_daemon_owner(&mut self, owner_id: &str) -> Result<()> {
+    pub fn renew_daemon_owner(&mut self, owner_id: &str, pid: u32) -> Result<bool> {
+        let registered = self
+            .connection
+            .query_row(
+                "SELECT pid, heartbeat_at FROM daemon_owners WHERE owner_id = ?1",
+                [owner_id],
+                |row| Ok((row.get::<_, u32>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()
+            .context("failed to inspect daemon owner before renewal")?;
+        let (registered_pid, previous_heartbeat) = match registered {
+            Some((registered_pid, _)) if registered_pid != pid => bail!(
+                "daemon owner {owner_id:?} belongs to PID {registered_pid}, not renewing PID {pid}"
+            ),
+            Some(registered) => registered,
+            None => bail!("daemon owner {owner_id:?} is not registered"),
+        };
         let now = now_millis()?;
         let changed = self
             .connection
             .execute(
                 "UPDATE daemon_owners SET heartbeat_at = ?1
-                 WHERE owner_id = ?2 AND heartbeat_at >= ?3",
-                params![now, owner_id, now - DAEMON_OWNER_LEASE_MILLIS],
+                 WHERE owner_id = ?2 AND pid = ?3",
+                params![now, owner_id, registered_pid],
             )
-            .context("failed to update daemon owner heartbeat")?;
+            .context("failed to renew daemon owner heartbeat")?;
         if changed != 1 {
-            bail!("daemon owner {owner_id:?} is not registered or its lease expired");
+            bail!("daemon owner {owner_id:?} changed while its lease was being renewed");
         }
-        Ok(())
+        Ok(previous_heartbeat < now.saturating_sub(DAEMON_OWNER_LEASE_MILLIS))
     }
 
     pub fn remove_daemon_owner(&mut self, owner_id: &str) -> Result<()> {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -331,8 +331,9 @@ impl WorkspaceManager {
     fn remove_orphaned(&self, path: &Path) -> Result<CleanupPreview> {
         let path = absolute_lexical(path)?;
         if path.exists() {
-            fs::remove_dir_all(&path)
-                .with_context(|| format!("failed to remove orphaned workspace {}", path.display()))?;
+            fs::remove_dir_all(&path).with_context(|| {
+                format!("failed to remove orphaned workspace {}", path.display())
+            })?;
         }
         Ok(CleanupPreview {
             path,

--- a/tests/source_polling.rs
+++ b/tests/source_polling.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use factory::config::{Config, ExecutionMode, SourceConfig, TriggerConfig, TriggerKind};
@@ -165,4 +166,52 @@ async fn source_conditions_are_passed_and_matching_work_is_revalidated() {
         .unwrap();
     assert_eq!(reentered.tasks_created(), 1);
     assert_eq!(ledger.tasks().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn failed_source_command_is_reported_and_polling_continues() {
+    let (_temp, config, catalog, mut ledger, source_path) = fixture();
+    let attempts_path = config.repositories[0].join(".source-attempts");
+    fs::write(
+        &source_path,
+        format!(
+            "#!/bin/sh\n\
+             attempts_file='{}'\n\
+             attempts=0\n\
+             if [ -f \"$attempts_file\" ]; then attempts=$(cat \"$attempts_file\"); fi\n\
+             attempts=$((attempts + 1))\n\
+             printf '%s\\n' \"$attempts\" > \"$attempts_file\"\n\
+             if [ \"$attempts\" -eq 1 ]; then printf '%s\\n' 'rate limited' >&2; exit 1; fi\n\
+             printf '%s\\n' '{{\"issues\":[]}}'\n",
+            attempts_path.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&source_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&source_path, permissions).unwrap();
+
+    let cancellation = CancellationToken::new();
+    let stop = cancellation.clone();
+    let reports = Arc::new(Mutex::new(Vec::new()));
+    let captured = reports.clone();
+    SourceClient
+        .poll_until_cancelled(
+            &config,
+            &catalog,
+            &mut ledger,
+            cancellation,
+            move |report| {
+                let mut captured = captured.lock().unwrap();
+                captured.push((report.failures(), report.tasks_created()));
+                if captured.len() == 2 {
+                    stop.cancel();
+                }
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(*reports.lock().unwrap(), vec![(1, 0), (0, 0)]);
+    assert_eq!(fs::read_to_string(attempts_path).unwrap(), "2\n");
 }

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -593,13 +593,11 @@ fn schedule_cursor_atomically_enqueues_advances_and_skips_downtime() {
         .unwrap();
     assert!(
         ledger
-            .heartbeat_daemon_owner("schedule-storage-owner")
-            .unwrap_err()
-            .to_string()
-            .contains("lease expired")
+            .renew_daemon_owner("schedule-storage-owner", std::process::id())
+            .unwrap()
     );
     let after_sleep = ledger
-        .initialize_schedule_cursor(
+        .initialize_schedule_cursor_after_pause(
             "owainlewis/factory",
             "find-bugs",
             "* * * * *|UTC",
@@ -974,6 +972,57 @@ fn expired_daemon_owner_cannot_claim_or_start_work() {
 }
 
 #[test]
+fn stale_daemon_owner_can_only_be_renewed_by_its_registered_identity_and_pid() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    let pid = std::process::id();
+    ledger.register_daemon_owner("sleeping-owner", pid).unwrap();
+    Connection::open(&path)
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+            ["sleeping-owner"],
+        )
+        .unwrap();
+
+    let wrong_pid = ledger
+        .renew_daemon_owner("sleeping-owner", pid.saturating_add(1))
+        .unwrap_err();
+    assert!(format!("{wrong_pid:#}").contains("belongs to PID"));
+    let wrong_owner = ledger
+        .renew_daemon_owner("different-owner", pid)
+        .unwrap_err();
+    assert!(format!("{wrong_owner:#}").contains("is not registered"));
+
+    let connection = Connection::open(&path).unwrap();
+    let stored: (u32, i64) = connection
+        .query_row(
+            "SELECT pid, heartbeat_at FROM daemon_owners WHERE owner_id = ?1",
+            ["sleeping-owner"],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(stored, (pid, 0));
+    let rows: i64 = connection
+        .query_row("SELECT COUNT(*) FROM daemon_owners", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 1);
+    drop(connection);
+
+    assert!(ledger.renew_daemon_owner("sleeping-owner", pid).unwrap());
+    let heartbeat: i64 = Connection::open(&path)
+        .unwrap()
+        .query_row(
+            "SELECT heartbeat_at FROM daemon_owners WHERE owner_id = ?1",
+            ["sleeping-owner"],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(heartbeat > 0);
+}
+
+#[test]
 fn owner_lease_is_checked_after_waiting_for_the_claim_lock() {
     let temp = tempfile::tempdir().unwrap();
     let path = temp.path().join("ledger.db");
@@ -1026,6 +1075,91 @@ fn owner_lease_is_checked_after_waiting_for_the_claim_lock() {
         TaskState::Queued
     );
     assert!(ledger.runs(None).unwrap().is_empty());
+}
+
+#[test]
+fn daemon_claim_renews_the_owner_after_waiting_past_the_lease() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut setup = Ledger::open(&path).unwrap();
+    setup.enqueue(&ticket("renewing-claim-lock-wait")).unwrap();
+    setup
+        .register_daemon_owner("renewing-claim-owner", std::process::id())
+        .unwrap();
+    let now = i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+    )
+    .unwrap();
+    Connection::open(&path)
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = ?1 WHERE owner_id = ?2",
+            rusqlite::params![now - 9_500, "renewing-claim-owner"],
+        )
+        .unwrap();
+    drop(setup);
+
+    let mut claimant = Ledger::open(&path).unwrap();
+    let blocker = Connection::open(&path).unwrap();
+    blocker.execute_batch("BEGIN IMMEDIATE;").unwrap();
+    let barrier = Arc::new(Barrier::new(2));
+    let waiting = {
+        let barrier = Arc::clone(&barrier);
+        thread::spawn(move || {
+            barrier.wait();
+            claimant.renew_daemon_owner_and_claim_with_workdirs_filtered(
+                &["owainlewis/factory".to_owned()],
+                &ticket_runtimes(),
+                "renewing-claim-owner",
+                std::process::id(),
+                &HashMap::from([(
+                    "owainlewis/factory".to_owned(),
+                    "/worktrees/factory-3".to_owned(),
+                )]),
+                true,
+            )
+        })
+    };
+    barrier.wait();
+    thread::sleep(Duration::from_millis(700));
+    blocker.execute_batch("COMMIT;").unwrap();
+
+    let (resumed_after_pause, claimed) = waiting.join().unwrap().unwrap();
+    assert!(resumed_after_pause);
+    let claimed = claimed.unwrap();
+    assert_eq!(claimed.task.state, TaskState::Running);
+    assert_eq!(
+        claimed.run.owner_id.as_deref(),
+        Some("renewing-claim-owner")
+    );
+}
+
+#[test]
+fn orphan_recovery_fences_a_stale_idle_owner() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("ledger.db");
+    let mut ledger = Ledger::open(&path).unwrap();
+    ledger
+        .register_daemon_owner("idle-stale-owner", std::process::id())
+        .unwrap();
+    Connection::open(&path)
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+            ["idle-stale-owner"],
+        )
+        .unwrap();
+
+    let report = ledger.recover_orphaned_runs().unwrap();
+    assert!(report.recovered_run_ids.is_empty());
+    assert!(report.exhausted_run_ids.is_empty());
+    let error = ledger
+        .renew_daemon_owner("idle-stale-owner", std::process::id())
+        .unwrap_err();
+    assert!(format!("{error:#}").contains("is not registered"));
 }
 
 #[test]
@@ -1339,11 +1473,21 @@ fn orphan_recovery_is_deduplicated_bounded_and_excludes_terminal_runs() {
             Some("PR https://github.com/owainlewis/factory/pull/99 SECRET=hunter2"),
         )
         .unwrap();
-    ledger.remove_daemon_owner("interrupted-owner").unwrap();
+    Connection::open(&path)
+        .unwrap()
+        .execute(
+            "UPDATE daemon_owners SET heartbeat_at = 0 WHERE owner_id = ?1",
+            ["interrupted-owner"],
+        )
+        .unwrap();
 
     let report = ledger.recover_orphaned_runs().unwrap();
     assert_eq!(report.recovered_run_ids, [interrupted.id]);
     assert!(report.exhausted_run_ids.is_empty());
+    let fenced = ledger
+        .renew_daemon_owner("interrupted-owner", std::process::id())
+        .unwrap_err();
+    assert!(format!("{fenced:#}").contains("is not registered"));
     let report = ledger.recover_orphaned_runs().unwrap();
     assert!(report.recovered_run_ids.is_empty());
     assert!(report.exhausted_run_ids.is_empty());
@@ -1651,7 +1795,11 @@ fn concurrent_completion_and_cancellation_always_leave_a_terminal_run() {
         .unwrap();
 
     for index in 0..25 {
-        setup.heartbeat_daemon_owner("race-owner").unwrap();
+        assert!(
+            !setup
+                .renew_daemon_owner("race-owner", std::process::id())
+                .unwrap()
+        );
         let task = setup
             .enqueue(&ticket(&format!("race-revision-{index}")))
             .unwrap()


### PR DESCRIPTION
Closes #104

## Summary

- allow an existing daemon owner to renew an expired heartbeat only when both owner identity and PID still match
- renew atomically inside daemon claim and recovery transactions, while fencing stale or dead owners to prevent split-brain revival
- carry pause detection into schedule reconciliation so the existing skip-backlog and deduplication policy is preserved
- keep active workers alive when the same daemon resumes, and continue polling after source command failures
- include the formatter-only correction already required by failing `main` CI in `src/workspace.rs`

## Acceptance coverage

- matching owner/PID can renew after the 10-second lease; missing owners, mismatched IDs, and mismatched PIDs fail without mutation
- daemon claim and recovery paths renew after lock acquisition using one transaction and timestamp
- stale active and idle owners are fenced during takeover, so old daemons cannot revive after orphan recovery
- a real `FactoryDaemon::run` regression keeps an active worker alive after an aged durable heartbeat, then polls, claims, and completes later work
- resumed schedules retain the existing missed-occurrence policy and do not duplicate occurrences
- source polling records a non-zero command exit and successfully performs a later poll
- existing cancellation, timeout, startup recovery, orphan recovery, and PID-reuse tests remain green

## Verification

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets`
- `git diff --check`
- fresh independent review: approved with no blocker or important findings

## Limitations

- host sleep is simulated by aging the durable heartbeat while the real daemon and worker lifecycle run; an actual OS suspend/resume is not automated
- concurrent-daemon takeover is covered at the transactional storage boundary rather than with two full daemon processes
