### PR TITLE
feat: add continuous fleet supervision

### DIFF
--- a/.factory/sources/github
+++ b/.factory/sources/github
@@ -33,7 +33,10 @@ if ((${#labels[@]} > 0)); then
   done
 fi
 
-FACTORY_SOURCE_STATE="$state" FACTORY_SOURCE_MAX_RESULTS="$max_results" gh "${args[@]}" --jq '
+stderr_file="$(mktemp)"
+trap 'rm -f "$stderr_file"' EXIT
+set +e
+output="$(FACTORY_SOURCE_STATE="$state" FACTORY_SOURCE_MAX_RESULTS="$max_results" gh "${args[@]}" --jq '
   if (length > (env.FACTORY_SOURCE_MAX_RESULTS | tonumber)) then
     error("gh issue list result was truncated; narrow the trigger state or labels")
   else
@@ -49,4 +52,35 @@ FACTORY_SOURCE_STATE="$state" FACTORY_SOURCE_MAX_RESULTS="$max_results" gh "${ar
         }
     ]}
   end
-'
+' 2>"$stderr_file")"
+status=$?
+set -e
+
+if ((status != 0)); then
+  diagnostic="$(tail -c 65536 "$stderr_file")"
+  normalized_diagnostic="$(printf '%s' "$diagnostic" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$normalized_diagnostic" == *" 403"* ||
+        "$normalized_diagnostic" == *" 429"* ||
+        "$normalized_diagnostic" == *"rate limit"* ||
+        "$normalized_diagnostic" == *"rate-limit"* ||
+        "$normalized_diagnostic" == *"rate_limit"* ||
+        "$normalized_diagnostic" == *"rate budget"*"exhaust"* ]]; then
+    retry_at=""
+    reset_epoch="$(gh api rate_limit --jq '[.resources[] | select(.remaining == 0) | .reset] | min // empty' 2>/dev/null || true)"
+    if [[ "$reset_epoch" =~ ^[0-9]+$ ]]; then
+      if date --version >/dev/null 2>&1; then
+        retry_at="$(date -u -d "@$reset_epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || true)"
+      else
+        retry_at="$(date -u -r "$reset_epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || true)"
+      fi
+    fi
+    jq -cn \
+      --arg message "${diagnostic:-GitHub API rate limit exhausted}" \
+      --arg retry_at "$retry_at" \
+      '{error: ({kind: "rate_limited", message: ($message | gsub("[[:cntrl:]]"; " ") | .[0:500])} + (if $retry_at == "" then {} else {retry_at: $retry_at} end))}'
+  fi
+  printf '%s\n' "$diagnostic" >&2
+  exit "$status"
+fi
+
+printf '%s\n' "$output"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0"
 sha2 = "0.11"
 rusqlite = { version = "0.37", features = ["bundled"] }
 tempfile = "3.20"
