### PR TITLE
Add fleet configuration and multi-repository --once evaluation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -877,7 +877,7 @@ fn canonical_github_identity(origin: &str) -> Result<String> {
     ))
 }
 
-fn ensure_primary_checkout(repository: &Path) -> Result<()> {
+pub(crate) fn ensure_primary_checkout(repository: &Path) -> Result<()> {
     let git_dir = git_output(
         repository,
         &["rev-parse", "--path-format=absolute", "--git-dir"],
@@ -935,7 +935,11 @@ fn canonical_directory(name: &str, path: &Path, base: &Path) -> Result<PathBuf> 
     Ok(canonical)
 }
 
-fn canonical_directory_or_missing(name: &str, path: &Path, base: &Path) -> Result<PathBuf> {
+pub(crate) fn canonical_directory_or_missing(
+    name: &str,
+    path: &Path,
+    base: &Path,
+) -> Result<PathBuf> {
     let expanded = expand_path(path, base)?;
     let mut ancestor = expanded.as_path();
     let mut missing = Vec::new();
@@ -987,7 +991,7 @@ fn canonical_directory_or_missing(name: &str, path: &Path, base: &Path) -> Resul
     }
 }
 
-fn expand_path(path: &Path, base: &Path) -> Result<PathBuf> {
+pub(crate) fn expand_path(path: &Path, base: &Path) -> Result<PathBuf> {
     let text = path
         .to_str()
         .with_context(|| format!("path is not valid UTF-8: {}", path.display()))?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -83,6 +83,7 @@ pub struct FactoryDaemon {
     config: Config,
     catalog: WorkflowCatalog,
     ledger_path: PathBuf,
+    pinned_identity: Option<String>,
     github: GitHubClient,
     source: SourceClient,
     runtime: Arc<dyn AgentRuntime>,
@@ -107,6 +108,17 @@ impl FactoryDaemon {
         )
     }
 
+    pub fn new_pinned(
+        identity: String,
+        config: Config,
+        catalog: WorkflowCatalog,
+        ledger_path: impl Into<PathBuf>,
+    ) -> Self {
+        let mut daemon = Self::new(config, catalog, ledger_path);
+        daemon.pinned_identity = Some(identity);
+        daemon
+    }
+
     pub fn with_clients(
         config: Config,
         catalog: WorkflowCatalog,
@@ -122,6 +134,7 @@ impl FactoryDaemon {
             config,
             catalog,
             ledger_path: ledger_path.into(),
+            pinned_identity: None,
             github,
             source: SourceClient,
             runtime,
@@ -346,6 +359,15 @@ impl FactoryDaemon {
     }
 
     pub async fn evaluate_once(&self, cancellation: CancellationToken) -> Result<OneShotReport> {
+        self.github.validate_global(&cancellation).await?;
+        self.evaluate_once_after_global_validation(cancellation)
+            .await
+    }
+
+    pub async fn evaluate_once_after_global_validation(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<OneShotReport> {
         for entry in self.catalog.invalid_scheduled_entries() {
             eprintln!(
                 "Factory skipped invalid scheduled workflow {}: {}",
@@ -354,7 +376,6 @@ impl FactoryDaemon {
             );
         }
         self.catalog.validate_ticket_workflows()?;
-        self.github.validate_global(&cancellation).await?;
         let targets = self.resolve_targets(&cancellation).await?;
         let mut ledger = Ledger::open(&self.ledger_path)?;
         let scheduled_before = ledger
@@ -389,14 +410,29 @@ impl FactoryDaemon {
                 )
                 .await?
         } else {
-            self.github
-                .poll_once_with_cancellation(
-                    &self.config,
-                    &self.catalog,
-                    &mut ledger,
-                    cancellation.clone(),
-                )
-                .await?
+            match self.pinned_identity.as_deref() {
+                Some(identity) => {
+                    self.github
+                        .poll_once_after_global_validation_for_identity(
+                            &self.config,
+                            &self.catalog,
+                            &mut ledger,
+                            cancellation.clone(),
+                            identity,
+                        )
+                        .await?
+                }
+                None => {
+                    self.github
+                        .poll_once_after_global_validation(
+                            &self.config,
+                            &self.catalog,
+                            &mut ledger,
+                            cancellation.clone(),
+                        )
+                        .await?
+                }
+            }
         };
         Ok(OneShotReport {
             source,
@@ -442,10 +478,21 @@ impl FactoryDaemon {
     ) -> Result<HashMap<String, RepositoryTarget>> {
         let mut targets = HashMap::new();
         for repository in &self.config.repositories {
-            let name = self
+            let discovered_name = self
                 .github
                 .validate_repository(repository, cancellation)
                 .await?;
+            let name = match self.pinned_identity.as_deref() {
+                Some(identity) if discovered_name.eq_ignore_ascii_case(identity) => {
+                    identity.to_owned()
+                }
+                Some(identity) => bail!(
+                    "GitHub repository identity {} does not match pinned repository identity {}",
+                    discovered_name,
+                    identity
+                ),
+                None => discovered_name,
+            };
             if let Some(source) = &self.config.source {
                 if source.command.is_empty() {
                     let statuses = self

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -1,0 +1,420 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+use crate::config::{
+    Config, canonical_directory_or_missing, ensure_primary_checkout, expand_path,
+    repository_config_path, repository_remote_identity,
+};
+use crate::storage::DATABASE_NAME;
+use crate::workflow::{Trigger, WorkflowCatalog};
+
+pub const MAX_ENABLED_REPOSITORIES: usize = 20;
+pub const MAX_SOURCE_WORKFLOWS_PER_REPOSITORY: usize = 3;
+pub const MIN_POLL_SECONDS: u64 = 60;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetConfig {
+    pub max_concurrent: usize,
+    pub repositories: Vec<FleetRepository>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FleetRepository {
+    pub identity: String,
+    pub display_name: String,
+    pub path: PathBuf,
+    pub enabled: bool,
+    pub max_concurrent: Option<usize>,
+}
+
+#[derive(Debug)]
+pub struct RepositoryRuntime {
+    pub identity: String,
+    pub path: PathBuf,
+    pub config: Config,
+    pub catalog: WorkflowCatalog,
+    pub ledger_path: PathBuf,
+    pub workspace_root: PathBuf,
+    pub health: RepositoryHealth,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepositoryHealth {
+    Loading,
+    Healthy,
+    InvalidConfig,
+    Unavailable,
+    Disabled,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawFleetConfig {
+    max_concurrent: usize,
+    #[serde(rename = "repository")]
+    repositories: Vec<RawFleetRepository>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawFleetRepository {
+    name: String,
+    path: PathBuf,
+    #[serde(default = "enabled_by_default")]
+    enabled: bool,
+    max_concurrent: Option<usize>,
+}
+
+fn enabled_by_default() -> bool {
+    true
+}
+
+impl FleetConfig {
+    pub fn load(path: &Path) -> Result<Self> {
+        let current_dir = std::env::current_dir().context("failed to resolve current directory")?;
+        let path = expand_path(path, &current_dir)?;
+        let contents = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read fleet config {}", path.display()))?;
+        let raw: RawFleetConfig = toml::from_str(&contents)
+            .with_context(|| format!("failed to parse fleet config {}", path.display()))?;
+        if raw.max_concurrent == 0 {
+            bail!("max_concurrent must be greater than zero");
+        }
+        if raw.repositories.is_empty() {
+            bail!("repository must contain at least one entry");
+        }
+        let enabled_count = raw
+            .repositories
+            .iter()
+            .filter(|repository| repository.enabled)
+            .count();
+        if enabled_count == 0 {
+            bail!("fleet must contain at least one enabled repository");
+        }
+        if enabled_count > MAX_ENABLED_REPOSITORIES {
+            bail!(
+                "fleet supports at most {MAX_ENABLED_REPOSITORIES} enabled repositories; got {enabled_count}"
+            );
+        }
+        let base = path
+            .parent()
+            .context("fleet configuration path has no parent directory")?;
+        let mut identities = HashSet::new();
+        let mut paths = HashSet::new();
+        let repositories = raw
+            .repositories
+            .into_iter()
+            .enumerate()
+            .map(|(index, repository)| {
+                let display_name = validate_identity(index, &repository.name)?;
+                let identity = display_name.to_ascii_lowercase();
+                if !identities.insert(identity.clone()) {
+                    bail!("duplicate repository identity {identity}");
+                }
+                if repository.max_concurrent == Some(0) {
+                    bail!("repository {display_name} max_concurrent must be greater than zero");
+                }
+                let path = resolve_repository_path(&repository.path, base)?;
+                if !paths.insert(path.clone()) {
+                    bail!("duplicate canonical repository path {}", path.display());
+                }
+                Ok(FleetRepository {
+                    identity,
+                    display_name,
+                    path,
+                    enabled: repository.enabled,
+                    max_concurrent: repository.max_concurrent,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            max_concurrent: raw.max_concurrent,
+            repositories,
+        })
+    }
+}
+
+fn resolve_repository_path(path: &Path, base: &Path) -> Result<PathBuf> {
+    let expanded = expand_path(path, base)?;
+    match expanded.canonicalize() {
+        Ok(path) => Ok(path),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            canonical_directory_or_missing("repository", &expanded, base).or(Ok(expanded))
+        }
+        Err(_) => Ok(expanded),
+    }
+}
+
+impl FleetRepository {
+    pub fn load_runtime(&self) -> Result<RepositoryRuntime> {
+        validate_checkout(&self.path, &self.identity)?;
+        let mut config = Config::load(&repository_config_path(&self.path))?;
+        if config.poll_every.as_secs() < MIN_POLL_SECONDS {
+            bail!("poll_every must be at least {MIN_POLL_SECONDS}s in fleet mode");
+        }
+        let catalog = WorkflowCatalog::load(&config)?;
+        catalog.validate_ticket_workflows()?;
+        let source_workflows = catalog
+            .entries
+            .iter()
+            .filter(|entry| {
+                entry.errors.is_empty()
+                    && matches!(
+                        entry.trigger,
+                        Some(Trigger::Source { .. } | Trigger::Status(_) | Trigger::Label(_))
+                    )
+            })
+            .count();
+        if source_workflows > MAX_SOURCE_WORKFLOWS_PER_REPOSITORY {
+            bail!(
+                "fleet supports at most {MAX_SOURCE_WORKFLOWS_PER_REPOSITORY} source-triggered workflows per repository; got {source_workflows}"
+            );
+        }
+        if let Some(limit) = self.max_concurrent {
+            let effective = config.max_concurrent_runs_per_repository.min(limit);
+            config.max_concurrent_runs = effective;
+            config.max_concurrent_runs_per_repository = effective;
+        }
+        let ledger_path = config.data_directory.join(DATABASE_NAME);
+        let workspace_root = config.workspace_root.clone();
+        Ok(RepositoryRuntime {
+            identity: self.identity.clone(),
+            path: self.path.clone(),
+            config,
+            catalog,
+            ledger_path,
+            workspace_root,
+            health: RepositoryHealth::Healthy,
+        })
+    }
+}
+
+fn validate_identity(index: usize, value: &str) -> Result<String> {
+    let value = value.trim();
+    let mut parts = value.split('/');
+    let owner = parts.next().unwrap_or_default();
+    let repository = parts.next().unwrap_or_default();
+    if parts.next().is_some()
+        || !valid_identity_segment(owner)
+        || !valid_identity_segment(repository)
+    {
+        bail!(
+            "repository entry {} name must have the GitHub owner/name shape",
+            index + 1
+        );
+    }
+    Ok(value.to_owned())
+}
+
+fn valid_identity_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 100
+        && !value.starts_with('.')
+        && !value.ends_with('.')
+        && value.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.')
+        })
+}
+
+fn validate_checkout(path: &Path, expected_identity: &str) -> Result<()> {
+    let bare = git_output(path, &["rev-parse", "--is-bare-repository"])
+        .context("repository path is not a Git checkout")?;
+    if bare.trim() != "false" {
+        bail!("repository path is a bare Git repository");
+    }
+    let root = git_output(path, &["rev-parse", "--show-toplevel"])
+        .context("repository path is not a Git checkout")?;
+    let root = PathBuf::from(root.trim())
+        .canonicalize()
+        .context("failed to resolve Git checkout root")?;
+    if root != path {
+        bail!(
+            "repository path must be the canonical Git checkout root; got {}",
+            path.display()
+        );
+    }
+    ensure_primary_checkout(path)?;
+    let actual = repository_remote_identity(path)?;
+    if actual != expected_identity {
+        bail!(
+            "origin identity {actual} does not match pinned repository identity {expected_identity}"
+        );
+    }
+    Ok(())
+}
+
+fn git_output(repository: &Path, arguments: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repository)
+        .args(arguments)
+        .output()
+        .context("failed to start git")?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            arguments.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    String::from_utf8(output.stdout).context("git output was not valid UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repository(root: &Path, name: &str, origin: &str) -> PathBuf {
+        let path = root.join(name);
+        fs::create_dir(&path).unwrap();
+        assert!(
+            Command::new("git")
+                .args(["init", "--quiet"])
+                .current_dir(&path)
+                .status()
+                .unwrap()
+                .success()
+        );
+        assert!(
+            Command::new("git")
+                .args(["remote", "add", "origin", origin])
+                .current_dir(&path)
+                .status()
+                .unwrap()
+                .success()
+        );
+        path.canonicalize().unwrap()
+    }
+
+    #[test]
+    fn loads_defaults_relative_paths_and_normalized_identities() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = repository(temp.path(), "first", "git@github.com:Acme/First.git");
+        let second = repository(temp.path(), "second", "https://github.com/acme/second");
+        let fleet = temp.path().join("fleet.toml");
+        fs::write(
+            &fleet,
+            "max_concurrent = 4\n[[repository]]\nname = \"Acme/First\"\npath = \"first\"\n[[repository]]\nname = \"acme/second\"\npath = \"second\"\nenabled = false\nmax_concurrent = 1\n",
+        )
+        .unwrap();
+        let loaded = FleetConfig::load(&fleet).unwrap();
+        assert_eq!(loaded.max_concurrent, 4);
+        assert_eq!(loaded.repositories[0].identity, "acme/first");
+        assert_eq!(loaded.repositories[0].path, first);
+        assert!(loaded.repositories[0].enabled);
+        assert_eq!(loaded.repositories[1].path, second);
+        assert!(!loaded.repositories[1].enabled);
+        assert_eq!(loaded.repositories[1].max_concurrent, Some(1));
+    }
+
+    #[test]
+    fn rejects_unknown_fields_zero_limits_and_empty_enabled_set() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = repository(temp.path(), "repo", "git@github.com:acme/repo.git");
+        for contents in [
+            format!(
+                "version = 1\nmax_concurrent = 1\n[[repository]]\nname = \"acme/repo\"\npath = {:?}\n",
+                path
+            ),
+            format!(
+                "max_concurrent = 0\n[[repository]]\nname = \"acme/repo\"\npath = {:?}\n",
+                path
+            ),
+            format!(
+                "max_concurrent = 1\n[[repository]]\nname = \"acme/repo\"\npath = {:?}\nenabled = false\n",
+                path
+            ),
+            format!(
+                "max_concurrent = 1\n[[repository]]\nname = \"acme/repo\"\npath = {:?}\nmax_concurrent = 0\n",
+                path
+            ),
+        ] {
+            let fleet = temp.path().join("fleet.toml");
+            fs::write(&fleet, contents).unwrap();
+            assert!(FleetConfig::load(&fleet).is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_duplicate_normalized_identity_and_canonical_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = repository(temp.path(), "first", "git@github.com:acme/first.git");
+        let second = repository(temp.path(), "second", "git@github.com:acme/second.git");
+        let fleet = temp.path().join("fleet.toml");
+        fs::write(
+            &fleet,
+            format!(
+                "max_concurrent = 1\n[[repository]]\nname = \"Acme/First\"\npath = {:?}\n[[repository]]\nname = \"acme/first\"\npath = {:?}\n",
+                first, second
+            ),
+        )
+        .unwrap();
+        assert!(
+            FleetConfig::load(&fleet)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate repository identity")
+        );
+        fs::write(
+            &fleet,
+            format!(
+                "max_concurrent = 1\n[[repository]]\nname = \"acme/first\"\npath = {:?}\n[[repository]]\nname = \"acme/second\"\npath = {:?}\n",
+                first, first
+            ),
+        )
+        .unwrap();
+        assert!(
+            FleetConfig::load(&fleet)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate canonical repository path")
+        );
+
+        let real = temp.path().join("real");
+        fs::create_dir(&real).unwrap();
+        std::os::unix::fs::symlink(&real, temp.path().join("link")).unwrap();
+        fs::write(
+            &fleet,
+            "max_concurrent = 1\n[[repository]]\nname = \"acme/first\"\npath = \"real/missing\"\n[[repository]]\nname = \"acme/second\"\npath = \"link/missing\"\n",
+        )
+        .unwrap();
+        assert!(
+            FleetConfig::load(&fleet)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate canonical repository path")
+        );
+    }
+
+    #[test]
+    fn checkout_identity_is_pinned() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = repository(
+            temp.path(),
+            "repo",
+            "ssh://git@ssh.github.com/acme/repo.git",
+        );
+        validate_checkout(&path, "acme/repo").unwrap();
+        let error = validate_checkout(&path, "acme/changed").unwrap_err();
+        assert!(error.to_string().contains("does not match pinned"));
+    }
+
+    #[test]
+    fn rejects_more_than_the_supported_enabled_repository_envelope() {
+        let temp = tempfile::tempdir().unwrap();
+        let entries = (0..=MAX_ENABLED_REPOSITORIES)
+            .map(|index| {
+                format!("[[repository]]\nname = \"acme/repo-{index}\"\npath = \"repo-{index}\"\n")
+            })
+            .collect::<String>();
+        let fleet = temp.path().join("fleet.toml");
+        fs::write(&fleet, format!("max_concurrent = 1\n{entries}")).unwrap();
+        let error = FleetConfig::load(&fleet).unwrap_err();
+        assert!(error.to_string().contains("supports at most 20"));
+    }
+}

--- a/src/github.rs
+++ b/src/github.rs
@@ -995,6 +995,53 @@ impl GitHubClient {
         cancellation: CancellationToken,
     ) -> Result<PollReport> {
         self.validate_global(&cancellation).await?;
+        self.poll_once_after_global_validation(config, catalog, ledger, cancellation)
+            .await
+    }
+
+    pub async fn poll_once_after_global_validation(
+        &self,
+        config: &Config,
+        catalog: &WorkflowCatalog,
+        ledger: &mut Ledger,
+        cancellation: CancellationToken,
+    ) -> Result<PollReport> {
+        self.poll_once_after_global_validation_with_identity(
+            config,
+            catalog,
+            ledger,
+            cancellation,
+            None,
+        )
+        .await
+    }
+
+    pub async fn poll_once_after_global_validation_for_identity(
+        &self,
+        config: &Config,
+        catalog: &WorkflowCatalog,
+        ledger: &mut Ledger,
+        cancellation: CancellationToken,
+        identity: &str,
+    ) -> Result<PollReport> {
+        self.poll_once_after_global_validation_with_identity(
+            config,
+            catalog,
+            ledger,
+            cancellation,
+            Some(identity),
+        )
+        .await
+    }
+
+    async fn poll_once_after_global_validation_with_identity(
+        &self,
+        config: &Config,
+        catalog: &WorkflowCatalog,
+        ledger: &mut Ledger,
+        cancellation: CancellationToken,
+        pinned_identity: Option<&str>,
+    ) -> Result<PollReport> {
         let label_workflows = label_workflows(catalog);
         let status_workflows = status_workflows(catalog);
         let mut repositories = Vec::with_capacity(config.repositories.len());
@@ -1019,6 +1066,7 @@ impl GitHubClient {
                             source,
                             ledger,
                             &cancellation,
+                            pinned_identity,
                         )
                         .await?;
                     report.name_with_owner = status.name_with_owner;
@@ -1033,6 +1081,7 @@ impl GitHubClient {
                             source,
                             ledger,
                             &cancellation,
+                            pinned_identity,
                         )
                         .await?;
                     report.name_with_owner = labels.name_with_owner;
@@ -1040,8 +1089,14 @@ impl GitHubClient {
                     report.tasks_created += labels.tasks_created;
                 }
                 if report.name_with_owner.is_none() {
-                    report.name_with_owner =
-                        Some(self.validate_repository(repository, &cancellation).await?);
+                    report.name_with_owner = Some(
+                        self.validated_repository_identity(
+                            repository,
+                            pinned_identity,
+                            &cancellation,
+                        )
+                        .await?,
+                    );
                 }
                 Ok(report)
             }
@@ -1067,8 +1122,11 @@ impl GitHubClient {
         source: &SourceConfig,
         ledger: &mut Ledger,
         cancellation: &CancellationToken,
+        pinned_identity: Option<&str>,
     ) -> Result<RepositoryPoll> {
-        let name = self.validate_repository(repository, cancellation).await?;
+        let name = self
+            .validated_repository_identity(repository, pinned_identity, cancellation)
+            .await?;
         let resolved = self
             .resolve_project_source(repository, source, cancellation)
             .await?;
@@ -1086,9 +1144,9 @@ impl GitHubClient {
         let issues_seen = items
             .iter()
             .filter(|item| {
-                item.content
-                    .as_ref()
-                    .is_some_and(|issue| issue.repository.name_with_owner == name)
+                item.content.as_ref().is_some_and(|issue| {
+                    issue.repository.name_with_owner.eq_ignore_ascii_case(&name)
+                })
             })
             .count();
         let mut tasks_created = 0;
@@ -1107,7 +1165,9 @@ impl GitHubClient {
                 let Some(issue) = &item.content else {
                     continue;
                 };
-                if issue.repository.name_with_owner != name || issue.state != "OPEN" {
+                if !issue.repository.name_with_owner.eq_ignore_ascii_case(&name)
+                    || issue.state != "OPEN"
+                {
                     continue;
                 }
                 let Some(author) = &issue.author else {
@@ -1199,8 +1259,11 @@ impl GitHubClient {
         source: &SourceConfig,
         ledger: &mut Ledger,
         cancellation: &CancellationToken,
+        pinned_identity: Option<&str>,
     ) -> Result<RepositoryPoll> {
-        let name = self.validate_repository(repository, cancellation).await?;
+        let name = self
+            .validated_repository_identity(repository, pinned_identity, cancellation)
+            .await?;
         let issues: Vec<ApiIssue> = self
             .api_pages(
                 repository,
@@ -1276,6 +1339,22 @@ impl GitHubClient {
             tasks_created,
             error: None,
         })
+    }
+
+    async fn validated_repository_identity(
+        &self,
+        repository: &Path,
+        pinned_identity: Option<&str>,
+        cancellation: &CancellationToken,
+    ) -> Result<String> {
+        let discovered = self.validate_repository(repository, cancellation).await?;
+        match pinned_identity {
+            Some(identity) if discovered.eq_ignore_ascii_case(identity) => Ok(identity.to_owned()),
+            Some(identity) => bail!(
+                "GitHub repository identity {discovered} does not match pinned repository identity {identity}"
+            ),
+            None => Ok(discovered),
+        }
     }
 
     async fn trusted_approver_ids(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod clone;
 pub mod config;
 pub mod daemon;
 pub mod execution;
+pub mod fleet;
 pub mod github;
 mod hash;
 pub mod init;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use factory::clone::CloneManager;
 use factory::config::{Config, ExecutionMode, repository_config_path};
 use factory::daemon::FactoryDaemon;
 use factory::execution::ResolvedWorkflow;
+use factory::fleet::FleetConfig;
 use factory::github::GitHubClient;
 use factory::init::{InitOptions, initialize};
 use factory::inspection::{
@@ -58,10 +59,17 @@ enum Command {
         #[arg(long, conflicts_with = "workflow_id")]
         once: bool,
         /// Path to the Factory configuration file.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "fleet")]
         config: Option<PathBuf>,
+        /// Path to a fleet configuration file. Supported with --once.
+        #[arg(
+            long,
+            requires = "once",
+            conflicts_with_all = ["config", "data_directory", "workflow_id"]
+        )]
+        fleet: Option<PathBuf>,
         /// Directory containing the durable Factory database.
-        #[arg(long, conflicts_with = "workflow_id")]
+        #[arg(long, conflicts_with_all = ["workflow_id", "fleet"])]
         data_directory: Option<PathBuf>,
     },
     /// Validate configuration, workflows, and configured GitHub Project IDs.
@@ -222,11 +230,15 @@ async fn run_cli() -> Result<u8> {
             workflow_id,
             once,
             config,
+            fleet,
             data_directory,
         } => {
             if let Some(workflow_id) = workflow_id {
                 return run_workflow(&workflow_id, None, config, WorkflowRunMode::ScheduledOnly)
                     .await;
+            }
+            if let Some(fleet) = fleet {
+                return run_fleet_once(&fleet).await;
             }
             return run_poller(config, data_directory, once).await;
         }
@@ -776,6 +788,115 @@ async fn run_poller(
     signal_task.abort();
     write_stderr_best_effort(b"Factory stopped.\n");
     Ok(0)
+}
+
+async fn run_fleet_once(path: &Path) -> Result<u8> {
+    write_stderr_best_effort(
+        format!(
+            "Factory starting: mode=fleet-once config={}\n",
+            path.display()
+        )
+        .as_bytes(),
+    );
+    let fleet = FleetConfig::load(path)?;
+    ensure_no_unscoped_ledger_overlap()?;
+    let cancellation = CancellationToken::new();
+    GitHubClient::default()
+        .validate_global(&cancellation)
+        .await?;
+
+    let mut failures = 0usize;
+    let mut healthy = 0usize;
+    for repository in &fleet.repositories {
+        if !repository.enabled {
+            write_stdout_best_effort(
+                format!("repository={} status=disabled\n", repository.identity).as_bytes(),
+            );
+            continue;
+        }
+        let runtime = match repository.load_runtime() {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                failures += 1;
+                write_stdout_best_effort(
+                    format!(
+                        "repository={} status=invalid_config error={}\n",
+                        repository.identity,
+                        single_line_error(&error)
+                    )
+                    .as_bytes(),
+                );
+                continue;
+            }
+        };
+        let ledger = match Ledger::open(&runtime.ledger_path) {
+            Ok(ledger) => ledger,
+            Err(error) => {
+                failures += 1;
+                write_stdout_best_effort(
+                    format!(
+                        "repository={} status=unavailable error={}\n",
+                        repository.identity,
+                        single_line_error(&error)
+                    )
+                    .as_bytes(),
+                );
+                continue;
+            }
+        };
+        let daemon = FactoryDaemon::new_pinned(
+            runtime.identity,
+            runtime.config,
+            runtime.catalog,
+            ledger.path(),
+        );
+        match daemon
+            .evaluate_once_after_global_validation(cancellation.clone())
+            .await
+        {
+            Ok(report) => {
+                let source_failures = report.source.failures();
+                if source_failures == 0 {
+                    healthy += 1;
+                } else {
+                    failures += 1;
+                }
+                write_stdout_best_effort(
+                    format!(
+                        "repository={} status={} scheduled_tasks_created={} source_tasks_created={} source_failures={}\n",
+                        repository.identity,
+                        if source_failures == 0 { "ok" } else { "failed" },
+                        report.scheduled_tasks_created,
+                        report.source.tasks_created(),
+                        source_failures
+                    )
+                    .as_bytes(),
+                );
+            }
+            Err(error) => {
+                failures += 1;
+                write_stdout_best_effort(
+                    format!(
+                        "repository={} status=unavailable error={}\n",
+                        repository.identity,
+                        single_line_error(&error)
+                    )
+                    .as_bytes(),
+                );
+            }
+        }
+    }
+    if healthy == 0 {
+        failures += 1;
+    }
+    Ok(u8::from(failures > 0))
+}
+
+fn single_line_error(error: &anyhow::Error) -> String {
+    format!("{error:#}")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn ensure_no_unscoped_ledger_overlap() -> Result<()> {

--- a/tests/fleet_once.rs
+++ b/tests/fleet_once.rs
@@ -1,0 +1,300 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+
+use assert_cmd::Command;
+use factory::storage::Ledger;
+use predicates::prelude::*;
+
+fn make_repository(root: &Path, data_home: &Path, name: &str, origin: &str) -> PathBuf {
+    let repository = root.join(name);
+    fs::create_dir(&repository).unwrap();
+    assert!(
+        ProcessCommand::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&repository)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        ProcessCommand::new("git")
+            .args(["remote", "add", "origin", origin])
+            .current_dir(&repository)
+            .status()
+            .unwrap()
+            .success()
+    );
+    Command::cargo_bin("factory")
+        .unwrap()
+        .current_dir(&repository)
+        .env("FACTORY_DATA_HOME", data_home)
+        .arg("init")
+        .assert()
+        .success();
+    fs::write(
+        repository.join(".factory/config.toml"),
+        r#"version = 1
+poll_every = "60s"
+
+[worker]
+runtime = "codex"
+sandbox = "worktree"
+timeout = "1h"
+maximum_timeout = "8h"
+max_concurrent = 2
+
+[source]
+command = ["./.factory/source.sh"]
+
+[trigger.implement]
+type = "source"
+state = "ready"
+labels = ["factory:ready"]
+workflow = ".factory/workflows/implement.md"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        repository.join(".factory/workflows/implement.md"),
+        "Implement the issue.\n",
+    )
+    .unwrap();
+    let source = repository.join(".factory/source.sh");
+    fs::write(
+        &source,
+        "#!/bin/sh\nprintf '%s\\n' '{\"issues\":[{\"key\":\"#42\",\"title\":\"Fleet task\",\"state\":\"ready\",\"labels\":[\"factory:ready\"]}]}'\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&source).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&source, permissions).unwrap();
+    repository.canonicalize().unwrap()
+}
+
+fn fake_github(root: &Path) -> PathBuf {
+    let bin = root.join("bin");
+    fs::create_dir(&bin).unwrap();
+    let gh = bin.join("gh");
+    fs::write(
+        &gh,
+        "#!/bin/sh\ncase \"$1\" in\n  --version) echo 'gh version 2.80.0' ;;\n  auth) exit 0 ;;\n  repo) if [ -n \"$FACTORY_FAKE_GH_IDENTITY\" ]; then echo \"$FACTORY_FAKE_GH_IDENTITY\"; else echo \"Acme/$(basename \"$PWD\")\"; fi ;;\n  *) exit 64 ;;\nesac\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&gh).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&gh, permissions).unwrap();
+    bin
+}
+
+fn fleet_command(bin: &Path, data_home: &Path) -> Command {
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let mut command = Command::cargo_bin("factory").unwrap();
+    command
+        .env("PATH", path)
+        .env("FACTORY_DATA_HOME", data_home);
+    command
+}
+
+fn ledgers(data_home: &Path) -> Vec<Ledger> {
+    fs::read_dir(data_home)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
+        .map(|path| Ledger::open_in(&path).unwrap())
+        .collect()
+}
+
+#[test]
+fn evaluates_two_repositories_once_with_isolated_durable_tasks_and_no_workers() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let first = make_repository(
+        temp.path(),
+        &data_home,
+        "first",
+        "git@github.com:acme/first.git",
+    );
+    let second = make_repository(
+        temp.path(),
+        &data_home,
+        "second",
+        "https://github.com/acme/second.git",
+    );
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        format!(
+            "max_concurrent = 2\n[[repository]]\nname = \"acme/first\"\npath = \"$FACTORY_FIRST_REPOSITORY\"\n[[repository]]\nname = \"acme/second\"\npath = {:?}\n",
+            second
+        ),
+    )
+    .unwrap();
+    let bin = fake_github(temp.path());
+
+    fleet_command(&bin, &data_home)
+        .env("FACTORY_FIRST_REPOSITORY", &first)
+        .args(["run", "--fleet", fleet.to_str().unwrap(), "--once"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("repository=acme/first status=ok"))
+        .stdout(predicate::str::contains("repository=acme/second status=ok"));
+
+    let ledgers = ledgers(&data_home);
+    assert_eq!(ledgers.len(), 2);
+    for ledger in ledgers {
+        let tasks = ledger.tasks().unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].source_item.as_deref(), Some("#42"));
+        assert!(ledger.runs(None).unwrap().is_empty());
+    }
+}
+
+#[test]
+fn continues_after_invalid_repository_and_returns_aggregate_failure() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let healthy = make_repository(
+        temp.path(),
+        &data_home,
+        "healthy",
+        "git@github.com:acme/healthy.git",
+    );
+    let changed = make_repository(
+        temp.path(),
+        &data_home,
+        "changed",
+        "git@github.com:acme/replacement.git",
+    );
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        format!(
+            "max_concurrent = 2\n[[repository]]\nname = \"acme/changed\"\npath = {:?}\n[[repository]]\nname = \"acme/healthy\"\npath = {:?}\n",
+            changed, healthy
+        ),
+    )
+    .unwrap();
+    let bin = fake_github(temp.path());
+
+    fleet_command(&bin, &data_home)
+        .args(["run", "--fleet", fleet.to_str().unwrap(), "--once"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "repository=acme/changed status=invalid_config",
+        ))
+        .stdout(predicate::str::contains(
+            "repository=acme/healthy status=ok",
+        ));
+
+    let task_counts = ledgers(&data_home)
+        .into_iter()
+        .map(|ledger| ledger.tasks().unwrap().len())
+        .collect::<Vec<_>>();
+    assert_eq!(task_counts.iter().sum::<usize>(), 1);
+}
+
+#[test]
+fn missing_repository_is_reported_without_hiding_later_results() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let _healthy = make_repository(
+        temp.path(),
+        &data_home,
+        "healthy",
+        "git@github.com:acme/healthy.git",
+    );
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        "max_concurrent = 2\n[[repository]]\nname = \"acme/missing\"\npath = \"missing\"\n[[repository]]\nname = \"acme/healthy\"\npath = \"~/healthy\"\n",
+    )
+    .unwrap();
+    let bin = fake_github(temp.path());
+
+    fleet_command(&bin, &data_home)
+        .current_dir(temp.path())
+        .env("HOME", temp.path())
+        .args(["run", "--fleet", fleet.to_str().unwrap(), "--once"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "repository=acme/missing status=invalid_config",
+        ))
+        .stdout(predicate::str::contains(
+            "repository=acme/healthy status=ok",
+        ));
+}
+
+#[test]
+fn fleet_requires_once_and_rejects_unset_path_variables() {
+    let temp = tempfile::tempdir().unwrap();
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        "max_concurrent = 1\n[[repository]]\nname = \"acme/repo\"\npath = \"$FACTORY_TEST_UNSET/repo\"\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("factory")
+        .unwrap()
+        .args(["run", "--fleet", fleet.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--once"));
+    Command::cargo_bin("factory")
+        .unwrap()
+        .env_remove("FACTORY_TEST_UNSET")
+        .args(["run", "--fleet", fleet.to_str().unwrap(), "--once"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "unset environment variable $FACTORY_TEST_UNSET",
+        ));
+}
+
+#[test]
+fn rejects_a_github_identity_that_differs_from_the_pinned_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let repository = make_repository(
+        temp.path(),
+        &data_home,
+        "repository",
+        "git@github.com:acme/repository.git",
+    );
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        format!(
+            "max_concurrent = 1\n[[repository]]\nname = \"acme/repository\"\npath = {:?}\n",
+            repository
+        ),
+    )
+    .unwrap();
+    let bin = fake_github(temp.path());
+
+    fleet_command(&bin, &data_home)
+        .env("FACTORY_FAKE_GH_IDENTITY", "acme/renamed")
+        .args(["run", "--fleet", fleet.to_str().unwrap(), "--once"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "does not match pinned repository identity acme/repository",
+        ));
+
+    assert!(
+        ledgers(&data_home)
+            .into_iter()
+            .all(|ledger| ledger.tasks().unwrap().is_empty())
+    );
+}


### PR DESCRIPTION
Closes #120

## What changed

- add strict fleet TOML loading with relative, environment, and home path expansion
- validate enabled repository limits, per-repository caps, duplicate normalized identities, duplicate canonical paths, primary checkouts, and pinned GitHub origins
- add `factory run --fleet <path> --once` with one independent repository runtime, workflow catalog, ledger, and workspace root per checkout
- continue after repository-local validation or polling failures, report every configured repository, aggregate exit status, and launch no workers
- preserve existing repository-scoped `run`, `--config`, and `--once` behavior
- keep configured lowercase fleet identities pinned through GitHub validation and durable task/schedule keys

## Verification

- `cargo test --test source_polling --test github_polling --test workflows`
- `cargo test --test validate --test daemon`
- `cargo test --all-targets --all-features`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Focused fleet tests cover two-repository durable isolation with the same workflow/issue key, no worker launches, mixed-case and mismatched GitHub identities, changed and missing checkouts, partial failure, path expansion, strict CLI use, supported fleet limits, and duplicate missing paths through symlink aliases.

## Review

A fresh independent subagent reviewed the implementation. Its two initial findings about pinned GitHub identities and missing-suffix canonicalization were fixed and regression-tested. The follow-up review approved the final diff with no remaining findings.