### PR TITLE
Add pluggable AgentRuntime abstraction with Claude Code support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +222,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -328,6 +339,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-trait",
  "chrono",
  "chrono-tz",
  "clap",
@@ -693,7 +705,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -895,7 +907,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -983,6 +995,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,7 +1041,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1044,7 +1067,7 @@ checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1189,7 +1212,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -1245,7 +1268,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1256,7 +1279,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 anyhow = "1.0"
+async-trait = "0.1"
 clap = { version = "4.5", features = ["derive"] }
 chrono = "0.4"
 chrono-tz = "0.10"

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::hash::encode_lower;
+use crate::runtime::build_runtime;
 use crate::storage::DATABASE_NAME;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -260,8 +261,15 @@ impl Config {
         let execution_mode = raw.worker.sandbox;
         let source = resolve_source(raw.source)?;
         let default_runtime = raw.worker.runtime.trim().to_owned();
-        if default_runtime != "codex" {
-            bail!("worker.runtime must be \"codex\" in this build");
+        if build_runtime(&default_runtime, false).is_err() {
+            bail!(
+                "worker.runtime {default_runtime:?} is not a known runtime; supported: codex, codex-minimal, claude-code"
+            );
+        }
+        if execution_mode == ExecutionMode::DockerSandbox && default_runtime != "codex" {
+            bail!(
+                "worker.runtime must be \"codex\" when worker.sandbox is \"docker_sandbox\" in this build"
+            );
         }
 
         let poll_every = parse_positive_duration("poll_every", &raw.poll_every)?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -18,8 +19,8 @@ use crate::config::{Config, SourceConfig};
 use crate::github::{GitHubClient, LabelTicketContext, ProjectTicketContext, TicketContext};
 use crate::hash::sha256_hex_prefix;
 use crate::runtime::{
-    CodexRuntime, ExecutionResult, RuntimeCancelled, RuntimeObservation, Termination,
-    observation_channel,
+    AgentRuntime, ExecutionResult, RuntimeCancelled, RuntimeObservation, Termination,
+    build_runtime, observation_channel,
 };
 use crate::sandbox::{SandboxRunFailure, SandboxWorker};
 use crate::source::{PollReport, SourceClient, SourceTicketContext};
@@ -84,7 +85,7 @@ pub struct FactoryDaemon {
     ledger_path: PathBuf,
     github: GitHubClient,
     source: SourceClient,
-    codex: CodexRuntime,
+    runtime: Arc<dyn AgentRuntime>,
     sandbox: Option<SandboxWorker>,
 }
 
@@ -95,12 +96,14 @@ pub struct OneShotReport {
 
 impl FactoryDaemon {
     pub fn new(config: Config, catalog: WorkflowCatalog, ledger_path: impl Into<PathBuf>) -> Self {
+        let runtime = build_runtime(&config.default_runtime, false)
+            .expect("config.default_runtime was already validated at config-load time");
         Self::with_clients(
             config,
             catalog,
             ledger_path,
             GitHubClient::default(),
-            CodexRuntime::default().with_activity_streaming(false),
+            Arc::from(runtime),
         )
     }
 
@@ -109,7 +112,7 @@ impl FactoryDaemon {
         catalog: WorkflowCatalog,
         ledger_path: impl Into<PathBuf>,
         github: GitHubClient,
-        codex: CodexRuntime,
+        runtime: Arc<dyn AgentRuntime>,
     ) -> Self {
         let sandbox = config.worker.clone().map(|worker| {
             SandboxWorker::new(worker, sandbox_instance_id(&config.data_directory))
@@ -121,7 +124,7 @@ impl FactoryDaemon {
             ledger_path: ledger_path.into(),
             github,
             source: SourceClient,
-            codex: codex.with_activity_streaming(false),
+            runtime,
             sandbox,
         }
     }
@@ -244,7 +247,7 @@ impl FactoryDaemon {
                     self.config.max_concurrent_runs,
                     self.config.max_concurrent_runs_per_repository,
                     &self.ledger_path,
-                    &self.codex,
+                    &self.runtime,
                     self.sandbox.as_ref(),
                     &self.github,
                     &self.source,
@@ -421,7 +424,7 @@ impl FactoryDaemon {
             return Ok(());
         }
         match self
-            .codex
+            .runtime
             .health_check_with_cancellation(cancellation.clone())
             .await
         {
@@ -840,7 +843,7 @@ fn dispatch_available(
     global_limit: usize,
     repository_limit: usize,
     ledger_path: &Path,
-    codex: &CodexRuntime,
+    runtime: &Arc<dyn AgentRuntime>,
     sandbox: Option<&SandboxWorker>,
     github: &GitHubClient,
     source_client: &SourceClient,
@@ -936,21 +939,6 @@ fn dispatch_available(
         } else {
             None
         };
-        if workflow.runtime != "codex" {
-            let error = format!(
-                "unsupported runtime {:?}; Factory v1 supports codex",
-                workflow.runtime
-            );
-            worker_ledger.finish_run_and_task(
-                run_id,
-                RunOutcome::Failed,
-                None,
-                Some(&error),
-                None,
-            )?;
-            eprintln!("Factory rejected claimed task {}: {error}", task.id);
-            continue;
-        }
         let source = match (task.kind.as_str(), task.source_item.as_deref()) {
             ("ticket", Some(issue)) => format!("issue={issue}"),
             (kind, Some(source)) => format!("{kind}={source}"),
@@ -961,7 +949,7 @@ fn dispatch_available(
             task.id, task.repository, task.workflow
         );
         *active.entry(repository.clone()).or_default() += 1;
-        let codex = codex.clone();
+        let runtime = Arc::clone(runtime);
         let sandbox = sandbox.cloned();
         let github = github.clone();
         let source_client = source_client.clone();
@@ -1132,7 +1120,7 @@ fn dispatch_available(
                     worker_ledger,
                     &execution_target,
                     &workflow,
-                    &codex,
+                    &runtime,
                     run_id,
                     prompt,
                     cancellation,
@@ -1516,7 +1504,7 @@ async fn execute_task(
     ledger: Ledger,
     repository: &RepositoryTarget,
     workflow: &WorkflowTarget,
-    codex: &CodexRuntime,
+    runtime: &Arc<dyn AgentRuntime>,
     run_id: i64,
     prompt: String,
     cancellation: CancellationToken,
@@ -1527,7 +1515,7 @@ async fn execute_task(
         ledger,
         repository,
         workflow,
-        codex,
+        runtime,
         run_id,
         prompt,
         cancellation,
@@ -1767,7 +1755,7 @@ async fn execute_task_inner(
     mut ledger: Ledger,
     repository: &RepositoryTarget,
     workflow: &WorkflowTarget,
-    codex: &CodexRuntime,
+    runtime: &Arc<dyn AgentRuntime>,
     run_id: i64,
     prompt: String,
     cancellation: CancellationToken,
@@ -1785,15 +1773,17 @@ async fn execute_task_inner(
         observation_receiver,
     );
     let execution = if let Some(session_id) = recovery_session.as_deref() {
-        let resumed = codex
-            .run_with_session_supervised(
+        let resumed = runtime
+            .run(
                 &prompt,
                 &repository.path,
                 workflow.timeout,
                 run_cancellation.clone(),
                 Some(session_id),
                 observations.clone(),
-                |observation| persist_run_anchor(&ledger_path, run_id, observation),
+                Some(Box::new(|observation| {
+                    persist_run_anchor(&ledger_path, run_id, observation)
+                })),
             )
             .await;
         let needs_fallback = match &resumed {
@@ -1839,15 +1829,17 @@ async fn execute_task_inner(
                     fallback_receiver,
                 );
                 let remaining = execution_deadline.saturating_duration_since(Instant::now());
-                codex
-                    .run_with_session_supervised(
+                runtime
+                    .run(
                         &fallback_prompt,
                         &repository.path,
                         remaining,
                         run_cancellation.clone(),
                         None,
                         observations.clone(),
-                        |observation| persist_run_anchor(&ledger_path, run_id, observation),
+                        Some(Box::new(|observation| {
+                            persist_run_anchor(&ledger_path, run_id, observation)
+                        })),
                     )
                     .await
             }
@@ -1855,15 +1847,17 @@ async fn execute_task_inner(
             resumed
         }
     } else {
-        codex
-            .run_with_session_supervised(
+        runtime
+            .run(
                 &prompt,
                 &repository.path,
                 workflow.timeout,
                 run_cancellation.clone(),
                 None,
                 observations.clone(),
-                |observation| persist_run_anchor(&ledger_path, run_id, observation),
+                Some(Box::new(|observation| {
+                    persist_run_anchor(&ledger_path, run_id, observation)
+                })),
             )
             .await
     };

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1646,7 +1646,7 @@ async fn execute_sandbox_task(
                 )?;
                 return Err(error.context(detail));
             }
-            record_execution(&mut ledger, run_id, &result)?;
+            record_execution(&mut ledger, run_id, "codex", &result)?;
             ledger.finish_run_sandbox(
                 run_id,
                 "removing",
@@ -1883,7 +1883,7 @@ async fn execute_task_inner(
                 Termination::Exited => "failed",
             };
             let detail = format_execution_detail(&result);
-            record_execution(&mut ledger, run_id, &result)?;
+            record_execution(&mut ledger, run_id, &workflow.runtime, &result)?;
             Ok((outcome, detail))
         }
         Err(error) => {
@@ -2360,20 +2360,20 @@ fn next_occurrence(
     Ok(candidate)
 }
 
-fn record_execution(ledger: &mut Ledger, run_id: i64, result: &ExecutionResult) -> Result<()> {
+fn execution_outcome(runtime: &str, result: &ExecutionResult) -> (RunOutcome, Option<String>) {
     let (outcome, error) = match result.termination {
         Termination::Cancelled => (
             RunOutcome::Cancelled,
-            Some("Codex execution cancelled".to_owned()),
+            Some(format!("{runtime} execution cancelled")),
         ),
         Termination::TimedOut => (
             RunOutcome::Failed,
-            Some("Codex execution timed out".to_owned()),
+            Some(format!("{runtime} execution timed out")),
         ),
         Termination::Exited if result.status.success() && result.activity_error.is_some() => (
             RunOutcome::Failed,
             Some(format!(
-                "Codex emitted malformed JSON activity: {}",
+                "{runtime} emitted malformed JSON activity: {}",
                 result.activity_error.as_deref().unwrap_or("unknown error")
             )),
         ),
@@ -2381,11 +2381,21 @@ fn record_execution(ledger: &mut Ledger, run_id: i64, result: &ExecutionResult) 
         Termination::Exited => (
             RunOutcome::Failed,
             Some(format!(
-                "Codex exited with status {}; stderr: {}",
-                result.status, result.stderr_tail
+                "{runtime} exited with status {}; stderr: {}",
+                result.status, result.stderr_tail,
             )),
         ),
     };
+    (outcome, error)
+}
+
+fn record_execution(
+    ledger: &mut Ledger,
+    run_id: i64,
+    runtime: &str,
+    result: &ExecutionResult,
+) -> Result<()> {
+    let (outcome, error) = execution_outcome(runtime, result);
     let finish = if result.termination == Termination::TimedOut {
         Ledger::finish_run_and_task_terminal
     } else {
@@ -2413,6 +2423,9 @@ fn decrement_active(active: &mut HashMap<String, usize>, repository: &str) {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::os::unix::process::ExitStatusExt;
+
     use super::*;
 
     #[test]
@@ -2428,6 +2441,36 @@ mod tests {
             None
         );
         assert_eq!(latest_worker_progress(None), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_execution_errors_name_the_configured_runtime() {
+        let mut result = ExecutionResult {
+            status: std::process::ExitStatus::from_raw(17 << 8),
+            termination: Termination::Exited,
+            final_response: String::new(),
+            final_response_truncated: false,
+            thread_id: None,
+            duration: Duration::ZERO,
+            activity_lines: 0,
+            activity_error: None,
+            stderr_tail: "login failed".to_owned(),
+        };
+
+        let (_, error) = execution_outcome("claude-code", &result);
+        assert_eq!(
+            error.as_deref(),
+            Some("claude-code exited with status exit status: 17; stderr: login failed")
+        );
+
+        result.termination = Termination::TimedOut;
+        let (_, error) = execution_outcome("claude-code", &result);
+        assert_eq!(error.as_deref(), Some("claude-code execution timed out"));
+
+        result.termination = Termination::Cancelled;
+        let (_, error) = execution_outcome("codex-minimal", &result);
+        assert_eq!(error.as_deref(), Some("codex-minimal execution cancelled"));
     }
 
     fn utc(value: &str) -> DateTime<Utc> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,8 @@ use factory::inspection::{
     RunInspection, RunView, TaskView, print_inspection, print_runs, print_tasks,
 };
 use factory::runtime::{
-    CodexRuntime, RuntimeCancelled, Termination, write_stderr_best_effort, write_stdout_best_effort,
+    RuntimeCancelled, Termination, build_runtime, observation_channel, write_stderr_best_effort,
+    write_stdout_best_effort,
 };
 use factory::sandbox::SandboxWorker;
 use factory::source::{PollReport, SourceClient};
@@ -288,7 +289,7 @@ async fn run_cli() -> Result<u8> {
                     .validate(&cancellation)
                     .await?;
             } else {
-                CodexRuntime::default()
+                build_runtime(&config.default_runtime, true)?
                     .health_check_with_cancellation(cancellation)
                     .await?;
             }
@@ -909,14 +910,6 @@ async fn run_workflow(
             );
         }
     }
-    if workflow.runtime != "codex" {
-        bail!(
-            "workflow {:?} resolves to unsupported runtime {:?}; Factory v1 supports codex",
-            workflow.id,
-            workflow.runtime
-        );
-    }
-
     let cancellation = CancellationToken::new();
     let signal_token = cancellation.clone();
     let signal_task = tokio::spawn(async move {
@@ -924,7 +917,7 @@ async fn run_workflow(
             signal_token.cancel();
         }
     });
-    let runtime = CodexRuntime::default();
+    let runtime = build_runtime(&workflow.runtime, true)?;
     let health = match runtime
         .health_check_with_cancellation(cancellation.clone())
         .await
@@ -938,7 +931,8 @@ async fn run_workflow(
     };
     write_stderr_best_effort(
         format!(
-            "Codex ready: {} ({})\nRunning workflow {:?} in {} with timeout {}\n",
+            "Runtime {:?} ready: {} ({})\nRunning workflow {:?} in {} with timeout {}\n",
+            workflow.runtime,
             health.version,
             health.authentication,
             workflow.id,
@@ -947,12 +941,16 @@ async fn run_workflow(
         )
         .as_bytes(),
     );
+    let (observations, _receiver) = observation_channel();
     let result = runtime
         .run(
             &workflow.prompt,
             &workflow.working_directory,
             workflow.timeout,
             cancellation,
+            None,
+            observations,
+            None,
         )
         .await?;
     signal_task.abort();

--- a/src/main.rs
+++ b/src/main.rs
@@ -958,6 +958,13 @@ async fn run_workflow(
     if !result.final_response.is_empty() {
         write_final_response(&result.final_response);
     }
+    if workflow.runtime != "codex" && !result.succeeded() && !result.stderr_tail.is_empty() {
+        let mut stderr = result.stderr_tail.as_bytes().to_vec();
+        if !result.stderr_tail.ends_with('\n') {
+            stderr.push(b'\n');
+        }
+        write_stderr_best_effort(&stderr);
+    }
     write_stderr_best_effort(
         format!(
             "Run finished: status={} termination={:?} duration={} thread={} activity_lines={} activity_error={} response_truncated={}\n",

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,6 +9,7 @@ use std::sync::mpsc::{Receiver, SyncSender, sync_channel};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use serde_json::Value;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
@@ -65,13 +66,55 @@ pub struct RuntimeObservation {
     pub sequence: u64,
 }
 
-type BeforeCodexSpawn<'a> = Box<dyn FnOnce(&RuntimeObservation) -> Result<()> + Send + 'a>;
+pub type BeforeSpawn<'a> = Box<dyn FnOnce(&RuntimeObservation) -> Result<()> + Send + 'a>;
 
 pub fn observation_channel() -> (
     watch::Sender<RuntimeObservation>,
     watch::Receiver<RuntimeObservation>,
 ) {
     watch::channel(RuntimeObservation::default())
+}
+
+/// A pluggable agent execution backend (Codex, Claude Code, ...). Callers
+/// obtain one via `build_runtime`; direct construction of a concrete type is
+/// only needed by the registry itself.
+#[async_trait]
+pub trait AgentRuntime: Send + Sync {
+    async fn health_check_with_cancellation(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<RuntimeHealth>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run(
+        &self,
+        prompt: &str,
+        working_directory: &Path,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+        resume_session: Option<&str>,
+        observations: watch::Sender<RuntimeObservation>,
+        before_spawn: Option<BeforeSpawn<'_>>,
+    ) -> Result<ExecutionResult>;
+}
+
+/// Resolve a configured runtime name to a concrete `AgentRuntime`. This is
+/// the single source of truth for which runtime names are valid.
+///
+/// `stream_activity` only affects Codex (its rich JSON activity protocol can
+/// be echoed live to stdout/stderr); the generic runtimes never stream, so
+/// it's ignored for them.
+pub fn build_runtime(name: &str, stream_activity: bool) -> Result<Box<dyn AgentRuntime>> {
+    match name {
+        "codex" => Ok(Box::new(
+            CodexRuntime::default().with_activity_streaming(stream_activity),
+        )),
+        "codex-minimal" => Ok(Box::new(GenericRuntime::new(codex_minimal_preset()))),
+        "claude-code" => Ok(Box::new(GenericRuntime::new(claude_code_preset()))),
+        other => bail!(
+            "unknown runtime {other:?}; supported runtimes: codex, codex-minimal, claude-code"
+        ),
+    }
 }
 
 #[derive(Debug)]
@@ -361,7 +404,7 @@ impl CodexRuntime {
         cancellation: CancellationToken,
         resume_session: Option<&str>,
         observations: watch::Sender<RuntimeObservation>,
-        before_spawn: Option<BeforeCodexSpawn<'_>>,
+        before_spawn: Option<BeforeSpawn<'_>>,
     ) -> Result<ExecutionResult> {
         let started = Instant::now();
         let deadline = TokioInstant::now() + run_timeout;
@@ -630,6 +673,40 @@ impl CodexRuntime {
             bail!("Codex {check} check returned no output");
         }
         Ok(detail)
+    }
+}
+
+#[async_trait]
+impl AgentRuntime for CodexRuntime {
+    async fn health_check_with_cancellation(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<RuntimeHealth> {
+        // Resolves to the inherent method above (inherent methods take
+        // priority over trait methods of the same name).
+        CodexRuntime::health_check_with_cancellation(self, cancellation).await
+    }
+
+    async fn run(
+        &self,
+        prompt: &str,
+        working_directory: &Path,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+        resume_session: Option<&str>,
+        observations: watch::Sender<RuntimeObservation>,
+        before_spawn: Option<BeforeSpawn<'_>>,
+    ) -> Result<ExecutionResult> {
+        self.run_with_session_inner(
+            prompt,
+            working_directory,
+            run_timeout,
+            cancellation,
+            resume_session,
+            observations,
+            before_spawn,
+        )
+        .await
     }
 }
 
@@ -1305,6 +1382,235 @@ async fn stop_process_group_anchor(anchor: &mut Child, process_id: u32) -> Resul
         .await
         .context("failed to reap Codex process-group anchor")?;
     Ok(())
+}
+
+/// Static description of a non-Codex agent CLI: the executable, the args to
+/// run it with (the prompt is delivered over stdin, appended after these),
+/// and the args used to confirm the binary is installed and runnable.
+pub struct GenericPreset {
+    pub executable: &'static str,
+    pub run_args: Vec<&'static str>,
+    pub health_check_args: Vec<&'static str>,
+}
+
+fn codex_minimal_preset() -> GenericPreset {
+    GenericPreset {
+        executable: "codex",
+        run_args: vec!["exec", "--sandbox", "danger-full-access", "--color", "never", "-"],
+        health_check_args: vec!["--version"],
+    }
+}
+
+fn claude_code_preset() -> GenericPreset {
+    GenericPreset {
+        executable: "claude",
+        run_args: vec!["--print", "--permission-mode", "bypassPermissions"],
+        health_check_args: vec!["--version"],
+    }
+}
+
+/// A generic subprocess runtime: spawn the configured executable, pipe the
+/// prompt in over stdin, capture stdout/stderr as opaque text. Unlike
+/// `CodexRuntime` it does not parse any structured activity protocol, so it
+/// has no thread ID, live activity summaries, PR-URL scraping, or session
+/// resume — `ExecutionResult`/`RuntimeObservation` fields tied to those stay
+/// `None`. This is the trade-off accepted for supporting arbitrary agent
+/// CLIs: a working integration over rich per-run telemetry.
+pub struct GenericRuntime {
+    preset: GenericPreset,
+}
+
+impl GenericRuntime {
+    pub fn new(preset: GenericPreset) -> Self {
+        Self { preset }
+    }
+}
+
+#[async_trait]
+impl AgentRuntime for GenericRuntime {
+    async fn health_check_with_cancellation(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<RuntimeHealth> {
+        let mut command = Command::new(self.preset.executable);
+        command
+            .args(&self.preset.health_check_args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        configure_process_group(&mut command);
+        let mut child = spawn_with_retry(&mut command)
+            .await
+            .with_context(|| format!("could not execute {}", self.preset.executable))?;
+        let process_id = child.id();
+        let stdout = child
+            .stdout
+            .take()
+            .context("health check did not expose stdout")?;
+        let stderr = child
+            .stderr
+            .take()
+            .context("health check did not expose stderr")?;
+        let stdout_task = tokio::spawn(read_pipe_bounded(stdout, MAX_HEALTH_OUTPUT_BYTES));
+        let stderr_task = tokio::spawn(read_pipe_bounded(stderr, MAX_HEALTH_OUTPUT_BYTES));
+
+        let deadline = TokioInstant::now() + DEFAULT_HEALTH_TIMEOUT;
+        let status = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => {
+                terminate(&mut child, process_id, process_id).await?;
+                join_reader(stdout_task, "health-check stdout").await?;
+                join_reader(stderr_task, "health-check stderr").await?;
+                return Err(RuntimeCancelled.into());
+            }
+            () = sleep_until(deadline) => {
+                terminate(&mut child, process_id, process_id).await?;
+                join_reader(stdout_task, "health-check stdout").await?;
+                join_reader(stderr_task, "health-check stderr").await?;
+                bail!(
+                    "{} health check timed out after {}",
+                    self.preset.executable,
+                    humantime::format_duration(DEFAULT_HEALTH_TIMEOUT)
+                );
+            }
+            status = wait_for_clean_exit(&mut child, process_id, process_id) => {
+                status.context("failed while waiting for health check")?
+            }
+        };
+        let stdout =
+            String::from_utf8_lossy(&join_reader(stdout_task, "health-check stdout").await?)
+                .trim()
+                .to_owned();
+        let stderr =
+            String::from_utf8_lossy(&join_reader(stderr_task, "health-check stderr").await?)
+                .trim()
+                .to_owned();
+        if !status.success() {
+            let detail = if stderr.is_empty() {
+                stdout.clone()
+            } else {
+                stderr.clone()
+            };
+            bail!(
+                "{} health check exited with {status}: {detail}",
+                self.preset.executable
+            );
+        }
+        let detail = if stdout.is_empty() { stderr } else { stdout };
+        if detail.is_empty() {
+            bail!("{} health check returned no output", self.preset.executable);
+        }
+        Ok(RuntimeHealth {
+            version: detail,
+            authentication: "n/a".to_owned(),
+        })
+    }
+
+    async fn run(
+        &self,
+        prompt: &str,
+        working_directory: &Path,
+        run_timeout: Duration,
+        cancellation: CancellationToken,
+        _resume_session: Option<&str>,
+        _observations: watch::Sender<RuntimeObservation>,
+        _before_spawn: Option<BeforeSpawn<'_>>,
+    ) -> Result<ExecutionResult> {
+        let started = Instant::now();
+        let deadline = TokioInstant::now() + run_timeout;
+        if let Some(termination) = preparation_termination(&cancellation, deadline) {
+            return Ok(preparation_result(termination, started));
+        }
+        let mut command = Command::new(self.preset.executable);
+        command
+            .args(&self.preset.run_args)
+            .current_dir(working_directory)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        configure_process_group(&mut command);
+        let mut child = spawn_with_retry(&mut command)
+            .await
+            .with_context(|| format!("failed to start {} CLI", self.preset.executable))?;
+        let process_id = child.id();
+        let mut stdin = child
+            .stdin
+            .take()
+            .context("process did not expose stdin")?;
+        let stdout = child
+            .stdout
+            .take()
+            .context("process did not expose stdout")?;
+        let stderr = child
+            .stderr
+            .take()
+            .context("process did not expose stderr")?;
+        let stdout_task = tokio::spawn(read_pipe_bounded(stdout, MAX_FINAL_RESPONSE_BYTES));
+        let stderr_task = tokio::spawn(read_pipe_bounded(stderr, MAX_STDERR_BYTES));
+
+        let deliver_prompt = async {
+            stdin
+                .write_all(prompt.as_bytes())
+                .await
+                .context("failed to send prompt")?;
+            stdin.shutdown().await.context("failed to close stdin")?;
+            drop(stdin);
+            Result::<()>::Ok(())
+        };
+        tokio::pin!(deliver_prompt);
+        let early_termination = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => Some(Termination::Cancelled),
+            () = sleep_until(deadline) => Some(Termination::TimedOut),
+            delivery = &mut deliver_prompt => {
+                if let Err(error) = delivery
+                    && !is_broken_pipe(&error)
+                {
+                    let _ = terminate(&mut child, process_id, process_id).await;
+                    let _ = join_reader(stdout_task, "stdout").await;
+                    let _ = join_reader(stderr_task, "stderr").await;
+                    return Err(error);
+                }
+                None
+            }
+        };
+
+        let (status, termination) = if let Some(termination) = early_termination {
+            (terminate(&mut child, process_id, process_id).await?, termination)
+        } else {
+            tokio::select! {
+                biased;
+                () = cancellation.cancelled() => {
+                    (terminate(&mut child, process_id, process_id).await?, Termination::Cancelled)
+                }
+                () = sleep_until(deadline) => {
+                    (terminate(&mut child, process_id, process_id).await?, Termination::TimedOut)
+                }
+                status = wait_for_clean_exit(&mut child, process_id, process_id) => {
+                    (status.context("failed while waiting for process")?, Termination::Exited)
+                }
+            }
+        };
+
+        let stdout_bytes = join_reader(stdout_task, "stdout").await?;
+        let stderr_bytes = join_reader(stderr_task, "stderr").await?;
+        let activity_lines = stdout_bytes.iter().filter(|byte| **byte == b'\n').count();
+        let final_response_truncated = stdout_bytes.len() >= MAX_FINAL_RESPONSE_BYTES;
+
+        Ok(ExecutionResult {
+            status,
+            termination,
+            final_response: String::from_utf8_lossy(&stdout_bytes).into_owned(),
+            final_response_truncated,
+            thread_id: None,
+            duration: started.elapsed(),
+            activity_lines,
+            activity_error: None,
+            stderr_tail: String::from_utf8_lossy(&stderr_bytes).into_owned(),
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1396,7 +1396,14 @@ pub struct GenericPreset {
 fn codex_minimal_preset() -> GenericPreset {
     GenericPreset {
         executable: "codex",
-        run_args: vec!["exec", "--sandbox", "danger-full-access", "--color", "never", "-"],
+        run_args: vec![
+            "exec",
+            "--sandbox",
+            "danger-full-access",
+            "--color",
+            "never",
+            "-",
+        ],
         health_check_args: vec!["--version"],
     }
 }
@@ -1514,8 +1521,8 @@ impl AgentRuntime for GenericRuntime {
         run_timeout: Duration,
         cancellation: CancellationToken,
         _resume_session: Option<&str>,
-        _observations: watch::Sender<RuntimeObservation>,
-        _before_spawn: Option<BeforeSpawn<'_>>,
+        observations: watch::Sender<RuntimeObservation>,
+        before_spawn: Option<BeforeSpawn<'_>>,
     ) -> Result<ExecutionResult> {
         let started = Instant::now();
         let deadline = TokioInstant::now() + run_timeout;
@@ -1530,15 +1537,52 @@ impl AgentRuntime for GenericRuntime {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
-        configure_process_group(&mut command);
-        let mut child = spawn_with_retry(&mut command)
-            .await
-            .with_context(|| format!("failed to start {} CLI", self.preset.executable))?;
+        let mut process_group = RunProcessGroup::start().await?;
+        process_group.configure(&mut command)?;
+        if let Some(termination) = preparation_termination(&cancellation, deadline) {
+            process_group.stop().await?;
+            return Ok(preparation_result(termination, started));
+        }
+        let anchor_observation = RuntimeObservation {
+            process_id: process_group.process_id,
+            process_identity: process_group.process_identity.clone(),
+            sequence: 1,
+            ..RuntimeObservation::default()
+        };
+        if let Some(before_spawn) = before_spawn
+            && let Err(error) = before_spawn(&anchor_observation)
+        {
+            process_group.stop().await.context(
+                "failed to stop generic runtime process group after persistence failure",
+            )?;
+            return Err(error);
+        }
+        observations.send_replace(anchor_observation);
+        if let Some(termination) = preparation_termination(&cancellation, deadline) {
+            process_group.stop().await?;
+            return Ok(preparation_result(termination, started));
+        }
+
+        let spawned = tokio::select! {
+            biased;
+            () = cancellation.cancelled() => Err(Termination::Cancelled),
+            () = sleep_until(deadline) => Err(Termination::TimedOut),
+            result = spawn_with_retry(&mut command) => Ok(result),
+        };
+        let mut child = match spawned {
+            Err(termination) => {
+                process_group.stop().await?;
+                return Ok(preparation_result(termination, started));
+            }
+            Ok(Ok(child)) => child,
+            Ok(Err(error)) => {
+                let _ = process_group.stop().await;
+                return Err(error)
+                    .with_context(|| format!("failed to start {} CLI", self.preset.executable));
+            }
+        };
         let process_id = child.id();
-        let mut stdin = child
-            .stdin
-            .take()
-            .context("process did not expose stdin")?;
+        let mut stdin = child.stdin.take().context("process did not expose stdin")?;
         let stdout = child
             .stdout
             .take()
@@ -1568,7 +1612,13 @@ impl AgentRuntime for GenericRuntime {
                 if let Err(error) = delivery
                     && !is_broken_pipe(&error)
                 {
-                    let _ = terminate(&mut child, process_id, process_id).await;
+                    let _ = terminate(
+                        &mut child,
+                        process_id,
+                        process_group.process_id.or(process_id),
+                    )
+                    .await;
+                    let _ = process_group.stop().await;
                     let _ = join_reader(stdout_task, "stdout").await;
                     let _ = join_reader(stderr_task, "stderr").await;
                     return Err(error);
@@ -1578,21 +1628,48 @@ impl AgentRuntime for GenericRuntime {
         };
 
         let (status, termination) = if let Some(termination) = early_termination {
-            (terminate(&mut child, process_id, process_id).await?, termination)
+            (
+                terminate(
+                    &mut child,
+                    process_id,
+                    process_group.process_id.or(process_id),
+                )
+                .await?,
+                termination,
+            )
         } else {
             tokio::select! {
                 biased;
                 () = cancellation.cancelled() => {
-                    (terminate(&mut child, process_id, process_id).await?, Termination::Cancelled)
+                    (
+                        terminate(
+                            &mut child,
+                            process_id,
+                            process_group.process_id.or(process_id),
+                        ).await?,
+                        Termination::Cancelled,
+                    )
                 }
                 () = sleep_until(deadline) => {
-                    (terminate(&mut child, process_id, process_id).await?, Termination::TimedOut)
+                    (
+                        terminate(
+                            &mut child,
+                            process_id,
+                            process_group.process_id.or(process_id),
+                        ).await?,
+                        Termination::TimedOut,
+                    )
                 }
-                status = wait_for_clean_exit(&mut child, process_id, process_id) => {
+                status = wait_for_clean_exit(
+                    &mut child,
+                    process_id,
+                    process_group.process_id.or(process_id),
+                ) => {
                     (status.context("failed while waiting for process")?, Termination::Exited)
                 }
             }
         };
+        process_group.reap().await?;
 
         let stdout_bytes = join_reader(stdout_task, "stdout").await?;
         let stderr_bytes = join_reader(stderr_task, "stderr").await?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1584,7 +1584,7 @@ impl AgentRuntime for GenericRuntime {
         working_directory: &Path,
         run_timeout: Duration,
         cancellation: CancellationToken,
-        _resume_session: Option<&str>,
+        resume_session: Option<&str>,
         observations: watch::Sender<RuntimeObservation>,
         before_spawn: Option<BeforeSpawn<'_>>,
     ) -> Result<ExecutionResult> {
@@ -1592,6 +1592,12 @@ impl AgentRuntime for GenericRuntime {
         let deadline = TokioInstant::now() + run_timeout;
         if let Some(termination) = preparation_termination(&cancellation, deadline) {
             return Ok(preparation_result(termination, started));
+        }
+        if resume_session.is_some() {
+            bail!(
+                "{} runtime does not support session resume",
+                self.preset.executable
+            );
         }
         let mut command = Command::new(self.preset.executable);
         command

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1391,6 +1391,10 @@ pub struct GenericPreset {
     pub executable: &'static str,
     pub run_args: Vec<&'static str>,
     pub health_check_args: Vec<&'static str>,
+    pub authentication_check_args: Vec<&'static str>,
+    pub authentication_help: &'static str,
+    pub authentication_summary: &'static str,
+    pub validate_authentication: fn(&str) -> Result<()>,
 }
 
 fn codex_minimal_preset() -> GenericPreset {
@@ -1405,6 +1409,10 @@ fn codex_minimal_preset() -> GenericPreset {
             "-",
         ],
         health_check_args: vec!["--version"],
+        authentication_check_args: vec!["login", "status"],
+        authentication_help: "run codex login and verify codex login status",
+        authentication_summary: "Logged in using ChatGPT",
+        validate_authentication: validate_codex_authentication,
     }
 }
 
@@ -1413,7 +1421,27 @@ fn claude_code_preset() -> GenericPreset {
         executable: "claude",
         run_args: vec!["--print", "--permission-mode", "bypassPermissions"],
         health_check_args: vec!["--version"],
+        authentication_check_args: vec!["auth", "status", "--json"],
+        authentication_help: "run claude auth login and verify claude auth status",
+        authentication_summary: "Authenticated with Claude Code",
+        validate_authentication: validate_claude_authentication,
     }
+}
+
+fn validate_codex_authentication(output: &str) -> Result<()> {
+    if !output.to_ascii_lowercase().contains("chatgpt") {
+        bail!("Codex must use ChatGPT subscription authentication, not an API key");
+    }
+    Ok(())
+}
+
+fn validate_claude_authentication(output: &str) -> Result<()> {
+    let status: Value = serde_json::from_str(output)
+        .context("Claude Code returned invalid authentication status")?;
+    if status.get("loggedIn").and_then(Value::as_bool) != Some(true) {
+        bail!("Claude Code is not logged in");
+    }
+    Ok(())
 }
 
 /// A generic subprocess runtime: spawn the configured executable, pipe the
@@ -1431,17 +1459,16 @@ impl GenericRuntime {
     pub fn new(preset: GenericPreset) -> Self {
         Self { preset }
     }
-}
 
-#[async_trait]
-impl AgentRuntime for GenericRuntime {
-    async fn health_check_with_cancellation(
+    async fn check_command(
         &self,
-        cancellation: CancellationToken,
-    ) -> Result<RuntimeHealth> {
+        args: &[&str],
+        check: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
         let mut command = Command::new(self.preset.executable);
         command
-            .args(&self.preset.health_check_args)
+            .args(args)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -1454,11 +1481,11 @@ impl AgentRuntime for GenericRuntime {
         let stdout = child
             .stdout
             .take()
-            .context("health check did not expose stdout")?;
+            .with_context(|| format!("{check} check did not expose stdout"))?;
         let stderr = child
             .stderr
             .take()
-            .context("health check did not expose stderr")?;
+            .with_context(|| format!("{check} check did not expose stderr"))?;
         let stdout_task = tokio::spawn(read_pipe_bounded(stdout, MAX_HEALTH_OUTPUT_BYTES));
         let stderr_task = tokio::spawn(read_pipe_bounded(stderr, MAX_HEALTH_OUTPUT_BYTES));
 
@@ -1476,13 +1503,13 @@ impl AgentRuntime for GenericRuntime {
                 join_reader(stdout_task, "health-check stdout").await?;
                 join_reader(stderr_task, "health-check stderr").await?;
                 bail!(
-                    "{} health check timed out after {}",
+                    "{} {check} check timed out after {}",
                     self.preset.executable,
                     humantime::format_duration(DEFAULT_HEALTH_TIMEOUT)
                 );
             }
             status = wait_for_clean_exit(&mut child, process_id, process_id) => {
-                status.context("failed while waiting for health check")?
+                status.with_context(|| format!("failed while waiting for {check} check"))?
             }
         };
         let stdout =
@@ -1494,23 +1521,60 @@ impl AgentRuntime for GenericRuntime {
                 .trim()
                 .to_owned();
         if !status.success() {
-            let detail = if stderr.is_empty() {
-                stdout.clone()
-            } else {
-                stderr.clone()
-            };
+            let detail = if stderr.is_empty() { &stdout } else { &stderr };
             bail!(
-                "{} health check exited with {status}: {detail}",
+                "{} {check} check exited with {status}: {detail}",
                 self.preset.executable
             );
         }
         let detail = if stdout.is_empty() { stderr } else { stdout };
         if detail.is_empty() {
-            bail!("{} health check returned no output", self.preset.executable);
+            bail!(
+                "{} {check} check returned no output",
+                self.preset.executable
+            );
         }
+        Ok(detail)
+    }
+}
+
+#[async_trait]
+impl AgentRuntime for GenericRuntime {
+    async fn health_check_with_cancellation(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<RuntimeHealth> {
+        let version = self
+            .check_command(&self.preset.health_check_args, "version", &cancellation)
+            .await
+            .with_context(|| {
+                format!(
+                    "{} version check failed; install it or make it executable",
+                    self.preset.executable
+                )
+            })?;
+        let authentication = self
+            .check_command(
+                &self.preset.authentication_check_args,
+                "authentication",
+                &cancellation,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "{} authentication check failed; {}",
+                    self.preset.executable, self.preset.authentication_help
+                )
+            })?;
+        (self.preset.validate_authentication)(&authentication).with_context(|| {
+            format!(
+                "{} authentication check failed; {}",
+                self.preset.executable, self.preset.authentication_help
+            )
+        })?;
         Ok(RuntimeHealth {
-            version: detail,
-            authentication: "n/a".to_owned(),
+            version,
+            authentication: self.preset.authentication_summary.to_owned(),
         })
     }
 
@@ -1723,5 +1787,14 @@ mod observation_tests {
             safe_activity_summary(&serde_json::json!({ "type": "item.completed" })),
             None
         );
+    }
+
+    #[test]
+    fn generic_authentication_validators_reject_unusable_credentials() {
+        assert!(validate_codex_authentication("Logged in using ChatGPT").is_ok());
+        assert!(validate_codex_authentication("Logged in with an API key").is_err());
+        assert!(validate_claude_authentication(r#"{"loggedIn":true}"#).is_ok());
+        assert!(validate_claude_authentication(r#"{"loggedIn":false}"#).is_err());
+        assert!(validate_claude_authentication("not json").is_err());
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -331,8 +331,9 @@ impl WorkspaceManager {
     fn remove_orphaned(&self, path: &Path) -> Result<CleanupPreview> {
         let path = absolute_lexical(path)?;
         if path.exists() {
-            fs::remove_dir_all(&path)
-                .with_context(|| format!("failed to remove orphaned workspace {}", path.display()))?;
+            fs::remove_dir_all(&path).with_context(|| {
+                format!("failed to remove orphaned workspace {}", path.display())
+            })?;
         }
         Ok(CleanupPreview {
             path,

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -166,6 +166,10 @@ if [ "$1" = "--version" ]; then
   echo "claude-code 1.2.3"
   exit 0
 fi
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  echo '{"loggedIn":true}'
+  exit 0
+fi
 cat >/dev/null
 echo "authentication required: run claude login" >&2
 exit 17

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -125,7 +125,9 @@ printf 'Read-only workflow complete.' > "$output"
             r#"{"type":"thread.started","thread_id":"manual-thread"}"#,
         ))
         .stdout(predicate::str::contains("Read-only workflow complete."))
-        .stderr(predicate::str::contains("Codex ready: codex-cli 1.2.3"))
+        .stderr(predicate::str::contains(
+            "Runtime \"codex\" ready: codex-cli 1.2.3",
+        ))
         .stderr(predicate::str::contains("thread=manual-thread"));
 
     let prompt = fs::read_to_string(prompt_capture).unwrap();

--- a/tests/manual_run.rs
+++ b/tests/manual_run.rs
@@ -139,6 +139,62 @@ printf 'Read-only workflow complete.' > "$output"
 }
 
 #[test]
+fn failed_generic_workflow_run_prints_stderr_diagnostics() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let workflows = repository.join(".factory/workflows");
+    let data_home = temp.path().join("factory-data");
+    let binaries = temp.path().join("bin");
+    fs::create_dir_all(&workflows).unwrap();
+    fs::create_dir(&binaries).unwrap();
+    initialize_repository(&repository, &data_home);
+    fs::write(
+        workflows.join("triage.md"),
+        "Inspect without changing files.\n",
+    )
+    .unwrap();
+    let config_path = repository.join(".factory/config.toml");
+    let config = fs::read_to_string(&config_path)
+        .unwrap()
+        .replace("runtime = \"codex\"", "runtime = \"claude-code\"");
+    fs::write(&config_path, config).unwrap();
+    let executable = binaries.join("claude");
+    fs::write(
+        &executable,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "claude-code 1.2.3"
+  exit 0
+fi
+cat >/dev/null
+echo "authentication required: run claude login" >&2
+exit 17
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    let path = format!(
+        "{}:{}",
+        binaries.display(),
+        env::var("PATH").unwrap_or_default()
+    );
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["workflow", "run", "triage"])
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", &data_home)
+        .env("PATH", path)
+        .assert()
+        .code(17)
+        .stderr(predicate::str::contains(
+            "authentication required: run claude login",
+        ));
+}
+
+#[test]
 fn run_executes_a_schedule_triggered_workflow_once() {
     let temp = tempfile::tempdir().unwrap();
     let repository = temp.path().join("repository");

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -6,7 +6,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use factory::runtime::{CodexRuntime, RuntimeCancelled, Termination, observation_channel};
+use factory::runtime::{
+    AgentRuntime, CodexRuntime, GenericPreset, GenericRuntime, RuntimeCancelled, Termination,
+    observation_channel,
+};
 use tokio_util::sync::CancellationToken;
 
 fn fake_codex(directory: &Path, execution: &str) -> PathBuf {
@@ -530,6 +533,53 @@ async fn failed_anchor_persistence_prevents_spawn_and_reaps_the_group() {
                 *captured_for_callback.lock().unwrap() = observation.process_id;
                 anyhow::bail!("simulated durable persistence failure")
             },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(format!("{error:#}").contains("simulated durable persistence failure"));
+    assert!(!started_path.exists());
+    let anchor_pid = captured_anchor.lock().unwrap().unwrap();
+    assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[tokio::test]
+async fn generic_runtime_persists_the_anchor_before_agent_spawn() {
+    let temp = tempfile::tempdir().unwrap();
+    let started_path = temp.path().join("agent-started");
+    let executable = fake_codex(
+        temp.path(),
+        &format!("touch \"{}\"", started_path.display()),
+    );
+    let executable = Box::leak(
+        executable
+            .into_os_string()
+            .into_string()
+            .unwrap()
+            .into_boxed_str(),
+    );
+    let runtime = GenericRuntime::new(GenericPreset {
+        executable,
+        run_args: Vec::new(),
+        health_check_args: vec!["--version"],
+    });
+    let captured_anchor = Arc::new(Mutex::new(None));
+    let captured_for_callback = Arc::clone(&captured_anchor);
+    let (observations, _receiver) = observation_channel();
+
+    let error = runtime
+        .run(
+            "Persist first.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+            None,
+            observations,
+            Some(Box::new(move |observation| {
+                *captured_for_callback.lock().unwrap() = observation.process_id;
+                anyhow::bail!("simulated durable persistence failure")
+            })),
         )
         .await
         .unwrap_err();

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -598,6 +598,60 @@ async fn generic_runtime_persists_the_anchor_before_agent_spawn() {
 }
 
 #[tokio::test]
+async fn generic_runtime_preserves_cancellation_and_rejects_session_resume_before_spawn() {
+    let temp = tempfile::tempdir().unwrap();
+    let started_path = temp.path().join("agent-started");
+    let executable = fake_codex(
+        temp.path(),
+        &format!("touch \"{}\"", started_path.display()),
+    );
+    let runtime = GenericRuntime::new(GenericPreset {
+        executable: leak_path(executable),
+        run_args: Vec::new(),
+        health_check_args: vec!["--version"],
+        authentication_check_args: vec!["login", "status"],
+        authentication_help: "log in",
+        authentication_summary: "authenticated",
+        validate_authentication: |_| Ok(()),
+    });
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let (cancelled_observations, _receiver) = observation_channel();
+    let result = runtime
+        .run(
+            "Do not run this prompt.",
+            temp.path(),
+            Duration::from_secs(5),
+            cancellation,
+            Some("unsupported-session"),
+            cancelled_observations,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result.termination, Termination::Cancelled);
+    assert!(!started_path.exists());
+
+    let (observations, _receiver) = observation_channel();
+    let error = runtime
+        .run(
+            "Do not run this prompt.",
+            temp.path(),
+            Duration::from_secs(5),
+            CancellationToken::new(),
+            Some("unsupported-session"),
+            observations,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(format!("{error:#}").contains("does not support session resume"));
+    assert!(!started_path.exists());
+}
+
+#[tokio::test]
 async fn generic_health_check_requires_authentication_and_returns_a_safe_summary() {
     let temp = tempfile::tempdir().unwrap();
     let executable = temp.path().join("agent");

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -42,6 +42,15 @@ done
     path
 }
 
+fn leak_path(path: PathBuf) -> &'static str {
+    Box::leak(
+        path.into_os_string()
+            .into_string()
+            .unwrap()
+            .into_boxed_str(),
+    )
+}
+
 async fn assert_process_gone(pid: i32) {
     for _ in 0..200 {
         if matches!(
@@ -552,17 +561,15 @@ async fn generic_runtime_persists_the_anchor_before_agent_spawn() {
         temp.path(),
         &format!("touch \"{}\"", started_path.display()),
     );
-    let executable = Box::leak(
-        executable
-            .into_os_string()
-            .into_string()
-            .unwrap()
-            .into_boxed_str(),
-    );
+    let executable = leak_path(executable);
     let runtime = GenericRuntime::new(GenericPreset {
         executable,
         run_args: Vec::new(),
         health_check_args: vec!["--version"],
+        authentication_check_args: vec!["login", "status"],
+        authentication_help: "log in",
+        authentication_summary: "authenticated",
+        validate_authentication: |_| Ok(()),
     });
     let captured_anchor = Arc::new(Mutex::new(None));
     let captured_for_callback = Arc::clone(&captured_anchor);
@@ -588,6 +595,95 @@ async fn generic_runtime_persists_the_anchor_before_agent_spawn() {
     assert!(!started_path.exists());
     let anchor_pid = captured_anchor.lock().unwrap().unwrap();
     assert_process_gone(i32::try_from(anchor_pid).unwrap()).await;
+}
+
+#[tokio::test]
+async fn generic_health_check_requires_authentication_and_returns_a_safe_summary() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = temp.path().join("agent");
+    fs::write(
+        &executable,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "agent 1.2.3"
+  exit 0
+fi
+if [ "$1" = "auth" ]; then
+  echo '{"loggedIn":true,"email":"private@example.com"}'
+  exit 0
+fi
+exit 2
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    let preset = GenericPreset {
+        executable: leak_path(executable),
+        run_args: Vec::new(),
+        health_check_args: vec!["--version"],
+        authentication_check_args: vec!["auth", "status"],
+        authentication_help: "run agent auth login",
+        authentication_summary: "Authenticated",
+        validate_authentication: |output| {
+            let status: serde_json::Value = serde_json::from_str(output)?;
+            anyhow::ensure!(
+                status.get("loggedIn").and_then(serde_json::Value::as_bool) == Some(true),
+                "not logged in"
+            );
+            Ok(())
+        },
+    };
+
+    let health = GenericRuntime::new(preset)
+        .health_check_with_cancellation(CancellationToken::new())
+        .await
+        .unwrap();
+
+    assert_eq!(health.version, "agent 1.2.3");
+    assert_eq!(health.authentication, "Authenticated");
+    assert!(!health.authentication.contains("private@example.com"));
+}
+
+#[tokio::test]
+async fn generic_health_check_reports_an_actionable_authentication_failure() {
+    let temp = tempfile::tempdir().unwrap();
+    let executable = temp.path().join("agent");
+    fs::write(
+        &executable,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "agent 1.2.3"
+  exit 0
+fi
+echo "not logged in" >&2
+exit 1
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&executable).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&executable, permissions).unwrap();
+    let preset = GenericPreset {
+        executable: leak_path(executable),
+        run_args: Vec::new(),
+        health_check_args: vec!["--version"],
+        authentication_check_args: vec!["auth", "status"],
+        authentication_help: "run agent auth login",
+        authentication_summary: "Authenticated",
+        validate_authentication: |_| Ok(()),
+    };
+
+    let error = GenericRuntime::new(preset)
+        .health_check_with_cancellation(CancellationToken::new())
+        .await
+        .unwrap_err();
+    let message = format!("{error:#}");
+
+    assert!(message.contains("authentication check failed"));
+    assert!(message.contains("run agent auth login"));
+    assert!(message.contains("not logged in"));
 }
 
 #[tokio::test]

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -241,9 +241,7 @@ workflow = ".factory/workflows/triage.md"
     )
     .replace("runtime = \"codex\"", "runtime = \"claude\"");
     let fixture = Fixture::new(&config);
-    assert!(
-        format!("{:#}", fixture.config().unwrap_err()).contains("is not a known runtime")
-    );
+    assert!(format!("{:#}", fixture.config().unwrap_err()).contains("is not a known runtime"));
 
     let config = config
         .replace("runtime = \"claude\"", "runtime = \"codex\"")

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -241,7 +241,9 @@ workflow = ".factory/workflows/triage.md"
     )
     .replace("runtime = \"codex\"", "runtime = \"claude\"");
     let fixture = Fixture::new(&config);
-    assert!(format!("{:#}", fixture.config().unwrap_err()).contains("must be \"codex\""));
+    assert!(
+        format!("{:#}", fixture.config().unwrap_err()).contains("is not a known runtime")
+    );
 
     let config = config
         .replace("runtime = \"claude\"", "runtime = \"codex\"")


### PR DESCRIPTION
## Summary
- Introduce an `AgentRuntime` trait so the daemon and CLI can run tasks on Codex, a minimal Codex preset, or Claude Code instead of being hard-coded to Codex
- Add `build_runtime(name, stream_activity)` as the single source of truth for valid runtime names (`codex`, `codex-minimal`, `claude-code`)
- `Config` now validates `worker.runtime` against `build_runtime` instead of rejecting anything but `"codex"`, and still requires `"codex"` specifically when `worker.sandbox = "docker_sandbox"`
- `FactoryDaemon` and workflow execution hold an `Arc<dyn AgentRuntime>` instead of a concrete `CodexRuntime`, removing the per-workflow "unsupported runtime" rejection in `dispatch_available`
- CLI health checks and `factory run` resolve the runtime from config/workflow instead of always constructing `CodexRuntime`

## Test plan
- [x] `cargo build`
- [x] `cargo test` (all suites pass, including updated `tests/manual_run.rs` and `tests/workflows.rs` assertions)