-tokio = { version = "1.47", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1.47", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "test-util", "time"] }
 tokio-util = "0.7"
 toml = "0.9"
 toml_edit = "0.23"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -10,12 +11,17 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, SecondsFormat, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
+use tokio::sync::{Notify, Semaphore};
 use tokio::task::JoinSet;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
 use crate::clone::CloneManager;
 use crate::config::{Config, SourceConfig};
+use crate::fleet::{
+    RepositoryHealth, RepositoryRuntime, delay_to_next_poll, repository_backoff,
+    resolve_rate_limit_delay,
+};
 use crate::github::{GitHubClient, LabelTicketContext, ProjectTicketContext, TicketContext};
 use crate::hash::sha256_hex_prefix;
 use crate::runtime::{
@@ -23,7 +29,9 @@ use crate::runtime::{
     build_runtime, observation_channel,
 };
 use crate::sandbox::{SandboxRunFailure, SandboxWorker};
-use crate::source::{PollReport, SourceClient, SourceTicketContext};
+use crate::source::{
+    PollReport, RepositoryPoll, SourceClient, SourceTicketContext, source_rate_limit,
+};
 use crate::storage::{
     AUTOMATIC_DELIVERY_CLEANUP, Ledger, OPERATOR_CONFIRMED_CLEANUP, Run, RunOutcome, RunSandbox,
     Task, TaskIdentity, TaskState, TaskWorkspace,
@@ -39,6 +47,215 @@ static OWNER_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 struct DaemonOwner {
     id: String,
     pid: u32,
+}
+
+#[cfg(test)]
+mod fleet_supervisor_state_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    fn health_fixture(identity: &str) -> FleetHealth {
+        Arc::new(Mutex::new(HashMap::from([(
+            identity.to_owned(),
+            RepositoryHealthRecord {
+                state: RepositoryHealth::Healthy,
+                consecutive_failures: 0,
+                retry_at: None,
+                pre_rate_limit: None,
+            },
+        )])))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn health_transitions_back_off_reset_and_rate_limit_without_disabling() {
+        let health = health_fixture("acme/repository");
+        let error = anyhow::anyhow!("transient");
+        set_repository_failure(
+            &health,
+            "acme/repository",
+            RepositoryHealth::BackingOff,
+            &error,
+        );
+        {
+            let records = health
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let record = &records["acme/repository"];
+            assert_eq!(record.state, RepositoryHealth::BackingOff);
+            assert_eq!(record.consecutive_failures, 1);
+            assert_eq!(
+                record.retry_at.unwrap().duration_since(Instant::now()),
+                Duration::from_secs(5)
+            );
+        }
+        tokio::time::advance(Duration::from_secs(5)).await;
+        set_repository_failure(
+            &health,
+            "acme/repository",
+            RepositoryHealth::Unavailable,
+            &error,
+        );
+        {
+            let records = health
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let record = &records["acme/repository"];
+            assert_eq!(record.state, RepositoryHealth::Unavailable);
+            assert_eq!(record.consecutive_failures, 2);
+            assert_eq!(
+                record.retry_at.unwrap().duration_since(Instant::now()),
+                Duration::from_secs(10)
+            );
+        }
+        set_repository_healthy(&health, "acme/repository");
+        assert_eq!(
+            health
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())["acme/repository"]
+                .state,
+            RepositoryHealth::Unavailable
+        );
+        tokio::time::advance(Duration::from_secs(10)).await;
+        set_repository_healthy(&health, "acme/repository");
+        {
+            let records = health
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let record = &records["acme/repository"];
+            assert_eq!(record.state, RepositoryHealth::Healthy);
+            assert_eq!(record.consecutive_failures, 0);
+            assert_eq!(record.retry_at, None);
+        }
+        let retry_at = Instant::now() + Duration::from_secs(60);
+        set_fleet_rate_limited(&health, retry_at, "rate limited");
+        let records = health
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let record = &records["acme/repository"];
+        assert_eq!(record.state, RepositoryHealth::RateLimited);
+        assert_eq!(record.retry_at, Some(retry_at));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn poll_failure_replaces_the_normal_interval_with_exact_backoff_deadline() {
+        let health = health_fixture("acme/repository");
+        let mut next_due = Instant::now() + Duration::from_secs(60);
+        apply_poll_failure(
+            &mut next_due,
+            &health,
+            "acme/repository",
+            &anyhow::anyhow!("transient"),
+        );
+        assert_eq!(
+            next_due.duration_since(Instant::now()),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shared_rate_pause_never_shortens_repository_backoff() {
+        let health = health_fixture("acme/repository");
+        let backoff = set_repository_failure(
+            &health,
+            "acme/repository",
+            RepositoryHealth::BackingOff,
+            &anyhow::anyhow!("transient"),
+        );
+        let shorter_shared_pause = Instant::now() + Duration::from_secs(2);
+        set_fleet_rate_limited(&health, shorter_shared_pause, "rate limited");
+        let records = health
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let record = &records["acme/repository"];
+        assert_eq!(record.state, RepositoryHealth::RateLimited);
+        assert_eq!(record.retry_at, Some(backoff));
+        assert_eq!(
+            record.pre_rate_limit,
+            Some((RepositoryHealth::BackingOff, Some(backoff)))
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn validation_and_polling_share_the_two_query_host_bound() {
+        let health = health_fixture("acme/repository");
+        let host = FleetHostCoordinator::new(health);
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let cancellation = CancellationToken::new();
+        let mut tasks = Vec::new();
+        for _ in 0..3 {
+            let host = host.clone();
+            let active = Arc::clone(&active);
+            let maximum = Arc::clone(&maximum);
+            let cancellation = cancellation.clone();
+            tasks.push(tokio::spawn(async move {
+                host.run(&cancellation, || async {
+                    let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(current, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    Ok(())
+                })
+                .await
+            }));
+        }
+        tokio::task::yield_now().await;
+        assert_eq!(active.load(Ordering::SeqCst), 2);
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        for task in tasks {
+            task.await.unwrap().unwrap();
+        }
+        assert_eq!(maximum.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn validation_rate_limit_pauses_later_host_queries_for_sixty_second_fallback() {
+        let health = health_fixture("acme/repository");
+        let host = FleetHostCoordinator::new(Arc::clone(&health));
+        let cancellation = CancellationToken::new();
+        let error = host
+            .run(&cancellation, || async {
+                Err::<(), _>(crate::source::test_source_rate_limit_error(
+                    "slow down",
+                    None,
+                ))
+            })
+            .await
+            .unwrap_err();
+        assert!(source_rate_limit(&error).is_some());
+        assert_eq!(
+            host.pause_until().unwrap().duration_since(Instant::now()),
+            Duration::from_secs(60)
+        );
+        assert_eq!(
+            health
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())["acme/repository"]
+                .state,
+            RepositoryHealth::RateLimited
+        );
+
+        let started = Arc::new(AtomicUsize::new(0));
+        let query_started = Arc::clone(&started);
+        let query_host = host.clone();
+        let query_cancellation = cancellation.clone();
+        let query = tokio::spawn(async move {
+            query_host
+                .run(&query_cancellation, || async move {
+                    query_started.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        assert_eq!(started.load(Ordering::SeqCst), 0);
+        tokio::time::advance(Duration::from_secs(60)).await;
+        query.await.unwrap().unwrap();
+        assert_eq!(started.load(Ordering::SeqCst), 1);
+    }
 }
 
 impl DaemonOwner {
@@ -101,6 +318,797 @@ pub struct FactoryDaemon {
 pub struct OneShotReport {
     pub source: PollReport,
     pub scheduled_tasks_created: usize,
+}
+
+#[derive(Clone)]
+pub struct FleetAdmission {
+    inner: Arc<FleetAdmissionInner>,
+}
+
+struct FleetAdmissionInner {
+    repositories: Vec<String>,
+    state: Mutex<FleetAdmissionState>,
+    changed: Notify,
+}
+
+struct FleetAdmissionState {
+    available: usize,
+    cursor: usize,
+    waiting: Vec<bool>,
+}
+
+pub struct FleetAdmissionPermit {
+    inner: Arc<FleetAdmissionInner>,
+}
+
+#[derive(Clone)]
+struct FleetHostCoordinator {
+    slots: Arc<Semaphore>,
+    pause_until: Arc<Mutex<Option<Instant>>>,
+    health: FleetHealth,
+}
+
+impl FleetHostCoordinator {
+    fn new(health: FleetHealth) -> Self {
+        Self {
+            slots: Arc::new(Semaphore::new(2)),
+            pause_until: Arc::new(Mutex::new(None)),
+            health,
+        }
+    }
+
+    async fn run<T, F, Fut>(&self, cancellation: &CancellationToken, operation: F) -> Result<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<T>>,
+    {
+        let mut operation = Some(operation);
+        loop {
+            if let Some(pause_until) = self.pause_until() {
+                tokio::select! {
+                    _ = cancellation.cancelled() => bail!("host query cancelled"),
+                    _ = tokio::time::sleep_until(pause_until) => {}
+                }
+            }
+            let permit = tokio::select! {
+                _ = cancellation.cancelled() => bail!("host query cancelled"),
+                permit = Arc::clone(&self.slots).acquire_owned() => {
+                    permit.context("host query coordinator closed")?
+                }
+            };
+            if self
+                .pause_until()
+                .is_some_and(|pause_until| pause_until > Instant::now())
+            {
+                drop(permit);
+                continue;
+            }
+            let result = operation.take().expect("host operation runs at most once")().await;
+            drop(permit);
+            if let Err(error) = &result
+                && let Some(rate_limit) = source_rate_limit(error)
+            {
+                let delay = resolve_rate_limit_delay(rate_limit.retry_at, Utc::now());
+                let retry_at = Instant::now() + delay;
+                let shared_retry_at = {
+                    let mut pause = self
+                        .pause_until
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    *pause = Some(pause.map_or(retry_at, |current| current.max(retry_at)));
+                    pause.expect("shared host pause was just set")
+                };
+                set_fleet_rate_limited(&self.health, shared_retry_at, &rate_limit.message);
+            }
+            return result;
+        }
+    }
+
+    fn pause_until(&self) -> Option<Instant> {
+        *self
+            .pause_until
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl Drop for FleetAdmissionPermit {
+    fn drop(&mut self) {
+        let mut state = lock_admission(&self.inner);
+        state.available += 1;
+        drop(state);
+        self.inner.changed.notify_waiters();
+    }
+}
+
+impl FleetAdmission {
+    pub fn new(repositories: Vec<String>, limit: usize) -> Result<Self> {
+        if repositories.is_empty() {
+            bail!("fleet admission requires at least one repository");
+        }
+        if limit == 0 {
+            bail!("fleet admission limit must be greater than zero");
+        }
+        let mut unique = HashSet::new();
+        if repositories
+            .iter()
+            .any(|repository| !unique.insert(repository.clone()))
+        {
+            bail!("fleet admission repository identities must be unique");
+        }
+        let waiting = vec![false; repositories.len()];
+        Ok(Self {
+            inner: Arc::new(FleetAdmissionInner {
+                repositories,
+                state: Mutex::new(FleetAdmissionState {
+                    available: limit,
+                    cursor: 0,
+                    waiting,
+                }),
+                changed: Notify::new(),
+            }),
+        })
+    }
+
+    pub async fn acquire(
+        &self,
+        repository: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<FleetAdmissionPermit> {
+        loop {
+            if let Some(permit) = self.try_acquire(repository)? {
+                return Ok(permit);
+            }
+            tokio::select! {
+                _ = cancellation.cancelled() => {
+                    self.cancel_wait(repository);
+                    bail!("fleet admission cancelled");
+                }
+                _ = self.inner.changed.notified() => {}
+            }
+        }
+    }
+
+    pub fn try_acquire(&self, repository: &str) -> Result<Option<FleetAdmissionPermit>> {
+        let index = self
+            .inner
+            .repositories
+            .iter()
+            .position(|candidate| candidate == repository)
+            .with_context(|| format!("repository {repository} is not registered for admission"))?;
+        let mut state = lock_admission(&self.inner);
+        if !state.waiting[index] {
+            state.waiting[index] = true;
+        }
+        if state.available > 0 && next_waiting_repository(&state).is_some_and(|next| next == index)
+        {
+            state.waiting[index] = false;
+            state.available -= 1;
+            state.cursor = (index + 1) % state.waiting.len();
+            return Ok(Some(FleetAdmissionPermit {
+                inner: Arc::clone(&self.inner),
+            }));
+        }
+        Ok(None)
+    }
+
+    fn cancel_wait(&self, repository: &str) {
+        let Some(index) = self
+            .inner
+            .repositories
+            .iter()
+            .position(|candidate| candidate == repository)
+        else {
+            return;
+        };
+        let mut state = lock_admission(&self.inner);
+        state.waiting[index] = false;
+        drop(state);
+        self.inner.changed.notify_waiters();
+    }
+
+    async fn changed(&self) {
+        self.inner.changed.notified().await;
+    }
+}
+
+fn lock_admission(inner: &FleetAdmissionInner) -> MutexGuard<'_, FleetAdmissionState> {
+    inner
+        .state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn next_waiting_repository(state: &FleetAdmissionState) -> Option<usize> {
+    (0..state.waiting.len())
+        .map(|offset| (state.cursor + offset) % state.waiting.len())
+        .find(|index| state.waiting[*index])
+}
+
+pub struct FleetSupervisor {
+    max_concurrent: usize,
+    repositories: Vec<RepositoryRuntime>,
+}
+
+#[derive(Clone)]
+struct FleetPollTarget {
+    runtime: RepositoryRuntime,
+    workflow: WorkflowEntry,
+    next_due: Instant,
+}
+
+struct RepositoryHealthRecord {
+    state: RepositoryHealth,
+    consecutive_failures: u32,
+    retry_at: Option<Instant>,
+    pre_rate_limit: Option<(RepositoryHealth, Option<Instant>)>,
+}
+
+type FleetHealth = Arc<Mutex<HashMap<String, RepositoryHealthRecord>>>;
+
+impl FleetSupervisor {
+    pub fn new(max_concurrent: usize, repositories: Vec<RepositoryRuntime>) -> Result<Self> {
+        if max_concurrent == 0 {
+            bail!("fleet max_concurrent must be greater than zero");
+        }
+        if repositories.is_empty() {
+            bail!("fleet supervisor requires at least one enabled repository");
+        }
+        Ok(Self {
+            max_concurrent,
+            repositories,
+        })
+    }
+
+    pub async fn run(&self, cancellation: CancellationToken) -> Result<()> {
+        GitHubClient::default()
+            .validate_global(&cancellation)
+            .await?;
+        let identities = self
+            .repositories
+            .iter()
+            .map(|runtime| runtime.identity.clone())
+            .collect::<Vec<_>>();
+        let admission = FleetAdmission::new(identities.clone(), self.max_concurrent)?;
+        let health = Arc::new(Mutex::new(
+            identities
+                .iter()
+                .map(|identity| {
+                    (
+                        identity.clone(),
+                        RepositoryHealthRecord {
+                            state: RepositoryHealth::Loading,
+                            consecutive_failures: 0,
+                            retry_at: None,
+                            pre_rate_limit: None,
+                        },
+                    )
+                })
+                .collect(),
+        ));
+        let host = FleetHostCoordinator::new(Arc::clone(&health));
+
+        let mut members = JoinSet::<(String, Result<()>)>::new();
+        let mut healthy = 0usize;
+        for runtime in &self.repositories {
+            if host
+                .pause_until()
+                .is_some_and(|pause_until| pause_until > Instant::now())
+            {
+                spawn_fleet_retry(
+                    &mut members,
+                    runtime.clone(),
+                    admission.clone(),
+                    host.clone(),
+                    Arc::clone(&health),
+                    cancellation.clone(),
+                );
+                continue;
+            }
+            let daemon = daemon_for_runtime(runtime)?;
+            match host
+                .run(&cancellation, || daemon.prepare_fleet(&cancellation))
+                .await
+            {
+                Ok(targets) => {
+                    healthy += 1;
+                    set_repository_healthy(&health, &runtime.identity);
+                    spawn_fleet_member(
+                        &mut members,
+                        runtime.clone(),
+                        daemon,
+                        targets,
+                        admission.clone(),
+                        host.clone(),
+                        Arc::clone(&health),
+                        cancellation.clone(),
+                    );
+                }
+                Err(_error) if cancellation.is_cancelled() => return Ok(()),
+                Err(error) => {
+                    set_repository_host_failure(&health, &runtime.identity, &error);
+                    spawn_fleet_retry(
+                        &mut members,
+                        runtime.clone(),
+                        admission.clone(),
+                        host.clone(),
+                        Arc::clone(&health),
+                        cancellation.clone(),
+                    );
+                }
+            }
+        }
+        if healthy == 0 {
+            cancellation.cancel();
+            while members.join_next().await.is_some() {}
+            bail!("fleet has no healthy enabled repository at startup");
+        }
+
+        let poll_targets = build_poll_targets(&self.repositories)?;
+        let poll_cancellation = cancellation.clone();
+        let poll_health = Arc::clone(&health);
+        let poll_host = host.clone();
+        let poller = tokio::spawn(async move {
+            run_fleet_poller(poll_targets, poll_health, poll_host, poll_cancellation).await
+        });
+        eprintln!(
+            "Factory fleet ready: repositories={} healthy={} max_concurrent={}; press Ctrl-C to stop.",
+            self.repositories.len(),
+            healthy,
+            self.max_concurrent
+        );
+
+        loop {
+            tokio::select! {
+                _ = cancellation.cancelled() => break,
+                completed = members.join_next(), if !members.is_empty() => {
+                    match completed {
+                        Some(Ok((identity, Ok(())))) if cancellation.is_cancelled() => {
+                            eprintln!("Factory repository stopped: repository={identity}");
+                        }
+                        Some(Ok((identity, Ok(())))) => {
+                            eprintln!("Factory repository loop stopped unexpectedly: repository={identity}");
+                        }
+                        Some(Ok((identity, Err(error)))) => {
+                            eprintln!("Factory repository loop failed: repository={identity} error={error:#}");
+                        }
+                        Some(Err(error)) => {
+                            eprintln!("Factory repository supervisor task panicked: {error}");
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+        cancellation.cancel();
+        while let Some(completed) = members.join_next().await {
+            if let Err(error) = completed {
+                eprintln!("Factory repository task panicked during shutdown: {error}");
+            }
+        }
+        poller
+            .await
+            .context("fleet polling task panicked")?
+            .context("fleet polling failed")?;
+        Ok(())
+    }
+}
+
+fn daemon_for_runtime(runtime: &RepositoryRuntime) -> Result<Arc<FactoryDaemon>> {
+    Ok(Arc::new(FactoryDaemon::new_pinned_for_repository(
+        runtime.identity.clone(),
+        runtime.path.clone(),
+        runtime.config.clone(),
+        runtime.catalog.clone(),
+        runtime.ledger_path.clone(),
+    )?))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_fleet_member(
+    members: &mut JoinSet<(String, Result<()>)>,
+    runtime: RepositoryRuntime,
+    daemon: Arc<FactoryDaemon>,
+    targets: HashMap<String, RepositoryTarget>,
+    admission: FleetAdmission,
+    host: FleetHostCoordinator,
+    health: FleetHealth,
+    cancellation: CancellationToken,
+) {
+    members.spawn(async move {
+        let identity = runtime.identity.clone();
+        let mut result = daemon
+            .run_fleet_member(cancellation.clone(), targets, admission.clone())
+            .await;
+        loop {
+            if cancellation.is_cancelled() {
+                return (identity, result);
+            }
+            if let Err(error) = &result {
+                set_repository_host_failure(&health, &identity, error);
+            } else {
+                let error = anyhow::anyhow!("repository loop stopped unexpectedly");
+                set_repository_failure(&health, &identity, RepositoryHealth::Unavailable, &error);
+            }
+            let retry_at = repository_retry_at(&health, &identity).unwrap_or_else(Instant::now);
+            tokio::select! {
+                _ = cancellation.cancelled() => return (identity, Ok(())),
+                _ = tokio::time::sleep_until(retry_at) => {}
+            }
+            let daemon = match daemon_for_runtime(&runtime) {
+                Ok(daemon) => daemon,
+                Err(error) => return (identity, Err(error)),
+            };
+            match host
+                .run(&cancellation, || daemon.prepare_fleet(&cancellation))
+                .await
+            {
+                Ok(targets) => {
+                    set_repository_healthy(&health, &identity);
+                    result = daemon
+                        .run_fleet_member(cancellation.clone(), targets, admission.clone())
+                        .await;
+                }
+                Err(_error) if cancellation.is_cancelled() => return (identity, Ok(())),
+                Err(error) => result = Err(error),
+            }
+        }
+    });
+}
+
+fn spawn_fleet_retry(
+    members: &mut JoinSet<(String, Result<()>)>,
+    runtime: RepositoryRuntime,
+    admission: FleetAdmission,
+    host: FleetHostCoordinator,
+    health: FleetHealth,
+    cancellation: CancellationToken,
+) {
+    members.spawn(async move {
+        let identity = runtime.identity.clone();
+        loop {
+            let retry_at = repository_retry_at(&health, &identity).unwrap_or_else(Instant::now);
+            tokio::select! {
+                _ = cancellation.cancelled() => return (identity, Ok(())),
+                _ = tokio::time::sleep_until(retry_at) => {}
+            }
+            let daemon = match daemon_for_runtime(&runtime) {
+                Ok(daemon) => daemon,
+                Err(error) => return (identity, Err(error)),
+            };
+            match host
+                .run(&cancellation, || daemon.prepare_fleet(&cancellation))
+                .await
+            {
+                Ok(targets) => {
+                    set_repository_healthy(&health, &identity);
+                    let result = daemon
+                        .run_fleet_member(cancellation.clone(), targets, admission.clone())
+                        .await;
+                    if cancellation.is_cancelled() {
+                        return (identity, result);
+                    }
+                    if let Err(error) = &result {
+                        set_repository_failure(
+                            &health,
+                            &identity,
+                            RepositoryHealth::Unavailable,
+                            error,
+                        );
+                    }
+                }
+                Err(_error) if cancellation.is_cancelled() => return (identity, Ok(())),
+                Err(error) => set_repository_host_failure(&health, &identity, &error),
+            }
+        }
+    });
+}
+
+fn build_poll_targets(repositories: &[RepositoryRuntime]) -> Result<Vec<FleetPollTarget>> {
+    let now = SystemTime::now();
+    let instant = Instant::now();
+    repositories
+        .iter()
+        .flat_map(|runtime| {
+            runtime
+                .catalog
+                .entries
+                .iter()
+                .filter(|entry| {
+                    entry.errors.is_empty()
+                        && matches!(
+                            entry.trigger,
+                            Some(Trigger::Source { .. } | Trigger::Status(_) | Trigger::Label(_))
+                        )
+                })
+                .map(move |workflow| (runtime, workflow))
+        })
+        .map(|(runtime, workflow)| {
+            Ok(FleetPollTarget {
+                runtime: runtime.clone(),
+                workflow: workflow.clone(),
+                next_due: instant
+                    + delay_to_next_poll(
+                        &runtime.identity,
+                        &workflow.id,
+                        runtime.config.poll_every,
+                        now,
+                    )?,
+            })
+        })
+        .collect()
+}
+
+async fn run_fleet_poller(
+    mut targets: Vec<FleetPollTarget>,
+    health: FleetHealth,
+    host: FleetHostCoordinator,
+    cancellation: CancellationToken,
+) -> Result<()> {
+    let mut active = JoinSet::<(usize, Result<RepositoryPoll>)>::new();
+    loop {
+        let now = Instant::now();
+        while active.len() < 2 {
+            let next = targets
+                .iter()
+                .enumerate()
+                .filter(|(_, target)| effective_poll_due(target, &health, &host) <= now)
+                .min_by_key(|(_, target)| effective_poll_due(target, &health, &host))
+                .map(|(index, _)| index);
+            let Some(index) = next else {
+                break;
+            };
+            let target = targets[index].clone();
+            advance_poll_due(&mut targets[index], now);
+            let poll_cancellation = cancellation.clone();
+            let poll_host = host.clone();
+            active.spawn(async move {
+                let result = poll_host
+                    .run(&poll_cancellation, || {
+                        poll_fleet_target(&target, &poll_cancellation)
+                    })
+                    .await;
+                (index, result)
+            });
+        }
+
+        let next_due = targets
+            .iter()
+            .map(|target| effective_poll_due(target, &health, &host))
+            .min()
+            .unwrap_or_else(|| Instant::now() + Duration::from_secs(60));
+        tokio::select! {
+            _ = cancellation.cancelled() => break,
+            completed = active.join_next(), if !active.is_empty() => {
+                let (_index, result) = completed
+                    .context("fleet source query task disappeared")?
+                    .context("fleet source query task panicked")?;
+                match result {
+                    Ok(report) => {
+                        let identity = report.name_with_owner.as_deref().unwrap_or("-");
+                        set_repository_healthy(&health, identity);
+                        if report.tasks_created > 0 {
+                            eprintln!(
+                                "Factory fleet poll: repository={} issues_seen={} tasks_queued={}",
+                                identity, report.issues_seen, report.tasks_created
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        let identity = targets[_index].runtime.identity.clone();
+                        apply_poll_failure(
+                            &mut targets[_index].next_due,
+                            &health,
+                            &identity,
+                            &error,
+                        );
+                    }
+                }
+            }
+            _ = tokio::time::sleep_until(next_due), if active.len() < 2 => {}
+        }
+    }
+    while active.join_next().await.is_some() {}
+    Ok(())
+}
+
+fn apply_poll_failure(
+    next_due: &mut Instant,
+    health: &FleetHealth,
+    identity: &str,
+    error: &anyhow::Error,
+) {
+    if source_rate_limit(error).is_none() {
+        *next_due = set_repository_failure(health, identity, RepositoryHealth::BackingOff, error);
+    }
+}
+
+async fn poll_fleet_target(
+    target: &FleetPollTarget,
+    cancellation: &CancellationToken,
+) -> Result<RepositoryPoll> {
+    let mut ledger = Ledger::open(&target.runtime.ledger_path)?;
+    let source = target
+        .runtime
+        .config
+        .source
+        .as_ref()
+        .context("source-triggered workflow has no configured source")?;
+    if !source.command.is_empty() {
+        return SourceClient
+            .poll_workflow(
+                &target.runtime.path,
+                &target.runtime.identity,
+                source,
+                &target.workflow,
+                &mut ledger,
+                cancellation,
+            )
+            .await;
+    }
+    let catalog = WorkflowCatalog {
+        entries: vec![target.workflow.clone()],
+    };
+    let report = GitHubClient::default()
+        .poll_once_after_global_validation_for_identity(
+            &target.runtime.config,
+            &catalog,
+            &mut ledger,
+            cancellation.clone(),
+            &target.runtime.identity,
+        )
+        .await?;
+    let poll = report
+        .repositories
+        .into_iter()
+        .next()
+        .context("GitHub polling returned no repository result")?;
+    if let Some(error) = &poll.error {
+        bail!("{error}");
+    }
+    Ok(poll)
+}
+
+fn advance_poll_due(target: &mut FleetPollTarget, now: Instant) {
+    loop {
+        target.next_due += target.runtime.config.poll_every;
+        if target.next_due > now {
+            break;
+        }
+    }
+}
+
+fn effective_poll_due(
+    target: &FleetPollTarget,
+    health: &FleetHealth,
+    host: &FleetHostCoordinator,
+) -> Instant {
+    let repository_retry = repository_retry_at(health, &target.runtime.identity);
+    let shared_retry = host.pause_until();
+    [Some(target.next_due), repository_retry, shared_retry]
+        .into_iter()
+        .flatten()
+        .max()
+        .expect("target due time is always present")
+}
+
+fn repository_retry_at(health: &FleetHealth, identity: &str) -> Option<Instant> {
+    health
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(identity)
+        .and_then(|record| record.retry_at)
+}
+
+fn set_repository_healthy(health: &FleetHealth, identity: &str) {
+    let mut health = health
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let Some(record) = health.get_mut(identity) else {
+        return;
+    };
+    if record
+        .retry_at
+        .is_some_and(|retry_at| retry_at > Instant::now())
+        && matches!(
+            record.state,
+            RepositoryHealth::BackingOff
+                | RepositoryHealth::RateLimited
+                | RepositoryHealth::Unavailable
+        )
+    {
+        return;
+    }
+    let changed = record.state != RepositoryHealth::Healthy
+        || record.consecutive_failures > 0
+        || record.pre_rate_limit.is_some();
+    record.state = RepositoryHealth::Healthy;
+    record.consecutive_failures = 0;
+    record.retry_at = None;
+    record.pre_rate_limit = None;
+    drop(health);
+    if changed {
+        eprintln!("Factory repository health: repository={identity} status=healthy");
+    }
+}
+
+fn set_repository_failure(
+    health: &FleetHealth,
+    identity: &str,
+    state: RepositoryHealth,
+    error: &anyhow::Error,
+) -> Instant {
+    let mut health = health
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let record = health
+        .get_mut(identity)
+        .expect("fleet health contains every configured repository");
+    record.consecutive_failures = record.consecutive_failures.saturating_add(1);
+    let delay = repository_backoff(record.consecutive_failures);
+    record.state = state;
+    record.pre_rate_limit = None;
+    let retry_at = Instant::now() + delay;
+    record.retry_at = Some(retry_at);
+    let failures = record.consecutive_failures;
+    drop(health);
+    eprintln!(
+        "Factory repository health: repository={identity} status={} consecutive_failures={failures} retry_in={} error={}",
+        health_name(state),
+        humantime::format_duration(delay),
+        format!("{error:#}")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    retry_at
+}
+
+fn set_repository_host_failure(health: &FleetHealth, identity: &str, error: &anyhow::Error) {
+    if source_rate_limit(error).is_none() {
+        set_repository_failure(health, identity, RepositoryHealth::Unavailable, error);
+    }
+}
+
+fn set_fleet_rate_limited(health: &FleetHealth, retry_at: Instant, message: &str) {
+    let mut health = health
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for (identity, record) in health.iter_mut() {
+        if matches!(
+            record.state,
+            RepositoryHealth::InvalidConfig | RepositoryHealth::Disabled
+        ) {
+            continue;
+        }
+        if record.state != RepositoryHealth::RateLimited {
+            record.pre_rate_limit = Some((record.state, record.retry_at));
+        }
+        record.state = RepositoryHealth::RateLimited;
+        let effective_retry_at = record
+            .retry_at
+            .map_or(retry_at, |current| current.max(retry_at));
+        record.retry_at = Some(effective_retry_at);
+        eprintln!(
+            "Factory repository health: repository={identity} status=rate_limited retry_in={} error={}",
+            humantime::format_duration(
+                effective_retry_at.saturating_duration_since(Instant::now())
+            ),
+            message.split_whitespace().collect::<Vec<_>>().join(" ")
+        );
+    }
+}
+
+fn health_name(health: RepositoryHealth) -> &'static str {
+    match health {
+        RepositoryHealth::Loading => "loading",
+        RepositoryHealth::Healthy => "healthy",
+        RepositoryHealth::BackingOff => "backing_off",
+        RepositoryHealth::RateLimited => "rate_limited",
+        RepositoryHealth::InvalidConfig => "invalid_config",
+        RepositoryHealth::Unavailable => "unavailable",
+        RepositoryHealth::Disabled => "disabled",
+    }
 }
 
 impl FactoryDaemon {
@@ -215,6 +1223,34 @@ impl FactoryDaemon {
             Err(_) if cancellation.is_cancelled() => return Ok(()),
             Err(error) => return Err(error),
         };
+        self.run_loop(cancellation, targets, true, None).await
+    }
+
+    async fn prepare_fleet(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> Result<HashMap<String, RepositoryTarget>> {
+        self.validate_without_github_global(cancellation).await?;
+        self.resolve_targets(cancellation).await
+    }
+
+    async fn run_fleet_member(
+        &self,
+        cancellation: CancellationToken,
+        targets: HashMap<String, RepositoryTarget>,
+        admission: FleetAdmission,
+    ) -> Result<()> {
+        self.run_loop(cancellation, targets, false, Some(admission))
+            .await
+    }
+
+    async fn run_loop(
+        &self,
+        cancellation: CancellationToken,
+        targets: HashMap<String, RepositoryTarget>,
+        poll_sources: bool,
+        admission: Option<FleetAdmission>,
+    ) -> Result<()> {
         let repository_owner = self.repository_owner(&targets)?;
         let mut ledger = Ledger::open(&self.ledger_path)?;
         retain_unresolvable_workspaces(&ledger, &repository_owner)?;
@@ -265,7 +1301,7 @@ impl FactoryDaemon {
             workflow_count,
             humantime::format_duration(self.config.poll_every)
         );
-        {
+        if poll_sources {
             let config = self.config.clone();
             let catalog = self.catalog.clone();
             let ledger_path = self.ledger_path.clone();
@@ -332,7 +1368,9 @@ impl FactoryDaemon {
                     &mut retention_warning_shown,
                     &cancellation,
                     &owner,
-                )?;
+                    admission.as_ref(),
+                )
+                .await?;
 
                 tokio::select! {
                     _ = cancellation.cancelled() => return Ok(()),
@@ -369,6 +1407,7 @@ impl FactoryDaemon {
                             eprintln!("Factory worker failed for {repository}: {error:#}");
                         }
                     }
+                    _ = wait_for_admission_change(admission.as_ref()), if admission.is_some() => {}
                 }
             }
         }
@@ -504,6 +1543,11 @@ impl FactoryDaemon {
     }
 
     async fn validate(&self, cancellation: &CancellationToken) -> Result<()> {
+        self.github.validate_global(cancellation).await?;
+        self.validate_without_github_global(cancellation).await
+    }
+
+    async fn validate_without_github_global(&self, cancellation: &CancellationToken) -> Result<()> {
         for entry in self.catalog.invalid_scheduled_entries() {
             eprintln!(
                 "Factory skipped invalid scheduled workflow {}: {}",
@@ -512,7 +1556,6 @@ impl FactoryDaemon {
             );
         }
         self.catalog.validate_ticket_workflows()?;
-        self.github.validate_global(cancellation).await?;
         if let Some(sandbox) = &self.sandbox {
             self.github
                 .validate_token_env(sandbox.github_token_env(), cancellation)
@@ -641,6 +1684,12 @@ impl FactoryDaemon {
             path: self.repository.clone(),
             workspace_root: self.config.workspace_root.clone(),
         })
+    }
+}
+
+async fn wait_for_admission_change(admission: Option<&FleetAdmission>) {
+    if let Some(admission) = admission {
+        admission.changed().await;
     }
 }
 
@@ -1036,7 +2085,7 @@ fn resolve_workflow_target(entry: &WorkflowEntry) -> Option<(String, WorkflowTar
 }
 
 #[allow(clippy::too_many_arguments)]
-fn dispatch_available(
+async fn dispatch_available(
     ledger: &mut Ledger,
     targets: &HashMap<String, RepositoryTarget>,
     active: &mut HashMap<String, usize>,
@@ -1053,6 +2102,7 @@ fn dispatch_available(
     retention_warning_shown: &mut bool,
     cancellation: &CancellationToken,
     owner: &DaemonOwner,
+    admission: Option<&FleetAdmission>,
 ) -> Result<()> {
     while runs.len() < global_limit && !cancellation.is_cancelled() {
         let available = targets
@@ -1060,6 +2110,9 @@ fn dispatch_available(
             .filter(|repository| active.get(*repository).copied().unwrap_or(0) < repository_limit)
             .cloned()
             .collect::<Vec<_>>();
+        if available.is_empty() {
+            break;
+        }
         let workflow_runtimes = targets
             .iter()
             .flat_map(|(repository, target)| {
@@ -1094,6 +2147,13 @@ fn dispatch_available(
         } else if delivery_slots_available {
             *retention_warning_shown = false;
         }
+        let admission_permit = match admission {
+            Some(admission) => match admission.try_acquire(&available[0])? {
+                Some(permit) => Some(permit),
+                None => break,
+            },
+            None => None,
+        };
         let mut worker_ledger = Ledger::open(ledger_path)?;
         let Some(claimed) = ledger.claim_and_start_run_with_workdirs_filtered(
             &available,
@@ -1159,6 +2219,7 @@ fn dispatch_available(
         let finalization_ledger_path = ledger_path.to_owned();
         let cancellation = cancellation.clone();
         runs.spawn(async move {
+            let _admission_permit = admission_permit;
             let authorization = match &workflow.trigger {
                 Trigger::Source { .. } => match source_config.as_ref() {
                     Some(source) => {

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -2,8 +2,10 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::config::{
@@ -32,7 +34,7 @@ pub struct FleetRepository {
     pub max_concurrent: Option<usize>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RepositoryRuntime {
     pub identity: String,
     pub path: PathBuf,
@@ -48,9 +50,66 @@ pub struct RepositoryRuntime {
 pub enum RepositoryHealth {
     Loading,
     Healthy,
+    BackingOff,
+    RateLimited,
     InvalidConfig,
     Unavailable,
     Disabled,
+}
+
+pub const INITIAL_BACKOFF: Duration = Duration::from_secs(5);
+pub const MAX_BACKOFF: Duration = Duration::from_secs(15 * 60);
+pub const RATE_LIMIT_FALLBACK: Duration = Duration::from_secs(60);
+
+pub fn repository_backoff(consecutive_failures: u32) -> Duration {
+    let exponent = consecutive_failures.saturating_sub(1).min(31);
+    INITIAL_BACKOFF
+        .saturating_mul(1_u32 << exponent)
+        .min(MAX_BACKOFF)
+}
+
+pub fn polling_stagger(repository: &str, workflow: &str, interval: Duration) -> Duration {
+    let interval_millis = interval.as_millis();
+    if interval_millis == 0 {
+        return Duration::ZERO;
+    }
+    let digest = crate::hash::sha256_hex(format!("{repository}\0{workflow}"));
+    let hash = u64::from_str_radix(&digest[..16], 16)
+        .expect("a SHA-256 hexadecimal prefix is always a valid u64");
+    Duration::from_millis((u128::from(hash) % interval_millis) as u64)
+}
+
+pub fn delay_to_next_poll(
+    repository: &str,
+    workflow: &str,
+    interval: Duration,
+    now: SystemTime,
+) -> Result<Duration> {
+    let interval_millis = interval.as_millis();
+    if interval_millis == 0 {
+        bail!("polling interval must be greater than zero");
+    }
+    let now_millis = now
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_millis();
+    let offset = polling_stagger(repository, workflow, interval).as_millis();
+    let period_start = now_millis - (now_millis % interval_millis);
+    let mut due = period_start + offset;
+    if due <= now_millis {
+        due += interval_millis;
+    }
+    Ok(Duration::from_millis((due - now_millis) as u64))
+}
+
+pub fn resolve_rate_limit_delay(
+    retry_at: Option<DateTime<Utc>>,
+    observed_at: DateTime<Utc>,
+) -> Duration {
+    retry_at
+        .filter(|retry_at| *retry_at > observed_at)
+        .and_then(|retry_at| (retry_at - observed_at).to_std().ok())
+        .unwrap_or(RATE_LIMIT_FALLBACK)
 }
 
 #[derive(Debug, Deserialize)]
@@ -433,5 +492,53 @@ mod tests {
         fs::write(&fleet, format!("max_concurrent = 1\n{entries}")).unwrap();
         let error = FleetConfig::load(&fleet).unwrap_err();
         assert!(error.to_string().contains("supports at most 20"));
+    }
+
+    #[test]
+    fn repository_backoff_doubles_from_five_seconds_and_caps_at_fifteen_minutes() {
+        assert_eq!(repository_backoff(1), Duration::from_secs(5));
+        assert_eq!(repository_backoff(2), Duration::from_secs(10));
+        assert_eq!(repository_backoff(8), Duration::from_secs(640));
+        assert_eq!(repository_backoff(9), Duration::from_secs(900));
+        assert_eq!(repository_backoff(100), Duration::from_secs(900));
+    }
+
+    #[test]
+    fn polling_stagger_is_stable_and_aligned_across_restart() {
+        let interval = Duration::from_secs(60);
+        let first = polling_stagger("acme/first", "implement", interval);
+        assert_eq!(first, polling_stagger("acme/first", "implement", interval));
+        assert!(first < interval);
+        assert_ne!(first, polling_stagger("acme/second", "implement", interval));
+        let now = UNIX_EPOCH + Duration::from_secs(1_700_000_013);
+        let delay = delay_to_next_poll("acme/first", "implement", interval, now).unwrap();
+        let restarted = delay_to_next_poll("acme/first", "implement", interval, now).unwrap();
+        assert_eq!(delay, restarted);
+        assert!(delay <= interval);
+    }
+
+    #[test]
+    fn rate_limit_retry_uses_future_timestamp_or_sixty_second_fallback() {
+        let observed = DateTime::parse_from_rfc3339("2026-07-27T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let future = DateTime::parse_from_rfc3339("2026-07-27T12:02:30+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let past = DateTime::parse_from_rfc3339("2026-07-27T11:59:59Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            resolve_rate_limit_delay(Some(future), observed),
+            Duration::from_secs(150)
+        );
+        assert_eq!(
+            resolve_rate_limit_delay(None, observed),
+            RATE_LIMIT_FALLBACK
+        );
+        assert_eq!(
+            resolve_rate_limit_delay(Some(past), observed),
+            RATE_LIMIT_FALLBACK
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 
 use factory::clone::CloneManager;
 use factory::config::{Config, ExecutionMode, repository_config_path};
-use factory::daemon::FactoryDaemon;
+use factory::daemon::{FactoryDaemon, FleetSupervisor};
 use factory::execution::ResolvedWorkflow;
 use factory::fleet::FleetConfig;
 use factory::github::GitHubClient;
@@ -61,10 +61,9 @@ enum Command {
         /// Path to the Factory configuration file.
         #[arg(long, conflicts_with = "fleet")]
         config: Option<PathBuf>,
-        /// Path to a fleet configuration file. Supported with --once.
+        /// Path to a fleet configuration file.
         #[arg(
             long,
-            requires = "once",
             conflicts_with_all = ["config", "data_directory", "workflow_id"]
         )]
         fleet: Option<PathBuf>,
@@ -238,7 +237,11 @@ async fn run_cli() -> Result<u8> {
                     .await;
             }
             if let Some(fleet) = fleet {
-                return run_fleet_once(&fleet).await;
+                return if once {
+                    run_fleet_once(&fleet).await
+                } else {
+                    run_fleet(&fleet).await
+                };
             }
             return run_poller(config, data_directory, once).await;
         }
@@ -917,6 +920,91 @@ async fn run_fleet_once(path: &Path) -> Result<u8> {
         failures += 1;
     }
     Ok(u8::from(failures > 0))
+}
+
+async fn run_fleet(path: &Path) -> Result<u8> {
+    write_stderr_best_effort(
+        format!(
+            "Factory starting: mode=fleet-continuous config={}\n",
+            path.display()
+        )
+        .as_bytes(),
+    );
+    let fleet = FleetConfig::load(path)?;
+    ensure_no_unscoped_ledger_overlap()?;
+    let mut runtimes = Vec::new();
+    let mut invalid = 0usize;
+    for repository in &fleet.repositories {
+        if !repository.enabled {
+            match repository.pinned_ledger_path() {
+                Ok(ledger_path) if ledger_path.exists() => {
+                    if let Err(error) = FactoryDaemon::reconcile_disabled_ledger(
+                        &repository.identity,
+                        &ledger_path,
+                    ) {
+                        write_stderr_best_effort(
+                            format!(
+                                "Factory disabled repository reconciliation failed for {}: {}\n",
+                                repository.identity,
+                                single_line_error(&error)
+                            )
+                            .as_bytes(),
+                        );
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => write_stderr_best_effort(
+                    format!(
+                        "Factory could not locate disabled repository {} for non-destructive reconciliation: {}\n",
+                        repository.identity,
+                        single_line_error(&error)
+                    )
+                    .as_bytes(),
+                ),
+            }
+            write_stdout_best_effort(
+                format!("repository={} status=disabled\n", repository.identity).as_bytes(),
+            );
+            continue;
+        }
+        match repository.load_runtime() {
+            Ok(runtime) => runtimes.push(runtime),
+            Err(error) => {
+                invalid += 1;
+                write_stdout_best_effort(
+                    format!(
+                        "repository={} status=invalid_config error={}\n",
+                        repository.identity,
+                        single_line_error(&error)
+                    )
+                    .as_bytes(),
+                );
+            }
+        }
+    }
+    if runtimes.is_empty() {
+        bail!("fleet has no locally valid enabled repository");
+    }
+    if invalid > 0 {
+        write_stderr_best_effort(
+            format!("Factory fleet continuing with {invalid} invalid repository entries.\n")
+                .as_bytes(),
+        );
+    }
+
+    let cancellation = CancellationToken::new();
+    let signal_token = cancellation.clone();
+    let signal_task = tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            signal_token.cancel();
+        }
+    });
+    FleetSupervisor::new(fleet.max_concurrent, runtimes)?
+        .run(cancellation)
+        .await?;
+    signal_task.abort();
+    write_stderr_best_effort(b"Factory fleet stopped.\n");
+    Ok(0)
 }
 
 fn single_line_error(error: &anyhow::Error) -> String {

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,10 +1,13 @@
 use std::collections::HashSet;
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
@@ -15,6 +18,8 @@ use crate::workflow::{Trigger, WorkflowCatalog, WorkflowEntry};
 
 const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
+const MAX_STDERR_BYTES: usize = 64 * 1024;
+const STDERR_TRUNCATION_MARKER: &str = " [stderr truncated]";
 
 #[derive(Debug, Clone, Default)]
 pub struct SourceClient;
@@ -31,6 +36,47 @@ pub struct RepositoryPoll {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PollReport {
     pub repositories: Vec<RepositoryPoll>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceRateLimit {
+    pub message: String,
+    pub retry_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug)]
+struct SourceCommandFailure {
+    message: String,
+    rate_limit: Option<SourceRateLimit>,
+}
+
+impl fmt::Display for SourceCommandFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SourceCommandFailure {}
+
+pub fn source_rate_limit(error: &anyhow::Error) -> Option<&SourceRateLimit> {
+    error
+        .downcast_ref::<SourceCommandFailure>()
+        .and_then(|failure| failure.rate_limit.as_ref())
+}
+
+#[cfg(test)]
+pub(crate) fn test_source_rate_limit_error(
+    message: impl Into<String>,
+    retry_at: Option<DateTime<Utc>>,
+) -> anyhow::Error {
+    SourceCommandFailure {
+        message: "test source rate limit".to_owned(),
+        rate_limit: Some(SourceRateLimit {
+            message: message.into(),
+            retry_at,
+        }),
+    }
+    .into()
 }
 
 impl PollReport {
@@ -69,6 +115,20 @@ pub struct SourceTicketContext {
 #[serde(deny_unknown_fields)]
 struct SourceOutput {
     issues: Vec<SourceIssue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SourceErrorEnvelope {
+    error: SourceErrorBody,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SourceErrorBody {
+    kind: String,
+    message: String,
+    retry_at: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -127,44 +187,11 @@ impl SourceClient {
                 let mut issues_seen = 0;
                 let mut tasks_created = 0;
                 for workflow in workflows {
-                    let Trigger::Source { state, labels } = workflow
-                        .trigger
-                        .as_ref()
-                        .expect("source workflow was filtered")
-                    else {
-                        unreachable!();
-                    };
-                    let issues = self
-                        .query(repository, source, state, labels, &cancellation)
+                    let report = self
+                        .poll_workflow(repository, &name, source, workflow, ledger, &cancellation)
                         .await?;
-                    issues_seen += issues.len();
-                    let observations = issues
-                        .into_iter()
-                        .map(|issue| observed_ticket(issue, state, labels))
-                        .collect::<Result<Vec<_>>>()?;
-                    for task in ledger.reconcile_ticket_poll(&name, &workflow.id, &observations)? {
-                        if task.created {
-                            tasks_created += 1;
-                            if let Some(payload) = task.task.payload.as_deref()
-                                && let Ok(ticket) =
-                                    serde_json::from_str::<SourceTicketContext>(payload)
-                            {
-                                eprintln!(
-                                    "Factory matched {}: {} [{}; labels={}]",
-                                    ticket.key,
-                                    one_line(&ticket.title, 120),
-                                    ticket.state,
-                                    ticket.labels.join(", ")
-                                );
-                                if !ticket.description.trim().is_empty() {
-                                    eprintln!(
-                                        "Factory issue description: {}",
-                                        one_line(&ticket.description, 240)
-                                    );
-                                }
-                            }
-                        }
-                    }
+                    issues_seen += report.issues_seen;
+                    tasks_created += report.tasks_created;
                 }
                 Ok(RepositoryPoll {
                     repository: repository.to_owned(),
@@ -187,6 +214,63 @@ impl SourceClient {
             });
         }
         Ok(PollReport { repositories })
+    }
+
+    pub async fn poll_workflow(
+        &self,
+        repository: &Path,
+        identity: &str,
+        source: &SourceConfig,
+        workflow: &WorkflowEntry,
+        ledger: &mut Ledger,
+        cancellation: &CancellationToken,
+    ) -> Result<RepositoryPoll> {
+        let Trigger::Source { state, labels } = workflow
+            .trigger
+            .as_ref()
+            .context("workflow is not source-triggered")?
+        else {
+            bail!("workflow is not source-triggered");
+        };
+        let issues = self
+            .query(repository, source, state, labels, cancellation)
+            .await?;
+        let issues_seen = issues.len();
+        let observations = issues
+            .into_iter()
+            .map(|issue| observed_ticket(issue, state, labels))
+            .collect::<Result<Vec<_>>>()?;
+        let mut tasks_created = 0;
+        for task in ledger.reconcile_ticket_poll(identity, &workflow.id, &observations)? {
+            if !task.created {
+                continue;
+            }
+            tasks_created += 1;
+            if let Some(payload) = task.task.payload.as_deref()
+                && let Ok(ticket) = serde_json::from_str::<SourceTicketContext>(payload)
+            {
+                eprintln!(
+                    "Factory matched {}: {} [{}; labels={}]",
+                    ticket.key,
+                    one_line(&ticket.title, 120),
+                    ticket.state,
+                    ticket.labels.join(", ")
+                );
+                if !ticket.description.trim().is_empty() {
+                    eprintln!(
+                        "Factory issue description: {}",
+                        one_line(&ticket.description, 240)
+                    );
+                }
+            }
+        }
+        Ok(RepositoryPoll {
+            repository: repository.to_owned(),
+            name_with_owner: Some(identity.to_owned()),
+            issues_seen,
+            tasks_created,
+            error: None,
+        })
     }
 
     pub async fn poll_until_cancelled<F>(
@@ -271,32 +355,177 @@ impl SourceClient {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true);
+        command.process_group(0);
         for label in labels {
             command.arg("--label").arg(label);
         }
-        let child = command
+        let mut child = command
             .spawn()
             .with_context(|| format!("failed to start source command {:?}", source.command))?;
-        let output = tokio::select! {
-            _ = cancellation.cancelled() => bail!("source command cancelled"),
-            result = tokio::time::timeout(COMMAND_TIMEOUT, child.wait_with_output()) => {
-                result.context("source command timed out after 30s")??
+        let process_group_id = child.id();
+        let stdout = child
+            .stdout
+            .take()
+            .context("source command stdout is unavailable")?;
+        let stderr = child
+            .stderr
+            .take()
+            .context("source command stderr is unavailable")?;
+        let mut stdout_task = tokio::spawn(read_bounded(stdout, MAX_OUTPUT_BYTES, false));
+        let mut stderr_task = tokio::spawn(read_bounded(stderr, MAX_STDERR_BYTES, true));
+        let deadline = tokio::time::Instant::now() + COMMAND_TIMEOUT;
+        let result: Result<_> = tokio::select! {
+            _ = cancellation.cancelled() => Err(anyhow::anyhow!("source command cancelled")),
+            _ = tokio::time::sleep_until(deadline) => {
+                Err(anyhow::anyhow!("source command timed out after 30s"))
             }
+            result = async {
+                let status = child.wait().await.context("failed to wait for source command")?;
+                let stdout = (&mut stdout_task)
+                    .await
+                    .context("source stdout reader task panicked")??;
+                let stderr = (&mut stderr_task)
+                    .await
+                    .context("source stderr reader task panicked")??;
+                Ok((status, stdout, stderr))
+            } => result,
         };
-        if !output.status.success() {
-            bail!(
-                "source command exited with {}; stderr: {}",
-                output.status,
-                one_line(&String::from_utf8_lossy(&output.stderr), 500)
-            );
+        if result.is_err() {
+            kill_source_process_group(process_group_id);
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            stdout_task.abort();
+            stderr_task.abort();
         }
-        if output.stdout.len() > MAX_OUTPUT_BYTES {
+        let (status, stdout, stderr) = result?;
+        let diagnostic = format_stderr(&stderr);
+        if !status.success() {
+            let rate_limit = (!stdout.truncated)
+                .then(|| parse_rate_limit(&stdout.bytes))
+                .flatten();
+            return Err(SourceCommandFailure {
+                message: format!("source command exited with {status}; stderr: {diagnostic}"),
+                rate_limit,
+            }
+            .into());
+        }
+        if stdout.truncated {
             bail!("source command output exceeded 1 MiB");
         }
-        let parsed: SourceOutput = serde_json::from_slice(&output.stdout)
+        let parsed: SourceOutput = serde_json::from_slice(&stdout.bytes)
             .context("source command returned invalid JSON")?;
         validate_issues(parsed.issues, state, labels)
     }
+}
+
+fn kill_source_process_group(process_group_id: Option<u32>) {
+    if let Some(process_id) = process_group_id
+        && let Ok(process_id) = i32::try_from(process_id)
+    {
+        let _ = nix::sys::signal::killpg(
+            nix::unistd::Pid::from_raw(process_id),
+            nix::sys::signal::Signal::SIGKILL,
+        );
+    }
+}
+
+struct BoundedBytes {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+async fn read_bounded(
+    mut reader: impl AsyncRead + Unpin,
+    maximum: usize,
+    retain_tail: bool,
+) -> std::io::Result<BoundedBytes> {
+    let mut bytes = Vec::with_capacity(maximum.min(8192));
+    let mut truncated = false;
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        if retain_tail {
+            if read >= maximum {
+                bytes.clear();
+                bytes.extend_from_slice(&buffer[read - maximum..read]);
+                truncated = true;
+            } else {
+                let overflow = bytes.len().saturating_add(read).saturating_sub(maximum);
+                if overflow > 0 {
+                    bytes.drain(..overflow);
+                    truncated = true;
+                }
+                bytes.extend_from_slice(&buffer[..read]);
+            }
+        } else {
+            let remaining = maximum.saturating_sub(bytes.len());
+            bytes.extend_from_slice(&buffer[..read.min(remaining)]);
+            truncated |= read > remaining;
+        }
+    }
+    Ok(BoundedBytes { bytes, truncated })
+}
+
+fn format_stderr(stderr: &BoundedBytes) -> String {
+    let sanitized =
+        crate::inspection::sanitize_for_storage(&String::from_utf8_lossy(&stderr.bytes))
+            .chars()
+            .map(|character| {
+                if character.is_control() {
+                    ' '
+                } else {
+                    character
+                }
+            })
+            .collect::<String>();
+    let line = sanitized.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut diagnostic = if line.chars().count() <= 500 {
+        line
+    } else {
+        let mut tail = line.chars().rev().take(499).collect::<Vec<_>>();
+        tail.reverse();
+        format!("…{}", tail.into_iter().collect::<String>())
+    };
+    if diagnostic.is_empty() {
+        diagnostic.push('-');
+    }
+    if stderr.truncated {
+        diagnostic.push_str(STDERR_TRUNCATION_MARKER);
+    }
+    diagnostic
+}
+
+fn parse_rate_limit(stdout: &[u8]) -> Option<SourceRateLimit> {
+    if stdout.is_empty() || stdout.len() > MAX_OUTPUT_BYTES {
+        return None;
+    }
+    let envelope: SourceErrorEnvelope = serde_json::from_slice(stdout).ok()?;
+    let kind = envelope.error.kind;
+    if kind.is_empty()
+        || kind.len() > 64
+        || !kind
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+        || kind != "rate_limited"
+    {
+        return None;
+    }
+    let message = envelope.error.message;
+    if message.is_empty() || message.chars().count() > 500 || message.chars().any(char::is_control)
+    {
+        return None;
+    }
+    let retry_at = envelope.error.retry_at.and_then(|value| {
+        value.as_str().and_then(|value| {
+            DateTime::parse_from_rfc3339(value)
+                .ok()
+                .map(|timestamp| timestamp.with_timezone(&Utc))
+        })
+    });
+    Some(SourceRateLimit { message, retry_at })
 }
 
 fn validate_issues(

--- a/tests/fleet_continuous.rs
+++ b/tests/fleet_continuous.rs
@@ -1,0 +1,441 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime};
+
+use factory::fleet::delay_to_next_poll;
+
+fn executable(path: &Path, contents: &str) {
+    fs::write(path, contents).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn repository(root: &Path, data_home: &Path, name: &str, source_body: &str) -> PathBuf {
+    let path = root.join(name);
+    fs::create_dir(&path).unwrap();
+    assert!(
+        Command::new("git")
+            .args(["init", "--quiet", "--initial-branch=main"])
+            .current_dir(&path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        Command::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                &format!("git@github.com:acme/{name}.git"),
+            ])
+            .current_dir(&path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        Command::new(env!("CARGO_BIN_EXE_factory"))
+            .arg("init")
+            .current_dir(&path)
+            .env("FACTORY_DATA_HOME", data_home)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap()
+            .success()
+    );
+    fs::create_dir_all(path.join(".factory/workflows")).unwrap();
+    fs::write(path.join(".factory/workflows/implement.md"), "Implement.\n").unwrap();
+    fs::write(
+        path.join(".factory/config.toml"),
+        r#"version = 1
+poll_every = "60s"
+
+[worker]
+runtime = "codex"
+sandbox = "worktree"
+timeout = "1h"
+maximum_timeout = "8h"
+max_concurrent = 1
+
+[source]
+command = ["./.factory/source.sh"]
+
+[trigger.implement]
+type = "source"
+state = "ready"
+labels = ["factory:ready"]
+workflow = ".factory/workflows/implement.md"
+"#,
+    )
+    .unwrap();
+    executable(&path.join(".factory/source.sh"), source_body);
+    for arguments in [
+        &["config", "user.email", "factory@example.com"][..],
+        &["config", "user.name", "Factory Test"][..],
+        &["add", "."][..],
+        &["commit", "--quiet", "-m", "fixture"][..],
+        &["update-ref", "refs/remotes/origin/main", "HEAD"][..],
+    ] {
+        assert!(
+            Command::new("git")
+                .args(arguments)
+                .current_dir(&path)
+                .status()
+                .unwrap()
+                .success()
+        );
+    }
+    path.canonicalize().unwrap()
+}
+
+fn fake_binaries(root: &Path, worker_marker: &Path) -> PathBuf {
+    let bin = root.join("bin");
+    fs::create_dir(&bin).unwrap();
+    executable(
+        &bin.join("gh"),
+        r#"#!/bin/sh
+case "$1" in
+  --version) echo "gh version 2.80.0" ;;
+  auth) echo "authenticated" ;;
+  repo)
+    case "$*" in
+      *defaultBranchRef*) echo "main" ;;
+      *) echo "Acme/$(basename "$PWD")" ;;
+    esac
+    ;;
+  *) exit 64 ;;
+esac
+"#,
+    );
+    executable(
+        &bin.join("codex"),
+        &format!(
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then echo "codex-cli 1.2.3"; exit 0; fi
+if [ "$1" = "login" ] && [ "$2" = "status" ]; then
+  echo "Logged in using ChatGPT"
+  exit 0
+fi
+output=""
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "--output-last-message" ]; then output="$argument"; fi
+  previous="$argument"
+done
+cat >/dev/null
+git remote get-url origin >> {:?}
+echo '{{"type":"thread.started","thread_id":"fleet-thread"}}'
+printf '%s' 'completed' > "$output"
+"#,
+            worker_marker
+        ),
+    );
+    let real_git =
+        String::from_utf8(Command::new("which").arg("git").output().unwrap().stdout).unwrap();
+    executable(
+        &bin.join("git"),
+        &format!(
+            r#"#!/bin/sh
+if [ "$1" = "fetch" ]; then exit 0; fi
+exec {:?} "$@"
+"#,
+            real_git.trim()
+        ),
+    );
+    bin
+}
+
+fn spawn_fleet(fleet: &Path, data_home: &Path, bin: &Path) -> Child {
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    Command::new(env!("CARGO_BIN_EXE_factory"))
+        .args(["run", "--fleet", fleet.to_str().unwrap()])
+        .env("PATH", path)
+        .env("FACTORY_DATA_HOME", data_home)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap()
+}
+
+fn wait_for_files(paths: &[&Path]) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if paths.iter().all(|path| path.exists()) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!("timed out waiting for {paths:?}");
+}
+
+fn wait_for_lines(path: &Path, expected: usize, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let lines = fs::read_to_string(path)
+            .map(|contents| contents.lines().count())
+            .unwrap_or(0);
+        if lines >= expected {
+            return;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!(
+        "timed out waiting for {expected} lines in {}",
+        path.display()
+    );
+}
+
+fn repositories_due_soon() -> [String; 2] {
+    let now = SystemTime::now();
+    let mut names = Vec::new();
+    for index in 0..10_000 {
+        let name = format!("poll-{index}");
+        let identity = format!("acme/{name}");
+        let delay =
+            delay_to_next_poll(&identity, "implement", Duration::from_secs(60), now).unwrap();
+        if (Duration::from_secs(20)..=Duration::from_secs(25)).contains(&delay) {
+            names.push(name);
+            if names.len() == 2 {
+                return names.try_into().unwrap();
+            }
+        }
+    }
+    panic!("could not find two repository identities due to poll soon");
+}
+
+fn source_with_issue_after_validation(counter: &Path) -> String {
+    format!(
+        r##"#!/bin/sh
+count=$(cat {:?} 2>/dev/null || echo 0)
+count=$((count + 1))
+printf '%s' "$count" > {:?}
+if [ "$count" -eq 1 ]; then
+  printf '%s\n' '{{"issues":[]}}'
+else
+  printf '%s\n' '{{"issues":[{{"key":"#42","title":"Fleet task","state":"ready","labels":["factory:ready"]}}]}}'
+fi
+"##,
+        counter, counter
+    )
+}
+
+fn stop(child: Child) -> Output {
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(child.id() as i32),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn wait_for_exit(mut child: Child) -> Output {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if child.try_wait().unwrap().is_some() {
+            return child.wait_with_output().unwrap();
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    let _ = child.kill();
+    panic!("fleet process did not exit");
+}
+
+#[test]
+fn continuous_polling_enqueues_and_dispatches_work_across_two_repositories() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let first_counter = temp.path().join("first-source-count");
+    let second_counter = temp.path().join("second-source-count");
+    let worker_marker = temp.path().join("workers-launched");
+    let [first_name, second_name] = repositories_due_soon();
+    let first = repository(
+        temp.path(),
+        &data_home,
+        &first_name,
+        &source_with_issue_after_validation(&first_counter),
+    );
+    let second = repository(
+        temp.path(),
+        &data_home,
+        &second_name,
+        &source_with_issue_after_validation(&second_counter),
+    );
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        format!(
+            "max_concurrent = 2\n[[repository]]\nname = \"acme/{first_name}\"\npath = {:?}\nmax_concurrent = 1\n[[repository]]\nname = \"acme/{second_name}\"\npath = {:?}\nmax_concurrent = 1\n",
+            first, second
+        ),
+    )
+    .unwrap();
+
+    let child = spawn_fleet(
+        &fleet,
+        &data_home,
+        &fake_binaries(temp.path(), &worker_marker),
+    );
+    wait_for_lines(&worker_marker, 2, Duration::from_secs(35));
+    let output = stop(child);
+    assert!(output.status.success(), "{output:?}");
+
+    let launches = fs::read_to_string(&worker_marker).unwrap();
+    assert!(
+        launches.contains(&format!("acme/{first_name}.git")),
+        "{launches}"
+    );
+    assert!(
+        launches.contains(&format!("acme/{second_name}.git")),
+        "{launches}"
+    );
+    for counter in [&first_counter, &second_counter] {
+        let queries = fs::read_to_string(counter).unwrap().parse::<u32>().unwrap();
+        assert!(
+            queries >= 3,
+            "{} was queried only {queries} times",
+            counter.display()
+        );
+    }
+}
+
+#[test]
+fn two_repository_idle_fleet_stays_running_and_launches_no_workers() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let first_marker = temp.path().join("first-polled");
+    let second_marker = temp.path().join("second-polled");
+    let worker_marker = temp.path().join("worker-launched");
+    let first = repository(
+        temp.path(),
+        &data_home,
+        "first",
+        &format!(
+            "#!/bin/sh\ntouch {:?}\nprintf '%s\\n' '{{\"issues\":[]}}'\n",
+            first_marker
+        ),
+    );
+    let second = repository(
+        temp.path(),
+        &data_home,
+        "second",
+        &format!(
+            "#!/bin/sh\ntouch {:?}\nprintf '%s\\n' '{{\"issues\":[]}}'\n",
+            second_marker
+        ),
+    );
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        format!(
+            "max_concurrent = 2\n[[repository]]\nname = \"acme/first\"\npath = {:?}\n[[repository]]\nname = \"acme/second\"\npath = {:?}\n",
+            first, second
+        ),
+    )
+    .unwrap();
+    let child = spawn_fleet(
+        &fleet,
+        &data_home,
+        &fake_binaries(temp.path(), &worker_marker),
+    );
+    wait_for_files(&[&first_marker, &second_marker]);
+    thread::sleep(Duration::from_millis(200));
+    let output = stop(child);
+    assert!(output.status.success(), "{output:?}");
+    assert!(!worker_marker.exists());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Factory fleet ready: repositories=2 healthy=2"));
+}
+
+#[test]
+fn unavailable_repository_does_not_stop_a_healthy_peer() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let failed_marker = temp.path().join("failed-polled");
+    let healthy_marker = temp.path().join("healthy-polled");
+    let worker_marker = temp.path().join("worker-launched");
+    let failed = repository(
+        temp.path(),
+        &data_home,
+        "failed",
+        &format!("#!/bin/sh\ntouch {:?}\nexit 1\n", failed_marker),
+    );
+    let healthy = repository(
+        temp.path(),
+        &data_home,
+        "healthy",
+        &format!(
+            "#!/bin/sh\ntouch {:?}\nprintf '%s\\n' '{{\"issues\":[]}}'\n",
+            healthy_marker
+        ),
+    );
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        format!(
+            "max_concurrent = 2\n[[repository]]\nname = \"acme/failed\"\npath = {:?}\n[[repository]]\nname = \"acme/healthy\"\npath = {:?}\n",
+            failed, healthy
+        ),
+    )
+    .unwrap();
+    let child = spawn_fleet(
+        &fleet,
+        &data_home,
+        &fake_binaries(temp.path(), &worker_marker),
+    );
+    wait_for_files(&[&failed_marker, &healthy_marker]);
+    thread::sleep(Duration::from_millis(200));
+    let output = stop(child);
+    assert!(output.status.success(), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("repository=acme/failed status=unavailable"));
+    assert!(stderr.contains("Factory fleet ready: repositories=2 healthy=1"));
+    assert!(!worker_marker.exists());
+}
+
+#[test]
+fn fleet_with_no_healthy_repository_exits_nonzero() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let failed_marker = temp.path().join("failed-polled");
+    let worker_marker = temp.path().join("worker-launched");
+    let failed = repository(
+        temp.path(),
+        &data_home,
+        "failed",
+        &format!("#!/bin/sh\ntouch {:?}\nexit 1\n", failed_marker),
+    );
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        format!(
+            "max_concurrent = 1\n[[repository]]\nname = \"acme/failed\"\npath = {:?}\n",
+            failed
+        ),
+    )
+    .unwrap();
+    let child = spawn_fleet(
+        &fleet,
+        &data_home,
+        &fake_binaries(temp.path(), &worker_marker),
+    );
+    let output = wait_for_exit(child);
+    assert!(!output.status.success());
+    assert!(failed_marker.exists(), "{output:?}");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("fleet has no healthy enabled repository at startup")
+    );
+    assert!(!worker_marker.exists());
+}

--- a/tests/fleet_once.rs
+++ b/tests/fleet_once.rs
@@ -237,7 +237,7 @@ fn missing_repository_is_reported_without_hiding_later_results() {
 }
 
 #[test]
-fn fleet_requires_once_and_rejects_unset_path_variables() {
+fn fleet_continuous_and_once_reject_unset_path_variables() {
     let temp = tempfile::tempdir().unwrap();
     let fleet = temp.path().join("fleet.toml");
     fs::write(
@@ -248,10 +248,13 @@ fn fleet_requires_once_and_rejects_unset_path_variables() {
 
     Command::cargo_bin("factory")
         .unwrap()
+        .env_remove("FACTORY_TEST_UNSET")
         .args(["run", "--fleet", fleet.to_str().unwrap()])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("--once"));
+        .stderr(predicate::str::contains(
+            "unset environment variable $FACTORY_TEST_UNSET",
+        ));
     Command::cargo_bin("factory")
         .unwrap()
         .env_remove("FACTORY_TEST_UNSET")

--- a/tests/fleet_supervisor.rs
+++ b/tests/fleet_supervisor.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use factory::daemon::FleetAdmission;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test(start_paused = true)]
+async fn round_robin_admission_survives_saturation_and_preserves_the_e_cycle_bound() {
+    let admission =
+        FleetAdmission::new(vec!["a".to_owned(), "b".to_owned(), "c".to_owned()], 1).unwrap();
+    let cancellation = CancellationToken::new();
+    let first = admission.acquire("a", &cancellation).await.unwrap();
+    let (sent, mut received) = mpsc::unbounded_channel();
+
+    for repository in ["b", "c", "a"] {
+        let admission = admission.clone();
+        let cancellation = cancellation.clone();
+        let sent = sent.clone();
+        tokio::spawn(async move {
+            let permit = admission.acquire(repository, &cancellation).await.unwrap();
+            sent.send(repository).unwrap();
+            drop(permit);
+        });
+    }
+    tokio::task::yield_now().await;
+    drop(first);
+
+    assert_eq!(received.recv().await, Some("b"));
+    assert_eq!(received.recv().await, Some("c"));
+    assert_eq!(received.recv().await, Some("a"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn fleet_admission_never_exceeds_the_global_limit() {
+    let admission = FleetAdmission::new(vec!["a".to_owned(), "b".to_owned()], 2).unwrap();
+    let active = Arc::new(AtomicUsize::new(0));
+    let maximum = Arc::new(AtomicUsize::new(0));
+    let cancellation = CancellationToken::new();
+    let mut tasks = Vec::new();
+    for repository in ["a", "b"] {
+        let admission = admission.clone();
+        let active = Arc::clone(&active);
+        let maximum = Arc::clone(&maximum);
+        let cancellation = cancellation.clone();
+        tasks.push(tokio::spawn(async move {
+            for _ in 0..10 {
+                let permit = admission.acquire(repository, &cancellation).await.unwrap();
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                maximum.fetch_max(current, Ordering::SeqCst);
+                tokio::task::yield_now().await;
+                active.fetch_sub(1, Ordering::SeqCst);
+                drop(permit);
+            }
+        }));
+    }
+    for task in tasks {
+        task.await.unwrap();
+    }
+    assert_eq!(maximum.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn saturated_fleet_admission_is_nonblocking_for_repository_housekeeping() {
+    let admission = FleetAdmission::new(vec!["a".to_owned(), "b".to_owned()], 1).unwrap();
+    let cancellation = CancellationToken::new();
+    let permit = admission.acquire("a", &cancellation).await.unwrap();
+    assert!(admission.try_acquire("b").unwrap().is_none());
+
+    let housekeeping = Arc::new(AtomicUsize::new(0));
+    housekeeping.fetch_add(1, Ordering::SeqCst);
+    assert_eq!(housekeeping.load(Ordering::SeqCst), 1);
+    drop(permit);
+    assert!(admission.try_acquire("b").unwrap().is_some());
+}

--- a/tests/github_source_adapter.rs
+++ b/tests/github_source_adapter.rs
@@ -233,3 +233,83 @@ fn github_adapter_accepts_exactly_the_maximum_result_count() {
     let value: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(value["issues"].as_array().unwrap().len(), 1000);
 }
+
+#[test]
+fn github_adapter_emits_structured_errors_for_403_and_429_rate_limits() {
+    for status in [403, 429] {
+        let temp = tempfile::tempdir().unwrap();
+        let bin = temp.path().join("bin");
+        fs::create_dir(&bin).unwrap();
+        let executable = bin.join("gh");
+        fs::write(
+            &executable,
+            format!(
+                r#"#!/bin/sh
+if [ "$1" = "api" ] && [ "$2" = "rate_limit" ]; then
+  printf '%s\n' '4102444800'
+  exit 0
+fi
+printf '%s\n' 'HTTP {status}: API rate limit exhausted' >&2
+exit 1
+"#
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(executable, permissions).unwrap();
+        let date = bin.join("date");
+        fs::write(
+            &date,
+            r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "date (GNU coreutils)"
+  exit 0
+fi
+if [ "$1" = "-u" ] && [ "$2" = "-d" ] && [ "$3" = "@4102444800" ]; then
+  echo "2100-01-01T00:00:00Z"
+  exit 0
+fi
+exit 64
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&date).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(date, permissions).unwrap();
+        let path = format!(
+            "{}:{}",
+            bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let adapter =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(".factory/sources/github");
+        let output = Command::new(adapter)
+            .args(["--state", "open"])
+            .env("PATH", path)
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "status={}; stdout={}; stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let value: Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+            panic!(
+                "{error}; stdout={}; stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        });
+        assert_eq!(value["error"]["kind"], "rate_limited");
+        assert!(
+            value["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains(&status.to_string())
+        );
+        assert_eq!(value["error"]["retry_at"], "2100-01-01T00:00:00Z");
+    }
+}

--- a/tests/source_errors.rs
+++ b/tests/source_errors.rs
@@ -1,0 +1,237 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use factory::config::SourceConfig;
+use factory::source::{SourceClient, source_rate_limit};
+use tokio_util::sync::CancellationToken;
+
+fn source_fixture(script: &str) -> (tempfile::TempDir, std::path::PathBuf, SourceConfig) {
+    let temp = tempfile::tempdir().unwrap();
+    let repository = temp.path().join("repository");
+    fs::create_dir(&repository).unwrap();
+    let source = temp.path().join("source.sh");
+    fs::write(&source, format!("#!/bin/sh\n{script}\n")).unwrap();
+    let mut permissions = fs::metadata(&source).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&source, permissions).unwrap();
+    let config = SourceConfig {
+        command: vec![source.display().to_string()],
+        owner: String::new(),
+        project_number: 0,
+        status_field: String::new(),
+        trusted_users: Vec::new(),
+    };
+    (temp, repository, config)
+}
+
+async fn source_error(script: &str) -> anyhow::Error {
+    let (_temp, repository, source) = source_fixture(script);
+    SourceClient
+        .validate(&repository, &source, "open", &[], &CancellationToken::new())
+        .await
+        .unwrap_err()
+}
+
+#[tokio::test]
+async fn structured_rate_limit_accepts_whitespace_and_normalizes_explicit_offsets() {
+    let error = source_error(
+        r#"printf ' \n{"error":{"kind":"rate_limited","message":"slow down","retry_at":"2099-01-01T01:30:00+01:30"}}\n '; exit 1"#,
+    )
+    .await;
+    let rate_limit = source_rate_limit(&error).unwrap();
+    assert_eq!(rate_limit.message, "slow down");
+    assert_eq!(
+        rate_limit.retry_at.unwrap().to_rfc3339(),
+        "2099-01-01T00:00:00+00:00"
+    );
+}
+
+#[tokio::test]
+async fn missing_invalid_and_non_offset_retry_times_remain_actionable_with_fallback() {
+    for retry in [
+        "",
+        r#","retry_at":"not-a-time""#,
+        r#","retry_at":"2099-01-01T00:00:00""#,
+    ] {
+        let script = format!(
+            r#"printf '%s' '{{"error":{{"kind":"rate_limited","message":"slow"{retry}}}}}'; exit 1"#
+        );
+        let error = source_error(&script).await;
+        assert_eq!(source_rate_limit(&error).unwrap().retry_at, None);
+    }
+    for retry_at in [
+        serde_json::json!(123),
+        serde_json::json!({"future": true}),
+        serde_json::json!(["2099-01-01T00:00:00Z"]),
+        serde_json::Value::Null,
+    ] {
+        let envelope = serde_json::json!({
+            "error": {
+                "kind": "rate_limited",
+                "message": "slow",
+                "retry_at": retry_at
+            }
+        });
+        let error = source_error(&format!("printf '%s' '{}'; exit 1", envelope)).await;
+        assert_eq!(source_rate_limit(&error).unwrap().retry_at, None);
+    }
+}
+
+#[tokio::test]
+async fn unknown_or_malformed_envelopes_are_ordinary_transient_failures() {
+    for output in [
+        r#"{"error":{"kind":"future_kind","message":"no"}}"#,
+        r#"{"error":{"kind":"RateLimited","message":"no"}}"#,
+        r#"{"error":{"kind":"rate_limited"}}"#,
+        r#"{"error":{"kind":"rate_limited","message":"","extra":true}}"#,
+        r#"{"error":{"kind":"rate_limited","message":"line\nbreak"}}"#,
+        r#"{"error":{"kind":"rate_limited","message":"ok"}} trailing"#,
+        "",
+    ] {
+        let script = format!("printf '%s' '{}'; exit 1", output.replace('\'', "'\\''"));
+        let error = source_error(&script).await;
+        assert!(source_rate_limit(&error).is_none(), "{output:?}");
+    }
+}
+
+#[tokio::test]
+async fn structured_error_field_limits_are_enforced_exactly() {
+    let invalid = [
+        serde_json::json!({"error": {"kind": "a".repeat(65), "message": "ok"}}),
+        serde_json::json!({"error": {"kind": "rate-limited", "message": "ok"}}),
+        serde_json::json!({"error": {"kind": "rate_limited", "message": "x".repeat(501)}}),
+    ];
+    for envelope in invalid {
+        let script = format!("printf '%s' '{}'; exit 1", envelope);
+        let error = source_error(&script).await;
+        assert!(source_rate_limit(&error).is_none(), "{envelope}");
+    }
+
+    let valid = serde_json::json!({
+        "error": {
+            "kind": "r".repeat(64),
+            "message": "m".repeat(500)
+        }
+    });
+    let error = source_error(&format!("printf '%s' '{}'; exit 1", valid)).await;
+    assert!(source_rate_limit(&error).is_none());
+}
+
+#[tokio::test]
+async fn stderr_never_supplies_the_structured_retry_signal() {
+    let error = source_error(
+        r#"printf '%s' '{"error":{"kind":"rate_limited","message":"slow"}}' >&2; exit 1"#,
+    )
+    .await;
+    assert!(source_rate_limit(&error).is_none());
+}
+
+#[tokio::test]
+async fn oversized_nonzero_stdout_is_not_treated_as_a_structured_error() {
+    let error = source_error("head -c 1048577 /dev/zero | tr '\\000' x; exit 1").await;
+    assert!(source_rate_limit(&error).is_none());
+}
+
+#[tokio::test]
+async fn an_error_envelope_on_success_is_invalid_source_output() {
+    let error =
+        source_error(r#"printf '%s' '{"error":{"kind":"rate_limited","message":"slow"}}'; exit 0"#)
+            .await;
+    assert!(source_rate_limit(&error).is_none());
+    assert!(format!("{error:#}").contains("invalid JSON"));
+}
+
+#[tokio::test]
+async fn stderr_retains_its_tail_and_marks_truncation_without_driving_retry() {
+    let error = source_error(
+        "head -c 70000 /dev/zero | tr '\\000' x >&2; printf ' FINAL-DIAGNOSTIC' >&2; exit 1",
+    )
+    .await;
+    let display = format!("{error:#}");
+    assert!(display.contains("FINAL-DIAGNOSTIC"), "{display}");
+    assert!(display.contains("[stderr truncated]"), "{display}");
+    assert!(source_rate_limit(&error).is_none());
+}
+
+#[tokio::test]
+async fn cancellation_kills_adapter_descendants_that_hold_output_pipes() {
+    let temp = tempfile::tempdir().unwrap();
+    let marker = temp.path().join("started");
+    let script = format!("touch {:?}; sleep 300 & wait", marker);
+    let (_fixture, repository, source) = source_fixture(&script);
+    let cancellation = CancellationToken::new();
+    let query_cancellation = cancellation.clone();
+    let task = tokio::spawn(async move {
+        SourceClient
+            .validate(&repository, &source, "open", &[], &query_cancellation)
+            .await
+    });
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !marker.exists() {
+        assert!(!task.is_finished(), "source query exited before its marker");
+        assert!(tokio::time::Instant::now() < deadline);
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    cancellation.cancel();
+    let result = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+        .await
+        .expect("source cancellation should not wait for descendants")
+        .unwrap();
+    assert!(format!("{:#}", result.unwrap_err()).contains("cancelled"));
+}
+
+#[tokio::test]
+async fn cancellation_still_applies_after_adapter_parent_exits_with_open_descendant_pipes() {
+    for exit in [0, 1] {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("parent-exited");
+        let descendant_pid = temp.path().join("descendant.pid");
+        let script = format!(
+            "sleep 300 & printf '%s' \"$!\" > {:?}; printf '%s' '{{\"issues\":[]}}'; touch {:?}; exit {exit}",
+            descendant_pid, marker
+        );
+        let (_fixture, repository, source) = source_fixture(&script);
+        let cancellation = CancellationToken::new();
+        let query_cancellation = cancellation.clone();
+        let task = tokio::spawn(async move {
+            SourceClient
+                .validate(&repository, &source, "open", &[], &query_cancellation)
+                .await
+        });
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !marker.exists() {
+            assert!(
+                !task.is_finished(),
+                "source parent exited before its marker"
+            );
+            assert!(tokio::time::Instant::now() < deadline);
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        cancellation.cancel();
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), task)
+            .await
+            .expect("pipe draining must remain cancellable after parent exit")
+            .unwrap();
+        assert!(format!("{:#}", result.unwrap_err()).contains("cancelled"));
+        let process_id = fs::read_to_string(&descendant_pid)
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            if matches!(
+                nix::sys::signal::kill(nix::unistd::Pid::from_raw(process_id), None),
+                Err(nix::errno::Errno::ESRCH)
+            ) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "source descendant {process_id} survived cancellation"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+}


### PR DESCRIPTION
Closes #122

## Summary

- run fleet mode continuously with isolated repository health, exponential backoff, stable staggered workflow polling, and shared structured rate-limit pauses
- bound host queries, global worker concurrency, per-repository concurrency, and round-robin admission without blocking housekeeping
- add a structured source-error protocol and make source process timeout/cancellation bounded across descendant-held pipes
- preserve one-shot and single-repository behavior plus repository-safe workspace and ledger ownership
- update the GitHub source adapter to emit portable structured rate-limit errors

## Verification

- `cargo test --test source_polling --test github_polling`
- `cargo test --test daemon --test runtime`
- `cargo test --all-targets --all-features`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- independent review and rereview: approved with no blocker or important findings

The continuous fleet integration test proves two repositories pass startup validation, receive staggered post-startup polls, enqueue durable work, reauthorize it, and launch workers under fleet and repository limits.