### PR TITLE
fix: cut GraphQL point cost of the GitHub Project source

### DIFF
--- a/.factory/sources/github-project
+++ b/.factory/sources/github-project
@@ -89,7 +89,7 @@ if ((has_labels)); then
   done
 fi
 
-graphql='query($searchQuery:String!,$endCursor:String,$statusField:String!){search(type:ISSUE,query:$searchQuery,first:100,after:$endCursor){pageInfo{hasNextPage endCursor} nodes{... on Issue{number title body url labels(first:100){nodes{name}} projectItems(first:100){nodes{project{id} fieldValueByName(name:$statusField){... on ProjectV2ItemFieldSingleSelectValue{name}}}}}}}}'
+graphql='query($searchQuery:String!,$endCursor:String,$statusField:String!){search(type:ISSUE,query:$searchQuery,first:100,after:$endCursor){pageInfo{hasNextPage endCursor} nodes{... on Issue{number title body url labels(first:20){nodes{name}} projectItems(first:10){nodes{project{id} fieldValueByName(name:$statusField){... on ProjectV2ItemFieldSingleSelectValue{name}}}}}}}}'
 results=$(mktemp -t factory-github-project-source.XXXXXX)
 trap 'rm -f "$results"' EXIT
 


### PR DESCRIPTION
## Problem

Running the daemon against a GitHub Project source exhausts the account's
GraphQL quota within minutes, after which every poll fails:

```
Factory poll failed: repository=/Users/me/CODE/my-repo error=source command
exited with exit status: 1; stderr: GraphQL: API rate limit exceeded for user ID …
```

The cause is the nested page sizes in the search query in
`.factory/sources/github-project`:

```graphql
search(type:ISSUE, query:$searchQuery, first:100) {
  nodes { ... on Issue {
    labels(first:100) { nodes { name } }
    projectItems(first:100) { nodes { … } }
  } }
}
```

GitHub bills GraphQL by node count, not by request count. The formula is
`max(1, node_count / 100)`, and node count multiplies through nested
connections:

```
100 issues + (100 × 100 labels) + (100 × 100 project items) = 20,100 nodes
→ ~201 points per source invocation
```

The default `poll_every = "30s"` with two source triggers issues 240 source
invocations per hour, so the 5,000 point/hour limit is gone in roughly ten
minutes. Neither the repository backlog size nor the project size changes
this — the cost is charged on what the query *requests*, so a two-issue
backlog pays the same 201 points as a full one.

## Fix

Lower the nested page sizes to values a real issue actually reaches:

```
100 issues + (100 × 20 labels) + (100 × 10 project items) = 3,100 nodes
→ ~31 points per source invocation
```

That is a 6.5× reduction and leaves comfortable headroom at the default poll
interval.

## Trade-off

An issue carrying more than 20 labels gets a truncated `labels` array in the
source payload, and an issue belonging to more than 10 projects could fail to
match the configured project. Both limits are well above what issues in a
Factory-managed backlog carry in practice; label-based trigger filtering is
unaffected because it happens in the search query string, not client-side.

## Verification

The point counts above are derived from GitHub's documented node-count
formula rather than measured, since the quota was exhausted at the time of
writing. Reviewers can confirm by adding `rateLimit { cost }` to the query
and comparing before/after.
