### PR TITLE
fix: retry cleanup for orphaned worktrees

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -486,7 +486,7 @@ async fn run_cli() -> Result<u8> {
             let preview = if workspace.backend == "clone" {
                 clone_manager.preview_cleanup(&workspace.path)?
             } else {
-                manager.preview_cleanup(&workspace.path)?
+                manager.cleanup(&workspace.path, false)?.1
             };
             println!("run: {run_id}");
             println!("workspace: {}", preview.path.display());

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -263,8 +263,7 @@ impl WorkspaceManager {
         self.ensure_managed_path(path)?;
         if self.registered_worktree(path)?.is_none() {
             if !confirm {
-                let preview = self.preview_cleanup(path)?;
-                return Ok((CleanupOutcome::Previewed, preview));
+                return Ok((CleanupOutcome::Previewed, self.preview_orphaned(path)?));
             }
             return Ok((CleanupOutcome::Removed, self.remove_orphaned(path)?));
         }
@@ -329,13 +328,21 @@ impl WorkspaceManager {
     /// such a path would fail `preview_cleanup`'s registration check forever, permanently
     /// stranding the task in `cleanup_pending`.
     fn remove_orphaned(&self, path: &Path) -> Result<CleanupPreview> {
-        let path = absolute_lexical(path)?;
-        if path.exists() {
-            fs::remove_dir_all(&path)
-                .with_context(|| format!("failed to remove orphaned workspace {}", path.display()))?;
+        let preview = self.preview_orphaned(path)?;
+        if preview.path.exists() {
+            fs::remove_dir_all(&preview.path).with_context(|| {
+                format!(
+                    "failed to remove orphaned workspace {}",
+                    preview.path.display()
+                )
+            })?;
         }
+        Ok(preview)
+    }
+
+    fn preview_orphaned(&self, path: &Path) -> Result<CleanupPreview> {
         Ok(CleanupPreview {
-            path,
+            path: absolute_lexical(path)?,
             branch: None,
             dirty: false,
         })

--- a/tests/cleanup_cli.rs
+++ b/tests/cleanup_cli.rs
@@ -180,6 +180,178 @@ fn cleanup_previews_then_removes_a_retained_worktree_and_preserves_its_branch() 
     );
 }
 
+#[test]
+fn cleanup_retries_an_orphaned_recorded_worktree() {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    let remote = temp.path().join("origin.git");
+    let data_home = temp.path().join("factory-data");
+    let ledger_directory = temp.path().join("ledger");
+    fs::create_dir(&repository).unwrap();
+    git(&repository, &["init", "-b", "main"]);
+    git(
+        &repository,
+        &["config", "user.email", "factory@example.test"],
+    );
+    git(&repository, &["config", "user.name", "Factory Test"]);
+    fs::write(repository.join("README.md"), "fixture\n").unwrap();
+    git(&repository, &["add", "README.md"]);
+    git(&repository, &["commit", "-m", "fixture"]);
+    git(temp.path(), &["init", "--bare", remote.to_str().unwrap()]);
+    let github_remote = "git@github.com:example/orphan-cleanup-fixture.git";
+    git(&repository, &["remote", "add", "origin", github_remote]);
+
+    AssertCommand::cargo_bin("factory")
+        .unwrap()
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", &data_home)
+        .arg("init")
+        .assert()
+        .success();
+
+    let rewrite = format!("url.file://{}.insteadOf", remote.display());
+    git(&repository, &["config", &rewrite, github_remote]);
+    git(&repository, &["push", "-u", "origin", "main"]);
+    let repository = repository.canonicalize().unwrap();
+    let state_directory = fs::read_dir(&data_home)
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let workspace_root = state_directory.join("worktrees").canonicalize().unwrap();
+    let manager = WorkspaceManager::new(&repository, &workspace_root).unwrap();
+    let base_sha = manager.fetch_default_branch("main").unwrap();
+
+    let mut ledger = Ledger::open_in(&ledger_directory).unwrap();
+    let task = ledger
+        .enqueue(
+            &TaskIdentity::ticket(
+                "example/orphan-cleanup-fixture",
+                "retry-orphaned-cleanup",
+                "105",
+                "approved-revision",
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .task;
+    let claimed = ledger.claim_next().unwrap().unwrap();
+    assert_eq!(claimed.id, task.id);
+    let run = ledger.start_run(task.id, "codex").unwrap();
+    let prepared = manager
+        .prepare_delivery(
+            105,
+            "Retry orphaned cleanup",
+            "main",
+            &base_sha,
+            DeliveryReuse::Reject,
+        )
+        .unwrap();
+    let branch = prepared.branch.clone().unwrap();
+    ledger
+        .reserve_task_workspace(&TaskWorkspace {
+            task_id: task.id,
+            kind: "delivery".into(),
+            backend: "worktree".into(),
+            repository: task.repository.clone(),
+            base_branch: "main".into(),
+            base_sha: base_sha.clone(),
+            factory_branch: Some(branch.clone()),
+            path: prepared.path.clone(),
+            state: "preparing".into(),
+            status_summary: None,
+            created_at: 0,
+            updated_at: 0,
+            cleaned_at: None,
+        })
+        .unwrap();
+    ledger
+        .record_run_workspace(
+            run.id,
+            &prepared.path,
+            "main",
+            &base_sha,
+            Some(&branch),
+            "delivery",
+        )
+        .unwrap();
+    ledger
+        .update_task_workspace_state(task.id, "retained", Some("test fixture"))
+        .unwrap();
+    ledger
+        .finish_run_and_task_terminal(
+            run.id,
+            RunOutcome::Failed,
+            None,
+            Some("retained for cleanup"),
+            None,
+        )
+        .unwrap();
+    drop(ledger);
+
+    let worktree_name = prepared.path.file_name().unwrap();
+    fs::remove_dir_all(repository.join(".git/worktrees").join(worktree_name)).unwrap();
+    git(&repository, &["worktree", "prune"]);
+    assert!(prepared.path.exists());
+    let readme_before = fs::read(prepared.path.join("README.md")).unwrap();
+
+    let config = repository.join(".factory/config.toml");
+    let run_id = run.id.to_string();
+    let mut preview = cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
+    preview.assert().success().stdout(
+        predicate::str::contains("action: preview only")
+            .and(predicate::str::contains("branch preserved: true")),
+    );
+    assert!(prepared.path.exists());
+    assert_eq!(
+        fs::read(prepared.path.join("README.md")).unwrap(),
+        readme_before
+    );
+    assert_eq!(
+        Ledger::open_in(&ledger_directory)
+            .unwrap()
+            .task_workspace(task.id)
+            .unwrap()
+            .unwrap()
+            .state,
+        "retained"
+    );
+
+    let mut confirm = cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
+    confirm
+        .arg("--confirm")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("action: removed worktree"));
+    assert!(!prepared.path.exists());
+    git(
+        &repository,
+        &["show-ref", "--verify", &format!("refs/heads/{branch}")],
+    );
+    assert_eq!(
+        Ledger::open_in(&ledger_directory)
+            .unwrap()
+            .task_workspace(task.id)
+            .unwrap()
+            .unwrap()
+            .state,
+        "cleaned"
+    );
+
+    let mut repeated =
+        cleanup_command(&repository, &data_home, &config, &ledger_directory, &run_id);
+    repeated
+        .arg("--confirm")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already cleaned; no changes made"));
+    git(
+        &repository,
+        &["show-ref", "--verify", &format!("refs/heads/{branch}")],
+    );
+}
+
 fn cleanup_command(
     repository: &Path,
     data_home: &Path,


### PR DESCRIPTION
Closes #105

## Summary

- preview Factory-owned recorded worktrees after Git registration is lost
- keep orphan removal behind explicit cleanup confirmation
- cover preview, confirmed removal, branch preservation, ledger cleanup, and repeated no-op in the CLI regression suite

## Verification

- `cargo fmt`
- `cargo fmt --check`
- `cargo test --test cleanup_cli`
- `cargo test --all-targets`
- `cargo clippy --locked --all-targets -- -D warnings`
- `git diff --check`

## Review

Fresh independent subagent review: Approve, with no blocker or important findings.