### PR TITLE
feat(fleet): add operator lifecycle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ factory run
 ```
 
 The [runnable guide](docs/local-v1.md) covers the complete configuration, source
-contract, first demonstration, and sandbox setup. The
+contract, first demonstration, two-repository fleet setup, and sandbox setup. The
 [operations guide](docs/operations.md) covers inspection, cancellation,
 recovery, and cleanup.
 
@@ -125,17 +125,17 @@ recovery, and cleanup.
 
 V1 intentionally supports:
 
-- one repository and one GitHub source;
+- one repository or an explicit fleet of repository-owned configurations;
 - status, label, and schedule triggers;
 - Codex workers in managed worktrees or Docker clones;
 - explicit Markdown workflows;
 - durable queueing, supervision, history, cancellation, and recovery.
 
-Jira, Linear, multiple repositories, other agent runtimes, hosted workers, and
-webhook wake-ups can fit behind the same source, trigger, workflow, and worker
-boundaries later. This repository includes a [Jira source adapter](docs/jira.md)
-as an example of that extension point, but Jira is not part of the supported V1
-scope.
+Jira, Linear, cross-repository workflows, other agent runtimes, hosted workers,
+and webhook wake-ups can fit behind the same source, trigger, workflow, and
+worker boundaries later. This repository includes a
+[Jira source adapter](docs/jira.md) as an example of that extension point, but
+Jira is not part of the supported V1 scope.
 
 ## Learn more
 

--- a/docs/local-v1.md
+++ b/docs/local-v1.md
@@ -163,6 +163,50 @@ task. Moving the issue out of the condition rearms it, so moving it back later
 can create a continuation task. Scheduled jobs create one task per due instant.
 Durable task keys and atomic claims prevent duplicate workers after restarts.
 
+## Run two repositories as a fleet
+
+Keep each repository's existing `.factory/config.toml`, workflows, source, data
+directory, and workspaces. Create a separate fleet file, for example
+`~/.config/factory/fleet.toml`:
+
+```toml
+max_concurrent = 4
+
+[[repository]]
+name = "acme/payments"
+path = "/code/payments"
+enabled = true
+max_concurrent = 1
+
+[[repository]]
+name = "acme/web"
+path = "../checkouts/web"
+enabled = true
+max_concurrent = 2
+```
+
+The fleet file has no `version` field. Relative paths such as
+`../checkouts/web` resolve from the fleet file's directory, not the shell's
+working directory. A leading `~` and `$NAME` environment variables are
+expanded; unset variables fail validation.
+
+Both paths must be canonical roots of primary, non-bare Git checkouts, not
+linked worktrees. Each checkout's `origin` must resolve to its pinned
+`repository.name`. Start with a no-worker evaluation, inspect the result, then
+start continuous supervision:
+
+```sh
+factory run --fleet ~/.config/factory/fleet.toml --once
+factory status --fleet ~/.config/factory/fleet.toml
+factory tasks --fleet ~/.config/factory/fleet.toml
+factory run --fleet ~/.config/factory/fleet.toml
+```
+
+Fleet configuration changes are restart-only. See the
+[operations guide](operations.md#fleet-operation) for health, retry and rate
+limits, filtering, scoped cancellation and cleanup, graceful shutdown,
+disable/re-enable behavior, and recovery.
+
 Run a schedule-triggered workflow immediately with `factory run ID`. This form
 rejects source-triggered workflows because the loop is what binds the issue
 identity and live source state to the task. It also rejects Docker Sandbox

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -42,6 +42,104 @@ by an old Factory process regardless of the `FACTORY_DATA_HOME` setting. These
 overlap guards run when `factory run` starts; inspection and cleanup commands
 remain available.
 
+## Fleet operation
+
+Run more than one trusted primary checkout from an explicit fleet file:
+
+```sh
+factory run --fleet ~/.config/factory/fleet.toml --once
+factory run --fleet ~/.config/factory/fleet.toml
+```
+
+Fleet configuration is read once at startup. Adding, removing, editing,
+enabling, or disabling a repository has no effect on the running process.
+Restart Factory to apply the changed file. There is no hot reload and no fleet
+`version` field. While that supervisor process is live, fleet inspection and
+mutation commands use its durable fleet and repository configuration startup
+snapshot, even if either file has since been edited. After the process stops,
+commands load the current files.
+
+Each `repository.name` is a pinned GitHub `owner/name` identity. Factory
+lowercases it for durable identity, verifies the canonical primary checkout and
+its `origin`, and never substitutes another remote or checkout for existing
+state. Relative repository paths resolve from the fleet file's parent
+directory. A leading `~` and `$NAME` environment variables use the same
+expansion rules as repository configuration. An unset variable is an error.
+
+The initial supported envelope is 20 enabled repositories, three
+source-triggered workflows per repository, and polling intervals of at least
+60 seconds. `max_concurrent` limits the fleet. An optional repository
+`max_concurrent` combines with its repository worker limit by taking the lower
+value. Factory admits eligible repositories round-robin, runs at most two host
+source queries concurrently, deterministically staggers polls, and shares a
+GitHub rate-limit pause across repositories using the same credential.
+
+Inspect a running or stopped fleet with:
+
+```sh
+factory status --fleet ~/.config/factory/fleet.toml
+factory tasks --fleet ~/.config/factory/fleet.toml
+factory tasks --fleet ~/.config/factory/fleet.toml --repository acme/payments
+factory runs --fleet ~/.config/factory/fleet.toml --repository acme/payments
+factory polls --fleet ~/.config/factory/fleet.toml
+factory workspaces --fleet ~/.config/factory/fleet.toml
+factory recovery --fleet ~/.config/factory/fleet.toml
+```
+
+All fleet rows and JSON objects include pinned repository identity. `status`
+reports `loading`, `healthy`, `invalid_config`, `unavailable`, `backing_off`,
+`rate_limited`, or `disabled`, plus the latest validation or runtime error,
+consecutive failure count, and next retry time when one exists. Ordinary
+transient failures retry after 5 seconds and double to a 15-minute cap.
+Rate-limit responses use the server retry time, or 60 seconds when no usable
+time is available. A locally valid repository remains `loading` until a
+supervisor durably records successful runtime validation; inspection never
+invents a healthy state for an unstarted fleet. `polls` reports the latest
+durable results. Continuous
+supervision records each staggered workflow query. A one-shot evaluation
+replaces those rows with one repository aggregate named `all`; later continuous
+workflow results replace that aggregate without mixing stale rows.
+`workspaces` reports active retained, recovery, and cleanup-pending ownership;
+add `--all` to include cleaned records.
+
+Read-only task and run lists aggregate every configured repository unless
+`--repository owner/name` filters them. A single `inspect RUN_ID` may omit the
+selector only when that numeric ID exists in one configured repository. If the
+same ID exists in more than one ledger, Factory rejects the request and names
+the required selector.
+
+Cancellation and cleanup are mutations, so fleet mode always requires the
+pinned repository:
+
+```sh
+factory cancel --fleet ~/.config/factory/fleet.toml \
+  --repository acme/payments RUN_ID
+factory cleanup --fleet ~/.config/factory/fleet.toml \
+  --repository acme/payments RUN_ID
+factory cleanup --fleet ~/.config/factory/fleet.toml \
+  --repository acme/payments RUN_ID --confirm
+```
+
+Factory resolves the selector before opening a ledger, verifies the run, task,
+and workspace ownership, and refuses unknown or inconsistent ownership without
+mutation. This is required because repository ledgers can both contain run
+`42`.
+
+Disabling a repository takes effect after restart. Ctrl-C and process shutdown
+first stop new polling and claims, cancel active workers, wait for them to
+finish durable finalization, and leave queued work durable. On the next startup
+a disabled repository is opened only for non-destructive reconciliation:
+interrupted work becomes bounded recoverable or queued work but stays dormant.
+Disabled repositories do not poll, create schedules, claim tasks, launch normal
+or recovery workers, or perform destructive cleanup. Their ledgers, history,
+branches, and owned workspaces remain. Re-enable the entry and restart to resume
+normal recovery, reconciliation, polling, and dispatch.
+
+Removing an entry from the fleet file does not open, move, reset, clean, or
+delete its data directory or workspaces. Restore the same pinned identity and
+canonical checkout path to operate that state again. Automatic cloning,
+checkout relocation, and state migration are not supported.
+
 ## Worker boundary
 
 Worktree mode runs the host Codex CLI in a Factory-owned Git worktree. It is
@@ -141,5 +239,11 @@ and worktree directories are preserved.
 - `factory run --once` proves polling without launching a model or worker.
 - `factory inspect RUN_ID` shows bounded task, workspace, optional sandbox,
   branch, pull-request, and error evidence.
+- `factory status --fleet FLEET` reports each configured repository even when a
+  peer is invalid or unavailable. Use its error, failure count, and retry time
+  before changing configuration.
+- An `invalid_config` repository is not retried until restart. `unavailable`,
+  `backing_off`, and `rate_limited` repositories remain retryable and never
+  become permanently disabled because of repeated transient failures.
 
 Scheduled workflows use the same configured worker as ticket workflows.

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -63,6 +63,8 @@ mod fleet_supervisor_state_tests {
                 consecutive_failures: 0,
                 retry_at: None,
                 pre_rate_limit: None,
+                validation_error: None,
+                ledger_path: None,
             },
         )])))
     }
@@ -542,6 +544,8 @@ struct RepositoryHealthRecord {
     consecutive_failures: u32,
     retry_at: Option<Instant>,
     pre_rate_limit: Option<(RepositoryHealth, Option<Instant>)>,
+    validation_error: Option<String>,
+    ledger_path: Option<PathBuf>,
 }
 
 type FleetHealth = Arc<Mutex<HashMap<String, RepositoryHealthRecord>>>;
@@ -581,11 +585,18 @@ impl FleetSupervisor {
                             consecutive_failures: 0,
                             retry_at: None,
                             pre_rate_limit: None,
+                            validation_error: None,
+                            ledger_path: self
+                                .repositories
+                                .iter()
+                                .find(|runtime| runtime.identity == *identity)
+                                .map(|runtime| runtime.ledger_path.clone()),
                         },
                     )
                 })
                 .collect(),
         ));
+        persist_fleet_health(&health);
         let host = FleetHostCoordinator::new(Arc::clone(&health));
 
         let mut members = JoinSet::<(String, Result<()>)>::new();
@@ -934,8 +945,8 @@ async fn poll_fleet_target(
         .source
         .as_ref()
         .context("source-triggered workflow has no configured source")?;
-    if !source.command.is_empty() {
-        return SourceClient
+    let result = if !source.command.is_empty() {
+        SourceClient
             .poll_workflow(
                 &target.runtime.path,
                 &target.runtime.identity,
@@ -944,29 +955,67 @@ async fn poll_fleet_target(
                 &mut ledger,
                 cancellation,
             )
-            .await;
-    }
-    let catalog = WorkflowCatalog {
-        entries: vec![target.workflow.clone()],
+            .await
+    } else {
+        async {
+            let catalog = WorkflowCatalog {
+                entries: vec![target.workflow.clone()],
+            };
+            let report = GitHubClient::default()
+                .poll_once_after_global_validation_for_identity(
+                    &target.runtime.config,
+                    &catalog,
+                    &mut ledger,
+                    cancellation.clone(),
+                    &target.runtime.identity,
+                )
+                .await?;
+            let poll = report
+                .repositories
+                .into_iter()
+                .next()
+                .context("GitHub polling returned no repository result")?;
+            if let Some(error) = &poll.error {
+                Err(anyhow::anyhow!("{error}"))
+            } else {
+                Ok(poll)
+            }
+        }
+        .await
     };
-    let report = GitHubClient::default()
-        .poll_once_after_global_validation_for_identity(
-            &target.runtime.config,
-            &catalog,
-            &mut ledger,
-            cancellation.clone(),
+    let snapshot_result = match &result {
+        Ok(poll) => ledger.record_poll_status(
             &target.runtime.identity,
-        )
-        .await?;
-    let poll = report
-        .repositories
-        .into_iter()
-        .next()
-        .context("GitHub polling returned no repository result")?;
-    if let Some(error) = &poll.error {
-        bail!("{error}");
+            &target.workflow.id,
+            "succeeded",
+            poll.issues_seen,
+            poll.tasks_created,
+            None,
+        ),
+        Err(error) => ledger.record_poll_status(
+            &target.runtime.identity,
+            &target.workflow.id,
+            "failed",
+            0,
+            0,
+            Some(&format!("{error:#}")),
+        ),
+    };
+    if let Err(snapshot_error) = snapshot_result {
+        eprintln!(
+            "Factory could not persist poll status: repository={} workflow={} error={}",
+            target.runtime.identity,
+            target.workflow.id,
+            format!("{snapshot_error:#}")
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        if result.is_ok() {
+            return Err(snapshot_error).context("failed to persist successful fleet poll status");
+        }
     }
-    Ok(poll)
+    result
 }
 
 fn advance_poll_due(target: &mut FleetPollTarget, now: Instant) {
@@ -1026,7 +1075,10 @@ fn set_repository_healthy(health: &FleetHealth, identity: &str) {
     record.consecutive_failures = 0;
     record.retry_at = None;
     record.pre_rate_limit = None;
+    record.validation_error = None;
+    let snapshot = health_snapshot(identity, record);
     drop(health);
+    persist_health_snapshot(snapshot);
     if changed {
         eprintln!("Factory repository health: repository={identity} status=healthy");
     }
@@ -1050,8 +1102,16 @@ fn set_repository_failure(
     record.pre_rate_limit = None;
     let retry_at = Instant::now() + delay;
     record.retry_at = Some(retry_at);
+    record.validation_error = Some(
+        format!("{error:#}")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" "),
+    );
     let failures = record.consecutive_failures;
+    let snapshot = health_snapshot(identity, record);
     drop(health);
+    persist_health_snapshot(snapshot);
     eprintln!(
         "Factory repository health: repository={identity} status={} consecutive_failures={failures} retry_in={} error={}",
         health_name(state),
@@ -1074,6 +1134,7 @@ fn set_fleet_rate_limited(health: &FleetHealth, retry_at: Instant, message: &str
     let mut health = health
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut snapshots = Vec::new();
     for (identity, record) in health.iter_mut() {
         if matches!(
             record.state,
@@ -1089,12 +1150,82 @@ fn set_fleet_rate_limited(health: &FleetHealth, retry_at: Instant, message: &str
             .retry_at
             .map_or(retry_at, |current| current.max(retry_at));
         record.retry_at = Some(effective_retry_at);
+        record.validation_error = Some(message.split_whitespace().collect::<Vec<_>>().join(" "));
+        snapshots.push(health_snapshot(identity, record));
         eprintln!(
             "Factory repository health: repository={identity} status=rate_limited retry_in={} error={}",
             humantime::format_duration(
                 effective_retry_at.saturating_duration_since(Instant::now())
             ),
             message.split_whitespace().collect::<Vec<_>>().join(" ")
+        );
+    }
+    drop(health);
+    for snapshot in snapshots {
+        persist_health_snapshot(snapshot);
+    }
+}
+
+type HealthSnapshot = (
+    String,
+    RepositoryHealth,
+    Option<String>,
+    u32,
+    Option<Instant>,
+    Option<PathBuf>,
+);
+
+fn health_snapshot(identity: &str, record: &RepositoryHealthRecord) -> HealthSnapshot {
+    (
+        identity.to_owned(),
+        record.state,
+        record.validation_error.clone(),
+        record.consecutive_failures,
+        record.retry_at,
+        record.ledger_path.clone(),
+    )
+}
+
+fn persist_fleet_health(health: &FleetHealth) {
+    let snapshots = health
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .iter()
+        .map(|(identity, record)| health_snapshot(identity, record))
+        .collect::<Vec<_>>();
+    for snapshot in snapshots {
+        persist_health_snapshot(snapshot);
+    }
+}
+
+fn persist_health_snapshot(
+    (identity, state, validation_error, consecutive_failures, retry_at, ledger_path): HealthSnapshot,
+) {
+    let Some(ledger_path) = ledger_path else {
+        return;
+    };
+    let next_retry_at = retry_at.map(|retry_at| {
+        let delay = retry_at.saturating_duration_since(Instant::now());
+        Utc::now()
+            .timestamp_millis()
+            .saturating_add(i64::try_from(delay.as_millis()).unwrap_or(i64::MAX))
+    });
+    let result = Ledger::open(&ledger_path).and_then(|ledger| {
+        ledger.record_repository_health(
+            &identity,
+            health_name(state),
+            validation_error.as_deref(),
+            consecutive_failures,
+            next_retry_at,
+        )
+    });
+    if let Err(error) = result {
+        eprintln!(
+            "Factory could not persist repository health: repository={identity} error={}",
+            format!("{error:#}")
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
         );
     }
 }

--- a/src/fleet.rs
+++ b/src/fleet.rs
@@ -1,12 +1,14 @@
 use std::collections::HashSet;
-use std::fs;
+use std::env;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
 
 use crate::config::{
     Config, canonical_directory_or_missing, ensure_primary_checkout, expand_path,
@@ -19,19 +21,70 @@ pub const MAX_ENABLED_REPOSITORIES: usize = 20;
 pub const MAX_SOURCE_WORKFLOWS_PER_REPOSITORY: usize = 3;
 pub const MIN_POLL_SECONDS: u64 = 60;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetConfig {
     pub max_concurrent: usize,
     pub repositories: Vec<FleetRepository>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FleetRepository {
     pub identity: String,
     pub display_name: String,
     pub path: PathBuf,
     pub enabled: bool,
     pub max_concurrent: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ActiveFleetManifest {
+    process_id: u32,
+    process_identity: String,
+    fleet: FleetConfig,
+    repositories: Vec<RepositoryOperationSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepositoryOperationSnapshot {
+    pub identity: String,
+    pub repository_path: PathBuf,
+    pub ledger_path: Option<PathBuf>,
+    pub workspace_root: Option<PathBuf>,
+    pub validation_error: Option<String>,
+}
+
+impl RepositoryOperationSnapshot {
+    pub fn from_runtime(runtime: &RepositoryRuntime) -> Self {
+        Self {
+            identity: runtime.identity.clone(),
+            repository_path: runtime.path.clone(),
+            ledger_path: Some(runtime.ledger_path.clone()),
+            workspace_root: Some(runtime.workspace_root.clone()),
+            validation_error: None,
+        }
+    }
+
+    pub fn from_error(repository: &FleetRepository, error: &anyhow::Error) -> Self {
+        Self {
+            identity: repository.identity.clone(),
+            repository_path: repository.path.clone(),
+            ledger_path: repository.pinned_ledger_path().ok(),
+            workspace_root: None,
+            validation_error: Some(
+                format!("{error:#}")
+                    .split_whitespace()
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            ),
+        }
+    }
+}
+
+pub struct ActiveFleetGuard {
+    state_path: PathBuf,
+    process_id: u32,
+    process_identity: String,
+    _lock: File,
 }
 
 #[derive(Debug, Clone)]
@@ -197,6 +250,168 @@ impl FleetConfig {
             repositories,
         })
     }
+
+    pub fn load_for_operation(path: &Path) -> Result<Self> {
+        if let Some(manifest) = active_fleet_manifest(path)? {
+            return Ok(manifest.fleet);
+        }
+        Self::load(path)
+    }
+}
+
+pub fn activate_fleet(
+    path: &Path,
+    fleet: &FleetConfig,
+    repositories: &[RepositoryOperationSnapshot],
+) -> Result<ActiveFleetGuard> {
+    let snapshot_identities = repositories
+        .iter()
+        .map(|repository| repository.identity.as_str())
+        .collect::<HashSet<_>>();
+    if snapshot_identities.len() != repositories.len()
+        || repositories.len() != fleet.repositories.len()
+        || fleet
+            .repositories
+            .iter()
+            .any(|repository| !snapshot_identities.contains(repository.identity.as_str()))
+    {
+        bail!("active fleet startup snapshot does not match the fleet repositories");
+    }
+    let state_path = active_fleet_state_path(path)?;
+    let parent = state_path
+        .parent()
+        .context("active fleet state path has no parent directory")?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create fleet state directory {}",
+            parent.display()
+        )
+    })?;
+    let lock_path = state_path.with_extension("lock");
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| {
+            format!(
+                "failed to open fleet supervisor lock {}",
+                lock_path.display()
+            )
+        })?;
+    lock.try_lock_exclusive().with_context(|| {
+        format!(
+            "fleet configuration is already supervised; lock {} is held",
+            lock_path.display()
+        )
+    })?;
+    let _ = fs::remove_file(&state_path);
+    let process_id = std::process::id();
+    let process_identity = crate::runtime::process_identity(process_id)
+        .context("failed to resolve Factory supervisor process identity")?;
+    let manifest = ActiveFleetManifest {
+        process_id,
+        process_identity: process_identity.clone(),
+        fleet: fleet.clone(),
+        repositories: repositories.to_vec(),
+    };
+    let bytes =
+        serde_json::to_vec(&manifest).context("failed to encode active fleet startup snapshot")?;
+    let temporary = parent.join(format!(
+        ".{}.{}.tmp",
+        state_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("fleet"),
+        process_id
+    ));
+    fs::write(&temporary, bytes).with_context(|| {
+        format!(
+            "failed to write active fleet startup snapshot {}",
+            temporary.display()
+        )
+    })?;
+    fs::rename(&temporary, &state_path).with_context(|| {
+        format!(
+            "failed to publish active fleet startup snapshot {}",
+            state_path.display()
+        )
+    })?;
+    Ok(ActiveFleetGuard {
+        state_path,
+        process_id,
+        process_identity,
+        _lock: lock,
+    })
+}
+
+pub fn active_repository_operation(
+    path: &Path,
+    identity: &str,
+) -> Result<Option<RepositoryOperationSnapshot>> {
+    Ok(active_fleet_manifest(path)?.and_then(|manifest| {
+        manifest
+            .repositories
+            .into_iter()
+            .find(|repository| repository.identity == identity)
+    }))
+}
+
+impl Drop for ActiveFleetGuard {
+    fn drop(&mut self) {
+        let Ok(contents) = fs::read(&self.state_path) else {
+            return;
+        };
+        let Ok(manifest) = serde_json::from_slice::<ActiveFleetManifest>(&contents) else {
+            return;
+        };
+        if manifest.process_id == self.process_id
+            && manifest.process_identity == self.process_identity
+        {
+            let _ = fs::remove_file(&self.state_path);
+        }
+    }
+}
+
+fn active_fleet_manifest(path: &Path) -> Result<Option<ActiveFleetManifest>> {
+    let state_path = active_fleet_state_path(path)?;
+    let contents = match fs::read(&state_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed to read active fleet state {}", state_path.display())
+            });
+        }
+    };
+    let manifest: ActiveFleetManifest = serde_json::from_slice(&contents).with_context(|| {
+        format!(
+            "failed to parse active fleet state {}",
+            state_path.display()
+        )
+    })?;
+    let active = crate::runtime::process_identity(manifest.process_id)
+        .is_some_and(|identity| identity == manifest.process_identity);
+    if active {
+        return Ok(Some(manifest));
+    }
+    Ok(None)
+}
+
+fn active_fleet_state_path(path: &Path) -> Result<PathBuf> {
+    let current_dir = env::current_dir().context("failed to resolve current directory")?;
+    let resolved = expand_path(path, &current_dir)?;
+    let resolved = resolved.canonicalize().unwrap_or(resolved);
+    let digest = crate::hash::sha256_hex(resolved.as_os_str().as_encoded_bytes());
+    let base = match env::var_os("FACTORY_DATA_HOME").map(PathBuf::from) {
+        Some(base) if base.is_absolute() => base,
+        Some(base) => current_dir.join(base),
+        None => dirs::home_dir()
+            .map(|home| home.join(".factory"))
+            .context("could not determine Factory data directory")?,
+    };
+    Ok(base.join("fleets").join(format!("{}.json", &digest[..20])))
 }
 
 fn resolve_repository_path(path: &Path, base: &Path) -> Result<PathBuf> {

--- a/src/inspection.rs
+++ b/src/inspection.rs
@@ -3,7 +3,7 @@ use std::sync::OnceLock;
 use regex::Regex;
 use serde::Serialize;
 
-use crate::storage::{Run, RunContainer, RunSandbox, Task, TaskState};
+use crate::storage::{PollStatus, Run, RunContainer, RunSandbox, Task, TaskState, TaskWorkspace};
 use crate::table;
 
 const MAX_SUMMARY_BYTES: usize = 240;
@@ -151,6 +151,81 @@ pub struct SandboxView {
     pub state: String,
     pub exit_code: Option<i32>,
     pub removed_at: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FleetStatusView {
+    pub repository: String,
+    pub path: String,
+    pub state: String,
+    pub validation_error: Option<String>,
+    pub consecutive_failures: u32,
+    pub next_retry_at: Option<String>,
+    pub updated_at: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PollStatusView {
+    pub repository: String,
+    pub workflow: String,
+    pub outcome: String,
+    pub issues_seen: usize,
+    pub tasks_created: usize,
+    pub error: Option<String>,
+    pub polled_at: i64,
+}
+
+impl From<&PollStatus> for PollStatusView {
+    fn from(status: &PollStatus) -> Self {
+        Self {
+            repository: status.repository.clone(),
+            workflow: status.workflow.clone(),
+            outcome: status.outcome.clone(),
+            issues_seen: status.issues_seen,
+            tasks_created: status.tasks_created,
+            error: status.error.clone(),
+            polled_at: status.polled_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkspaceView {
+    pub repository: String,
+    pub task_id: i64,
+    pub kind: String,
+    pub backend: String,
+    pub state: String,
+    pub path: String,
+    pub branch: Option<String>,
+    pub summary: Option<String>,
+    pub updated_at: i64,
+}
+
+impl From<&TaskWorkspace> for WorkspaceView {
+    fn from(workspace: &TaskWorkspace) -> Self {
+        Self {
+            repository: workspace.repository.clone(),
+            task_id: workspace.task_id,
+            kind: workspace.kind.clone(),
+            backend: workspace.backend.clone(),
+            state: workspace.state.clone(),
+            path: workspace.path.display().to_string(),
+            branch: workspace.factory_branch.clone(),
+            summary: workspace.status_summary.clone(),
+            updated_at: workspace.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct RecoveryView {
+    pub repository: String,
+    pub task_id: i64,
+    pub run_id: Option<i64>,
+    pub recovery_of: i64,
+    pub recovery_attempt: u32,
+    pub outcome: String,
 }
 
 impl RunInspection {
@@ -348,6 +423,138 @@ pub fn print_inspection(inspection: &RunInspection) {
     print_detail("Result", inspection.result.as_ref());
     print_detail("Error", inspection.error.as_ref());
     print_detail("Activity", inspection.activity.as_ref());
+}
+
+pub fn print_fleet_status(statuses: &[FleetStatusView]) {
+    let rows = statuses
+        .iter()
+        .map(|status| {
+            [
+                safe_column(&status.repository, 48),
+                safe_column(&status.state, 20),
+                status.consecutive_failures.to_string(),
+                safe_column(status.next_retry_at.as_deref().unwrap_or("-"), 32),
+                safe_column(status.validation_error.as_deref().unwrap_or("-"), 80),
+                safe_column(&status.path, 80),
+            ]
+        })
+        .collect::<Vec<_>>();
+    print!(
+        "{}",
+        table::render(
+            [
+                "REPOSITORY",
+                "HEALTH",
+                "FAILURES",
+                "NEXT_RETRY",
+                "ERROR",
+                "PATH",
+            ],
+            &rows,
+            &[2],
+        )
+    );
+}
+
+pub fn print_poll_statuses(statuses: &[PollStatus]) {
+    let rows = statuses
+        .iter()
+        .map(|status| {
+            [
+                safe_column(&status.repository, 48),
+                safe_column(&status.workflow, 36),
+                safe_column(&status.outcome, 16),
+                status.issues_seen.to_string(),
+                status.tasks_created.to_string(),
+                status.polled_at.to_string(),
+                safe_column(status.error.as_deref().unwrap_or("-"), 80),
+            ]
+        })
+        .collect::<Vec<_>>();
+    print!(
+        "{}",
+        table::render(
+            [
+                "REPOSITORY",
+                "WORKFLOW",
+                "OUTCOME",
+                "ISSUES",
+                "TASKS",
+                "POLLED_AT",
+                "ERROR",
+            ],
+            &rows,
+            &[3, 4, 5],
+        )
+    );
+}
+
+pub fn print_workspaces(workspaces: &[TaskWorkspace]) {
+    let rows = workspaces
+        .iter()
+        .map(|workspace| {
+            [
+                safe_column(&workspace.repository, 48),
+                workspace.task_id.to_string(),
+                safe_column(&workspace.kind, 16),
+                safe_column(&workspace.backend, 16),
+                safe_column(&workspace.state, 20),
+                safe_column(
+                    workspace.factory_branch.as_deref().unwrap_or("detached"),
+                    48,
+                ),
+                safe_column(&workspace.path.display().to_string(), 80),
+            ]
+        })
+        .collect::<Vec<_>>();
+    print!(
+        "{}",
+        table::render(
+            [
+                "REPOSITORY",
+                "TASK",
+                "KIND",
+                "BACKEND",
+                "STATE",
+                "BRANCH",
+                "PATH",
+            ],
+            &rows,
+            &[1],
+        )
+    );
+}
+
+pub fn print_recovery(recovery: &[RecoveryView]) {
+    let rows = recovery
+        .iter()
+        .map(|item| {
+            [
+                safe_column(&item.repository, 48),
+                item.task_id.to_string(),
+                item.run_id
+                    .map_or_else(|| "-".to_owned(), |value| value.to_string()),
+                item.recovery_of.to_string(),
+                item.recovery_attempt.to_string(),
+                safe_column(&item.outcome, 16),
+            ]
+        })
+        .collect::<Vec<_>>();
+    print!(
+        "{}",
+        table::render(
+            [
+                "REPOSITORY",
+                "TASK",
+                "RUN",
+                "RECOVERY_OF",
+                "ATTEMPT",
+                "OUTCOME",
+            ],
+            &rows,
+            &[1, 2, 3, 4],
+        )
+    );
 }
 
 fn print_detail(label: &str, detail: Option<&BoundedText>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,16 @@ use factory::clone::CloneManager;
 use factory::config::{Config, ExecutionMode, repository_config_path};
 use factory::daemon::{FactoryDaemon, FleetSupervisor};
 use factory::execution::ResolvedWorkflow;
-use factory::fleet::FleetConfig;
+use factory::fleet::{
+    FleetConfig, FleetRepository, RepositoryOperationSnapshot, activate_fleet,
+    active_repository_operation,
+};
 use factory::github::GitHubClient;
 use factory::init::{InitOptions, initialize};
 use factory::inspection::{
-    RunInspection, RunView, TaskView, print_inspection, print_runs, print_tasks,
+    FleetStatusView, PollStatusView, RecoveryView, RunInspection, RunView, TaskView, WorkspaceView,
+    print_fleet_status, print_inspection, print_poll_statuses, print_recovery, print_runs,
+    print_tasks, print_workspaces,
 };
 use factory::runtime::{
     RuntimeCancelled, Termination, build_runtime, observation_channel, write_stderr_best_effort,
@@ -24,8 +29,9 @@ use factory::runtime::{
 use factory::sandbox::SandboxWorker;
 use factory::source::{PollReport, SourceClient};
 use factory::storage::{
-    CancellationRequest, DATABASE_NAME, Ledger, OPERATOR_CONFIRMED_CLEANUP, TaskState,
-    acquire_state_reset_lock, inspect_reset_state, validate_data_directory,
+    CancellationRequest, DATABASE_NAME, Ledger, OPERATOR_CONFIRMED_CLEANUP, PollStatus, Run, Task,
+    TaskState, TaskWorkspace, acquire_state_reset_lock, inspect_reset_state,
+    validate_data_directory,
 };
 use factory::workflow::{Trigger, WorkflowCatalog};
 use factory::workspace::WorkspaceManager;
@@ -99,6 +105,12 @@ enum Command {
         /// Directory containing the durable Factory database.
         #[arg(long)]
         data_directory: Option<PathBuf>,
+        /// Fleet configuration to inspect across repositories.
+        #[arg(long, conflicts_with_all = ["config", "data_directory"])]
+        fleet: Option<PathBuf>,
+        /// Pinned owner/name identity to filter in fleet mode.
+        #[arg(long, requires = "fleet")]
+        repository: Option<String>,
     },
     /// List run attempts, optionally filtered by workflow.
     Runs {
@@ -113,6 +125,12 @@ enum Command {
         /// Directory containing the durable Factory database.
         #[arg(long)]
         data_directory: Option<PathBuf>,
+        /// Fleet configuration to inspect across repositories.
+        #[arg(long, conflicts_with_all = ["config", "data_directory"])]
+        fleet: Option<PathBuf>,
+        /// Pinned owner/name identity to filter in fleet mode.
+        #[arg(long, requires = "fleet")]
+        repository: Option<String>,
     },
     /// Inspect one run and its resolved task context.
     Inspect {
@@ -126,6 +144,12 @@ enum Command {
         /// Directory containing the durable Factory database.
         #[arg(long)]
         data_directory: Option<PathBuf>,
+        /// Fleet configuration to inspect.
+        #[arg(long, conflicts_with_all = ["config", "data_directory"])]
+        fleet: Option<PathBuf>,
+        /// Pinned owner/name identity. Required when an ID overlaps.
+        #[arg(long, requires = "fleet")]
+        repository: Option<String>,
     },
     /// Request cancellation of an active local run.
     Cancel {
@@ -139,6 +163,12 @@ enum Command {
         /// Directory containing the durable Factory database.
         #[arg(long)]
         data_directory: Option<PathBuf>,
+        /// Fleet configuration containing the target repository.
+        #[arg(long, conflicts_with_all = ["config", "data_directory"])]
+        fleet: Option<PathBuf>,
+        /// Pinned owner/name identity. Required for fleet mutation.
+        #[arg(long, requires = "fleet")]
+        repository: Option<String>,
     },
     /// Preview or confirm removal of one retained Factory worktree.
     Cleanup {
@@ -152,6 +182,63 @@ enum Command {
         /// Directory containing the durable Factory database.
         #[arg(long)]
         data_directory: Option<PathBuf>,
+        /// Fleet configuration containing the target repository.
+        #[arg(long, conflicts_with_all = ["config", "data_directory"])]
+        fleet: Option<PathBuf>,
+        /// Pinned owner/name identity. Required for fleet mutation.
+        #[arg(long, requires = "fleet")]
+        repository: Option<String>,
+    },
+    /// Report configured fleet health and retry state.
+    Status {
+        /// Path to a fleet configuration file.
+        #[arg(long)]
+        fleet: PathBuf,
+        /// Pinned owner/name identity to filter.
+        #[arg(long)]
+        repository: Option<String>,
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List the latest durable fleet poll results.
+    Polls {
+        /// Path to a fleet configuration file.
+        #[arg(long)]
+        fleet: PathBuf,
+        /// Pinned owner/name identity to filter.
+        #[arg(long)]
+        repository: Option<String>,
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List retained and recoverable fleet workspaces.
+    Workspaces {
+        /// Path to a fleet configuration file.
+        #[arg(long)]
+        fleet: PathBuf,
+        /// Pinned owner/name identity to filter.
+        #[arg(long)]
+        repository: Option<String>,
+        /// Include cleaned workspace records.
+        #[arg(long)]
+        all: bool,
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// List pending and attempted fleet recovery runs.
+    Recovery {
+        /// Path to a fleet configuration file.
+        #[arg(long)]
+        fleet: PathBuf,
+        /// Pinned owner/name identity to filter.
+        #[arg(long)]
+        repository: Option<String>,
+        /// Print stable machine-readable JSON.
+        #[arg(long)]
+        json: bool,
     },
     /// Preview or confirm removal of durable state for the current repository.
     Reset {
@@ -184,6 +271,8 @@ enum WorkflowCommand {
 
 #[derive(Serialize)]
 struct CancellationResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    repository: Option<String>,
     run_id: i64,
     status: &'static str,
     owner_kind: &'static str,
@@ -343,9 +432,17 @@ async fn run_cli() -> Result<u8> {
             json,
             config,
             data_directory,
+            fleet,
+            repository,
         } => {
-            let ledger = open_data_ledger(config, data_directory)?;
-            let tasks = ledger.tasks()?;
+            let mut tasks = if let Some(fleet) = fleet {
+                collect_fleet_tasks(&fleet, repository.as_deref())?
+            } else {
+                open_data_ledger(config, data_directory)?.tasks()?
+            };
+            tasks.sort_by(|left, right| {
+                (&left.repository, left.id).cmp(&(&right.repository, right.id))
+            });
             if json {
                 let views = tasks.iter().map(TaskView::from).collect::<Vec<_>>();
                 print_json(&views)?;
@@ -358,9 +455,17 @@ async fn run_cli() -> Result<u8> {
             json,
             config,
             data_directory,
+            fleet,
+            repository,
         } => {
-            let ledger = open_data_ledger(config, data_directory)?;
-            let runs = ledger.runs(workflow.as_deref())?;
+            let mut runs = if let Some(fleet) = fleet {
+                collect_fleet_runs(&fleet, repository.as_deref(), workflow.as_deref())?
+            } else {
+                open_data_ledger(config, data_directory)?.runs(workflow.as_deref())?
+            };
+            runs.sort_by(|left, right| {
+                (&left.repository, left.id).cmp(&(&right.repository, right.id))
+            });
             if json {
                 let views = runs.iter().map(RunView::from).collect::<Vec<_>>();
                 print_json(&views)?;
@@ -373,14 +478,21 @@ async fn run_cli() -> Result<u8> {
             json,
             config,
             data_directory,
+            fleet,
+            repository,
         } => {
-            let ledger = open_data_ledger(config, data_directory)?;
-            let run = ledger
-                .run(run_id)?
-                .with_context(|| format!("run {run_id} does not exist"))?;
-            let task = ledger
-                .task(run.task_id)?
-                .with_context(|| format!("task {} for run {run_id} does not exist", run.task_id))?;
+            let (ledger, run, task) = if let Some(fleet) = fleet {
+                fleet_run_context(&fleet, repository.as_deref(), run_id)?
+            } else {
+                let ledger = open_data_ledger(config, data_directory)?;
+                let run = ledger
+                    .run(run_id)?
+                    .with_context(|| format!("run {run_id} does not exist"))?;
+                let task = ledger.task(run.task_id)?.with_context(|| {
+                    format!("task {} for run {run_id} does not exist", run.task_id)
+                })?;
+                (ledger, run, task)
+            };
             let container = ledger.run_container(run_id)?;
             let sandbox = ledger.run_sandbox(run_id)?;
             let inspection = RunInspection::new(&run, &task, container.as_ref(), sandbox.as_ref());
@@ -395,46 +507,28 @@ async fn run_cli() -> Result<u8> {
             json,
             config,
             data_directory,
+            fleet,
+            repository,
         } => {
-            let mut ledger = open_data_ledger(config, data_directory)?;
-            let response = match ledger.request_run_cancellation(run_id)? {
-                CancellationRequest::Requested(run) => CancellationResponse {
-                    run_id: run.id,
-                    status: "requested",
-                    owner_kind: "factory-daemon",
-                    owner_pid: run.owner_pid,
-                    outcome: run.outcome,
-                    message: "cancellation requested; the owning Factory daemon will stop the active process tree",
-                },
-                CancellationRequest::AlreadyRequested(run) => CancellationResponse {
-                    run_id: run.id,
-                    status: "already_requested",
-                    owner_kind: "factory-daemon",
-                    owner_pid: run.owner_pid,
-                    outcome: run.outcome,
-                    message: "cancellation was already requested from the owning Factory daemon",
-                },
-                CancellationRequest::Terminal(run) => CancellationResponse {
-                    run_id: run.id,
-                    status: "already_terminal",
-                    owner_kind: "none",
-                    owner_pid: None,
-                    outcome: run.outcome,
-                    message: "run is already terminal",
-                },
-                CancellationRequest::OwnedElsewhere(run) => CancellationResponse {
-                    run_id: run.id,
-                    status: "owned_elsewhere",
-                    owner_kind: "stale-or-foreign",
-                    owner_pid: run.owner_pid,
-                    outcome: run.outcome,
-                    message: "run has no live local Factory daemon owner; inspect or recover it before retrying cancellation",
-                },
-                CancellationRequest::NotFound => bail!("run {run_id} does not exist"),
+            let (mut ledger, selected_repository) = if let Some(fleet) = fleet {
+                let repository = repository
+                    .as_deref()
+                    .context("--repository owner/name is required for fleet cancellation")?;
+                (
+                    fleet_mutation_ledger(&fleet, repository, run_id)?,
+                    Some(repository.trim().to_ascii_lowercase()),
+                )
+            } else {
+                (open_data_ledger(config, data_directory)?, None)
             };
+            let response =
+                cancellation_response(&mut ledger, run_id, selected_repository.as_deref())?;
             if json {
                 print_json(&response)?;
             } else {
+                if let Some(repository) = &response.repository {
+                    println!("Repository: {repository}");
+                }
                 println!(
                     "Run {}: {} ({})",
                     response.run_id, response.message, response.status
@@ -446,102 +540,138 @@ async fn run_cli() -> Result<u8> {
             confirm,
             config,
             data_directory,
+            fleet,
+            repository,
         } => {
-            let path = resolve_config_path(config)?;
-            let config = Config::load(&path)?;
-            let data_directory = data_directory.unwrap_or_else(|| config.data_directory.clone());
-            let ledger = Ledger::open_in(&data_directory)?;
-            let run = ledger
-                .run(run_id)?
-                .with_context(|| format!("run {run_id} does not exist"))?;
-            let task = ledger
-                .task(run.task_id)?
-                .with_context(|| format!("task {} for run {run_id} does not exist", run.task_id))?;
-            let workspace = ledger
-                .task_workspace(task.id)?
-                .with_context(|| format!("run {run_id} has no Factory-owned workspace"))?;
-            if workspace.state == "cleaned" {
-                println!("run: {run_id}");
-                println!("workspace: {}", workspace.path.display());
-                println!("branch preserved: true");
-                println!("action: workspace reservation is already cleaned; no changes made");
-                return Ok(0);
-            }
-            let manager = WorkspaceManager::new(&config.repositories[0], &config.workspace_root)?;
-            let clone_manager = CloneManager::new(&config.workspace_root)?;
-            if !workspace.path.exists() {
-                println!("run: {run_id}");
-                println!("workspace: {}", workspace.path.display());
-                println!(
-                    "branch: {}",
-                    workspace.factory_branch.as_deref().unwrap_or("detached")
-                );
-                println!("workspace exists: false");
-                println!("branch preserved: true");
-                if !confirm {
-                    println!(
-                        "action: preview only; rerun with --confirm to release the workspace reservation"
+            if let Some(fleet) = fleet {
+                let repository = repository
+                    .as_deref()
+                    .context("--repository owner/name is required for fleet cleanup")?;
+                let fleet_config = FleetConfig::load_for_operation(&fleet)?;
+                let repository = required_fleet_repository(&fleet_config, repository)?.clone();
+                if confirm && !repository.enabled {
+                    bail!(
+                        "repository {} is disabled; re-enable it and restart Factory before destructive cleanup",
+                        repository.identity
                     );
-                } else {
-                    if matches!(task.state, TaskState::Queued | TaskState::Running) {
+                }
+                let active = active_repository_operation(&fleet, &repository.identity)?;
+                let (repository_path, ledger_path, workspace_root) = if let Some(snapshot) = active
+                {
+                    if let Some(error) = snapshot.validation_error {
                         bail!(
-                            "refusing to release workspace for {:?} task {}; cancel or finish it first",
-                            task.state,
-                            task.id
+                            "failed to load repository {} from the supervisor startup snapshot: {}",
+                            repository.identity,
+                            error
                         );
                     }
-                    ledger.update_task_workspace_state(
-                        task.id,
-                        "cleaned",
-                        Some("operator confirmed absent workspace; local branch preserved"),
-                    )?;
-                    println!("action: released workspace reservation; local branch preserved");
+                    (
+                        snapshot.repository_path,
+                        snapshot.ledger_path.with_context(|| {
+                            format!(
+                                "repository {} startup snapshot has no ledger path",
+                                repository.identity
+                            )
+                        })?,
+                        snapshot.workspace_root.with_context(|| {
+                            format!(
+                                "repository {} startup snapshot has no workspace root",
+                                repository.identity
+                            )
+                        })?,
+                    )
+                } else {
+                    let runtime = repository.load_runtime().with_context(|| {
+                        format!(
+                            "failed to load repository {} for cleanup",
+                            repository.identity
+                        )
+                    })?;
+                    (runtime.path, runtime.ledger_path, runtime.workspace_root)
+                };
+                if !ledger_path.exists() {
+                    bail!("repository {} has no durable state", repository.identity);
                 }
-                return Ok(0);
+                let ledger = Ledger::open(&ledger_path)?;
+                cleanup_run(
+                    &repository_path,
+                    &workspace_root,
+                    &ledger,
+                    run_id,
+                    confirm,
+                    Some(&repository.identity),
+                )?;
+            } else {
+                let path = resolve_config_path(config)?;
+                let config = Config::load(&path)?;
+                let data_directory =
+                    data_directory.unwrap_or_else(|| config.data_directory.clone());
+                let ledger = Ledger::open_in(&data_directory)?;
+                cleanup_run(
+                    &config.repositories[0],
+                    &config.workspace_root,
+                    &ledger,
+                    run_id,
+                    confirm,
+                    None,
+                )?;
             }
-            let preview = if workspace.backend == "clone" {
-                clone_manager.preview_cleanup(&workspace.path)?
+        }
+        Command::Status {
+            fleet,
+            repository,
+            json,
+        } => {
+            let statuses = fleet_statuses(&fleet, repository.as_deref())?;
+            if json {
+                print_json(&statuses)?;
             } else {
-                manager.cleanup(&workspace.path, false)?.1
-            };
-            println!("run: {run_id}");
-            println!("workspace: {}", preview.path.display());
-            println!(
-                "branch: {}",
-                preview.branch.as_deref().unwrap_or("detached")
-            );
-            println!("dirty: {}", preview.dirty);
-            println!("branch preserved: true");
-            if !confirm {
-                println!("action: preview only; rerun with --confirm to remove the workspace");
+                print_fleet_status(&statuses);
+            }
+        }
+        Command::Polls {
+            fleet,
+            repository,
+            json,
+        } => {
+            let statuses = collect_fleet_poll_statuses(&fleet, repository.as_deref())?;
+            if json {
+                let views = statuses
+                    .iter()
+                    .map(PollStatusView::from)
+                    .collect::<Vec<_>>();
+                print_json(&views)?;
             } else {
-                if matches!(task.state, TaskState::Queued | TaskState::Running) {
-                    bail!(
-                        "refusing to clean workspace for {:?} task {}; cancel or finish it first",
-                        task.state,
-                        task.id
-                    );
-                }
-                ledger.update_task_workspace_state(
-                    task.id,
-                    "cleanup_pending",
-                    Some(OPERATOR_CONFIRMED_CLEANUP),
-                )?;
-                if workspace.backend == "clone" {
-                    clone_manager.remove(&workspace.path)?;
-                } else {
-                    manager.cleanup(&workspace.path, true)?;
-                }
-                ledger.update_task_workspace_state(
-                    task.id,
-                    "cleaned",
-                    Some("operator-confirmed cleanup completed"),
-                )?;
-                if workspace.backend == "clone" {
-                    println!("action: removed clone; remote branch preserved");
-                } else {
-                    println!("action: removed worktree; local branch preserved");
-                }
+                print_poll_statuses(&statuses);
+            }
+        }
+        Command::Workspaces {
+            fleet,
+            repository,
+            all,
+            json,
+        } => {
+            let workspaces = collect_fleet_workspaces(&fleet, repository.as_deref(), all)?;
+            if json {
+                let views = workspaces
+                    .iter()
+                    .map(WorkspaceView::from)
+                    .collect::<Vec<_>>();
+                print_json(&views)?;
+            } else {
+                print_workspaces(&workspaces);
+            }
+        }
+        Command::Recovery {
+            fleet,
+            repository,
+            json,
+        } => {
+            let recovery = collect_fleet_recovery(&fleet, repository.as_deref())?;
+            if json {
+                print_json(&recovery)?;
+            } else {
+                print_recovery(&recovery);
             }
         }
         Command::Reset {
@@ -631,6 +761,488 @@ async fn run_cli() -> Result<u8> {
     }
 
     Ok(0)
+}
+
+fn selected_fleet_repositories<'a>(
+    fleet: &'a FleetConfig,
+    selector: Option<&str>,
+) -> Result<Vec<&'a FleetRepository>> {
+    let Some(selector) = selector else {
+        return Ok(fleet.repositories.iter().collect());
+    };
+    let selector = selector.trim().to_ascii_lowercase();
+    if selector.is_empty() {
+        bail!("repository selector must not be empty");
+    }
+    let repository = fleet
+        .repositories
+        .iter()
+        .find(|repository| repository.identity == selector)
+        .with_context(|| format!("repository {selector} is not configured in this fleet"))?;
+    Ok(vec![repository])
+}
+
+fn required_fleet_repository<'a>(
+    fleet: &'a FleetConfig,
+    selector: &str,
+) -> Result<&'a FleetRepository> {
+    selected_fleet_repositories(fleet, Some(selector))?
+        .into_iter()
+        .next()
+        .context("repository selector did not resolve")
+}
+
+fn existing_fleet_ledger(repository: &FleetRepository) -> Result<Option<Ledger>> {
+    let ledger_path = repository.pinned_ledger_path()?;
+    if !ledger_path.exists() {
+        return Ok(None);
+    }
+    Ledger::open(&ledger_path).map(Some)
+}
+
+fn collect_fleet_tasks(path: &Path, selector: Option<&str>) -> Result<Vec<Task>> {
+    let fleet = FleetConfig::load_for_operation(path)?;
+    let mut tasks = Vec::new();
+    for repository in selected_fleet_repositories(&fleet, selector)? {
+        if let Some(ledger) = existing_fleet_ledger(repository)? {
+            tasks.extend(ledger.tasks()?);
+        }
+    }
+    Ok(tasks)
+}
+
+fn collect_fleet_runs(
+    path: &Path,
+    selector: Option<&str>,
+    workflow: Option<&str>,
+) -> Result<Vec<Run>> {
+    let fleet = FleetConfig::load_for_operation(path)?;
+    let mut runs = Vec::new();
+    for repository in selected_fleet_repositories(&fleet, selector)? {
+        if let Some(ledger) = existing_fleet_ledger(repository)? {
+            runs.extend(ledger.runs(workflow)?);
+        }
+    }
+    Ok(runs)
+}
+
+fn fleet_run_context(
+    path: &Path,
+    selector: Option<&str>,
+    run_id: i64,
+) -> Result<(Ledger, Run, Task)> {
+    let fleet = FleetConfig::load_for_operation(path)?;
+    let mut matches = Vec::new();
+    for repository in selected_fleet_repositories(&fleet, selector)? {
+        let Some(ledger) = existing_fleet_ledger(repository)? else {
+            continue;
+        };
+        let Some(run) = ledger.run(run_id)? else {
+            continue;
+        };
+        let task = ledger
+            .task(run.task_id)?
+            .with_context(|| format!("task {} for run {run_id} does not exist", run.task_id))?;
+        if run.repository != repository.identity || task.repository != repository.identity {
+            bail!(
+                "run {run_id} in repository {} has inconsistent durable repository ownership; no fallback repository was used",
+                repository.identity
+            );
+        }
+        matches.push((repository.identity.clone(), ledger, run, task));
+    }
+    match matches.len() {
+        0 => bail!("run {run_id} does not exist in the selected fleet repositories"),
+        1 => {
+            let (_, ledger, run, task) = matches.pop().expect("one fleet run match exists");
+            Ok((ledger, run, task))
+        }
+        _ => {
+            let identities = matches
+                .iter()
+                .map(|(identity, _, _, _)| identity.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "run {run_id} exists in multiple repositories ({identities}); use --repository owner/name"
+            )
+        }
+    }
+}
+
+fn fleet_mutation_ledger(path: &Path, selector: &str, run_id: i64) -> Result<Ledger> {
+    let fleet = FleetConfig::load_for_operation(path)?;
+    let repository = required_fleet_repository(&fleet, selector)?;
+    let ledger = existing_fleet_ledger(repository)?
+        .with_context(|| format!("repository {} has no durable state", repository.identity))?;
+    let run = ledger.run(run_id)?.with_context(|| {
+        format!(
+            "run {run_id} does not exist in repository {}",
+            repository.identity
+        )
+    })?;
+    let task = ledger
+        .task(run.task_id)?
+        .with_context(|| format!("task {} for run {run_id} does not exist", run.task_id))?;
+    if run.repository != repository.identity || task.repository != repository.identity {
+        bail!(
+            "run {run_id} does not belong to repository {}; no mutation was made",
+            repository.identity
+        );
+    }
+    Ok(ledger)
+}
+
+fn cancellation_response(
+    ledger: &mut Ledger,
+    run_id: i64,
+    repository: Option<&str>,
+) -> Result<CancellationResponse> {
+    let response = match ledger.request_run_cancellation(run_id)? {
+        CancellationRequest::Requested(run) => CancellationResponse {
+            repository: repository.map(str::to_owned),
+            run_id: run.id,
+            status: "requested",
+            owner_kind: "factory-daemon",
+            owner_pid: run.owner_pid,
+            outcome: run.outcome,
+            message: "cancellation requested; the owning Factory daemon will stop the active process tree",
+        },
+        CancellationRequest::AlreadyRequested(run) => CancellationResponse {
+            repository: repository.map(str::to_owned),
+            run_id: run.id,
+            status: "already_requested",
+            owner_kind: "factory-daemon",
+            owner_pid: run.owner_pid,
+            outcome: run.outcome,
+            message: "cancellation was already requested from the owning Factory daemon",
+        },
+        CancellationRequest::Terminal(run) => CancellationResponse {
+            repository: repository.map(str::to_owned),
+            run_id: run.id,
+            status: "already_terminal",
+            owner_kind: "none",
+            owner_pid: None,
+            outcome: run.outcome,
+            message: "run is already terminal",
+        },
+        CancellationRequest::OwnedElsewhere(run) => CancellationResponse {
+            repository: repository.map(str::to_owned),
+            run_id: run.id,
+            status: "owned_elsewhere",
+            owner_kind: "stale-or-foreign",
+            owner_pid: run.owner_pid,
+            outcome: run.outcome,
+            message: "run has no live local Factory daemon owner; inspect or recover it before retrying cancellation",
+        },
+        CancellationRequest::NotFound => bail!("run {run_id} does not exist"),
+    };
+    Ok(response)
+}
+
+fn cleanup_run(
+    repository_path: &Path,
+    workspace_root: &Path,
+    ledger: &Ledger,
+    run_id: i64,
+    confirm: bool,
+    expected_repository: Option<&str>,
+) -> Result<()> {
+    let run = ledger
+        .run(run_id)?
+        .with_context(|| format!("run {run_id} does not exist"))?;
+    let task = ledger
+        .task(run.task_id)?
+        .with_context(|| format!("task {} for run {run_id} does not exist", run.task_id))?;
+    let workspace = ledger
+        .task_workspace(task.id)?
+        .with_context(|| format!("run {run_id} has no Factory-owned workspace"))?;
+    if let Some(repository) = expected_repository {
+        if run.repository != repository
+            || task.repository != repository
+            || workspace.repository != repository
+        {
+            bail!(
+                "run {run_id} does not have consistent ownership by repository {repository}; no cleanup was performed"
+            );
+        }
+        println!("repository: {repository}");
+    }
+    if workspace.state == "cleaned" {
+        println!("run: {run_id}");
+        println!("workspace: {}", workspace.path.display());
+        println!("branch preserved: true");
+        println!("action: workspace reservation is already cleaned; no changes made");
+        return Ok(());
+    }
+    let manager = WorkspaceManager::new(repository_path, workspace_root)?;
+    let clone_manager = CloneManager::new(workspace_root)?;
+    if !workspace.path.exists() {
+        println!("run: {run_id}");
+        println!("workspace: {}", workspace.path.display());
+        println!(
+            "branch: {}",
+            workspace.factory_branch.as_deref().unwrap_or("detached")
+        );
+        println!("workspace exists: false");
+        println!("branch preserved: true");
+        if !confirm {
+            println!(
+                "action: preview only; rerun with --confirm to release the workspace reservation"
+            );
+        } else {
+            if matches!(task.state, TaskState::Queued | TaskState::Running) {
+                bail!(
+                    "refusing to release workspace for {:?} task {}; cancel or finish it first",
+                    task.state,
+                    task.id
+                );
+            }
+            ledger.update_task_workspace_state(
+                task.id,
+                "cleaned",
+                Some("operator confirmed absent workspace; local branch preserved"),
+            )?;
+            println!("action: released workspace reservation; local branch preserved");
+        }
+        return Ok(());
+    }
+    let preview = if workspace.backend == "clone" {
+        clone_manager.preview_cleanup(&workspace.path)?
+    } else {
+        manager.cleanup(&workspace.path, false)?.1
+    };
+    println!("run: {run_id}");
+    println!("workspace: {}", preview.path.display());
+    println!(
+        "branch: {}",
+        preview.branch.as_deref().unwrap_or("detached")
+    );
+    println!("dirty: {}", preview.dirty);
+    println!("branch preserved: true");
+    if !confirm {
+        println!("action: preview only; rerun with --confirm to remove the workspace");
+        return Ok(());
+    }
+    if matches!(task.state, TaskState::Queued | TaskState::Running) {
+        bail!(
+            "refusing to clean workspace for {:?} task {}; cancel or finish it first",
+            task.state,
+            task.id
+        );
+    }
+    ledger.update_task_workspace_state(
+        task.id,
+        "cleanup_pending",
+        Some(OPERATOR_CONFIRMED_CLEANUP),
+    )?;
+    if workspace.backend == "clone" {
+        clone_manager.remove(&workspace.path)?;
+    } else {
+        manager.cleanup(&workspace.path, true)?;
+    }
+    ledger.update_task_workspace_state(
+        task.id,
+        "cleaned",
+        Some("operator-confirmed cleanup completed"),
+    )?;
+    if workspace.backend == "clone" {
+        println!("action: removed clone; remote branch preserved");
+    } else {
+        println!("action: removed worktree; local branch preserved");
+    }
+    Ok(())
+}
+
+fn fleet_statuses(path: &Path, selector: Option<&str>) -> Result<Vec<FleetStatusView>> {
+    let fleet = FleetConfig::load_for_operation(path)?;
+    let mut statuses = Vec::new();
+    for repository in selected_fleet_repositories(&fleet, selector)? {
+        let mut status = FleetStatusView {
+            repository: repository.identity.clone(),
+            path: repository.path.display().to_string(),
+            state: if repository.enabled {
+                "loading".to_owned()
+            } else {
+                "disabled".to_owned()
+            },
+            validation_error: None,
+            consecutive_failures: 0,
+            next_retry_at: None,
+            updated_at: None,
+        };
+        if !repository.enabled {
+            statuses.push(status);
+            continue;
+        }
+        let ledger_path =
+            if let Some(snapshot) = active_repository_operation(path, &repository.identity)? {
+                status.path = snapshot.repository_path.display().to_string();
+                if let Some(error) = snapshot.validation_error {
+                    status.state = "invalid_config".to_owned();
+                    status.validation_error = Some(error);
+                    statuses.push(status);
+                    continue;
+                }
+                snapshot.ledger_path.with_context(|| {
+                    format!(
+                        "repository {} startup snapshot has no ledger path",
+                        repository.identity
+                    )
+                })?
+            } else {
+                let runtime = match repository.load_runtime() {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        status.state = "invalid_config".to_owned();
+                        status.validation_error = Some(single_line_error(&error));
+                        statuses.push(status);
+                        continue;
+                    }
+                };
+                runtime.ledger_path
+            };
+        if !ledger_path.exists() {
+            statuses.push(status);
+            continue;
+        }
+        match Ledger::open(&ledger_path) {
+            Ok(ledger) => {
+                if let Some(snapshot) = ledger.repository_health(&repository.identity)? {
+                    status.state = snapshot.state;
+                    status.validation_error = snapshot.validation_error;
+                    status.consecutive_failures = snapshot.consecutive_failures;
+                    status.next_retry_at = snapshot.next_retry_at.and_then(format_retry_at);
+                    status.updated_at = Some(snapshot.updated_at);
+                }
+            }
+            Err(error) => {
+                status.state = "unavailable".to_owned();
+                status.validation_error = Some(single_line_error(&error));
+            }
+        }
+        statuses.push(status);
+    }
+    Ok(statuses)
+}
+
+fn format_retry_at(timestamp_millis: i64) -> Option<String> {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(timestamp_millis)
+        .map(|value| value.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
+}
+
+fn collect_fleet_poll_statuses(path: &Path, selector: Option<&str>) -> Result<Vec<PollStatus>> {
+    let fleet = FleetConfig::load_for_operation(path)?;
+    let mut statuses = Vec::new();
+    for repository in selected_fleet_repositories(&fleet, selector)? {
+        if let Some(ledger) = existing_fleet_ledger(repository)? {
+            statuses.extend(ledger.poll_statuses()?);
+        }
+    }
+    statuses.sort_by(|left, right| {
+        (&left.repository, &left.workflow).cmp(&(&right.repository, &right.workflow))
+    });
+    Ok(statuses)
+}
+
+fn collect_fleet_workspaces(
+    path: &Path,
+    selector: Option<&str>,
+    all: bool,
+) -> Result<Vec<TaskWorkspace>> {
+    let fleet = FleetConfig::load_for_operation(path)?;
+    let mut workspaces = Vec::new();
+    for repository in selected_fleet_repositories(&fleet, selector)? {
+        let Some(ledger) = existing_fleet_ledger(repository)? else {
+            continue;
+        };
+        if all {
+            for state in [
+                "preparing",
+                "ready",
+                "retained",
+                "cleanup_pending",
+                "cleaned",
+            ] {
+                workspaces.extend(ledger.task_workspaces_in_state(state)?);
+            }
+        } else {
+            workspaces.extend(ledger.active_task_workspaces()?);
+        }
+    }
+    workspaces.sort_by(|left, right| {
+        (&left.repository, left.task_id).cmp(&(&right.repository, right.task_id))
+    });
+    Ok(workspaces)
+}
+
+fn collect_fleet_recovery(path: &Path, selector: Option<&str>) -> Result<Vec<RecoveryView>> {
+    let fleet = FleetConfig::load_for_operation(path)?;
+    let mut recovery = Vec::new();
+    for repository in selected_fleet_repositories(&fleet, selector)? {
+        let Some(ledger) = existing_fleet_ledger(repository)? else {
+            continue;
+        };
+        let tasks = ledger.tasks()?;
+        for task in tasks.iter().filter(|task| {
+            task.recovery_source_run_id.is_some()
+                && matches!(task.state, TaskState::Queued | TaskState::Running)
+        }) {
+            let recovery_of = task
+                .recovery_source_run_id
+                .expect("filtered recovery task has a source run");
+            let source = ledger.run(recovery_of)?.with_context(|| {
+                format!(
+                    "recovery source run {recovery_of} for task {} does not exist",
+                    task.id
+                )
+            })?;
+            recovery.push(RecoveryView {
+                repository: task.repository.clone(),
+                task_id: task.id,
+                run_id: None,
+                recovery_of,
+                recovery_attempt: source.recovery_attempt.saturating_add(1),
+                outcome: match task.state {
+                    TaskState::Queued => "queued",
+                    TaskState::Running => "running",
+                    TaskState::Succeeded => "succeeded",
+                    TaskState::Failed => "failed",
+                    TaskState::Cancelled => "cancelled",
+                }
+                .to_owned(),
+            });
+        }
+        for run in ledger
+            .runs(None)?
+            .into_iter()
+            .filter(|run| run.recovery_of.is_some())
+        {
+            recovery.push(RecoveryView {
+                repository: run.repository,
+                task_id: run.task_id,
+                run_id: Some(run.id),
+                recovery_of: run
+                    .recovery_of
+                    .expect("filtered recovery run has a source run"),
+                recovery_attempt: run.recovery_attempt,
+                outcome: run.outcome,
+            });
+        }
+    }
+    recovery.sort_by(|left, right| {
+        (
+            &left.repository,
+            left.task_id,
+            left.run_id.unwrap_or(i64::MAX),
+        )
+            .cmp(&(
+                &right.repository,
+                right.task_id,
+                right.run_id.unwrap_or(i64::MAX),
+            ))
+    });
+    Ok(recovery)
 }
 
 fn remove_database_files(database: &Path) -> Result<()> {
@@ -827,6 +1439,15 @@ async fn run_fleet_once(path: &Path) -> Result<u8> {
                             .as_bytes(),
                         );
                     }
+                    if let Ok(ledger) = Ledger::open(&ledger_path) {
+                        let _ = ledger.record_repository_health(
+                            &repository.identity,
+                            "disabled",
+                            None,
+                            0,
+                            None,
+                        );
+                    }
                 }
                 Ok(_) => {}
                 Err(error) => write_stderr_best_effort(
@@ -886,6 +1507,63 @@ async fn run_fleet_once(path: &Path) -> Result<u8> {
         {
             Ok(report) => {
                 let source_failures = report.source.failures();
+                let issues_seen = report
+                    .source
+                    .repositories
+                    .iter()
+                    .map(|poll| poll.issues_seen)
+                    .sum();
+                let poll_error = report
+                    .source
+                    .repositories
+                    .iter()
+                    .filter_map(|poll| poll.error.as_deref())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                for (snapshot, result) in [
+                    (
+                        "poll",
+                        ledger.record_poll_status(
+                            &repository.identity,
+                            "all",
+                            if source_failures == 0 {
+                                "succeeded"
+                            } else {
+                                "failed"
+                            },
+                            issues_seen,
+                            report.source.tasks_created(),
+                            (source_failures > 0).then_some(poll_error.as_str()),
+                        ),
+                    ),
+                    (
+                        "health",
+                        ledger.record_repository_health(
+                            &repository.identity,
+                            if source_failures == 0 {
+                                "healthy"
+                            } else {
+                                "backing_off"
+                            },
+                            (source_failures > 0).then_some(poll_error.as_str()),
+                            u32::from(source_failures > 0),
+                            None,
+                        ),
+                    ),
+                ] {
+                    if let Err(error) = result {
+                        failures += 1;
+                        write_stderr_best_effort(
+                            format!(
+                                "Factory could not persist operator snapshot: repository={} snapshot={} error={}\n",
+                                repository.identity,
+                                snapshot,
+                                single_line_error(&error)
+                            )
+                            .as_bytes(),
+                        );
+                    }
+                }
                 if source_failures == 0 {
                     healthy += 1;
                 } else {
@@ -905,11 +1583,47 @@ async fn run_fleet_once(path: &Path) -> Result<u8> {
             }
             Err(error) => {
                 failures += 1;
+                let message = single_line_error(&error);
+                for (snapshot, result) in [
+                    (
+                        "poll",
+                        ledger.record_poll_status(
+                            &repository.identity,
+                            "all",
+                            "failed",
+                            0,
+                            0,
+                            Some(&message),
+                        ),
+                    ),
+                    (
+                        "health",
+                        ledger.record_repository_health(
+                            &repository.identity,
+                            "unavailable",
+                            Some(&message),
+                            1,
+                            None,
+                        ),
+                    ),
+                ] {
+                    if let Err(snapshot_error) = result {
+                        failures += 1;
+                        write_stderr_best_effort(
+                            format!(
+                                "Factory could not persist operator snapshot: repository={} snapshot={} error={}\n",
+                                repository.identity,
+                                snapshot,
+                                single_line_error(&snapshot_error)
+                            )
+                            .as_bytes(),
+                        );
+                    }
+                }
                 write_stdout_best_effort(
                     format!(
                         "repository={} status=unavailable error={}\n",
-                        repository.identity,
-                        single_line_error(&error)
+                        repository.identity, message
                     )
                     .as_bytes(),
                 );
@@ -933,9 +1647,17 @@ async fn run_fleet(path: &Path) -> Result<u8> {
     let fleet = FleetConfig::load(path)?;
     ensure_no_unscoped_ledger_overlap()?;
     let mut runtimes = Vec::new();
+    let mut operation_snapshots = Vec::new();
     let mut invalid = 0usize;
     for repository in &fleet.repositories {
         if !repository.enabled {
+            match repository.load_runtime() {
+                Ok(runtime) => {
+                    operation_snapshots.push(RepositoryOperationSnapshot::from_runtime(&runtime))
+                }
+                Err(error) => operation_snapshots
+                    .push(RepositoryOperationSnapshot::from_error(repository, &error)),
+            }
             match repository.pinned_ledger_path() {
                 Ok(ledger_path) if ledger_path.exists() => {
                     if let Err(error) = FactoryDaemon::reconcile_disabled_ledger(
@@ -949,6 +1671,15 @@ async fn run_fleet(path: &Path) -> Result<u8> {
                                 single_line_error(&error)
                             )
                             .as_bytes(),
+                        );
+                    }
+                    if let Ok(ledger) = Ledger::open(&ledger_path) {
+                        let _ = ledger.record_repository_health(
+                            &repository.identity,
+                            "disabled",
+                            None,
+                            0,
+                            None,
                         );
                     }
                 }
@@ -968,8 +1699,13 @@ async fn run_fleet(path: &Path) -> Result<u8> {
             continue;
         }
         match repository.load_runtime() {
-            Ok(runtime) => runtimes.push(runtime),
+            Ok(runtime) => {
+                operation_snapshots.push(RepositoryOperationSnapshot::from_runtime(&runtime));
+                runtimes.push(runtime);
+            }
             Err(error) => {
+                operation_snapshots
+                    .push(RepositoryOperationSnapshot::from_error(repository, &error));
                 invalid += 1;
                 write_stdout_best_effort(
                     format!(
@@ -991,6 +1727,7 @@ async fn run_fleet(path: &Path) -> Result<u8> {
                 .as_bytes(),
         );
     }
+    let _active_fleet = activate_fleet(path, &fleet, &operation_snapshots)?;
 
     let cancellation = CancellationToken::new();
     let signal_token = cancellation.clone();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -9,7 +9,7 @@ use fs2::FileExt;
 use rusqlite::{Connection, OpenFlags, OptionalExtension, TransactionBehavior, params};
 
 pub const DATABASE_NAME: &str = "factory.sqlite3";
-const SCHEMA_VERSION: i64 = 11;
+const SCHEMA_VERSION: i64 = 12;
 pub const MAX_RESULT_BYTES: usize = 256 * 1024;
 pub const MAX_ERROR_BYTES: usize = 64 * 1024;
 pub const MAX_SESSION_ID_BYTES: usize = 1024;
@@ -629,6 +629,27 @@ pub struct RecoveryReport {
 pub struct RepositoryRecoveryReport {
     pub recovery: RecoveryReport,
     pub unresolved_run_ids: Vec<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepositoryHealthSnapshot {
+    pub repository: String,
+    pub state: String,
+    pub validation_error: Option<String>,
+    pub consecutive_failures: u32,
+    pub next_retry_at: Option<i64>,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PollStatus {
+    pub repository: String,
+    pub workflow: String,
+    pub outcome: String,
+    pub issues_seen: usize,
+    pub tasks_created: usize,
+    pub error: Option<String>,
+    pub polled_at: i64,
 }
 
 pub struct Ledger {
@@ -2377,6 +2398,158 @@ impl Ledger {
             .context("failed to read runs")
     }
 
+    pub fn record_repository_health(
+        &self,
+        repository: &str,
+        state: &str,
+        validation_error: Option<&str>,
+        consecutive_failures: u32,
+        next_retry_at: Option<i64>,
+    ) -> Result<()> {
+        if repository.trim().is_empty() {
+            bail!("repository health identity must not be empty");
+        }
+        let validation_error = validation_error.map(|value| {
+            truncate_utf8(
+                &crate::inspection::sanitize_for_storage(value),
+                MAX_ERROR_BYTES,
+            )
+        });
+        self.connection
+            .execute(
+                "INSERT INTO repository_health
+                 (repository, state, validation_error, consecutive_failures, next_retry_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(repository) DO UPDATE SET
+                   state = excluded.state,
+                   validation_error = excluded.validation_error,
+                   consecutive_failures = excluded.consecutive_failures,
+                   next_retry_at = excluded.next_retry_at,
+                   updated_at = excluded.updated_at",
+                params![
+                    repository,
+                    state,
+                    validation_error,
+                    consecutive_failures,
+                    next_retry_at,
+                    now_millis()?
+                ],
+            )
+            .context("failed to persist repository health")?;
+        Ok(())
+    }
+
+    pub fn repository_health(&self, repository: &str) -> Result<Option<RepositoryHealthSnapshot>> {
+        self.connection
+            .query_row(
+                "SELECT repository, state, validation_error, consecutive_failures,
+                        next_retry_at, updated_at
+                 FROM repository_health WHERE repository = ?1",
+                [repository],
+                |row| {
+                    Ok(RepositoryHealthSnapshot {
+                        repository: row.get(0)?,
+                        state: row.get(1)?,
+                        validation_error: row.get(2)?,
+                        consecutive_failures: row.get(3)?,
+                        next_retry_at: row.get(4)?,
+                        updated_at: row.get(5)?,
+                    })
+                },
+            )
+            .optional()
+            .context("failed to read repository health")
+    }
+
+    pub fn record_poll_status(
+        &self,
+        repository: &str,
+        workflow: &str,
+        outcome: &str,
+        issues_seen: usize,
+        tasks_created: usize,
+        error: Option<&str>,
+    ) -> Result<()> {
+        if repository.trim().is_empty() || workflow.trim().is_empty() {
+            bail!("poll status repository and workflow must not be empty");
+        }
+        if !matches!(outcome, "succeeded" | "failed") {
+            bail!("poll status outcome must be succeeded or failed");
+        }
+        let error = error.map(|value| {
+            truncate_utf8(
+                &crate::inspection::sanitize_for_storage(value),
+                MAX_ERROR_BYTES,
+            )
+        });
+        let transaction = self
+            .connection
+            .unchecked_transaction()
+            .context("failed to begin poll status transaction")?;
+        if workflow == "all" {
+            transaction
+                .execute(
+                    "DELETE FROM poll_status WHERE repository = ?1",
+                    [repository],
+                )
+                .context("failed to replace repository poll status")?;
+        } else {
+            transaction
+                .execute(
+                    "DELETE FROM poll_status WHERE repository = ?1 AND workflow = 'all'",
+                    [repository],
+                )
+                .context("failed to replace aggregate poll status")?;
+        }
+        transaction
+            .execute(
+                "INSERT INTO poll_status
+                 (repository, workflow, outcome, issues_seen, tasks_created, error, polled_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                 ON CONFLICT(repository, workflow) DO UPDATE SET
+                   outcome = excluded.outcome,
+                   issues_seen = excluded.issues_seen,
+                   tasks_created = excluded.tasks_created,
+                   error = excluded.error,
+                   polled_at = excluded.polled_at",
+                params![
+                    repository,
+                    workflow,
+                    outcome,
+                    issues_seen,
+                    tasks_created,
+                    error,
+                    now_millis()?
+                ],
+            )
+            .context("failed to persist poll status")?;
+        transaction
+            .commit()
+            .context("failed to commit poll status")?;
+        Ok(())
+    }
+
+    pub fn poll_statuses(&self) -> Result<Vec<PollStatus>> {
+        let mut statement = self.connection.prepare(
+            "SELECT repository, workflow, outcome, issues_seen, tasks_created, error, polled_at
+             FROM poll_status ORDER BY repository, workflow",
+        )?;
+        statement
+            .query_map([], |row| {
+                Ok(PollStatus {
+                    repository: row.get(0)?,
+                    workflow: row.get(1)?,
+                    outcome: row.get(2)?,
+                    issues_seen: row.get(3)?,
+                    tasks_created: row.get(4)?,
+                    error: row.get(5)?,
+                    polled_at: row.get(6)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("failed to read poll status")
+    }
+
     pub fn run(&self, id: i64) -> Result<Option<Run>> {
         query_run(&self.connection, id)
     }
@@ -2788,6 +2961,9 @@ fn migrate(connection: &Connection) -> Result<()> {
         if version < 11 {
             migrate_v11(connection)?;
         }
+        if version < 12 {
+            migrate_v12(connection)?;
+        }
         Ok(())
     })();
     match result {
@@ -3107,6 +3283,37 @@ fn migrate_v11(connection: &Connection) -> Result<()> {
              PRAGMA user_version = 11;",
         )
         .context("failed to migrate SQLite ledger to version 11")?;
+    Ok(())
+}
+
+fn migrate_v12(connection: &Connection) -> Result<()> {
+    connection
+        .execute_batch(
+            "CREATE TABLE repository_health (
+                 repository TEXT PRIMARY KEY,
+                 state TEXT NOT NULL CHECK (state IN
+                   ('loading', 'healthy', 'backing_off', 'rate_limited',
+                    'invalid_config', 'unavailable', 'disabled')),
+                 validation_error TEXT,
+                 consecutive_failures INTEGER NOT NULL,
+                 next_retry_at INTEGER,
+                 updated_at INTEGER NOT NULL
+             );
+             CREATE TABLE poll_status (
+                 repository TEXT NOT NULL,
+                 workflow TEXT NOT NULL,
+                 outcome TEXT NOT NULL CHECK (outcome IN ('succeeded', 'failed')),
+                 issues_seen INTEGER NOT NULL,
+                 tasks_created INTEGER NOT NULL,
+                 error TEXT,
+                 polled_at INTEGER NOT NULL,
+                 PRIMARY KEY(repository, workflow)
+             );
+             INSERT INTO schema_migrations(version, applied_at)
+                 VALUES (12, unixepoch('subsec') * 1000);
+             PRAGMA user_version = 12;",
+        )
+        .context("failed to migrate SQLite ledger to version 12")?;
     Ok(())
 }
 

--- a/tests/fleet_once.rs
+++ b/tests/fleet_once.rs
@@ -7,7 +7,7 @@ use std::process::Command as ProcessCommand;
 
 use assert_cmd::Command;
 use factory::config::Config;
-use factory::storage::{Ledger, TaskIdentity, TaskState, TaskWorkspace};
+use factory::storage::{CancellationRequest, Ledger, TaskIdentity, TaskState, TaskWorkspace};
 use predicates::prelude::*;
 
 fn make_repository(root: &Path, data_home: &Path, name: &str, origin: &str) -> PathBuf {
@@ -157,6 +157,71 @@ fn evaluates_two_repositories_once_with_isolated_durable_tasks_and_no_workers() 
         assert_eq!(tasks[0].source_item.as_deref(), Some("#42"));
         assert!(ledger.runs(None).unwrap().is_empty());
     }
+}
+
+#[test]
+fn snapshot_persistence_failure_does_not_skip_later_repositories() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let first = make_repository(
+        temp.path(),
+        &data_home,
+        "first",
+        "git@github.com:acme/first.git",
+    );
+    let second = make_repository(
+        temp.path(),
+        &data_home,
+        "second",
+        "git@github.com:acme/second.git",
+    );
+    let first_config =
+        Config::load_with_data_home(&first.join(".factory/config.toml"), &data_home).unwrap();
+    let first_ledger = Ledger::open_in(&first_config.data_directory).unwrap();
+    rusqlite::Connection::open(first_ledger.path())
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER reject_poll_snapshot
+             BEFORE INSERT ON poll_status
+             BEGIN
+               SELECT RAISE(FAIL, 'simulated poll snapshot failure');
+             END;",
+        )
+        .unwrap();
+    drop(first_ledger);
+    let fleet = temp.path().join("fleet.toml");
+    fs::write(
+        &fleet,
+        format!(
+            "max_concurrent = 2\n[[repository]]\nname = \"acme/first\"\npath = {:?}\n[[repository]]\nname = \"acme/second\"\npath = {:?}\n",
+            first, second
+        ),
+    )
+    .unwrap();
+    let bin = fake_github(temp.path());
+
+    fleet_command(&bin, &data_home)
+        .args(["run", "--fleet"])
+        .arg(&fleet)
+        .arg("--once")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("repository=acme/first status=ok"))
+        .stdout(predicate::str::contains("repository=acme/second status=ok"))
+        .stderr(predicate::str::contains(
+            "repository=acme/first snapshot=poll",
+        ));
+
+    let second_config =
+        Config::load_with_data_home(&second.join(".factory/config.toml"), &data_home).unwrap();
+    assert_eq!(
+        Ledger::open_in(&second_config.data_directory)
+            .unwrap()
+            .tasks()
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 #[test]
@@ -351,6 +416,37 @@ fn disabled_repository_records_orphan_recovery_without_launch_or_cleanup() {
     disabled_ledger
         .update_task_workspace_state(task.id, "ready", None)
         .unwrap();
+    let owner = "disabled-shutdown-owner";
+    disabled_ledger
+        .register_daemon_owner(owner, std::process::id())
+        .unwrap();
+    let draining_task = disabled_ledger
+        .enqueue(
+            &TaskIdentity::scheduled("acme/disabled", "implement", "2026-07-28T12:00:00Z").unwrap(),
+        )
+        .unwrap()
+        .task;
+    assert_eq!(
+        disabled_ledger.claim_next().unwrap().unwrap().id,
+        draining_task.id
+    );
+    let draining_run = disabled_ledger
+        .start_run(draining_task.id, "codex")
+        .unwrap();
+    rusqlite::Connection::open(disabled_ledger.path())
+        .unwrap()
+        .execute(
+            "UPDATE runs SET owner_id = ?1, owner_pid = ?2 WHERE id = ?3",
+            rusqlite::params![owner, std::process::id(), draining_run.id],
+        )
+        .unwrap();
+    assert!(matches!(
+        disabled_ledger
+            .request_run_cancellation(draining_run.id)
+            .unwrap(),
+        CancellationRequest::Requested(_)
+    ));
+    disabled_ledger.remove_daemon_owner(owner).unwrap();
     drop(disabled_ledger);
 
     let launch_marker = disabled.join("disabled-source-ran");
@@ -406,6 +502,22 @@ fn disabled_repository_records_orphan_recovery_without_launch_or_cleanup() {
     assert_eq!(
         disabled_ledger.run(run.id).unwrap().unwrap().outcome,
         "failed"
+    );
+    assert_eq!(
+        disabled_ledger
+            .task(draining_task.id)
+            .unwrap()
+            .unwrap()
+            .state,
+        TaskState::Cancelled
+    );
+    assert_eq!(
+        disabled_ledger
+            .run(draining_run.id)
+            .unwrap()
+            .unwrap()
+            .outcome,
+        "cancelled"
     );
     assert_eq!(
         disabled_ledger

--- a/tests/fleet_operations.rs
+++ b/tests/fleet_operations.rs
@@ -1,0 +1,586 @@
+#![cfg(unix)]
+
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+use std::sync::Mutex;
+
+use assert_cmd::Command;
+use factory::fleet::{FleetConfig, RepositoryOperationSnapshot, activate_fleet};
+use factory::storage::{Ledger, RunOutcome, TaskIdentity, TaskWorkspace};
+use predicates::prelude::*;
+
+struct RepositoryFixture {
+    identity: String,
+    path: PathBuf,
+    data: PathBuf,
+}
+
+static ENVIRONMENT_LOCK: Mutex<()> = Mutex::new(());
+
+struct EnvironmentRestore {
+    name: &'static str,
+    value: Option<std::ffi::OsString>,
+}
+
+impl EnvironmentRestore {
+    fn set(name: &'static str, value: &Path) -> Self {
+        let previous = std::env::var_os(name);
+        // SAFETY: every test in this binary serializes environment changes with
+        // ENVIRONMENT_LOCK, and child commands receive an explicit value too.
+        unsafe { std::env::set_var(name, value) };
+        Self {
+            name,
+            value: previous,
+        }
+    }
+}
+
+impl Drop for EnvironmentRestore {
+    fn drop(&mut self) {
+        // SAFETY: the EnvironmentRestore is dropped while ENVIRONMENT_LOCK is held.
+        unsafe {
+            if let Some(value) = &self.value {
+                std::env::set_var(self.name, value);
+            } else {
+                std::env::remove_var(self.name);
+            }
+        }
+    }
+}
+
+fn data_directories(root: &Path) -> BTreeSet<PathBuf> {
+    fs::read_dir(root)
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|path| path.is_dir())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn repository(root: &Path, data_home: &Path, name: &str) -> RepositoryFixture {
+    let path = root.join(name);
+    let identity = format!("acme/{name}");
+    fs::create_dir(&path).unwrap();
+    assert!(
+        ProcessCommand::new("git")
+            .args(["init", "--quiet", "--initial-branch=main"])
+            .current_dir(&path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    assert!(
+        ProcessCommand::new("git")
+            .args([
+                "remote",
+                "add",
+                "origin",
+                &format!("git@github.com:{identity}.git"),
+            ])
+            .current_dir(&path)
+            .status()
+            .unwrap()
+            .success()
+    );
+    let before = data_directories(data_home);
+    Command::cargo_bin("factory")
+        .unwrap()
+        .current_dir(&path)
+        .env("FACTORY_DATA_HOME", data_home)
+        .arg("init")
+        .assert()
+        .success();
+    let config = path.join(".factory/config.toml");
+    let contents = fs::read_to_string(&config).unwrap();
+    fs::write(
+        &config,
+        contents.replace("poll_every = \"30s\"", "poll_every = \"60s\""),
+    )
+    .unwrap();
+    let data = data_directories(data_home)
+        .difference(&before)
+        .next()
+        .cloned()
+        .expect("initialization creates one repository data directory");
+    RepositoryFixture {
+        identity,
+        path: path.canonicalize().unwrap(),
+        data,
+    }
+}
+
+fn fleet(path: &Path, first: &RepositoryFixture, second: &RepositoryFixture, first_enabled: bool) {
+    fs::write(
+        path,
+        format!(
+            "max_concurrent = 2\n\
+             [[repository]]\n\
+             name = {:?}\n\
+             path = {:?}\n\
+             enabled = {}\n\
+             [[repository]]\n\
+             name = {:?}\n\
+             path = {:?}\n",
+            first.identity, first.path, first_enabled, second.identity, second.path
+        ),
+    )
+    .unwrap();
+}
+
+fn running_run(repository: &RepositoryFixture) -> i64 {
+    let mut ledger = Ledger::open_in(&repository.data).unwrap();
+    let owner = format!("owner-{}", repository.identity);
+    ledger
+        .register_daemon_owner(&owner, std::process::id())
+        .unwrap();
+    ledger
+        .enqueue(
+            &TaskIdentity::ticket(&repository.identity, "implement", "42", "revision").unwrap(),
+        )
+        .unwrap();
+    let runtimes = HashMap::from([(
+        (
+            repository.identity.clone(),
+            "implement".to_owned(),
+            "ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    ledger
+        .claim_and_start_run(
+            std::slice::from_ref(&repository.identity),
+            &runtimes,
+            &owner,
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap()
+        .run
+        .id
+}
+
+fn command(data_home: &Path) -> Command {
+    let mut command = Command::cargo_bin("factory").unwrap();
+    command.env("FACTORY_DATA_HOME", data_home);
+    command
+}
+
+#[test]
+fn fleet_inspection_aggregates_and_numeric_mutation_is_repository_scoped() {
+    let _environment = ENVIRONMENT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let first = repository(temp.path(), &data_home, "first");
+    let second = repository(temp.path(), &data_home, "second");
+    let fleet_path = temp.path().join("fleet.toml");
+    fleet(&fleet_path, &first, &second, true);
+    let initial_status = command(&data_home)
+        .args(["status", "--fleet"])
+        .arg(&fleet_path)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(initial_status.status.success());
+    let initial_status: serde_json::Value = serde_json::from_slice(&initial_status.stdout).unwrap();
+    assert!(
+        initial_status
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|repository| repository["state"] == "loading")
+    );
+    let first_run = running_run(&first);
+    let second_run = running_run(&second);
+    assert_eq!(first_run, second_run);
+
+    let tasks = command(&data_home)
+        .args(["tasks", "--fleet"])
+        .arg(&fleet_path)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(tasks.status.success());
+    let tasks: serde_json::Value = serde_json::from_slice(&tasks.stdout).unwrap();
+    assert_eq!(tasks.as_array().unwrap().len(), 2);
+    assert!(
+        tasks
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|task| task["repository"] == first.identity)
+    );
+    assert!(
+        tasks
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|task| task["repository"] == second.identity)
+    );
+
+    command(&data_home)
+        .args(["inspect", &first_run.to_string(), "--fleet"])
+        .arg(&fleet_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("exists in multiple repositories"));
+
+    command(&data_home)
+        .args(["cancel", &first_run.to_string(), "--fleet"])
+        .arg(&fleet_path)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--repository owner/name is required",
+        ));
+    command(&data_home)
+        .args(["cancel", &first_run.to_string(), "--fleet"])
+        .arg(&fleet_path)
+        .args(["--repository", "acme/unknown"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("is not configured"));
+    assert!(
+        !Ledger::open_in(&first.data)
+            .unwrap()
+            .cancellation_requested(first_run)
+            .unwrap()
+    );
+    assert!(
+        !Ledger::open_in(&second.data)
+            .unwrap()
+            .cancellation_requested(second_run)
+            .unwrap()
+    );
+
+    command(&data_home)
+        .args(["cancel", &first_run.to_string(), "--fleet"])
+        .arg(&fleet_path)
+        .args(["--repository", &first.identity, "--json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "\"repository\": \"{}\"",
+            first.identity
+        )));
+    assert!(
+        Ledger::open_in(&first.data)
+            .unwrap()
+            .cancellation_requested(first_run)
+            .unwrap()
+    );
+    assert!(
+        !Ledger::open_in(&second.data)
+            .unwrap()
+            .cancellation_requested(second_run)
+            .unwrap()
+    );
+}
+
+#[test]
+fn fleet_status_poll_workspace_recovery_and_disabled_lifecycle_remain_inspectable() {
+    let _environment = ENVIRONMENT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let first = repository(temp.path(), &data_home, "first");
+    let second = repository(temp.path(), &data_home, "second");
+    let fleet_path = temp.path().join("fleet.toml");
+    fleet(&fleet_path, &first, &second, true);
+
+    let first_run = running_run(&first);
+    let mut first_ledger = Ledger::open_in(&first.data).unwrap();
+    let first_task = first_ledger.run(first_run).unwrap().unwrap().task_id;
+    let retained = temp.path().join("retained-first");
+    fs::create_dir(&retained).unwrap();
+    first_ledger
+        .reserve_task_workspace(&TaskWorkspace {
+            task_id: first_task,
+            kind: "delivery".into(),
+            backend: "worktree".into(),
+            repository: first.identity.clone(),
+            base_branch: "main".into(),
+            base_sha: "deadbeef".into(),
+            factory_branch: Some("factory/42-first".into()),
+            path: retained.clone(),
+            state: "retained".into(),
+            status_summary: Some("retained for operator".into()),
+            created_at: 0,
+            updated_at: 0,
+            cleaned_at: None,
+        })
+        .unwrap();
+    first_ledger
+        .update_task_workspace_state(first_task, "retained", Some("retained for operator"))
+        .unwrap();
+    first_ledger
+        .record_repository_health(
+            &first.identity,
+            "backing_off",
+            Some("temporary source failure"),
+            3,
+            Some(1_800_000_000_000),
+        )
+        .unwrap();
+    first_ledger
+        .record_poll_status(
+            &first.identity,
+            "implement",
+            "failed",
+            0,
+            0,
+            Some("temporary source failure"),
+        )
+        .unwrap();
+
+    let second_run = running_run(&second);
+    let mut second_ledger = Ledger::open_in(&second.data).unwrap();
+    second_ledger
+        .observe_run(
+            second_run,
+            Some(std::process::id()),
+            Some("test-process"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    second_ledger
+        .finish_run_and_task(
+            second_run,
+            RunOutcome::Failed,
+            None,
+            Some("interrupted"),
+            None,
+        )
+        .unwrap();
+    let owner = format!("owner-{}", second.identity);
+    let runtimes = HashMap::from([(
+        (
+            second.identity.clone(),
+            "implement".to_owned(),
+            "ticket".to_owned(),
+        ),
+        "codex".to_owned(),
+    )]);
+    let first_recovery = second_ledger
+        .claim_and_start_run(
+            std::slice::from_ref(&second.identity),
+            &runtimes,
+            &owner,
+            std::process::id(),
+        )
+        .unwrap()
+        .unwrap()
+        .run;
+    assert_eq!(first_recovery.recovery_attempt, 1);
+    second_ledger
+        .observe_run(
+            first_recovery.id,
+            Some(std::process::id()),
+            Some("test-process"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    second_ledger
+        .finish_run_and_task(
+            first_recovery.id,
+            RunOutcome::Failed,
+            None,
+            Some("interrupted again"),
+            None,
+        )
+        .unwrap();
+
+    command(&data_home)
+        .args(["status", "--fleet"])
+        .arg(&fleet_path)
+        .arg("--json")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"state\": \"backing_off\""))
+        .stdout(predicate::str::contains("\"consecutive_failures\": 3"))
+        .stdout(predicate::str::contains(
+            "\"validation_error\": \"temporary source failure\"",
+        ))
+        .stdout(predicate::str::contains("\"state\": \"loading\""));
+    command(&data_home)
+        .args(["polls", "--fleet"])
+        .arg(&fleet_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&first.identity))
+        .stdout(predicate::str::contains("temporary source failure"));
+    command(&data_home)
+        .args(["workspaces", "--fleet"])
+        .arg(&fleet_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&first.identity))
+        .stdout(predicate::str::contains(retained.display().to_string()));
+    let recovery = command(&data_home)
+        .args(["recovery", "--fleet"])
+        .arg(&fleet_path)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(recovery.status.success());
+    let recovery: serde_json::Value = serde_json::from_slice(&recovery.stdout).unwrap();
+    let queued = recovery
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["outcome"] == "queued")
+        .expect("queued recovery is reported");
+    assert_eq!(queued["repository"], second.identity);
+    assert_eq!(queued["recovery_attempt"], 2);
+
+    fleet(&fleet_path, &first, &second, false);
+    command(&data_home)
+        .args(["status", "--fleet"])
+        .arg(&fleet_path)
+        .args(["--repository", &first.identity])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("disabled"));
+    command(&data_home)
+        .args(["cleanup", &first_run.to_string(), "--fleet"])
+        .arg(&fleet_path)
+        .args(["--repository", &first.identity, "--confirm"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "disabled; re-enable it and restart Factory",
+        ));
+    assert!(retained.exists());
+    assert_eq!(
+        Ledger::open_in(&first.data)
+            .unwrap()
+            .task_workspace(first_task)
+            .unwrap()
+            .unwrap()
+            .state,
+        "retained"
+    );
+
+    fs::write(
+        &fleet_path,
+        format!(
+            "max_concurrent = 1\n[[repository]]\nname = {:?}\npath = {:?}\n",
+            second.identity, second.path
+        ),
+    )
+    .unwrap();
+    command(&data_home)
+        .args(["status", "--fleet"])
+        .arg(&fleet_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&second.identity));
+    assert!(first.data.exists());
+    assert!(retained.exists());
+}
+
+#[test]
+fn live_fleet_operations_use_the_supervisor_startup_snapshot_until_stop() {
+    let _environment = ENVIRONMENT_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp = tempfile::tempdir().unwrap();
+    let data_home = temp.path().join("data");
+    let first = repository(temp.path(), &data_home, "first");
+    let second = repository(temp.path(), &data_home, "second");
+    let fleet_path = temp.path().join("fleet.toml");
+    fleet(&fleet_path, &first, &second, true);
+    let first_run = running_run(&first);
+    let mut first_ledger = Ledger::open_in(&first.data).unwrap();
+    let first_task = first_ledger.run(first_run).unwrap().unwrap().task_id;
+    first_ledger
+        .reserve_task_workspace(&TaskWorkspace {
+            task_id: first_task,
+            kind: "delivery".into(),
+            backend: "worktree".into(),
+            repository: first.identity.clone(),
+            base_branch: "main".into(),
+            base_sha: "deadbeef".into(),
+            factory_branch: Some("factory/42-startup".into()),
+            path: temp.path().join("absent-startup-workspace"),
+            state: "retained".into(),
+            status_summary: None,
+            created_at: 0,
+            updated_at: 0,
+            cleaned_at: None,
+        })
+        .unwrap();
+
+    let _restore = EnvironmentRestore::set("FACTORY_DATA_HOME", &data_home);
+    let startup = FleetConfig::load(&fleet_path).unwrap();
+    let snapshots = startup
+        .repositories
+        .iter()
+        .map(|repository| {
+            RepositoryOperationSnapshot::from_runtime(&repository.load_runtime().unwrap())
+        })
+        .collect::<Vec<_>>();
+    let active = activate_fleet(&fleet_path, &startup, &snapshots).unwrap();
+
+    fs::write(
+        first.path.join(".factory/config.toml"),
+        "this is no longer valid repository configuration",
+    )
+    .unwrap();
+    fs::write(
+        &fleet_path,
+        format!(
+            "max_concurrent = 1\n[[repository]]\nname = {:?}\npath = {:?}\n",
+            second.identity, second.path
+        ),
+    )
+    .unwrap();
+
+    command(&data_home)
+        .args(["status", "--fleet"])
+        .arg(&fleet_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&first.identity))
+        .stdout(predicate::str::contains(&second.identity));
+    command(&data_home)
+        .args(["cleanup", &first_run.to_string(), "--fleet"])
+        .arg(&fleet_path)
+        .args(["--repository", &first.identity])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("preview only"));
+    command(&data_home)
+        .args(["cancel", &first_run.to_string(), "--fleet"])
+        .arg(&fleet_path)
+        .args(["--repository", &first.identity])
+        .assert()
+        .success();
+    assert!(
+        Ledger::open_in(&first.data)
+            .unwrap()
+            .cancellation_requested(first_run)
+            .unwrap()
+    );
+
+    drop(active);
+
+    command(&data_home)
+        .args(["status", "--fleet"])
+        .arg(&fleet_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&second.identity))
+        .stdout(predicate::str::contains(&first.identity).not());
+}

--- a/tests/storage.rs
+++ b/tests/storage.rs
@@ -168,7 +168,7 @@ fn concurrent_first_open_converges_on_one_complete_schema() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 11);
+    assert_eq!(version, 12);
     let schedule_tables: i64 = connection
         .query_row(
             "SELECT COUNT(*) FROM sqlite_schema
@@ -1197,7 +1197,7 @@ fn migrates_a_version_one_ledger_without_losing_tasks() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 11);
+    assert_eq!(version, 12);
 }
 
 #[test]
@@ -1209,10 +1209,13 @@ fn opens_an_existing_version_eight_ledger() {
     let connection = Connection::open(&path).unwrap();
     connection
         .execute_batch(
-            "DROP TABLE run_sandboxes;
+            "DROP TABLE poll_status;
+             DROP TABLE repository_health;
+             DROP TABLE run_sandboxes;
              DROP TABLE run_containers;
              ALTER TABLE task_workspaces DROP COLUMN backend;
              DROP TABLE project_claims;
+             DELETE FROM schema_migrations WHERE version = 12;
              DELETE FROM schema_migrations WHERE version = 11;
              DELETE FROM schema_migrations WHERE version = 10;
              DELETE FROM schema_migrations WHERE version = 9;
@@ -1230,7 +1233,69 @@ fn opens_an_existing_version_eight_ledger() {
     let version: i64 = connection
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 11);
+    assert_eq!(version, 12);
+}
+
+#[test]
+fn repository_health_and_poll_status_keep_the_latest_operator_snapshot() {
+    let temp = tempfile::tempdir().unwrap();
+    let ledger = Ledger::open(&temp.path().join("ledger.db")).unwrap();
+
+    ledger
+        .record_repository_health(
+            "acme/repository",
+            "backing_off",
+            Some("temporary failure"),
+            2,
+            Some(1_800_000_000_000),
+        )
+        .unwrap();
+    ledger
+        .record_poll_status(
+            "acme/repository",
+            "implement",
+            "failed",
+            3,
+            0,
+            Some("temporary failure"),
+        )
+        .unwrap();
+    ledger
+        .record_poll_status(
+            "acme/repository",
+            "all",
+            "failed",
+            4,
+            0,
+            Some("aggregate failure"),
+        )
+        .unwrap();
+    let aggregate = ledger.poll_statuses().unwrap();
+    assert_eq!(aggregate.len(), 1);
+    assert_eq!(aggregate[0].workflow, "all");
+    ledger
+        .record_repository_health("acme/repository", "healthy", None, 0, None)
+        .unwrap();
+    ledger
+        .record_poll_status("acme/repository", "implement", "succeeded", 4, 1, None)
+        .unwrap();
+
+    let health = ledger
+        .repository_health("acme/repository")
+        .unwrap()
+        .unwrap();
+    assert_eq!(health.state, "healthy");
+    assert_eq!(health.validation_error, None);
+    assert_eq!(health.consecutive_failures, 0);
+    assert_eq!(health.next_retry_at, None);
+    let polls = ledger.poll_statuses().unwrap();
+    assert_eq!(polls.len(), 1);
+    assert_eq!(polls[0].repository, "acme/repository");
+    assert_eq!(polls[0].workflow, "implement");
+    assert_eq!(polls[0].outcome, "succeeded");
+    assert_eq!(polls[0].issues_seen, 4);
+    assert_eq!(polls[0].tasks_created, 1);
+    assert_eq!(polls[0].error, None);
 }
 
 #[test]


### PR DESCRIPTION
Closes #123

## What changed

- Add fleet-wide and repository-filtered inspection for status, tasks, runs, polls, workspaces, and recovery state.
- Add repository-scoped cancellation and cleanup with strict identity checks and disabled-repository mutation guards.
- Persist health, retry, poll, and active startup snapshots so operator commands match the running supervisor until restart.
- Define disabled repository drain, shutdown finalization, retained state, restart-only configuration, and re-enable behavior.
- Preserve per-repository isolation, shared host budgeting, fair admission, health backoff, rate-limit coordination, and bounded recovery.
- Document two-repository setup, config path rules, limits, lifecycle operations, and failure reporting. No fleet config version field was added.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo build --all-targets --all-features`
- `git diff --check`
- CLI help checks for fleet inspection and mutation flags
- End-to-end two-repository tests, including overlapping numeric IDs, disabled lifecycle, shutdown finalization, startup snapshot consistency, failure isolation, and retained state

## Review

A fresh independent reviewer inspected the final diff against #123 and parent #114. The review found snapshot consistency and failure-isolation issues during earlier passes. Those were fixed, regression-tested, and rereviewed. Final verdict: approved with no actionable findings.