### PR TITLE
docs: redraw README workflow diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ creates a durable task, prepares an isolated workspace, and gives one Markdown
 workflow to an agent. The agent uses normal tools such as `gh` and `git` to do
 the work. When nothing matches, Factory does nothing and spends no model tokens.
 
-![AI-native development cycle: Intake, Spec, Task, Build, Validate, Review, Merge, Learn, then feedback returns to Intake](docs/assets/readme/factory-loop.svg)
+![Human intent enters a trusted ticket queue; Factory runs isolated work and produces evidence; human review gates the team's merge; shipped changes return signals to the queue](docs/assets/readme/factory-loop.svg)
 
 ## Why Factory exists
 
@@ -41,7 +41,7 @@ problem, clarify scope, add testable acceptance criteria, and ask for the
 smallest missing human decision. Once the ticket is clear, it becomes the spec
 for implementation.
 
-![A ticket moves from specification through implementation and review](docs/assets/readme/ticket-workflow.svg)
+![An example ticket moves through specification, human approval, implementation, and human review, with feedback requesting another implementation pass](docs/assets/readme/ticket-workflow.svg)
 
 The status names in this example are not built into Factory. They are ordinary
 issue labels and repository-owned prompts. You may also track them on a

--- a/docs/assets/readme/factory-loop.svg
+++ b/docs/assets/readme/factory-loop.svg
@@ -1,74 +1,83 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="640" height="900" viewBox="0 0 640 900" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="940" viewBox="0 0 720 940" role="img" aria-labelledby="title desc">
   <title id="title">How Factory moves work from intent to a human shipping decision</title>
   <desc id="desc">Human intent enters a trusted ticket queue. Factory matches a trigger, creates a durable task, and runs a workflow in an isolated worker. Checks produce evidence and a reviewable pull request. A human reviews and decides whether to merge. Shipped changes create signals that return to the ticket queue.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-      <path d="M0 0 10 5 0 10z" fill="#858176"/>
+      <path d="M0 0 10 5 0 10z" fill="#888378"/>
     </marker>
     <marker id="feedback-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
       <path d="M0 0 10 5 0 10z" fill="#9b5f5b"/>
     </marker>
     <style>
-      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#1e1d1a}
-      .label{font-size:24px;font-weight:700}
-      .detail{font-size:19px;fill:#6f6a60}
-      .caption{font-size:17px;font-weight:700;letter-spacing:.8px}
-      .box{fill:#fff;stroke:#d8d3c7;stroke-width:2}
-      .flow{fill:none;stroke:#858176;stroke-width:3;marker-end:url(#arrow)}
-      .feedback{fill:none;stroke:#9b5f5b;stroke-width:3;stroke-dasharray:8 8;marker-end:url(#feedback-arrow)}
+      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#201f1c}
+      .label{font-size:22px;font-weight:700;letter-spacing:-.25px}
+      .detail{font-size:16px;fill:#6e6960}
+      .kicker{font-size:13px;font-weight:750;letter-spacing:1.25px}
+      .card{fill:#fff;stroke:#d8d3c8;stroke-width:1.75}
+      .flow{fill:none;stroke:#888378;stroke-width:2.75;stroke-linecap:round;stroke-linejoin:round;marker-end:url(#arrow)}
+      .feedback{fill:none;stroke:#9b5f5b;stroke-width:2.75;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:7 8;marker-end:url(#feedback-arrow)}
     </style>
   </defs>
 
-  <rect width="640" height="900" rx="24" fill="#faf8f2"/>
-  <text class="text caption" x="40" y="48" fill="#777166">INTENT IN</text>
-  <text class="text caption" x="600" y="48" text-anchor="end" fill="#777166">CHANGE OUT</text>
+  <rect width="720" height="940" rx="28" fill="#faf8f2"/>
 
-  <rect x="40" y="80" width="240" height="126" rx="18" fill="#edf4e9" stroke="#aec5a3" stroke-width="2"/>
-  <text class="text label" x="160" y="132" text-anchor="middle">Human intent</text>
-  <text class="text detail" x="160" y="170" text-anchor="middle">problem · priority</text>
+  <text class="text kicker" x="48" y="49" fill="#746f66">INTENT IN</text>
+  <text class="text kicker" x="672" y="49" text-anchor="end" fill="#746f66">REVIEWABLE CHANGE OUT</text>
 
-  <rect class="box" x="360" y="80" width="240" height="126" rx="18"/>
-  <text class="text label" x="480" y="132" text-anchor="middle">Trusted queue</text>
-  <text class="text detail" x="480" y="170" text-anchor="middle">ticket is the control plane</text>
-  <path class="flow" d="M280 143H360"/>
+  <rect x="48" y="80" width="272" height="124" rx="18" fill="#edf3e9" stroke="#adc1a3" stroke-width="1.75"/>
+  <text class="text label" x="184" y="132" text-anchor="middle">Human intent</text>
+  <text class="text detail" x="184" y="168" text-anchor="middle">problem · priority</text>
 
-  <rect x="40" y="258" width="560" height="178" rx="22" fill="#eaf1ff" stroke="#a9c1ee" stroke-width="2"/>
-  <text class="text caption" x="66" y="296" fill="#3262b7">FACTORY</text>
-  <rect x="66" y="318" width="146" height="86" rx="14" fill="#fff" stroke="#c8d7f3" stroke-width="2"/>
-  <rect x="247" y="318" width="146" height="86" rx="14" fill="#fff" stroke="#c8d7f3" stroke-width="2"/>
-  <rect x="428" y="318" width="146" height="86" rx="14" fill="#fff" stroke="#c8d7f3" stroke-width="2"/>
-  <text class="text label" x="139" y="352" text-anchor="middle">Trigger</text>
-  <text class="text detail" x="139" y="384" text-anchor="middle">match</text>
-  <text class="text label" x="320" y="352" text-anchor="middle">Task</text>
-  <text class="text detail" x="320" y="384" text-anchor="middle">durable</text>
-  <text class="text label" x="501" y="352" text-anchor="middle">Worker</text>
-  <text class="text detail" x="501" y="384" text-anchor="middle">isolated</text>
-  <path class="flow" d="M480 206V258"/>
+  <rect class="card" x="400" y="80" width="272" height="124" rx="18"/>
+  <text class="text label" x="536" y="132" text-anchor="middle">Trusted queue</text>
+  <text class="text detail" x="536" y="168" text-anchor="middle">ticket is the control plane</text>
 
-  <rect class="box" x="40" y="488" width="240" height="132" rx="18"/>
-  <text class="text label" x="160" y="537" text-anchor="middle">Evidence</text>
-  <text class="text detail" x="160" y="572" text-anchor="middle">tests · CI</text>
-  <text class="text detail" x="160" y="599" text-anchor="middle">reviewable PR</text>
+  <path class="flow" d="M320 142H400"/>
+  <path class="flow" d="M536 204V276"/>
 
-  <rect x="360" y="476" width="240" height="156" rx="20" fill="#fff0c9" stroke="#cf8d18" stroke-width="3"/>
-  <text class="text label" x="480" y="525" text-anchor="middle">Human review</text>
-  <text class="text detail" x="480" y="564" text-anchor="middle">approve or respond</text>
-  <text class="text caption" x="480" y="608" text-anchor="middle" fill="#845100">SHIPPING GATE</text>
-  <path class="flow" d="M320 436V462C320 478 304 488 280 488"/>
-  <path class="flow" d="M280 554H360"/>
+  <path class="feedback" d="M48 800H24V244H624V204"/>
+  <text class="text kicker" x="48" y="232" fill="#9b5f5b">FEEDBACK LOOP</text>
 
-  <rect x="360" y="694" width="240" height="126" rx="18" fill="#e4f3eb" stroke="#8db9a0" stroke-width="2"/>
-  <text class="text label" x="480" y="746" text-anchor="middle">Shipped change</text>
-  <text class="text detail" x="480" y="784" text-anchor="middle">owned by the team</text>
-  <path class="flow" d="M480 632V694"/>
-  <text class="text caption" x="498" y="672" fill="#777166">MERGE</text>
+  <rect x="48" y="276" width="624" height="188" rx="22" fill="#eaf0fb" stroke="#a9bee6" stroke-width="1.75"/>
+  <text class="text kicker" x="72" y="313" fill="#315ca8">FACTORY</text>
 
-  <rect x="40" y="694" width="240" height="126" rx="18" fill="#f6e8e6" stroke="#cf9995" stroke-width="2"/>
-  <text class="text label" x="160" y="746" text-anchor="middle">Signals</text>
-  <text class="text detail" x="160" y="780" text-anchor="middle">feedback · incidents</text>
-  <text class="text detail" x="160" y="807" text-anchor="middle">feature requests</text>
-  <path class="flow" d="M360 757H280"/>
+  <rect x="72" y="334" width="164" height="98" rx="15" fill="#fff" stroke="#c7d4ec" stroke-width="1.75"/>
+  <rect x="278" y="334" width="164" height="98" rx="15" fill="#fff" stroke="#c7d4ec" stroke-width="1.75"/>
+  <rect x="484" y="334" width="164" height="98" rx="15" fill="#fff" stroke="#c7d4ec" stroke-width="1.75"/>
 
-  <path class="feedback" d="M160 820V850H616V143C616 126 608 116 600 116"/>
-  <text class="text detail" x="320" y="866" text-anchor="middle" fill="#9b5f5b">Useful signals return to the trusted queue.</text>
+  <text class="text label" x="154" y="373" text-anchor="middle">Trigger</text>
+  <text class="text detail" x="154" y="405" text-anchor="middle">match</text>
+  <text class="text label" x="360" y="373" text-anchor="middle">Task</text>
+  <text class="text detail" x="360" y="405" text-anchor="middle">durable</text>
+  <text class="text label" x="566" y="373" text-anchor="middle">Worker</text>
+  <text class="text detail" x="566" y="405" text-anchor="middle">isolated</text>
+
+  <path class="flow" d="M360 464V486Q360 500 346 500H184Q184 500 184 516"/>
+
+  <rect class="card" x="48" y="516" width="272" height="140" rx="18"/>
+  <text class="text label" x="184" y="563" text-anchor="middle">Evidence</text>
+  <text class="text detail" x="184" y="598" text-anchor="middle">tests · CI</text>
+  <text class="text detail" x="184" y="625" text-anchor="middle">reviewable pull request</text>
+
+  <rect x="400" y="504" width="272" height="164" rx="20" fill="#fff0ca" stroke="#c98918" stroke-width="2.5"/>
+  <text class="text label" x="536" y="553" text-anchor="middle">Human review</text>
+  <text class="text detail" x="536" y="591" text-anchor="middle">approve or respond</text>
+  <text class="text kicker" x="536" y="638" text-anchor="middle" fill="#845100">SHIPPING GATE</text>
+
+  <path class="flow" d="M320 586H400"/>
+  <path class="flow" d="M536 668V734"/>
+  <text class="text kicker" x="552" y="707" fill="#746f66">MERGE</text>
+
+  <rect x="400" y="734" width="272" height="132" rx="18" fill="#e5f1ea" stroke="#8fb3a0" stroke-width="1.75"/>
+  <text class="text label" x="536" y="787" text-anchor="middle">Shipped change</text>
+  <text class="text detail" x="536" y="824" text-anchor="middle">owned by the team</text>
+
+  <rect x="48" y="734" width="272" height="132" rx="18" fill="#f5e9e7" stroke="#c6908c" stroke-width="1.75"/>
+  <text class="text label" x="184" y="782" text-anchor="middle">Signals</text>
+  <text class="text detail" x="184" y="817" text-anchor="middle">feedback · incidents</text>
+  <text class="text detail" x="184" y="844" text-anchor="middle">feature requests</text>
+
+  <path class="flow" d="M400 800H320"/>
+
+  <text class="text detail" x="360" y="910" text-anchor="middle">Factory coordinates the work. Humans remain accountable for what ships.</text>
 </svg>

--- a/docs/assets/readme/factory-loop.svg
+++ b/docs/assets/readme/factory-loop.svg
@@ -1,39 +1,74 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="620" viewBox="0 0 960 620" role="img" aria-labelledby="title desc">
-  <title id="title">The AI-native software development lifecycle</title>
-  <desc id="desc">A minimal clockwise cycle moves through Intake, Spec, Task, Build, Validate, Review, Merge, and Learn. Learning returns feedback and evidence to Intake for the next repository-owned pass.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="900" viewBox="0 0 640 900" role="img" aria-labelledby="title desc">
+  <title id="title">How Factory moves work from intent to a human shipping decision</title>
+  <desc id="desc">Human intent enters a trusted ticket queue. Factory matches a trigger, creates a durable task, and runs a workflow in an isolated worker. Checks produce evidence and a reviewable pull request. A human reviews and decides whether to merge. Shipped changes create signals that return to the ticket queue.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-      <path d="M0 0 10 5 0 10z" fill="#171717"/>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#858176"/>
+    </marker>
+    <marker id="feedback-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#9b5f5b"/>
     </marker>
     <style>
-      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#171717}
-      .stage{font-size:20px;font-weight:450;letter-spacing:-.25px}
-      .center{font-size:34px;font-weight:400;letter-spacing:-1px}
+      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#1e1d1a}
+      .label{font-size:24px;font-weight:700}
+      .detail{font-size:19px;fill:#6f6a60}
+      .caption{font-size:17px;font-weight:700;letter-spacing:.8px}
+      .box{fill:#fff;stroke:#d8d3c7;stroke-width:2}
+      .flow{fill:none;stroke:#858176;stroke-width:3;marker-end:url(#arrow)}
+      .feedback{fill:none;stroke:#9b5f5b;stroke-width:3;stroke-dasharray:8 8;marker-end:url(#feedback-arrow)}
     </style>
   </defs>
 
-  <rect width="960" height="620" fill="#fff"/>
+  <rect width="640" height="900" rx="24" fill="#faf8f2"/>
+  <text class="text caption" x="40" y="48" fill="#777166">INTENT IN</text>
+  <text class="text caption" x="600" y="48" text-anchor="end" fill="#777166">CHANGE OUT</text>
 
-  <circle cx="480" cy="340" r="176" fill="none" stroke="#171717" stroke-width="2.5"/>
-  <path d="M450 167Q480 157 510 167" fill="none" stroke="#171717" stroke-width="2.5" marker-end="url(#arrow)"/>
+  <rect x="40" y="80" width="240" height="126" rx="18" fill="#edf4e9" stroke="#aec5a3" stroke-width="2"/>
+  <text class="text label" x="160" y="132" text-anchor="middle">Human intent</text>
+  <text class="text detail" x="160" y="170" text-anchor="middle">problem · priority</text>
 
-  <circle cx="480" cy="164" r="5.5" fill="#1267e9"/>
-  <path d="M480 130v28" fill="none" stroke="#1267e9" stroke-width="2" stroke-dasharray="4 5"/>
+  <rect class="box" x="360" y="80" width="240" height="126" rx="18"/>
+  <text class="text label" x="480" y="132" text-anchor="middle">Trusted queue</text>
+  <text class="text detail" x="480" y="170" text-anchor="middle">ticket is the control plane</text>
+  <path class="flow" d="M280 143H360"/>
 
-  <g class="text stage">
-    <text x="480" y="105" text-anchor="middle" fill="#1267e9">Intake</text>
-    <text x="686" y="207">Spec</text>
-    <text x="716" y="347">Task</text>
-    <text x="674" y="493">Build</text>
-    <text x="480" y="576" text-anchor="middle">Validate</text>
-    <text x="286" y="493" text-anchor="end">Review</text>
-    <text x="244" y="347" text-anchor="end">Merge</text>
-    <text x="274" y="207" text-anchor="end">Learn</text>
-  </g>
+  <rect x="40" y="258" width="560" height="178" rx="22" fill="#eaf1ff" stroke="#a9c1ee" stroke-width="2"/>
+  <text class="text caption" x="66" y="296" fill="#3262b7">FACTORY</text>
+  <rect x="66" y="318" width="146" height="86" rx="14" fill="#fff" stroke="#c8d7f3" stroke-width="2"/>
+  <rect x="247" y="318" width="146" height="86" rx="14" fill="#fff" stroke="#c8d7f3" stroke-width="2"/>
+  <rect x="428" y="318" width="146" height="86" rx="14" fill="#fff" stroke="#c8d7f3" stroke-width="2"/>
+  <text class="text label" x="139" y="352" text-anchor="middle">Trigger</text>
+  <text class="text detail" x="139" y="384" text-anchor="middle">match</text>
+  <text class="text label" x="320" y="352" text-anchor="middle">Task</text>
+  <text class="text detail" x="320" y="384" text-anchor="middle">durable</text>
+  <text class="text label" x="501" y="352" text-anchor="middle">Worker</text>
+  <text class="text detail" x="501" y="384" text-anchor="middle">isolated</text>
+  <path class="flow" d="M480 206V258"/>
 
-  <g class="text center" text-anchor="middle">
-    <text x="480" y="306">An AI-native</text>
-    <text x="480" y="348">software</text>
-    <text x="480" y="390">factory</text>
-  </g>
+  <rect class="box" x="40" y="488" width="240" height="132" rx="18"/>
+  <text class="text label" x="160" y="537" text-anchor="middle">Evidence</text>
+  <text class="text detail" x="160" y="572" text-anchor="middle">tests · CI</text>
+  <text class="text detail" x="160" y="599" text-anchor="middle">reviewable PR</text>
+
+  <rect x="360" y="476" width="240" height="156" rx="20" fill="#fff0c9" stroke="#cf8d18" stroke-width="3"/>
+  <text class="text label" x="480" y="525" text-anchor="middle">Human review</text>
+  <text class="text detail" x="480" y="564" text-anchor="middle">approve or respond</text>
+  <text class="text caption" x="480" y="608" text-anchor="middle" fill="#845100">SHIPPING GATE</text>
+  <path class="flow" d="M320 436V462C320 478 304 488 280 488"/>
+  <path class="flow" d="M280 554H360"/>
+
+  <rect x="360" y="694" width="240" height="126" rx="18" fill="#e4f3eb" stroke="#8db9a0" stroke-width="2"/>
+  <text class="text label" x="480" y="746" text-anchor="middle">Shipped change</text>
+  <text class="text detail" x="480" y="784" text-anchor="middle">owned by the team</text>
+  <path class="flow" d="M480 632V694"/>
+  <text class="text caption" x="498" y="672" fill="#777166">MERGE</text>
+
+  <rect x="40" y="694" width="240" height="126" rx="18" fill="#f6e8e6" stroke="#cf9995" stroke-width="2"/>
+  <text class="text label" x="160" y="746" text-anchor="middle">Signals</text>
+  <text class="text detail" x="160" y="780" text-anchor="middle">feedback · incidents</text>
+  <text class="text detail" x="160" y="807" text-anchor="middle">feature requests</text>
+  <path class="flow" d="M360 757H280"/>
+
+  <path class="feedback" d="M160 820V850H616V143C616 126 608 116 600 116"/>
+  <text class="text detail" x="320" y="866" text-anchor="middle" fill="#9b5f5b">Useful signals return to the trusted queue.</text>
 </svg>

--- a/docs/assets/readme/ticket-workflow.svg
+++ b/docs/assets/readme/ticket-workflow.svg
@@ -1,67 +1,72 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="640" height="900" viewBox="0 0 640 900" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="940" viewBox="0 0 720 940" role="img" aria-labelledby="title desc">
   <title id="title">Example repository-owned ticket workflow</title>
   <desc id="desc">A ticket moves from Ready For Spec to Creating Spec, then through human approval to Ready To Implement. An agent implements and proves the change before human review marks it done or sends feedback back for another implementation pass. These states are an example policy and are not built into Factory.</desc>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-      <path d="M0 0 10 5 0 10z" fill="#858176"/>
+      <path d="M0 0 10 5 0 10z" fill="#888378"/>
     </marker>
     <marker id="feedback-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-      <path d="M0 0 10 5 0 10z" fill="#7560c5"/>
+      <path d="M0 0 10 5 0 10z" fill="#6652b3"/>
     </marker>
     <style>
-      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#1e1d1a}
-      .label{font-size:21px;font-weight:700}
-      .detail{font-size:17px;fill:#6f6a60}
-      .caption{font-size:17px;font-weight:700;letter-spacing:.8px}
-      .box{fill:#fff;stroke:#d8d3c7;stroke-width:2}
-      .flow{fill:none;stroke:#858176;stroke-width:3;marker-end:url(#arrow)}
-      .feedback{fill:none;stroke:#7560c5;stroke-width:3;stroke-dasharray:8 8;marker-end:url(#feedback-arrow)}
+      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#201f1c}
+      .label{font-size:20px;font-weight:700;letter-spacing:-.2px}
+      .detail{font-size:16px;fill:#6e6960}
+      .kicker{font-size:13px;font-weight:750;letter-spacing:1.25px}
+      .card{fill:#fff;stroke:#d8d3c8;stroke-width:1.75}
+      .flow{fill:none;stroke:#888378;stroke-width:2.75;stroke-linecap:round;stroke-linejoin:round;marker-end:url(#arrow)}
+      .feedback{fill:none;stroke:#6652b3;stroke-width:2.75;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:7 8;marker-end:url(#feedback-arrow)}
     </style>
   </defs>
 
-  <rect width="640" height="900" rx="24" fill="#faf8f2"/>
-  <text class="text caption" x="40" y="48" fill="#3262b7">DEFINE THE WORK</text>
+  <rect width="720" height="940" rx="28" fill="#faf8f2"/>
 
-  <rect class="box" x="40" y="80" width="240" height="112" rx="17"/>
-  <text class="text label" x="160" y="126" text-anchor="middle">Ready for spec</text>
-  <text class="text detail" x="160" y="161" text-anchor="middle">human intent</text>
+  <text class="text kicker" x="48" y="49" fill="#315ca8">DEFINE THE WORK</text>
 
-  <rect class="box" x="360" y="80" width="240" height="112" rx="17"/>
-  <text class="text label" x="480" y="126" text-anchor="middle">Creating spec</text>
-  <text class="text detail" x="480" y="161" text-anchor="middle">agent clarifies</text>
-  <path class="flow" d="M280 136H360"/>
+  <rect class="card" x="48" y="80" width="272" height="120" rx="18"/>
+  <text class="text label" x="184" y="129" text-anchor="middle">Ready for spec</text>
+  <text class="text detail" x="184" y="165" text-anchor="middle">human intent</text>
 
-  <rect x="40" y="248" width="240" height="136" rx="18" fill="#fff0c9" stroke="#d8a03c" stroke-width="2"/>
-  <text class="text label" x="160" y="297" text-anchor="middle">Human approval</text>
-  <text class="text detail" x="160" y="334" text-anchor="middle">review intent</text>
-  <text class="text caption" x="160" y="367" text-anchor="middle" fill="#845100">GATE</text>
+  <rect class="card" x="400" y="80" width="272" height="120" rx="18"/>
+  <text class="text label" x="536" y="129" text-anchor="middle">Creating spec</text>
+  <text class="text detail" x="536" y="165" text-anchor="middle">agent clarifies</text>
 
-  <rect x="360" y="260" width="240" height="112" rx="17" fill="#edf4e9" stroke="#aec5a3" stroke-width="2"/>
-  <text class="text label" x="480" y="305" text-anchor="middle">Ready to implement</text>
-  <text class="text detail" x="480" y="340" text-anchor="middle">clear contract</text>
-  <path class="flow" d="M480 192V220C480 236 464 248 440 248H280"/>
-  <path class="flow" d="M280 316H360"/>
+  <path class="flow" d="M320 140H400"/>
+  <path class="flow" d="M536 200V226Q536 240 522 240H184Q184 240 184 260"/>
 
-  <text class="text caption" x="40" y="424" fill="#7560c5">BUILD AND PROVE</text>
+  <rect x="48" y="260" width="272" height="144" rx="20" fill="#fff0ca" stroke="#d39a32" stroke-width="2"/>
+  <text class="text label" x="184" y="310" text-anchor="middle">Human approval</text>
+  <text class="text detail" x="184" y="347" text-anchor="middle">review intent</text>
+  <text class="text kicker" x="184" y="382" text-anchor="middle" fill="#845100">GATE</text>
 
-  <rect x="40" y="486" width="240" height="112" rx="17" fill="#eaf1ff" stroke="#a9c1ee" stroke-width="2"/>
-  <text class="text label" x="160" y="532" text-anchor="middle">Implementing</text>
-  <text class="text detail" x="160" y="567" text-anchor="middle">change + proof</text>
+  <rect x="400" y="272" width="272" height="120" rx="18" fill="#edf3e9" stroke="#adc1a3" stroke-width="1.75"/>
+  <text class="text label" x="536" y="321" text-anchor="middle">Ready to implement</text>
+  <text class="text detail" x="536" y="357" text-anchor="middle">clear contract</text>
 
-  <rect x="360" y="474" width="240" height="136" rx="18" fill="#fff0c9" stroke="#d8a03c" stroke-width="2"/>
-  <text class="text label" x="480" y="523" text-anchor="middle">Human review</text>
-  <text class="text detail" x="480" y="560" text-anchor="middle">accept or respond</text>
-  <text class="text caption" x="480" y="593" text-anchor="middle" fill="#845100">GATE</text>
-  <path class="flow" d="M480 372V414C480 430 464 442 440 442H200C176 442 160 454 160 470V486"/>
-  <path class="flow" d="M280 542H360"/>
+  <path class="flow" d="M320 332H400"/>
+  <path class="flow" d="M536 392V438Q536 452 522 452H184Q184 452 184 496"/>
 
-  <rect x="360" y="692" width="240" height="112" rx="17" fill="#e4f3eb" stroke="#8db9a0" stroke-width="2"/>
-  <text class="text label" x="480" y="738" text-anchor="middle">Done</text>
-  <text class="text detail" x="480" y="773" text-anchor="middle">human decision</text>
-  <path class="flow" d="M480 610V692"/>
+  <text class="text kicker" x="48" y="468" fill="#6652b3">BUILD + PROVE</text>
 
-  <path class="feedback" d="M360 574H320C304 574 296 590 296 614V846H616V316C616 292 608 280 600 280"/>
-  <text class="text label" x="160" y="660" text-anchor="middle" fill="#6652b3">Feedback requests</text>
-  <text class="text label" x="160" y="687" text-anchor="middle" fill="#6652b3">another bounded pass</text>
-  <text class="text detail" x="320" y="876" text-anchor="middle">Example policy. Factory does not hard-code these states.</text>
+  <rect x="48" y="496" width="272" height="120" rx="18" fill="#eaf0fb" stroke="#a9bee6" stroke-width="1.75"/>
+  <text class="text label" x="184" y="545" text-anchor="middle">Implementing</text>
+  <text class="text detail" x="184" y="581" text-anchor="middle">change + proof</text>
+
+  <rect x="400" y="484" width="272" height="144" rx="20" fill="#fff0ca" stroke="#d39a32" stroke-width="2"/>
+  <text class="text label" x="536" y="534" text-anchor="middle">Human review</text>
+  <text class="text detail" x="536" y="571" text-anchor="middle">accept or respond</text>
+  <text class="text kicker" x="536" y="606" text-anchor="middle" fill="#845100">GATE</text>
+
+  <path class="flow" d="M320 556H400"/>
+  <path class="flow" d="M536 628V724"/>
+
+  <rect x="400" y="724" width="272" height="120" rx="18" fill="#e5f1ea" stroke="#8fb3a0" stroke-width="1.75"/>
+  <text class="text label" x="536" y="773" text-anchor="middle">Done</text>
+  <text class="text detail" x="536" y="809" text-anchor="middle">human decision</text>
+
+  <path class="feedback" d="M672 556H696V332H672"/>
+  <path d="M48 676H80" fill="none" stroke="#6652b3" stroke-width="2.75" stroke-linecap="round" stroke-dasharray="7 8"/>
+  <text class="text kicker" x="92" y="681" fill="#6652b3">REVIEW FEEDBACK → ANOTHER PASS</text>
+
+  <text class="text detail" x="360" y="902" text-anchor="middle">Example repository policy. Factory does not hard-code these states.</text>
 </svg>

--- a/docs/assets/readme/ticket-workflow.svg
+++ b/docs/assets/readme/ticket-workflow.svg
@@ -1,64 +1,67 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
-  <title id="title">Example ticket workflow</title>
-  <desc id="desc">A ticket moves from Ready For Spec to Creating Spec. Human approval moves it to Ready To Implement, then it moves through Implementing and Reviewing to Done. CI and human feedback can return the ticket through Ready To Implement for a new pass.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="900" viewBox="0 0 640 900" role="img" aria-labelledby="title desc">
+  <title id="title">Example repository-owned ticket workflow</title>
+  <desc id="desc">A ticket moves from Ready For Spec to Creating Spec, then through human approval to Ready To Implement. An agent implements and proves the change before human review marks it done or sends feedback back for another implementation pass. These states are an example policy and are not built into Factory.</desc>
   <defs>
-    <filter id="shadow" x="-20%" y="-30%" width="140%" height="170%">
-      <feDropShadow dx="0" dy="7" stdDeviation="9" flood-color="#172033" flood-opacity=".08"/>
-    </filter>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-      <path d="M0 0 10 5 0 10z" fill="#71809d"/>
+      <path d="M0 0 10 5 0 10z" fill="#858176"/>
     </marker>
-    <marker id="arrow-purple" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
-      <path d="M0 0 10 5 0 10z" fill="#7457d6"/>
+    <marker id="feedback-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+      <path d="M0 0 10 5 0 10z" fill="#7560c5"/>
     </marker>
     <style>
-      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#172033}
-      .eyebrow{font-size:14px;font-weight:750;letter-spacing:1.2px}
-      .label{font-size:17px;font-weight:720}
-      .detail{font-size:14px;fill:#5f6c84}
-      .card{fill:#fff;stroke:#dce2ee;stroke-width:2}
-      .flow{fill:none;stroke:#71809d;stroke-width:3;marker-end:url(#arrow)}
+      .text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",sans-serif;fill:#1e1d1a}
+      .label{font-size:21px;font-weight:700}
+      .detail{font-size:17px;fill:#6f6a60}
+      .caption{font-size:17px;font-weight:700;letter-spacing:.8px}
+      .box{fill:#fff;stroke:#d8d3c7;stroke-width:2}
+      .flow{fill:none;stroke:#858176;stroke-width:3;marker-end:url(#arrow)}
+      .feedback{fill:none;stroke:#7560c5;stroke-width:3;stroke-dasharray:8 8;marker-end:url(#feedback-arrow)}
     </style>
   </defs>
-  <rect width="1280" height="520" rx="28" fill="#f7f8fc"/>
 
-  <text class="text eyebrow" x="64" y="58" fill="#2e5cc2">DEFINE THE WORK</text>
-  <rect x="52" y="80" width="580" height="166" rx="22" fill="#eef4ff" stroke="#c5d5f7" stroke-width="2"/>
-  <g filter="url(#shadow)">
-    <rect class="card" x="72" y="112" width="126" height="102" rx="17"/>
-    <rect class="card" x="214" y="112" width="126" height="102" rx="17"/>
-    <rect x="356" y="112" width="126" height="102" rx="17" fill="#fff2de" stroke="#f0c982" stroke-width="2"/>
-    <rect x="498" y="112" width="126" height="102" rx="17" fill="#e5f6f1" stroke="#9dd9c8" stroke-width="2"/>
-  </g>
-  <g class="text" text-anchor="middle">
-    <text class="label" x="135" y="143">Ready For</text><text class="label" x="135" y="166">Spec</text><text class="detail" x="135" y="194">human intent</text>
-    <text class="label" x="277" y="143">Creating</text><text class="label" x="277" y="166">Spec</text><text class="detail" x="277" y="194">agent clarifies</text>
-    <text class="label" x="419" y="143">Human</text><text class="label" x="419" y="166">approval</text><text class="detail" x="419" y="194">review intent</text>
-    <text class="label" x="561" y="143">Ready To</text><text class="label" x="561" y="166">Implement</text><text class="detail" x="561" y="194">clear contract</text>
-  </g>
-  <path class="flow" d="M198 163h16M340 163h16M482 163h16"/>
+  <rect width="640" height="900" rx="24" fill="#faf8f2"/>
+  <text class="text caption" x="40" y="48" fill="#3262b7">DEFINE THE WORK</text>
 
-  <text class="text eyebrow" x="676" y="58" fill="#6042b4">BUILD AND PROVE</text>
-  <rect x="652" y="80" width="576" height="166" rx="22" fill="#f3efff" stroke="#d3c7f5" stroke-width="2"/>
-  <g filter="url(#shadow)">
-    <rect class="card" x="678" y="112" width="160" height="102" rx="17"/>
-    <rect class="card" x="862" y="112" width="160" height="102" rx="17"/>
-    <rect x="1046" y="112" width="156" height="102" rx="17" fill="#e5f6f1" stroke="#9dd9c8" stroke-width="2"/>
-  </g>
-  <g class="text" text-anchor="middle">
-    <text class="label" x="758" y="151">Implementing</text><text class="detail" x="758" y="180">change + tests</text>
-    <text class="label" x="942" y="151">Reviewing</text><text class="detail" x="942" y="180">CI + humans</text>
-    <text class="label" x="1124" y="151">Done</text><text class="detail" x="1124" y="180">human decision</text>
-  </g>
-  <path class="flow" d="M838 163h24M1022 163h24"/>
-  <path class="flow" d="M624 163h54"/>
+  <rect class="box" x="40" y="80" width="240" height="112" rx="17"/>
+  <text class="text label" x="160" y="126" text-anchor="middle">Ready for spec</text>
+  <text class="text detail" x="160" y="161" text-anchor="middle">human intent</text>
 
-  <rect x="262" y="330" width="760" height="96" rx="20" fill="#fff" stroke="#dce2ee" stroke-width="2"/>
-  <circle cx="310" cy="378" r="18" fill="#7457d6"/>
-  <path d="M301 378h18M310 369v18" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
-  <text class="text label" x="346" y="369">Feedback can request another pass</text>
-  <text class="text detail" x="346" y="397">The ticket re-enters the configured trigger, creating a new bounded implementation task.</text>
-  <path d="M942 214v116" fill="none" stroke="#7457d6" stroke-width="3" marker-end="url(#arrow-purple)"/>
-  <path d="M561 330V214" fill="none" stroke="#7457d6" stroke-width="3" marker-end="url(#arrow-purple)"/>
-  <text class="text detail" x="640" y="474" text-anchor="middle">Status names are repository-owned policy, not hard-coded Factory behavior.</text>
+  <rect class="box" x="360" y="80" width="240" height="112" rx="17"/>
+  <text class="text label" x="480" y="126" text-anchor="middle">Creating spec</text>
+  <text class="text detail" x="480" y="161" text-anchor="middle">agent clarifies</text>
+  <path class="flow" d="M280 136H360"/>
+
+  <rect x="40" y="248" width="240" height="136" rx="18" fill="#fff0c9" stroke="#d8a03c" stroke-width="2"/>
+  <text class="text label" x="160" y="297" text-anchor="middle">Human approval</text>
+  <text class="text detail" x="160" y="334" text-anchor="middle">review intent</text>
+  <text class="text caption" x="160" y="367" text-anchor="middle" fill="#845100">GATE</text>
+
+  <rect x="360" y="260" width="240" height="112" rx="17" fill="#edf4e9" stroke="#aec5a3" stroke-width="2"/>
+  <text class="text label" x="480" y="305" text-anchor="middle">Ready to implement</text>
+  <text class="text detail" x="480" y="340" text-anchor="middle">clear contract</text>
+  <path class="flow" d="M480 192V220C480 236 464 248 440 248H280"/>
+  <path class="flow" d="M280 316H360"/>
+
+  <text class="text caption" x="40" y="424" fill="#7560c5">BUILD AND PROVE</text>
+
+  <rect x="40" y="486" width="240" height="112" rx="17" fill="#eaf1ff" stroke="#a9c1ee" stroke-width="2"/>
+  <text class="text label" x="160" y="532" text-anchor="middle">Implementing</text>
+  <text class="text detail" x="160" y="567" text-anchor="middle">change + proof</text>
+
+  <rect x="360" y="474" width="240" height="136" rx="18" fill="#fff0c9" stroke="#d8a03c" stroke-width="2"/>
+  <text class="text label" x="480" y="523" text-anchor="middle">Human review</text>
+  <text class="text detail" x="480" y="560" text-anchor="middle">accept or respond</text>
+  <text class="text caption" x="480" y="593" text-anchor="middle" fill="#845100">GATE</text>
+  <path class="flow" d="M480 372V414C480 430 464 442 440 442H200C176 442 160 454 160 470V486"/>
+  <path class="flow" d="M280 542H360"/>
+
+  <rect x="360" y="692" width="240" height="112" rx="17" fill="#e4f3eb" stroke="#8db9a0" stroke-width="2"/>
+  <text class="text label" x="480" y="738" text-anchor="middle">Done</text>
+  <text class="text detail" x="480" y="773" text-anchor="middle">human decision</text>
+  <path class="flow" d="M480 610V692"/>
+
+  <path class="feedback" d="M360 574H320C304 574 296 590 296 614V846H616V316C616 292 608 280 600 280"/>
+  <text class="text label" x="160" y="660" text-anchor="middle" fill="#6652b3">Feedback requests</text>
+  <text class="text label" x="160" y="687" text-anchor="middle" fill="#6652b3">another bounded pass</text>
+  <text class="text detail" x="320" y="876" text-anchor="middle">Example policy. Factory does not hard-code these states.</text>
 </svg>


### PR DESCRIPTION
## Summary

- replace the abstract lifecycle circle with a product-specific Factory loop
- make the Factory ownership boundary and human merge gate explicit
- simplify the example ticket workflow into the same minimalist visual language
- polish spacing with a consistent grid, matched card geometry, and dedicated connector channels
- improve SVG accessibility, mobile readability, and README alt text

## Verification

- `xmllint --noout docs/assets/readme/factory-loop.svg docs/assets/readme/ticket-workflow.svg`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- browser render at 1280x900 and 390x844 with no clipping, overlap, or horizontal overflow
- fresh independent review: approved with no blocker or important findings