### PR TITLE
feat(worker): add V2 local Codex execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,12 @@ jobs:
         run: test -z "$(gofmt -l cmd internal migrations web/*.go)"
       - name: Run Go vet
         run: go vet ./...
-      - name: Run Go tests
-        run: go test ./...
+      - name: Check worker-control-plane boundary
+        run: |
+          ! go list -deps ./internal/worker |
+            grep -qx 'github.com/owainlewis/factory/internal/controlplane'
+      - name: Run Go server and worker tests
+        run: go test -timeout 5m ./...
       - name: Install Chromium
         working-directory: web
         run: npx playwright install --with-deps chromium

--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ contract, first demonstration, two-repository fleet setup, and sandbox setup. Th
 [operations guide](docs/operations.md) covers inspection, cancellation,
 recovery, and cleanup.
 
-## V2 control plane
+## V2 control plane and local worker
 
-The local V2 server includes its web interface in the Go binary. Production
+The local V2 server includes its web interface in the Go binary, and the Unix
+worker runs assigned Codex tasks in separate managed Git worktrees. Production
 does not need Node.js or cross-origin configuration:
 
 ```sh
@@ -132,13 +133,32 @@ npm ci
 npm run build
 cd ..
 go build -o factory-server ./cmd/factory-server
+go build -o factory-worker ./cmd/factory-worker
 ./factory-server
 ```
 
-Open `http://127.0.0.1:7337/` to inspect registered workers, delegate work, and
-follow durable task state. The server remains loopback-only and stores V2 state
-separately from V1. See the [V2 MVP architecture](docs/v2-architecture/design.md)
-for the API, trust boundary, and current scope.
+In another terminal, create a worker configuration and start the worker:
+
+```toml
+server = "http://127.0.0.1:7337"
+name = "local"
+max_concurrent = 1
+data_directory = "/Users/me/.factory-v2/workers/local"
+
+[repositories.factory]
+path = "/Users/me/Code/factory"
+```
+
+```sh
+./factory-worker --config /path/to/worker.toml
+```
+
+Open `http://127.0.0.1:7337/` to inspect the registered worker, delegate work,
+and follow durable task state. The server remains loopback-only and V2 state and
+worktrees remain separate from V1. The [V2 worker guide](docs/v2-worker.md)
+covers configuration, health, execution, and retained worktrees. See the
+[V2 MVP architecture](docs/v2-architecture/design.md) for the API and trust
+boundary.
 
 ## V1 scope
 
@@ -162,6 +182,7 @@ Jira is not part of the supported V1 scope.
 - [Labels and ticket status](docs/labels.md)
 - [Setup, configuration, and first run](docs/local-v1.md)
 - [Operations and recovery](docs/operations.md)
+- [V2 local worker](docs/v2-worker.md)
 - [Jira source adapter](docs/jira.md)
 - [Docker Sandbox development environment](docs/docker-sandbox-template.md)
 - [Contributing](CONTRIBUTING.md)

--- a/cmd/factory-worker/main.go
+++ b/cmd/factory-worker/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+
+	"github.com/owainlewis/factory/internal/worker"
+)
+
+var version = "dev"
+
+func main() {
+	if worker.IsSupervisorCommand(os.Args[1:]) {
+		control := os.NewFile(3, "factory-worker-control")
+		if err := worker.RunSupervisor(control, os.Stdin, os.Stdout, os.Stderr); err != nil {
+			fmt.Fprintln(os.Stderr, "factory-worker supervisor:", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "factory-worker:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	defaultConfig, err := worker.DefaultConfigPath()
+	if err != nil {
+		return err
+	}
+	flags := flag.NewFlagSet("factory-worker", flag.ContinueOnError)
+	configPath := flags.String("config", defaultConfig, "Factory V2 worker TOML configuration path")
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected arguments: %v", flags.Args())
+	}
+	config, err := worker.LoadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	manager, err := worker.New(config, worker.Options{WorkerVersion: version}, logger)
+	if err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), worker.ShutdownSignals()...)
+	defer stop()
+	logger.Info("worker_started", "worker_id", manager.ID(), "name", config.Name)
+	if err := manager.Run(ctx); err != nil {
+		return err
+	}
+	logger.Info("worker_stopped", "worker_id", manager.ID())
+	return nil
+}

--- a/docs/v2-architecture/design.md
+++ b/docs/v2-architecture/design.md
@@ -2,6 +2,10 @@
 
 > **Status:** Proposed for review
 
+> **Implementation:** The control plane, UI, and local Unix worker execution
+> core are implemented. Durable worker manifests, restart reconciliation,
+> retained-worktree limits, and the cleanup CLI remain in issue #132.
+
 ## 1. Executive summary
 
 Factory V1 is a local Rust supervisor that can watch one repository or an

--- a/docs/v2-worker.md
+++ b/docs/v2-worker.md
@@ -1,0 +1,133 @@
+# Factory V2 local worker
+
+`factory-worker` is the local Unix execution process for Factory V2. It
+registers with the loopback control plane, advertises configured Git
+repositories, claims work assigned to its stable worker ID, and runs Codex in a
+V2-owned worktree.
+
+The worker is separate from Factory V1. It does not import the control-plane
+implementation, open SQLite, inspect V1 state, or use V1 worktree paths.
+
+## Prerequisites
+
+- A Unix host.
+- Git available on `PATH`.
+- Codex available on `PATH` and authenticated. Verify with `codex login status`.
+- A running `factory-server` on a loopback address.
+- One or more local non-bare Git repositories with an `origin` remote.
+
+Build the binary from the repository root:
+
+```sh
+go build -o factory-worker ./cmd/factory-worker
+```
+
+## Configuration
+
+The worker reads one TOML file. Pass it with `--config`. Without that flag it
+uses `FACTORY_V2_WORKER_CONFIG`, then
+`$FACTORY_V2_DATA_HOME/worker.toml`, then
+`~/.factory-v2/worker.toml`.
+
+```toml
+server = "http://127.0.0.1:7337"
+name = "owains-mac"
+max_concurrent = 1
+data_directory = "/Users/owainlewis/.factory-v2/workers/owains-mac"
+
+[repositories.factory]
+path = "/Users/owainlewis/Code/github/owainlewis/factory"
+
+[repositories.website]
+path = "/Users/owainlewis/Code/github/owainlewis/website"
+```
+
+`server` must be plain HTTP on a loopback IP or `localhost`. The worker refuses
+public hosts. `max_concurrent` defaults to one and accepts one through four.
+Repository keys are stable operator-chosen names. Repository and data paths may
+be relative to the configuration file.
+
+At startup the worker canonicalizes every repository path and reads its
+normalized `origin` identity. Missing paths, duplicate paths, duplicate
+remotes, non-Git directories, missing origins, and unknown TOML fields stop
+startup. A repository key already registered with another remote is rejected
+by the control plane.
+
+The data directory is owner-only and held with an exclusive lock for the
+worker lifetime. The first start writes an owner-only `worker-id`; later starts
+reuse it. A second process cannot use the same data directory. The worker also
+refuses a data directory below a Factory V1 `factory.sqlite3` state root.
+
+## Run
+
+Start the server first, then:
+
+```sh
+./factory-worker --config /path/to/worker.toml
+```
+
+The worker checks Git, the Codex version, and Codex login status. Failed health
+checks register the worker as unhealthy and prevent claims. Checks repeat every
+thirty seconds, so restoring Git or Codex recovers without restarting the
+worker.
+
+Healthy workers heartbeat their capacity and repositories, reserve a local
+slot, and poll for assigned work. Claim retries reuse the same request ID and
+lease secret, so a lost response cannot start a duplicate attempt.
+
+## Execution and failure behavior
+
+Each claim is matched back to the configured repository key and normalized
+remote identity. The worker creates:
+
+```text
+<data_directory>/worktrees/<attempt-id>
+```
+
+on a local branch named:
+
+```text
+factory-v2/<task-id-prefix>-<attempt-id-prefix>
+```
+
+The Codex prompt contains a fixed Factory safety preamble, task title,
+description, and repository identity. The prompt is sent over standard input
+and is not placed in command arguments or normal logs.
+
+A separate supervisor owns a process-group anchor. The control plane accepts
+the attempt start before the supervisor launches Codex. The supervisor then
+stops Codex and every descendant on:
+
+- task cancellation;
+- task timeout;
+- worker shutdown or parent-process loss;
+- lease loss or loss of the server.
+
+The worker renews leases every ten seconds. The supervisor begins termination
+early enough to kill a process that ignores the graceful signal before the
+thirty-second lease expires. Cancellation and shutdown use a five-second
+graceful period before killing the complete group.
+
+Codex JSON output is sent as ordered bounded events. One event, one batch, total
+event history, result, and error sizes follow the limits in the V2 architecture.
+Reaching an event limit does not stop lease renewal, cancellation, or terminal
+completion.
+
+## Worktree retention
+
+After the control plane accepts a successful result, the worker removes a
+worktree only when all live-attempt checks pass:
+
+- its canonical path is a direct child of the V2 worktree root;
+- Git lists exactly that path, branch, and commit;
+- the worktree is clean;
+- its current commit is the original base or is reachable from a remote ref.
+
+Cleanup uses `git worktree remove` without force and never deletes the branch.
+Any mismatch or cleanup error retains the worktree. Failed, cancelled, dirty,
+and unpublished worktrees are also retained for inspection.
+
+Durable attempt manifests, restart reconciliation, retained-worktree capacity,
+and preview or confirmed cleanup commands are intentionally delivered by issue
+#132. Until then, the worker does not scan, repair, or delete worktrees left by
+an earlier worker process.

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.24
 require modernc.org/sqlite v1.38.2
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/sys v0.34.0 // indirect
+	golang.org/x/sys v0.34.0
 	modernc.org/libc v1.66.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -231,12 +231,36 @@ func (s *Store) migrate(ctx context.Context) error {
 }
 
 func (s *Store) Close() error {
-	_, checkpointErr := s.db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+	checkpointErr := retrySQLiteContention(func() error {
+		_, err := s.db.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+		return err
+	})
 	closeErr := s.db.Close()
 	if checkpointErr != nil {
 		return checkpointErr
 	}
 	return closeErr
+}
+
+func retrySQLiteContention(operation func() error) error {
+	deadline := time.Now().Add(time.Second)
+	for {
+		err := operation()
+		if err == nil || !isSQLiteContention(err) || time.Now().After(deadline) {
+			return err
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func isSQLiteContention(err error) bool {
+	var coded interface{ Code() int }
+	if !errors.As(err, &coded) {
+		return false
+	}
+	// SQLite extended result codes retain the primary code in the low byte.
+	code := coded.Code() & 0xff
+	return code == 5 || code == 6 // SQLITE_BUSY or SQLITE_LOCKED
 }
 
 func newID() (string, error) {

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -877,4 +877,32 @@ func TestWorkerCanRenameAKeyForTheSameRepository(t *testing.T) {
 	}
 }
 
+type testSQLiteError int
+
+func (err testSQLiteError) Error() string { return fmt.Sprintf("sqlite code %d", err) }
+func (err testSQLiteError) Code() int     { return int(err) }
+
+func TestRetrySQLiteContention(t *testing.T) {
+	calls := 0
+	err := retrySQLiteContention(func() error {
+		calls++
+		if calls < 3 {
+			return testSQLiteError(6)
+		}
+		return nil
+	})
+	if err != nil || calls != 3 {
+		t.Fatalf("locked retry: calls=%d err=%v", calls, err)
+	}
+
+	calls = 0
+	err = retrySQLiteContention(func() error {
+		calls++
+		return testSQLiteError(1)
+	})
+	if err == nil || calls != 1 {
+		t.Fatalf("non-contention retry: calls=%d err=%v", calls, err)
+	}
+}
+
 func pointer[T any](value T) *T { return &value }

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -1,0 +1,204 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const requestTimeout = 10 * time.Second
+
+type APIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (err *APIError) Error() string {
+	return fmt.Sprintf("control plane returned %d %s: %s", err.Status, err.Code, err.Message)
+}
+
+type client struct {
+	baseURL string
+	http    *http.Client
+}
+
+func newClient(server string, httpClient *http.Client) *client {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
+	return &client{baseURL: strings.TrimRight(server, "/"), http: httpClient}
+}
+
+func (client *client) register(ctx context.Context, workerID string, input protocol.WorkerRegistration) (protocol.Worker, error) {
+	var worker protocol.Worker
+	_, err := client.request(ctx, http.MethodPut, "/api/v1/workers/"+url.PathEscape(workerID), input, &worker)
+	return worker, err
+}
+
+func (client *client) claim(ctx context.Context, workerID string, input protocol.ClaimRequest, minimumBackoff, maximumBackoff time.Duration) (*protocol.Claim, error) {
+	var claim protocol.Claim
+	status, err := client.retry(ctx, http.MethodPost,
+		"/api/v1/workers/"+url.PathEscape(workerID)+"/claims", input, &claim, minimumBackoff, maximumBackoff)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusNoContent {
+		return nil, nil
+	}
+	return &claim, nil
+}
+
+func (client *client) start(ctx context.Context, attemptID string, input protocol.StartAttemptRequest) (protocol.Attempt, error) {
+	var attempt protocol.Attempt
+	_, err := client.retry(ctx, http.MethodPost, "/api/v1/attempts/"+url.PathEscape(attemptID)+"/start",
+		input, &attempt, time.Second, 5*time.Second)
+	return attempt, err
+}
+
+func (client *client) heartbeat(ctx context.Context, attemptID, token string) (protocol.HeartbeatResponse, error) {
+	var heartbeat protocol.HeartbeatResponse
+	_, err := client.request(ctx, http.MethodPut, "/api/v1/attempts/"+url.PathEscape(attemptID)+"/heartbeat",
+		protocol.LeaseRequest{LeaseToken: token}, &heartbeat)
+	return heartbeat, err
+}
+
+func (client *client) events(ctx context.Context, attemptID string, input protocol.EventBatchRequest) error {
+	_, err := client.request(ctx, http.MethodPost, "/api/v1/attempts/"+url.PathEscape(attemptID)+"/events", input, nil)
+	return err
+}
+
+func (client *client) complete(ctx context.Context, attemptID string, input protocol.CompleteAttemptRequest) (protocol.Attempt, error) {
+	input = boundedCompletionRequest(input)
+	var attempt protocol.Attempt
+	_, err := client.retry(ctx, http.MethodPost, "/api/v1/attempts/"+url.PathEscape(attemptID)+"/complete",
+		input, &attempt, time.Second, 5*time.Second)
+	return attempt, err
+}
+
+func boundedCompletionRequest(input protocol.CompleteAttemptRequest) protocol.CompleteAttemptRequest {
+	input.Result = boundedText(strings.ToValidUTF8(input.Result, "\uFFFD"), protocol.MaxResultBytes)
+	input.Error = boundedText(strings.ToValidUTF8(input.Error, "\uFFFD"), protocol.MaxErrorBytes)
+	if completionRequestFits(input) {
+		return input
+	}
+	input.Result = largestCompletionField(input, input.Result, true)
+	if completionRequestFits(input) {
+		return input
+	}
+	input.Error = largestCompletionField(input, input.Error, false)
+	return input
+}
+
+func largestCompletionField(input protocol.CompleteAttemptRequest, value string, result bool) string {
+	low, high := 0, len(value)
+	for low < high {
+		middle := low + (high-low+1)/2
+		candidate := boundedText(value, middle)
+		if result {
+			input.Result = candidate
+		} else {
+			input.Error = candidate
+		}
+		if completionRequestFits(input) {
+			low = middle
+		} else {
+			high = middle - 1
+		}
+	}
+	return boundedText(value, low)
+}
+
+func completionRequestFits(input protocol.CompleteAttemptRequest) bool {
+	body, err := json.Marshal(input)
+	return err == nil && len(body) <= protocol.MaxBodyBytes
+}
+
+func (client *client) retry(
+	ctx context.Context,
+	method string,
+	path string,
+	input any,
+	output any,
+	minimumBackoff time.Duration,
+	maximumBackoff time.Duration,
+) (int, error) {
+	backoff := minimumBackoff
+	for {
+		status, err := client.request(ctx, method, path, input, output)
+		if err == nil {
+			return status, nil
+		}
+		var apiError *APIError
+		if errors.As(err, &apiError) && apiError.Status < 500 {
+			return status, err
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return 0, ctx.Err()
+		case <-timer.C:
+		}
+		backoff *= 2
+		if backoff > maximumBackoff {
+			backoff = maximumBackoff
+		}
+	}
+}
+
+func (client *client) request(ctx context.Context, method, path string, input any, output any) (int, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return 0, fmt.Errorf("encode request: %w", err)
+	}
+	requestContext, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(requestContext, method, client.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("create request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	response, err := client.http.Do(request)
+	if err != nil {
+		return 0, fmt.Errorf("send request: %w", err)
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, protocol.MaxBodyBytes+1))
+	if err != nil {
+		return response.StatusCode, fmt.Errorf("read response: %w", err)
+	}
+	if len(responseBody) > protocol.MaxBodyBytes {
+		return response.StatusCode, errors.New("control-plane response exceeds 1 MiB")
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		var errorBody protocol.ErrorBody
+		if err := json.Unmarshal(responseBody, &errorBody); err != nil {
+			return response.StatusCode, &APIError{
+				Status: response.StatusCode, Code: "invalid_error_response", Message: strings.TrimSpace(string(responseBody)),
+			}
+		}
+		return response.StatusCode, &APIError{
+			Status: response.StatusCode, Code: errorBody.Error.Code, Message: errorBody.Error.Message,
+		}
+	}
+	if response.StatusCode == http.StatusNoContent || output == nil {
+		return response.StatusCode, nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(responseBody))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(output); err != nil {
+		return response.StatusCode, fmt.Errorf("decode response: %w", err)
+	}
+	return response.StatusCode, nil
+}

--- a/internal/worker/command.go
+++ b/internal/worker/command.go
@@ -1,0 +1,98 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+type limitBuffer struct {
+	mu        sync.Mutex
+	bytes     []byte
+	limit     int
+	truncated bool
+}
+
+func newLimitBuffer(limit int) *limitBuffer {
+	return &limitBuffer{limit: limit}
+}
+
+func (buffer *limitBuffer) Write(value []byte) (int, error) {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	available := buffer.limit - len(buffer.bytes)
+	if available > 0 {
+		count := len(value)
+		if count > available {
+			count = available
+		}
+		buffer.bytes = append(buffer.bytes, value[:count]...)
+	}
+	if len(value) > available {
+		buffer.truncated = true
+	}
+	return len(value), nil
+}
+
+func (buffer *limitBuffer) String() string {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return string(append([]byte(nil), buffer.bytes...))
+}
+
+func (buffer *limitBuffer) Bytes() []byte {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return append([]byte(nil), buffer.bytes...)
+}
+
+func (buffer *limitBuffer) Truncated() bool {
+	buffer.mu.Lock()
+	defer buffer.mu.Unlock()
+	return buffer.truncated
+}
+
+func runCommand(ctx context.Context, executable, directory string, outputLimit int, arguments ...string) ([]byte, []byte, error) {
+	command := exec.Command(executable, arguments...)
+	command.Dir = directory
+	configureNewProcessGroup(command)
+	stdout := newLimitBuffer(outputLimit)
+	stderr := newLimitBuffer(outputLimit)
+	command.Stdout = stdout
+	command.Stderr = stderr
+	if err := command.Start(); err != nil {
+		return nil, nil, err
+	}
+	pid := command.Process.Pid
+	identity, identityErr := processIdentity(pid)
+	done := make(chan error, 1)
+	go func() {
+		done <- command.Wait()
+	}()
+	select {
+	case err := <-done:
+		return stdout.Bytes(), stderr.Bytes(), err
+	case <-ctx.Done():
+		if identityErr == nil {
+			_ = stopOwnedProcessGroup(pid, identity, time.Second)
+		} else {
+			_ = forceStopStartedProcessGroup(pid)
+		}
+		<-done
+		return stdout.Bytes(), stderr.Bytes(), ctx.Err()
+	}
+}
+
+func commandFailure(action string, stdout, stderr []byte, err error) error {
+	detail := bytes.TrimSpace(stderr)
+	if len(detail) == 0 {
+		detail = bytes.TrimSpace(stdout)
+	}
+	if len(detail) == 0 {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+	return fmt.Errorf("%s: %w: %s", action, err, detail)
+}

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -148,17 +148,33 @@ func resolveDataDirectory(path string) (string, error) {
 	} else if found {
 		return "", fmt.Errorf("refusing a worker data directory below V1 state at %s", marker)
 	}
-	if err := os.MkdirAll(absolute, 0o700); err != nil {
+	if info, err := os.Lstat(absolute); err == nil {
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return "", errors.New("data_directory must be a real directory, not a symlink")
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect data directory: %w", err)
+	}
+	canonical, err := canonicalProspectivePath(absolute)
+	if err != nil {
+		return "", err
+	}
+	if marker, found, err := findV1DatabaseMarker(canonical); err != nil {
+		return "", err
+	} else if found {
+		return "", fmt.Errorf("refusing a worker data directory below V1 state at %s", marker)
+	}
+	if err := os.MkdirAll(canonical, 0o700); err != nil {
 		return "", fmt.Errorf("create data directory: %w", err)
 	}
-	info, err := os.Lstat(absolute)
+	info, err := os.Lstat(canonical)
 	if err != nil {
 		return "", fmt.Errorf("inspect data directory: %w", err)
 	}
 	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return "", errors.New("data_directory must be a real directory, not a symlink")
 	}
-	canonical, err := filepath.EvalSymlinks(absolute)
+	canonical, err = filepath.EvalSymlinks(canonical)
 	if err != nil {
 		return "", fmt.Errorf("canonicalize data directory: %w", err)
 	}
@@ -166,6 +182,29 @@ func resolveDataDirectory(path string) (string, error) {
 		return "", fmt.Errorf("protect data directory: %w", err)
 	}
 	return canonical, nil
+}
+
+func canonicalProspectivePath(path string) (string, error) {
+	var missing []string
+	current := path
+	for {
+		canonical, err := filepath.EvalSymlinks(current)
+		if err == nil {
+			for index := len(missing) - 1; index >= 0; index-- {
+				canonical = filepath.Join(canonical, missing[index])
+			}
+			return canonical, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("canonicalize data directory: %w", err)
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", fmt.Errorf("canonicalize data directory: no existing ancestor for %s", path)
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
 }
 
 func findV1DatabaseMarker(path string) (string, bool, error) {

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -1,0 +1,188 @@
+package worker
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+const (
+	defaultServer        = "http://127.0.0.1:7337"
+	defaultMaxConcurrent = 1
+	maxConcurrent        = 4
+)
+
+type RepositoryConfig struct {
+	Path string `toml:"path"`
+}
+
+type Config struct {
+	Server        string                      `toml:"server"`
+	Name          string                      `toml:"name"`
+	MaxConcurrent int                         `toml:"max_concurrent"`
+	DataDirectory string                      `toml:"data_directory"`
+	Repositories  map[string]RepositoryConfig `toml:"repositories"`
+}
+
+type Repository struct {
+	Key            string
+	Path           string
+	RemoteIdentity string
+}
+
+func LoadConfig(path string) (Config, error) {
+	var config Config
+	metadata, err := toml.DecodeFile(path, &config)
+	if err != nil {
+		return Config{}, fmt.Errorf("load worker configuration: %w", err)
+	}
+	if undecoded := metadata.Undecoded(); len(undecoded) != 0 {
+		keys := make([]string, 0, len(undecoded))
+		for _, key := range undecoded {
+			keys = append(keys, key.String())
+		}
+		sort.Strings(keys)
+		return Config{}, fmt.Errorf("unknown worker configuration fields: %s", strings.Join(keys, ", "))
+	}
+	if config.Server == "" {
+		config.Server = defaultServer
+	}
+	if config.MaxConcurrent == 0 {
+		config.MaxConcurrent = defaultMaxConcurrent
+	}
+	if config.DataDirectory == "" {
+		return Config{}, errors.New("data_directory is required")
+	}
+	if !filepath.IsAbs(config.DataDirectory) {
+		config.DataDirectory = filepath.Join(filepath.Dir(path), config.DataDirectory)
+	}
+	for key, repository := range config.Repositories {
+		if !filepath.IsAbs(repository.Path) {
+			repository.Path = filepath.Join(filepath.Dir(path), repository.Path)
+			config.Repositories[key] = repository
+		}
+	}
+	return config, validateConfig(config)
+}
+
+func validateConfig(config Config) error {
+	if err := validateServerURL(config.Server); err != nil {
+		return err
+	}
+	if strings.TrimSpace(config.Name) == "" || len(config.Name) > 200 {
+		return errors.New("name is required and must be at most 200 bytes")
+	}
+	if config.MaxConcurrent < 1 || config.MaxConcurrent > maxConcurrent {
+		return fmt.Errorf("max_concurrent must be between 1 and %d", maxConcurrent)
+	}
+	if strings.TrimSpace(config.DataDirectory) == "" {
+		return errors.New("data_directory is required")
+	}
+	if len(config.Repositories) == 0 {
+		return errors.New("at least one repository is required")
+	}
+	for key, repository := range config.Repositories {
+		if strings.TrimSpace(key) == "" || len(key) > 200 || key != strings.TrimSpace(key) {
+			return errors.New("repository keys are required, must not have surrounding whitespace, and must be at most 200 bytes")
+		}
+		if strings.TrimSpace(repository.Path) == "" {
+			return fmt.Errorf("repository %q path is required", key)
+		}
+	}
+	return nil
+}
+
+func validateServerURL(value string) error {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return fmt.Errorf("parse server URL: %w", err)
+	}
+	if parsed.Scheme != "http" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return errors.New("server must be a plain loopback HTTP URL without credentials, query, or fragment")
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return errors.New("server URL must not contain a path")
+	}
+	host := parsed.Hostname()
+	if host == "" || parsed.Port() == "" {
+		return errors.New("server URL must include a loopback host and port")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if !ip.IsLoopback() {
+			return errors.New("server URL host must be loopback")
+		}
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSuffix(host, "."), "localhost") {
+		return errors.New("server URL host must be a loopback IP or localhost")
+	}
+	addresses, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("resolve server URL host: %w", err)
+	}
+	if len(addresses) == 0 {
+		return errors.New("server URL host resolved to no addresses")
+	}
+	for _, address := range addresses {
+		if !address.IsLoopback() {
+			return errors.New("server URL host must resolve only to loopback")
+		}
+	}
+	return nil
+}
+
+func resolveDataDirectory(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve data directory: %w", err)
+	}
+	if marker, found, err := findV1DatabaseMarker(absolute); err != nil {
+		return "", err
+	} else if found {
+		return "", fmt.Errorf("refusing a worker data directory below V1 state at %s", marker)
+	}
+	if err := os.MkdirAll(absolute, 0o700); err != nil {
+		return "", fmt.Errorf("create data directory: %w", err)
+	}
+	info, err := os.Lstat(absolute)
+	if err != nil {
+		return "", fmt.Errorf("inspect data directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("data_directory must be a real directory, not a symlink")
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize data directory: %w", err)
+	}
+	if err := os.Chmod(canonical, 0o700); err != nil {
+		return "", fmt.Errorf("protect data directory: %w", err)
+	}
+	return canonical, nil
+}
+
+func findV1DatabaseMarker(path string) (string, bool, error) {
+	for {
+		marker := filepath.Join(path, "factory.sqlite3")
+		if info, err := os.Lstat(marker); err == nil {
+			if info.Mode().IsRegular() {
+				return marker, true, nil
+			}
+			return "", false, fmt.Errorf("inspect possible V1 database marker %s: not a regular file", marker)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return "", false, fmt.Errorf("inspect possible V1 database marker: %w", err)
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return "", false, nil
+		}
+		path = parent
+	}
+}

--- a/internal/worker/events.go
+++ b/internal/worker/events.go
@@ -1,0 +1,132 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+type eventSender struct {
+	client    *client
+	attemptID string
+	token     string
+	input     chan protocol.AttemptEvent
+	done      chan struct{}
+	mutex     sync.Mutex
+	next      int64
+	disabled  bool
+	closed    bool
+}
+
+func newEventSender(ctx context.Context, client *client, attemptID, token string) *eventSender {
+	sender := &eventSender{
+		client: client, attemptID: attemptID, token: token,
+		input: make(chan protocol.AttemptEvent, 100), done: make(chan struct{}),
+	}
+	go sender.run(ctx)
+	return sender
+}
+
+func (sender *eventSender) enqueue(stream, text string, truncated bool) {
+	sender.mutex.Lock()
+	if sender.disabled || sender.closed {
+		sender.mutex.Unlock()
+		return
+	}
+	payload := eventPayload(stream, text, truncated)
+	event := protocol.AttemptEvent{Sequence: sender.next, Kind: "codex", Payload: payload}
+	select {
+	case sender.input <- event:
+		sender.next++
+	default:
+		sender.disabled = true
+	}
+	sender.mutex.Unlock()
+}
+
+func (sender *eventSender) closeAndWait(timeout time.Duration) {
+	sender.mutex.Lock()
+	if !sender.closed {
+		close(sender.input)
+		sender.closed = true
+	}
+	sender.mutex.Unlock()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-sender.done:
+	case <-timer.C:
+	}
+}
+
+func (sender *eventSender) run(ctx context.Context) {
+	defer close(sender.done)
+	for event := range sender.input {
+		backoff := 100 * time.Millisecond
+		for {
+			requestContext, cancel := context.WithTimeout(ctx, requestTimeout)
+			err := sender.client.events(requestContext, sender.attemptID, protocol.EventBatchRequest{
+				LeaseToken: sender.token,
+				Events:     []protocol.AttemptEvent{event},
+			})
+			cancel()
+			if err == nil {
+				break
+			}
+			var apiError *APIError
+			if errors.As(err, &apiError) && apiError.Status < 500 {
+				sender.mutex.Lock()
+				sender.disabled = true
+				sender.mutex.Unlock()
+				return
+			}
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+			backoff *= 2
+			if backoff > 2*time.Second {
+				backoff = 2 * time.Second
+			}
+		}
+	}
+}
+
+func eventPayload(stream, text string, truncated bool) json.RawMessage {
+	if stream == "stdout" && !truncated && json.Valid([]byte(text)) && len(text) <= protocol.MaxEventBytes {
+		return json.RawMessage(append([]byte(nil), text...))
+	}
+	maximumText := protocol.MaxEventBytes - 256
+	if len(text) < maximumText {
+		maximumText = len(text)
+	}
+	encode := func(length int, wasTruncated bool) json.RawMessage {
+		payload, _ := json.Marshal(map[string]any{
+			"stream":    stream,
+			"text":      boundedText(text, length),
+			"truncated": wasTruncated,
+		})
+		return payload
+	}
+	payload := encode(maximumText, truncated || maximumText < len(text))
+	if len(payload) <= protocol.MaxEventBytes {
+		return payload
+	}
+	low, high := 0, maximumText
+	for low < high {
+		middle := low + (high-low+1)/2
+		if len(encode(middle, true)) <= protocol.MaxEventBytes {
+			low = middle
+		} else {
+			high = middle - 1
+		}
+	}
+	return encode(low, true)
+}

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -84,6 +85,9 @@ func resolveRepository(key, path, gitExecutable string) (Repository, error) {
 		}
 	}
 	if commandErr != nil {
+		if !executableUnavailable(commandErr) {
+			return Repository{}, commandFailure("verify Git repository", stdout, stderr, commandErr)
+		}
 		remote, err = readOriginRemote(canonical)
 		if err != nil {
 			return Repository{}, commandFailure("verify Git repository", stdout, stderr, commandErr)
@@ -94,6 +98,14 @@ func resolveRepository(key, path, gitExecutable string) (Repository, error) {
 		return Repository{}, err
 	}
 	return Repository{Key: key, Path: canonical, RemoteIdentity: identity}, nil
+}
+
+func executableUnavailable(err error) bool {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	var executableError *exec.Error
+	return errors.As(err, &executableError) && errors.Is(executableError.Err, exec.ErrNotFound)
 }
 
 func readOriginRemote(repository string) (string, error) {

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -1,0 +1,380 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+const gitCommandTimeout = 30 * time.Second
+
+var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}([0-9a-f]{24})?$`)
+
+type worktree struct {
+	Path       string
+	Branch     string
+	BaseCommit string
+	HeadCommit string
+}
+
+func resolveRepositories(config Config, gitExecutable string) ([]Repository, error) {
+	keys := make([]string, 0, len(config.Repositories))
+	for key := range config.Repositories {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	repositories := make([]Repository, 0, len(keys))
+	paths := make(map[string]string)
+	identities := make(map[string]string)
+	for _, key := range keys {
+		repository, err := resolveRepository(key, config.Repositories[key].Path, gitExecutable)
+		if err != nil {
+			return nil, fmt.Errorf("repository %q: %w", key, err)
+		}
+		if previous := paths[repository.Path]; previous != "" {
+			return nil, fmt.Errorf("repositories %q and %q resolve to the same path", previous, key)
+		}
+		if previous := identities[repository.RemoteIdentity]; previous != "" {
+			return nil, fmt.Errorf("repositories %q and %q resolve to the same remote", previous, key)
+		}
+		paths[repository.Path] = key
+		identities[repository.RemoteIdentity] = key
+		repositories = append(repositories, repository)
+	}
+	return repositories, nil
+}
+
+func resolveRepository(key, path, gitExecutable string) (Repository, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return Repository{}, fmt.Errorf("resolve path: %w", err)
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil {
+		return Repository{}, fmt.Errorf("canonicalize path: %w", err)
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return Repository{}, fmt.Errorf("inspect path: %w", err)
+	}
+	if !info.IsDir() {
+		return Repository{}, errors.New("path is not a directory")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
+	stdout, stderr, commandErr := runCommand(ctx, gitExecutable, canonical, 64<<10, "rev-parse", "--is-inside-work-tree")
+	cancel()
+	if commandErr == nil && strings.TrimSpace(string(stdout)) != "true" {
+		commandErr = errors.New("not a Git worktree")
+	}
+	var remote string
+	if commandErr == nil {
+		ctx, cancel = context.WithTimeout(context.Background(), gitCommandTimeout)
+		stdout, stderr, commandErr = runCommand(ctx, gitExecutable, canonical, 64<<10, "remote", "get-url", "origin")
+		cancel()
+		if commandErr == nil {
+			remote = strings.TrimSpace(string(stdout))
+		}
+	}
+	if commandErr != nil {
+		remote, err = readOriginRemote(canonical)
+		if err != nil {
+			return Repository{}, commandFailure("verify Git repository", stdout, stderr, commandErr)
+		}
+	}
+	identity, err := normalizeRemoteIdentity(remote, canonical)
+	if err != nil {
+		return Repository{}, err
+	}
+	return Repository{Key: key, Path: canonical, RemoteIdentity: identity}, nil
+}
+
+func readOriginRemote(repository string) (string, error) {
+	gitPath := filepath.Join(repository, ".git")
+	info, err := os.Lstat(gitPath)
+	if err != nil {
+		return "", err
+	}
+	var configPath string
+	if info.IsDir() {
+		configPath = filepath.Join(gitPath, "config")
+	} else if info.Mode().IsRegular() {
+		body, err := os.ReadFile(gitPath)
+		if err != nil {
+			return "", err
+		}
+		line := strings.TrimSpace(string(body))
+		if !strings.HasPrefix(line, "gitdir: ") {
+			return "", errors.New(".git file has no gitdir")
+		}
+		gitDirectory := strings.TrimSpace(strings.TrimPrefix(line, "gitdir: "))
+		if !filepath.IsAbs(gitDirectory) {
+			gitDirectory = filepath.Join(repository, gitDirectory)
+		}
+		gitDirectory, err = filepath.Abs(gitDirectory)
+		if err != nil {
+			return "", err
+		}
+		commonDirectory := gitDirectory
+		if common, readErr := os.ReadFile(filepath.Join(gitDirectory, "commondir")); readErr == nil {
+			commonDirectory = filepath.Join(gitDirectory, strings.TrimSpace(string(common)))
+		}
+		configPath = filepath.Join(commonDirectory, "config")
+	} else {
+		return "", errors.New(".git is neither a directory nor a gitdir file")
+	}
+	file, err := os.Open(configPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	inOrigin := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "[") {
+			inOrigin = line == `[remote "origin"]`
+			continue
+		}
+		if inOrigin {
+			key, value, found := strings.Cut(line, "=")
+			if found && strings.TrimSpace(key) == "url" {
+				remote := strings.TrimSpace(value)
+				if remote != "" {
+					return remote, nil
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", errors.New("origin remote is required")
+}
+
+func normalizeRemoteIdentity(remote, repositoryPath string) (string, error) {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return "", errors.New("origin remote is empty")
+	}
+	if prefix, path, found := strings.Cut(remote, ":"); found && strings.Contains(prefix, "@") {
+		at := strings.LastIndex(prefix, "@")
+		host := prefix[at+1:]
+		if host == "" || path == "" {
+			return "", errors.New("origin SSH remote is malformed")
+		}
+		return normalizeHostPath(host, path), nil
+	}
+	parsed, err := url.Parse(remote)
+	if err == nil && parsed.Scheme != "" {
+		if parsed.Scheme == "file" {
+			path, err := filepath.EvalSymlinks(parsed.Path)
+			if err != nil {
+				return "", fmt.Errorf("canonicalize file remote: %w", err)
+			}
+			return "file://" + filepath.ToSlash(path), nil
+		}
+		if parsed.Hostname() == "" || parsed.Path == "" {
+			return "", errors.New("origin remote URL is malformed")
+		}
+		return normalizeHostPath(parsed.Host, parsed.Path), nil
+	}
+	path := remote
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(repositoryPath, path)
+	}
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize origin path: %w", err)
+	}
+	return "file://" + filepath.ToSlash(canonical), nil
+}
+
+func normalizeHostPath(host, path string) string {
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	return strings.ToLower(host) + "/" + path
+}
+
+func createWorktree(ctx context.Context, gitExecutable, root string, repository Repository, taskID, attemptID string) (worktree, error) {
+	if !uuidPattern.MatchString(taskID) || !uuidPattern.MatchString(attemptID) {
+		return worktree{}, errors.New("server returned an invalid task or attempt ID")
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return worktree{}, fmt.Errorf("create worktree root: %w", err)
+	}
+	if info, err := os.Lstat(root); err != nil {
+		return worktree{}, fmt.Errorf("inspect worktree root: %w", err)
+	} else if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return worktree{}, errors.New("worktree root must be a real directory, not a symlink")
+	}
+	root, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return worktree{}, fmt.Errorf("canonicalize worktree root: %w", err)
+	}
+	path := filepath.Join(root, attemptID)
+	if _, err := os.Lstat(path); err == nil {
+		return worktree{}, errors.New("attempt worktree path already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return worktree{}, fmt.Errorf("inspect attempt worktree path: %w", err)
+	}
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10, "rev-parse", "HEAD")
+	if err != nil {
+		return worktree{}, commandFailure("resolve repository HEAD", stdout, stderr, err)
+	}
+	base := strings.TrimSpace(string(stdout))
+	if !commitPattern.MatchString(base) {
+		return worktree{}, errors.New("repository HEAD is not a full commit ID")
+	}
+	branch := "factory-v2/" + taskID[:12] + "-" + attemptID[:12]
+	value := worktree{Path: path, Branch: branch, BaseCommit: base, HeadCommit: base}
+	stdout, stderr, err = runGitCommand(ctx, gitExecutable, repository.Path, 256<<10,
+		"worktree", "add", "-b", branch, path, base)
+	if err != nil {
+		return value, commandFailure("create managed worktree", stdout, stderr, err)
+	}
+	return value, nil
+}
+
+type gitWorktreeEntry struct {
+	Path   string
+	Head   string
+	Branch string
+}
+
+func listGitWorktrees(ctx context.Context, gitExecutable, repository string) ([]gitWorktreeEntry, error) {
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository, 1<<20, "worktree", "list", "--porcelain", "-z")
+	if err != nil {
+		return nil, commandFailure("list Git worktrees", stdout, stderr, err)
+	}
+	var entries []gitWorktreeEntry
+	var current gitWorktreeEntry
+	for _, token := range strings.Split(string(stdout), "\x00") {
+		if token == "" {
+			if current.Path != "" {
+				entries = append(entries, current)
+				current = gitWorktreeEntry{}
+			}
+			continue
+		}
+		key, value, _ := strings.Cut(token, " ")
+		switch key {
+		case "worktree":
+			if current.Path != "" {
+				entries = append(entries, current)
+				current = gitWorktreeEntry{}
+			}
+			current.Path = value
+		case "HEAD":
+			current.Head = value
+		case "branch":
+			current.Branch = strings.TrimPrefix(value, "refs/heads/")
+		}
+	}
+	if current.Path != "" {
+		entries = append(entries, current)
+	}
+	return entries, nil
+}
+
+func cleanupSuccessfulWorktree(ctx context.Context, gitExecutable, root string, repository Repository, value worktree) error {
+	root, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return fmt.Errorf("canonicalize worktree root: %w", err)
+	}
+	path, err := filepath.EvalSymlinks(value.Path)
+	if err != nil {
+		return fmt.Errorf("canonicalize worktree path: %w", err)
+	}
+	relative, err := filepath.Rel(root, path)
+	if err != nil || relative == "." || relative == ".." ||
+		strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+		return errors.New("worktree is outside the V2 worktree root")
+	}
+	if strings.Contains(relative, string(filepath.Separator)) {
+		return errors.New("worktree is not a direct child of the V2 worktree root")
+	}
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, path, 1<<20, "status", "--porcelain=v1", "-z")
+	if err != nil {
+		return commandFailure("inspect worktree status", stdout, stderr, err)
+	}
+	if len(stdout) != 0 {
+		return errors.New("worktree is dirty")
+	}
+	stdout, stderr, err = runGitCommand(ctx, gitExecutable, path, 64<<10, "rev-parse", "HEAD")
+	if err != nil {
+		return commandFailure("resolve worktree HEAD", stdout, stderr, err)
+	}
+	value.HeadCommit = strings.TrimSpace(string(stdout))
+	if !commitPattern.MatchString(value.HeadCommit) {
+		return errors.New("worktree HEAD is not a full commit ID")
+	}
+	if value.HeadCommit != value.BaseCommit {
+		stdout, stderr, err = runGitCommand(ctx, gitExecutable, path, 256<<10,
+			"for-each-ref", "--format=%(refname)", "--contains", value.HeadCommit, "refs/remotes")
+		if err != nil {
+			return commandFailure("inspect published refs", stdout, stderr, err)
+		}
+		if strings.TrimSpace(string(stdout)) == "" {
+			return errors.New("worktree contains unpublished commits")
+		}
+	}
+	entries, err := listGitWorktrees(ctx, gitExecutable, repository.Path)
+	if err != nil {
+		return err
+	}
+	matches := 0
+	for _, entry := range entries {
+		entryPath, err := filepath.EvalSymlinks(entry.Path)
+		if err != nil {
+			continue
+		}
+		if entryPath == path {
+			matches++
+			if entry.Branch != value.Branch || entry.Head != value.HeadCommit {
+				return errors.New("Git worktree identity does not match the live attempt")
+			}
+		}
+	}
+	if matches != 1 {
+		return fmt.Errorf("expected one registered Git worktree, found %d", matches)
+	}
+	stdout, stderr, err = runGitCommand(ctx, gitExecutable, repository.Path, 256<<10, "worktree", "remove", path)
+	if err != nil {
+		return commandFailure("remove successful worktree", stdout, stderr, err)
+	}
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		return errors.New("Git reported cleanup success but the worktree path remains")
+	}
+	entries, err = listGitWorktrees(ctx, gitExecutable, repository.Path)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		entryPath, err := filepath.Abs(entry.Path)
+		if err == nil && entryPath == path {
+			return errors.New("Git reported cleanup success but the worktree registration remains")
+		}
+	}
+	return nil
+}
+
+func runGitCommand(
+	ctx context.Context,
+	gitExecutable string,
+	directory string,
+	outputLimit int,
+	arguments ...string,
+) ([]byte, []byte, error) {
+	commandContext, cancel := context.WithTimeout(ctx, gitCommandTimeout)
+	defer cancel()
+	return runCommand(commandContext, gitExecutable, directory, outputLimit, arguments...)
+}

--- a/internal/worker/health.go
+++ b/internal/worker/health.go
@@ -1,0 +1,60 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+const healthCheckTimeout = 10 * time.Second
+
+type health struct {
+	State        string
+	GitVersion   string
+	CodexVersion string
+	Error        error
+}
+
+func checkHealth(ctx context.Context, gitExecutable, codexExecutable string) health {
+	result := health{State: "unhealthy"}
+	gitContext, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	stdout, stderr, err := runCommand(gitContext, gitExecutable, "", 64<<10, "--version")
+	cancel()
+	if err != nil {
+		result.Error = errors.New("Git health check failed; install Git and make it available on PATH")
+		return result
+	}
+	result.GitVersion = strings.TrimSpace(string(stdout))
+	if result.GitVersion == "" {
+		result.Error = errors.New("Git health check returned no version")
+		return result
+	}
+
+	codexContext, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	stdout, stderr, err = runCommand(codexContext, codexExecutable, "", 64<<10, "--version")
+	cancel()
+	if err != nil {
+		result.Error = errors.New("Codex version check failed; install Codex and make it available on PATH")
+		return result
+	}
+	result.CodexVersion = strings.TrimSpace(string(stdout))
+	if result.CodexVersion == "" {
+		result.Error = errors.New("Codex version check returned no version")
+		return result
+	}
+
+	authContext, cancel := context.WithTimeout(ctx, healthCheckTimeout)
+	stdout, stderr, err = runCommand(authContext, codexExecutable, "", 64<<10, "login", "status")
+	cancel()
+	if err != nil {
+		result.Error = errors.New("Codex authentication check failed; run codex login and verify codex login status")
+		return result
+	}
+	if strings.TrimSpace(string(stdout))+strings.TrimSpace(string(stderr)) == "" {
+		result.Error = errors.New("Codex authentication check returned no status")
+		return result
+	}
+	result.State = "healthy"
+	return result
+}

--- a/internal/worker/identity.go
+++ b/internal/worker/identity.go
@@ -1,0 +1,112 @@
+package worker
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+type dataLock struct {
+	file *os.File
+}
+
+func lockDataDirectory(directory string) (*dataLock, error) {
+	path := filepath.Join(directory, "worker.lock")
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("worker.lock must not be a symlink")
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect worker lock: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open worker lock: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("protect worker lock: %w", err)
+	}
+	if err := lockFile(file); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("lock data directory: %w", err)
+	}
+	return &dataLock{file: file}, nil
+}
+
+func (lock *dataLock) Close() error {
+	if lock == nil || lock.file == nil {
+		return nil
+	}
+	unlockErr := unlockFile(lock.file)
+	closeErr := lock.file.Close()
+	return errors.Join(unlockErr, closeErr)
+}
+
+func loadOrCreateWorkerID(directory string, random io.Reader) (string, error) {
+	path := filepath.Join(directory, "worker-id")
+	if info, err := os.Lstat(path); err == nil {
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return "", errors.New("worker-id must be a regular non-symlink file")
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			return "", errors.New("worker-id permissions must not allow group or other access")
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read worker ID: %w", err)
+		}
+		id := strings.TrimSpace(string(body))
+		if !uuidPattern.MatchString(id) {
+			return "", errors.New("worker-id does not contain a valid UUID")
+		}
+		return id, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect worker ID: %w", err)
+	}
+	id, err := newUUID(random)
+	if err != nil {
+		return "", fmt.Errorf("generate worker ID: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("create worker ID: %w", err)
+	}
+	if _, err := io.WriteString(file, id+"\n"); err != nil {
+		file.Close()
+		os.Remove(path)
+		return "", fmt.Errorf("write worker ID: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		os.Remove(path)
+		return "", fmt.Errorf("sync worker ID: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		os.Remove(path)
+		return "", fmt.Errorf("close worker ID: %w", err)
+	}
+	if err := syncDirectory(directory); err != nil {
+		return "", fmt.Errorf("sync worker ID directory: %w", err)
+	}
+	return id, nil
+}
+
+func newUUID(random io.Reader) (string, error) {
+	if random == nil {
+		random = rand.Reader
+	}
+	var value [16]byte
+	if _, err := io.ReadFull(random, value[:]); err != nil {
+		return "", err
+	}
+	value[6] = (value[6] & 0x0f) | 0x40
+	value[8] = (value[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		value[0:4], value[4:6], value[6:8], value[8:10], value[10:16]), nil
+}

--- a/internal/worker/manager.go
+++ b/internal/worker/manager.go
@@ -675,17 +675,6 @@ func (manager *Manager) waitForSupervisorMessage(process *supervisorProcess) sup
 			manager.emergencyStop(process, err)
 			return supervisorMessage{Type: "exit", Reason: "supervisor_error", ExitCode: -1,
 				Error: "attempt supervisor output ended unexpectedly"}
-		case err := <-process.wait:
-			select {
-			case message := <-process.messages:
-				if message.Type == "exit" || message.Type == "output" {
-					return message
-				}
-			case <-time.After(250 * time.Millisecond):
-			}
-			manager.emergencyStop(process, err)
-			return supervisorMessage{Type: "exit", Reason: "supervisor_error", ExitCode: -1,
-				Error: "attempt supervisor exited unexpectedly"}
 		}
 	}
 }

--- a/internal/worker/manager.go
+++ b/internal/worker/manager.go
@@ -1,0 +1,945 @@
+package worker
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const (
+	defaultPollInterval         = 2 * time.Second
+	defaultHealthInterval       = 30 * time.Second
+	defaultRegistrationInterval = 10 * time.Second
+	defaultLeaseRenewInterval   = 10 * time.Second
+	defaultLeaseRetryInterval   = 2 * time.Second
+	defaultShutdownTimeout      = 30 * time.Second
+	defaultWorkerVersion        = "dev"
+)
+
+type Options struct {
+	GitExecutable        string
+	CodexExecutable      string
+	SupervisorCommand    []string
+	HTTPClient           *http.Client
+	Random               io.Reader
+	WorkerVersion        string
+	PollInterval         time.Duration
+	HealthInterval       time.Duration
+	RegistrationInterval time.Duration
+	LeaseRenewInterval   time.Duration
+	LeaseRetryInterval   time.Duration
+	TransportBackoffMin  time.Duration
+	TransportBackoffMax  time.Duration
+	ShutdownTimeout      time.Duration
+}
+
+type Manager struct {
+	config            Config
+	options           Options
+	logger            *slog.Logger
+	id                string
+	dataDirectory     string
+	lock              *dataLock
+	repositories      []Repository
+	repositoriesByKey map[string]Repository
+	client            *client
+	slots             chan struct{}
+
+	stateMutex  sync.Mutex
+	health      health
+	active      map[string]*attemptHandle
+	seen        map[string]bool
+	retained    map[string]protocol.RetainedWorktree
+	pending     map[string]context.CancelFunc
+	fatalHealth error
+	registered  bool
+	closed      bool
+
+	randomMutex sync.Mutex
+	waitGroup   sync.WaitGroup
+}
+
+type attemptHandle struct {
+	context context.Context
+	cancel  context.CancelFunc
+	done    chan struct{}
+
+	mutex      sync.Mutex
+	reason     string
+	expiry     time.Time
+	supervisor *supervisorProcess
+}
+
+func New(config Config, options Options, logger *slog.Logger) (*Manager, error) {
+	if err := ensureSupportedPlatform(); err != nil {
+		return nil, err
+	}
+	if err := validateConfig(config); err != nil {
+		return nil, err
+	}
+	options = options.withDefaults()
+	if len(options.SupervisorCommand) == 0 {
+		return nil, errors.New("resolve factory-worker executable for attempt supervision")
+	}
+	dataDirectory, err := resolveDataDirectory(config.DataDirectory)
+	if err != nil {
+		return nil, err
+	}
+	lock, err := lockDataDirectory(dataDirectory)
+	if err != nil {
+		return nil, err
+	}
+	cleanupLock := true
+	defer func() {
+		if cleanupLock {
+			_ = lock.Close()
+		}
+	}()
+	id, err := loadOrCreateWorkerID(dataDirectory, options.Random)
+	if err != nil {
+		return nil, err
+	}
+	repositories, err := resolveRepositories(config, options.GitExecutable)
+	if err != nil {
+		return nil, err
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	byKey := make(map[string]Repository, len(repositories))
+	for _, repository := range repositories {
+		byKey[repository.Key] = repository
+	}
+	cleanupLock = false
+	return &Manager{
+		config:            config,
+		options:           options,
+		logger:            logger,
+		id:                id,
+		dataDirectory:     dataDirectory,
+		lock:              lock,
+		repositories:      repositories,
+		repositoriesByKey: byKey,
+		client:            newClient(config.Server, options.HTTPClient),
+		slots:             make(chan struct{}, config.MaxConcurrent),
+		health:            health{State: "unhealthy"},
+		active:            make(map[string]*attemptHandle),
+		seen:              make(map[string]bool),
+		retained:          make(map[string]protocol.RetainedWorktree),
+		pending:           make(map[string]context.CancelFunc),
+	}, nil
+}
+
+func (options Options) withDefaults() Options {
+	if options.GitExecutable == "" {
+		options.GitExecutable = "git"
+	}
+	if options.CodexExecutable == "" {
+		options.CodexExecutable = "codex"
+	}
+	if len(options.SupervisorCommand) == 0 {
+		executable, err := os.Executable()
+		if err == nil {
+			options.SupervisorCommand = supervisorCommandLine(executable)
+		}
+	}
+	if options.Random == nil {
+		options.Random = rand.Reader
+	}
+	if options.WorkerVersion == "" {
+		options.WorkerVersion = defaultWorkerVersion
+	}
+	if options.PollInterval <= 0 {
+		options.PollInterval = defaultPollInterval
+	}
+	if options.HealthInterval <= 0 {
+		options.HealthInterval = defaultHealthInterval
+	}
+	if options.RegistrationInterval <= 0 {
+		options.RegistrationInterval = defaultRegistrationInterval
+	}
+	if options.LeaseRenewInterval <= 0 {
+		options.LeaseRenewInterval = defaultLeaseRenewInterval
+	}
+	if options.LeaseRetryInterval <= 0 {
+		options.LeaseRetryInterval = defaultLeaseRetryInterval
+	}
+	if options.TransportBackoffMin <= 0 {
+		options.TransportBackoffMin = time.Second
+	}
+	if options.TransportBackoffMax <= 0 {
+		options.TransportBackoffMax = 30 * time.Second
+	}
+	if options.ShutdownTimeout <= 0 {
+		options.ShutdownTimeout = defaultShutdownTimeout
+	}
+	return options
+}
+
+func (manager *Manager) ID() string { return manager.id }
+
+func (manager *Manager) Run(ctx context.Context) error {
+	defer manager.Close()
+	manager.setHealth(checkHealth(ctx, manager.options.GitExecutable, manager.options.CodexExecutable))
+	manager.register(ctx)
+
+	healthTicker := time.NewTicker(manager.options.HealthInterval)
+	defer healthTicker.Stop()
+	registrationTicker := time.NewTicker(manager.options.RegistrationInterval)
+	defer registrationTicker.Stop()
+	claimTimer := time.NewTimer(0)
+	defer claimTimer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			manager.stopAll("cancelled")
+			return manager.waitForShutdown()
+		case <-healthTicker.C:
+			manager.setHealth(checkHealth(ctx, manager.options.GitExecutable, manager.options.CodexExecutable))
+		case <-registrationTicker.C:
+			manager.register(ctx)
+		case <-claimTimer.C:
+			if manager.isHealthy() {
+				manager.reserveAndClaim(ctx)
+			}
+			claimTimer.Reset(manager.jitteredPollInterval())
+		}
+	}
+}
+
+func (manager *Manager) Close() error {
+	manager.stateMutex.Lock()
+	if manager.closed {
+		manager.stateMutex.Unlock()
+		return nil
+	}
+	manager.closed = true
+	manager.stateMutex.Unlock()
+	return manager.lock.Close()
+}
+
+func (manager *Manager) setHealth(value health) {
+	manager.stateMutex.Lock()
+	previous := manager.health.State
+	if manager.fatalHealth != nil {
+		value = health{State: "unhealthy", Error: manager.fatalHealth}
+	}
+	manager.health = value
+	if previous != value.State {
+		manager.registered = false
+	}
+	if value.State != "healthy" {
+		manager.cancelPendingClaimsLocked()
+	}
+	manager.stateMutex.Unlock()
+	if value.Error != nil && previous != value.State {
+		manager.logger.Warn("worker_unhealthy", "error_class", "runtime_health", "error", value.Error)
+	}
+	if value.State == "healthy" && previous != "healthy" {
+		manager.logger.Info("worker_healthy", "git_version", value.GitVersion, "codex_version", value.CodexVersion)
+	}
+}
+
+func (manager *Manager) markUnhealthy(errorClass string, err error) {
+	manager.stateMutex.Lock()
+	manager.fatalHealth = err
+	manager.health.State = "unhealthy"
+	manager.health.Error = err
+	manager.registered = false
+	manager.cancelPendingClaimsLocked()
+	manager.stateMutex.Unlock()
+	manager.logger.Error("worker_unhealthy", "error_class", errorClass, "error", err)
+}
+
+func (manager *Manager) isHealthy() bool {
+	manager.stateMutex.Lock()
+	defer manager.stateMutex.Unlock()
+	return manager.health.State == "healthy" && manager.registered
+}
+
+func (manager *Manager) registration() protocol.WorkerRegistration {
+	manager.stateMutex.Lock()
+	defer manager.stateMutex.Unlock()
+	repositories := make([]protocol.RepositoryRegistration, 0, len(manager.repositories))
+	retained := make([]protocol.RetainedWorktree, 0, len(manager.retained))
+	for _, value := range manager.retained {
+		retained = append(retained, value)
+	}
+	for _, repository := range manager.repositories {
+		repositories = append(repositories, protocol.RepositoryRegistration{
+			Key: repository.Key, RemoteIdentity: repository.RemoteIdentity,
+		})
+	}
+	return protocol.WorkerRegistration{
+		Name:              strings.TrimSpace(manager.config.Name),
+		WorkerVersion:     manager.options.WorkerVersion,
+		CodexVersion:      manager.health.CodexVersion,
+		Capacity:          manager.config.MaxConcurrent,
+		ActiveCount:       len(manager.slots),
+		Health:            manager.health.State,
+		Repositories:      repositories,
+		RetainedWorktrees: retained,
+	}
+}
+
+func (manager *Manager) register(ctx context.Context) {
+	requestContext, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+	if _, err := manager.client.register(requestContext, manager.id, manager.registration()); err != nil {
+		manager.stateMutex.Lock()
+		manager.registered = false
+		manager.cancelPendingClaimsLocked()
+		manager.stateMutex.Unlock()
+		var apiError *APIError
+		if errors.As(err, &apiError) && apiError.Status < 500 {
+			manager.markUnhealthy("worker_registration", errors.New("worker configuration was rejected by the control plane"))
+		}
+		manager.logger.Warn("worker_registration_failed", "error_class", apiErrorClass(err))
+		return
+	}
+	manager.stateMutex.Lock()
+	manager.registered = true
+	manager.stateMutex.Unlock()
+}
+
+func (manager *Manager) reserveAndClaim(ctx context.Context) {
+	for {
+		select {
+		case manager.slots <- struct{}{}:
+			manager.waitGroup.Add(1)
+			go manager.claimOnce(ctx)
+		default:
+			return
+		}
+	}
+}
+
+func (manager *Manager) claimOnce(ctx context.Context) {
+	defer manager.waitGroup.Done()
+	release := true
+	defer func() {
+		if release {
+			<-manager.slots
+		}
+	}()
+	requestID, err := manager.randomUUID()
+	if err != nil {
+		manager.markUnhealthy("randomness", err)
+		return
+	}
+	token, err := manager.randomSecret()
+	if err != nil {
+		manager.markUnhealthy("randomness", err)
+		return
+	}
+	claimContext, cancelClaim, eligible := manager.beginClaim(ctx, requestID)
+	if !eligible {
+		cancelClaim()
+		return
+	}
+	claim, err := manager.client.claim(claimContext, manager.id, protocol.ClaimRequest{
+		RequestID: requestID, LeaseToken: token,
+	}, manager.options.TransportBackoffMin, manager.options.TransportBackoffMax)
+	eligible = manager.endClaim(requestID)
+	cancelClaim()
+	if err != nil {
+		if ctx.Err() == nil && !errors.Is(err, context.Canceled) {
+			manager.logger.Warn("worker_claim_failed", "error_class", apiErrorClass(err))
+		}
+		return
+	}
+	if claim == nil {
+		return
+	}
+	if !eligible {
+		handle := &attemptHandle{expiry: claim.Attempt.LeaseExpiresAt}
+		manager.complete(claim.Attempt.ID, token, "failed", "",
+			"worker became ineligible before attempt start", handle)
+		return
+	}
+	manager.stateMutex.Lock()
+	if manager.seen[claim.Attempt.ID] {
+		manager.stateMutex.Unlock()
+		manager.logger.Warn("duplicate_claim_ignored", "attempt_id", claim.Attempt.ID)
+		return
+	}
+	manager.seen[claim.Attempt.ID] = true
+	manager.stateMutex.Unlock()
+	release = false
+	manager.runAttempt(ctx, *claim, token)
+	<-manager.slots
+}
+
+func (manager *Manager) beginClaim(
+	parent context.Context,
+	requestID string,
+) (context.Context, context.CancelFunc, bool) {
+	ctx, cancel := context.WithCancel(parent)
+	manager.stateMutex.Lock()
+	defer manager.stateMutex.Unlock()
+	if manager.health.State != "healthy" || !manager.registered {
+		return ctx, cancel, false
+	}
+	manager.pending[requestID] = cancel
+	return ctx, cancel, true
+}
+
+func (manager *Manager) endClaim(requestID string) bool {
+	manager.stateMutex.Lock()
+	defer manager.stateMutex.Unlock()
+	delete(manager.pending, requestID)
+	return manager.health.State == "healthy" && manager.registered
+}
+
+func (manager *Manager) cancelPendingClaimsLocked() {
+	for requestID, cancel := range manager.pending {
+		cancel()
+		delete(manager.pending, requestID)
+	}
+}
+
+func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim, token string) {
+	attemptContext, cancel := context.WithCancel(parent)
+	handle := &attemptHandle{
+		context: attemptContext, cancel: cancel, done: make(chan struct{}), expiry: claim.Attempt.LeaseExpiresAt,
+	}
+	manager.stateMutex.Lock()
+	manager.active[claim.Attempt.ID] = handle
+	manager.stateMutex.Unlock()
+	if parent.Err() != nil {
+		handle.stop("cancelled")
+	}
+	defer func() {
+		close(handle.done)
+		cancel()
+		manager.stateMutex.Lock()
+		delete(manager.active, claim.Attempt.ID)
+		manager.stateMutex.Unlock()
+	}()
+	go manager.heartbeatAttempt(handle, claim.Attempt.ID, token)
+
+	repository, err := manager.validateClaim(claim)
+	if err != nil {
+		manager.finishWithoutWorktree(claim, token, handle, "failed", err)
+		return
+	}
+	taskDeadline := claim.Attempt.CreatedAt.Add(time.Duration(claim.Task.TimeoutSeconds) * time.Second)
+	taskTimer := time.AfterFunc(time.Until(taskDeadline), func() {
+		handle.stop("timeout")
+	})
+	defer taskTimer.Stop()
+	worktreeRoot := filepath.Join(manager.dataDirectory, "worktrees")
+	value, err := createWorktree(handle.context, manager.options.GitExecutable, worktreeRoot,
+		repository, claim.Task.ID, claim.Attempt.ID)
+	if err != nil {
+		state := "failed"
+		if handle.stopReason() == "cancelled" {
+			state = "cancelled"
+		}
+		err = stoppedAttemptError(handle, err)
+		if value.Path != "" {
+			if _, pathErr := os.Lstat(value.Path); pathErr == nil {
+				manager.finishWithWorktree(claim, token, handle, repository, value, state, "", err.Error())
+				return
+			}
+		}
+		manager.finishWithoutWorktree(claim, token, handle, state, err)
+		return
+	}
+
+	path, err := resultPath(manager.dataDirectory, claim.Attempt.ID)
+	if err != nil {
+		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", "", err.Error())
+		return
+	}
+	defer os.Remove(path)
+	process, err := startSupervisor(manager.options.SupervisorCommand, supervisorInit{
+		CodexExecutable: manager.options.CodexExecutable,
+		Worktree:        value.Path,
+		ResultPath:      path,
+		Prompt:          buildPrompt(claim),
+		TimeoutSeconds:  remainingTimeoutSeconds(taskDeadline),
+	}, os.Stderr)
+	if err != nil {
+		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", "", err.Error())
+		return
+	}
+	if err := process.awaitReady(handle.context); err != nil {
+		_ = process.closeControl()
+		manager.finishWithWorktree(claim, token, handle, repository, value,
+			terminalForStop(handle), "", stoppedAttemptError(handle, err).Error())
+		return
+	}
+	handle.setSupervisor(process)
+
+	started, err := manager.client.start(handle.context, claim.Attempt.ID, supervisorStartRequest(process, token))
+	if err != nil {
+		reason := handle.stopReason()
+		var apiError *APIError
+		if errors.As(err, &apiError) && apiError.Code == "lease_not_owner" {
+			reason = "lease_lost"
+		}
+		if reason == "" {
+			reason = "failed"
+		}
+		handle.stop(reason)
+		message := manager.waitForSupervisor(process)
+		errorText := err.Error()
+		if reason == "timeout" {
+			errorText = "task timeout reached"
+		}
+		manager.finishWithWorktree(claim, token, handle, repository, value,
+			terminalState(message), message.Result, firstNonEmpty(errorText, message.Error))
+		return
+	}
+	if started.State != "running" {
+		handle.stop("lease_lost")
+		message := manager.waitForSupervisor(process)
+		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", message.Result,
+			"control plane did not accept the running transition")
+		return
+	}
+	if err := process.send("start"); err != nil {
+		manager.emergencyStop(process, err)
+		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", "", err.Error())
+		return
+	}
+	manager.logger.Info("attempt_started", "attempt_id", claim.Attempt.ID, "repository", repository.Key,
+		"process", processSummary(process))
+	sender := newEventSender(handle.context, manager.client, claim.Attempt.ID, token)
+	message := manager.waitForSupervisorWithEvents(process, sender)
+	sender.closeAndWait(5 * time.Second)
+	manager.finishWithWorktree(claim, token, handle, repository, value,
+		terminalState(message), message.Result, message.Error)
+}
+
+func (manager *Manager) validateClaim(claim protocol.Claim) (Repository, error) {
+	if !uuidPattern.MatchString(claim.Attempt.ID) || !uuidPattern.MatchString(claim.Task.ID) {
+		return Repository{}, errors.New("claim contains invalid IDs")
+	}
+	if claim.Attempt.WorkerID != manager.id || claim.Execution.AssignedWorkerID != manager.id {
+		return Repository{}, errors.New("claim is assigned to a different worker")
+	}
+	if claim.Execution.RequiredRuntime != "codex" {
+		return Repository{}, errors.New("claim requires an unsupported runtime")
+	}
+	if claim.Task.RepositoryID != claim.Repository.ID {
+		return Repository{}, errors.New("claim repository IDs do not match")
+	}
+	if claim.Task.TimeoutSeconds < 1 || claim.Task.TimeoutSeconds > int(protocol.MaxTimeout/time.Second) {
+		return Repository{}, errors.New("claim timeout is outside the supported range")
+	}
+	repository, exists := manager.repositoriesByKey[claim.Repository.Key]
+	if !exists || repository.RemoteIdentity != claim.Repository.RemoteIdentity {
+		return Repository{}, errors.New("claim repository is not advertised by this worker")
+	}
+	return repository, nil
+}
+
+func (manager *Manager) heartbeatAttempt(handle *attemptHandle, attemptID, token string) {
+	delay := manager.options.LeaseRenewInterval
+	for {
+		timer := time.NewTimer(delay)
+		select {
+		case <-handle.done:
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+		requestContext, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		heartbeat, err := manager.client.heartbeat(requestContext, attemptID, token)
+		cancel()
+		if err == nil {
+			handle.updateExpiry(heartbeat.LeaseExpiresAt)
+			if heartbeat.CancellationRequested {
+				handle.stop("cancelled")
+				return
+			}
+			delay = manager.options.LeaseRenewInterval
+			continue
+		}
+		var apiError *APIError
+		if errors.As(err, &apiError) && apiError.Code == "lease_not_owner" {
+			handle.stop("lease_lost")
+			return
+		}
+		if time.Now().After(handle.leaseExpiry()) {
+			handle.stop("lease_lost")
+			return
+		}
+		delay = manager.options.LeaseRetryInterval
+	}
+}
+
+func (handle *attemptHandle) setSupervisor(process *supervisorProcess) {
+	handle.mutex.Lock()
+	handle.supervisor = process
+	reason := handle.reason
+	expiry := handle.expiry
+	handle.mutex.Unlock()
+	if reason != "" {
+		_ = process.send(stopCommand(reason))
+	} else {
+		_ = process.renew(expiry)
+	}
+}
+
+func (handle *attemptHandle) updateExpiry(expiry time.Time) {
+	handle.mutex.Lock()
+	handle.expiry = expiry
+	process := handle.supervisor
+	handle.mutex.Unlock()
+	if process != nil {
+		_ = process.renew(expiry)
+	}
+}
+
+func (handle *attemptHandle) leaseExpiry() time.Time {
+	handle.mutex.Lock()
+	defer handle.mutex.Unlock()
+	return handle.expiry
+}
+
+func (handle *attemptHandle) stop(reason string) {
+	handle.mutex.Lock()
+	if handle.reason != "" {
+		handle.mutex.Unlock()
+		return
+	}
+	handle.reason = reason
+	process := handle.supervisor
+	handle.mutex.Unlock()
+	handle.cancel()
+	if process != nil {
+		_ = process.send(stopCommand(reason))
+	}
+}
+
+func (handle *attemptHandle) stopReason() string {
+	handle.mutex.Lock()
+	defer handle.mutex.Unlock()
+	return handle.reason
+}
+
+func (manager *Manager) waitForSupervisorWithEvents(process *supervisorProcess, sender *eventSender) supervisorMessage {
+	for {
+		message := manager.waitForSupervisorMessage(process)
+		if message.Type == "output" {
+			sender.enqueue(message.Stream, message.Text, message.Truncated)
+			continue
+		}
+		return message
+	}
+}
+
+func (manager *Manager) waitForSupervisor(process *supervisorProcess) supervisorMessage {
+	for {
+		message := manager.waitForSupervisorMessage(process)
+		if message.Type != "output" {
+			return message
+		}
+	}
+}
+
+func (manager *Manager) waitForSupervisorMessage(process *supervisorProcess) supervisorMessage {
+	for {
+		select {
+		case message := <-process.messages:
+			if message.Type == "exit" || message.Type == "output" {
+				if message.Type == "exit" {
+					_ = process.closeControl()
+				}
+				return message
+			}
+		case err := <-process.decodeErrors:
+			select {
+			case message := <-process.messages:
+				if message.Type == "exit" || message.Type == "output" {
+					return message
+				}
+			default:
+			}
+			manager.emergencyStop(process, err)
+			return supervisorMessage{Type: "exit", Reason: "supervisor_error", ExitCode: -1,
+				Error: "attempt supervisor output ended unexpectedly"}
+		case err := <-process.wait:
+			select {
+			case message := <-process.messages:
+				if message.Type == "exit" || message.Type == "output" {
+					return message
+				}
+			case <-time.After(250 * time.Millisecond):
+			}
+			manager.emergencyStop(process, err)
+			return supervisorMessage{Type: "exit", Reason: "supervisor_error", ExitCode: -1,
+				Error: "attempt supervisor exited unexpectedly"}
+		}
+	}
+}
+
+func (manager *Manager) emergencyStop(process *supervisorProcess, cause error) {
+	_ = process.closeControl()
+	if process.processGroupID > 0 && process.groupIdentity != "" {
+		if err := stopOwnedProcessGroup(int(process.processGroupID), process.groupIdentity, terminationGrace); err != nil {
+			manager.markUnhealthy("process_group_stop", errors.Join(cause, err))
+		}
+	}
+}
+
+func (manager *Manager) finishWithoutWorktree(
+	claim protocol.Claim,
+	token string,
+	handle *attemptHandle,
+	state string,
+	cause error,
+) {
+	errorText := ""
+	if cause != nil {
+		errorText = boundedText(cause.Error(), protocol.MaxErrorBytes)
+	}
+	manager.complete(claim.Attempt.ID, token, state, "", errorText, handle)
+}
+
+func (manager *Manager) finishWithWorktree(
+	claim protocol.Claim,
+	token string,
+	handle *attemptHandle,
+	repository Repository,
+	value worktree,
+	state string,
+	result string,
+	errorText string,
+) {
+	result = boundedText(result, protocol.MaxResultBytes)
+	errorText = boundedText(errorText, protocol.MaxErrorBytes)
+	completed := manager.complete(claim.Attempt.ID, token, state, result, errorText, handle)
+	if completed && state == "succeeded" {
+		cleanupContext, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
+		err := cleanupSuccessfulWorktree(cleanupContext, manager.options.GitExecutable,
+			filepath.Join(manager.dataDirectory, "worktrees"), repository, value)
+		cancel()
+		if err == nil {
+			manager.logger.Info("attempt_worktree_cleaned", "attempt_id", claim.Attempt.ID, "repository", repository.Key)
+			return
+		}
+		errorText = err.Error()
+	}
+	reason := firstNonEmpty(errorText, state+" attempt retained for inspection")
+	manager.retain(claim, repository, value, reason)
+}
+
+func (manager *Manager) complete(
+	attemptID string,
+	token string,
+	state string,
+	result string,
+	errorText string,
+	handle *attemptHandle,
+) bool {
+	timeout := requestTimeout
+	if remaining := time.Until(handle.leaseExpiry()); remaining > 0 && remaining < timeout {
+		timeout = remaining
+	}
+	if timeout <= 0 {
+		manager.logger.Warn("attempt_completion_not_recorded", "attempt_id", attemptID, "error_class", "lease_expired")
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, err := manager.client.complete(ctx, attemptID, protocol.CompleteAttemptRequest{
+		LeaseToken: token, State: state, Result: result, Error: errorText,
+	})
+	if err != nil {
+		manager.logger.Warn("attempt_completion_not_recorded", "attempt_id", attemptID, "error_class", apiErrorClass(err))
+		return false
+	}
+	manager.logger.Info("attempt_completed", "attempt_id", attemptID, "state", state)
+	return true
+}
+
+func (manager *Manager) retain(claim protocol.Claim, repository Repository, value worktree, reason string) {
+	manager.stateMutex.Lock()
+	manager.retained[claim.Attempt.ID] = protocol.RetainedWorktree{
+		AttemptID: claim.Attempt.ID, RepositoryID: claim.Repository.ID,
+		Path: value.Path, Reason: boundedText(reason, 1000),
+	}
+	manager.stateMutex.Unlock()
+	manager.logger.Info("attempt_worktree_retained", "attempt_id", claim.Attempt.ID, "repository", repository.Key)
+}
+
+func (manager *Manager) stopAll(reason string) {
+	manager.stateMutex.Lock()
+	handles := make([]*attemptHandle, 0, len(manager.active))
+	for _, handle := range manager.active {
+		handles = append(handles, handle)
+	}
+	manager.stateMutex.Unlock()
+	for _, handle := range handles {
+		handle.stop(reason)
+	}
+}
+
+func (manager *Manager) waitForShutdown() error {
+	done := make(chan struct{})
+	go func() {
+		manager.waitGroup.Wait()
+		close(done)
+	}()
+	timer := time.NewTimer(manager.options.ShutdownTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		return nil
+	case <-timer.C:
+		manager.stateMutex.Lock()
+		for _, handle := range manager.active {
+			handle.mutex.Lock()
+			if handle.supervisor != nil {
+				_ = handle.supervisor.closeControl()
+			}
+			handle.mutex.Unlock()
+		}
+		manager.stateMutex.Unlock()
+		return errors.New("worker shutdown exceeded thirty seconds")
+	}
+}
+
+func (manager *Manager) randomUUID() (string, error) {
+	manager.randomMutex.Lock()
+	defer manager.randomMutex.Unlock()
+	return newUUID(manager.options.Random)
+}
+
+func (manager *Manager) randomSecret() (string, error) {
+	manager.randomMutex.Lock()
+	defer manager.randomMutex.Unlock()
+	body := make([]byte, 32)
+	if _, err := io.ReadFull(manager.options.Random, body); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(body), nil
+}
+
+func (manager *Manager) jitteredPollInterval() time.Duration {
+	manager.randomMutex.Lock()
+	defer manager.randomMutex.Unlock()
+	var value [1]byte
+	if _, err := io.ReadFull(manager.options.Random, value[:]); err != nil {
+		return manager.options.PollInterval
+	}
+	// Empty polls use up to 20 percent positive jitter.
+	return manager.options.PollInterval + time.Duration(int64(manager.options.PollInterval)*int64(value[0])/1275)
+}
+
+func terminalForStop(handle *attemptHandle) string {
+	if handle.stopReason() == "cancelled" {
+		return "cancelled"
+	}
+	return "failed"
+}
+
+func stoppedAttemptError(handle *attemptHandle, fallback error) error {
+	switch handle.stopReason() {
+	case "cancelled":
+		return errors.New("attempt cancelled")
+	case "timeout":
+		return errors.New("task timeout reached")
+	case "lease_lost":
+		return errors.New("control-plane lease was lost")
+	default:
+		return fallback
+	}
+}
+
+func terminalState(message supervisorMessage) string {
+	if message.Reason == "cancelled" {
+		return "cancelled"
+	}
+	if message.Reason == "exited" && message.ExitCode == 0 {
+		return "succeeded"
+	}
+	return "failed"
+}
+
+func buildPrompt(claim protocol.Claim) string {
+	return "You are running in a Factory V2 managed Git worktree.\n" +
+		"Work only on the assigned task and repository. Preserve unrelated changes, do not touch Factory V1 state or worktrees, " +
+		"and do not delete worktrees or branches. Complete and verify the task before returning a concise result.\n\n" +
+		"Task title: " + claim.Task.Title + "\n" +
+		"Repository: " + claim.Repository.RemoteIdentity + "\n\n" +
+		claim.Task.Description
+}
+
+func apiErrorClass(err error) string {
+	var apiError *APIError
+	if errors.As(err, &apiError) && apiError.Code != "" {
+		return apiError.Code
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "cancelled"
+	}
+	return "transport"
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stopCommand(reason string) string {
+	if reason == "cancelled" {
+		return "cancel"
+	}
+	if reason == "failed" {
+		return "fail"
+	}
+	return reason
+}
+
+func remainingTimeoutSeconds(deadline time.Time) int {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 1
+	}
+	seconds := int((remaining + time.Second - 1) / time.Second)
+	maximum := int(protocol.MaxTimeout / time.Second)
+	if seconds > maximum {
+		return maximum
+	}
+	return seconds
+}
+
+func DefaultConfigPath() (string, error) {
+	if value := os.Getenv("FACTORY_V2_WORKER_CONFIG"); value != "" {
+		return value, nil
+	}
+	root := os.Getenv("FACTORY_V2_DATA_HOME")
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		root = filepath.Join(home, ".factory-v2")
+	}
+	return filepath.Join(root, "worker.toml"), nil
+}

--- a/internal/worker/platform_unix.go
+++ b/internal/worker/platform_unix.go
@@ -1,0 +1,128 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package worker
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func ensureSupportedPlatform() error { return nil }
+
+func ShutdownSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}
+
+func lockFile(file *os.File) error {
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+			return errors.New("another factory-worker already owns this data directory")
+		}
+		return err
+	}
+	return nil
+}
+
+func unlockFile(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+func configureNewProcessGroup(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+func configureExistingProcessGroup(command *exec.Cmd, processGroupID int) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: processGroupID}
+}
+
+func processGroupID(pid int) (int, error) {
+	return unix.Getpgid(pid)
+}
+
+func processIdentity(pid int) (string, error) {
+	command := exec.Command("ps", "-o", "lstart=", "-o", "command=", "-p", strconv.Itoa(pid))
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("inspect process %d: %w", pid, err)
+	}
+	identity := strings.TrimSpace(string(output))
+	if identity == "" {
+		return "", fmt.Errorf("process %d has no observable identity", pid)
+	}
+	return identity, nil
+}
+
+func verifyProcessIdentity(pid int, expected string) error {
+	actual, err := processIdentity(pid)
+	if err != nil {
+		return err
+	}
+	if actual != expected {
+		return fmt.Errorf("process %d identity changed", pid)
+	}
+	return nil
+}
+
+func signalProcessGroup(processGroupID int, signal unix.Signal) error {
+	err := unix.Kill(-processGroupID, signal)
+	if errors.Is(err, unix.ESRCH) {
+		return nil
+	}
+	return err
+}
+
+func forceStopStartedProcessGroup(processGroupID int) error {
+	err := unix.Kill(-processGroupID, unix.SIGKILL)
+	if errors.Is(err, unix.ESRCH) {
+		return nil
+	}
+	return err
+}
+
+func processGroupAlive(processGroupID int) bool {
+	err := unix.Kill(-processGroupID, 0)
+	return err == nil || errors.Is(err, unix.EPERM)
+}
+
+func stopOwnedProcessGroup(pid int, identity string, grace time.Duration) error {
+	if err := verifyProcessIdentity(pid, identity); err != nil {
+		return fmt.Errorf("refuse to signal unverified process group: %w", err)
+	}
+	if err := signalProcessGroup(pid, unix.SIGTERM); err != nil {
+		return fmt.Errorf("terminate process group %d: %w", pid, err)
+	}
+	deadline := time.Now().Add(grace)
+	for grace > 0 && time.Now().Before(deadline) {
+		time.Sleep(25 * time.Millisecond)
+		if !processGroupAlive(pid) {
+			return nil
+		}
+	}
+	if err := verifyProcessIdentity(pid, identity); err != nil {
+		if !processGroupAlive(pid) {
+			return nil
+		}
+		return fmt.Errorf("refuse to kill unverified process group: %w", err)
+	}
+	if err := signalProcessGroup(pid, unix.SIGKILL); err != nil {
+		return fmt.Errorf("kill process group %d: %w", pid, err)
+	}
+	return nil
+}

--- a/internal/worker/platform_unsupported.go
+++ b/internal/worker/platform_unsupported.go
@@ -1,0 +1,27 @@
+//go:build !(darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
+
+package worker
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func ensureSupportedPlatform() error {
+	return errors.New("factory-worker is supported only on Unix")
+}
+
+func ShutdownSignals() []os.Signal                           { return []os.Signal{os.Interrupt} }
+func lockFile(*os.File) error                                { return ensureSupportedPlatform() }
+func unlockFile(*os.File) error                              { return nil }
+func syncDirectory(string) error                             { return ensureSupportedPlatform() }
+func configureNewProcessGroup(*exec.Cmd)                     {}
+func configureExistingProcessGroup(*exec.Cmd, int)           {}
+func processGroupID(int) (int, error)                        { return 0, ensureSupportedPlatform() }
+func processIdentity(int) (string, error)                    { return "", ensureSupportedPlatform() }
+func verifyProcessIdentity(int, string) error                { return ensureSupportedPlatform() }
+func processGroupAlive(int) bool                             { return false }
+func forceStopStartedProcessGroup(int) error                 { return ensureSupportedPlatform() }
+func stopOwnedProcessGroup(int, string, time.Duration) error { return ensureSupportedPlatform() }

--- a/internal/worker/supervisor.go
+++ b/internal/worker/supervisor.go
@@ -409,15 +409,35 @@ func parseControlCommand(command string) (string, time.Duration, error) {
 
 func streamSupervisorOutput(reader io.Reader, stream string, writer *synchronizedEncoder, tail *tailBuffer) {
 	buffered := bufio.NewReaderSize(reader, 32<<10)
+	line := make([]byte, 0, 32<<10)
+	hadData := false
+	truncated := false
 	for {
-		line, prefix, err := buffered.ReadLine()
-		if len(line) > 0 {
+		fragment, prefix, err := buffered.ReadLine()
+		if len(fragment) > 0 {
+			hadData = true
 			if tail != nil {
-				_, _ = tail.Write(line)
-				_, _ = tail.Write([]byte{'\n'})
+				_, _ = tail.Write(fragment)
 			}
-			text := boundedText(string(line), maxSupervisorLineBytes)
-			_ = writer.send(supervisorMessage{Type: "output", Stream: stream, Text: text, Truncated: prefix})
+			remaining := maxSupervisorLineBytes - len(line)
+			if len(fragment) > remaining {
+				fragment = fragment[:remaining]
+				truncated = true
+			}
+			line = append(line, fragment...)
+		}
+		if !prefix || err != nil {
+			if hadData {
+				if tail != nil {
+					_, _ = tail.Write([]byte{'\n'})
+				}
+				_ = writer.send(supervisorMessage{
+					Type: "output", Stream: stream, Text: string(line), Truncated: truncated,
+				})
+			}
+			line = line[:0]
+			hadData = false
+			truncated = false
 		}
 		if err != nil {
 			return
@@ -516,6 +536,7 @@ func startSupervisor(commandLine []string, init supervisorInit, errorOutput io.W
 		return nil, fmt.Errorf("create supervisor control pipe: %w", err)
 	}
 	command := exec.Command(commandLine[0], commandLine[1:]...)
+	configureNewProcessGroup(command)
 	command.ExtraFiles = []*os.File{controlRead}
 	stdin, err := command.StdinPipe()
 	if err != nil {

--- a/internal/worker/supervisor.go
+++ b/internal/worker/supervisor.go
@@ -1,0 +1,671 @@
+package worker
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const (
+	supervisorCommand       = "__factory_worker_supervisor"
+	supervisorReadyTimeout  = 10 * time.Second
+	terminationGrace        = 5 * time.Second
+	maxSupervisorLineBytes  = 1 << 20
+	maxSupervisorErrorBytes = 64 << 10
+)
+
+type supervisorInit struct {
+	CodexExecutable string `json:"codex_executable"`
+	Worktree        string `json:"worktree"`
+	ResultPath      string `json:"result_path"`
+	Prompt          string `json:"prompt"`
+	TimeoutSeconds  int    `json:"timeout_seconds"`
+}
+
+type supervisorMessage struct {
+	Type            string `json:"type"`
+	SupervisorPID   int64  `json:"supervisor_pid,omitempty"`
+	ProcessIdentity string `json:"process_identity,omitempty"`
+	ProcessGroupID  int64  `json:"process_group_id,omitempty"`
+	GroupIdentity   string `json:"group_identity,omitempty"`
+	Stream          string `json:"stream,omitempty"`
+	Text            string `json:"text,omitempty"`
+	ExitCode        int    `json:"exit_code,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	Result          string `json:"result,omitempty"`
+	Error           string `json:"error,omitempty"`
+	Truncated       bool   `json:"truncated,omitempty"`
+}
+
+type supervisorProcess struct {
+	command            *exec.Cmd
+	control            *os.File
+	messages           chan supervisorMessage
+	decodeErrors       chan error
+	wait               chan error
+	stderr             *limitBuffer
+	controlMutex       sync.Mutex
+	supervisorPID      int64
+	supervisorIdentity string
+	processGroupID     int64
+	groupIdentity      string
+}
+
+func IsSupervisorCommand(arguments []string) bool {
+	return len(arguments) > 0 && arguments[0] == supervisorCommand
+}
+
+func RunSupervisor(control *os.File, input io.Reader, output, errorOutput io.Writer) error {
+	if err := ensureSupportedPlatform(); err != nil {
+		return err
+	}
+	if control == nil {
+		return errors.New("supervisor control pipe is required")
+	}
+	var init supervisorInit
+	decoder := json.NewDecoder(io.LimitReader(input, protocol.MaxBodyBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&init); err != nil {
+		return fmt.Errorf("decode supervisor input: %w", err)
+	}
+	if init.CodexExecutable == "" || init.Worktree == "" || init.ResultPath == "" || init.TimeoutSeconds < 1 {
+		return errors.New("supervisor input is incomplete")
+	}
+	if init.TimeoutSeconds > int(protocol.MaxTimeout/time.Second) {
+		return errors.New("supervisor timeout exceeds eight hours")
+	}
+
+	anchorToken, err := newUUID(nil)
+	if err != nil {
+		return fmt.Errorf("create process-group token: %w", err)
+	}
+	anchor := exec.Command("/bin/sh", "-c", "trap '' TERM; while :; do sleep 3600; done", "factory-v2-anchor-"+anchorToken)
+	anchor.Stdin = nil
+	anchor.Stdout = nil
+	anchor.Stderr = errorOutput
+	configureNewProcessGroup(anchor)
+	if err := anchor.Start(); err != nil {
+		return fmt.Errorf("start process-group anchor: %w", err)
+	}
+	anchorPID := anchor.Process.Pid
+	anchorIdentity, err := processIdentity(anchorPID)
+	if err != nil {
+		_ = anchor.Process.Kill()
+		_ = anchor.Wait()
+		return fmt.Errorf("establish process-group identity: %w", err)
+	}
+	groupID, err := processGroupID(anchorPID)
+	if err != nil || groupID != anchorPID {
+		_ = anchor.Process.Kill()
+		_ = anchor.Wait()
+		return errors.New("process-group anchor did not become its group leader")
+	}
+	supervisorIdentity, err := processIdentity(os.Getpid())
+	if err != nil {
+		_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, 0)
+		_ = anchor.Wait()
+		return fmt.Errorf("establish supervisor process identity: %w", err)
+	}
+
+	writer := &synchronizedEncoder{encoder: json.NewEncoder(output)}
+	if err := writer.send(supervisorMessage{
+		Type:            "ready",
+		SupervisorPID:   int64(os.Getpid()),
+		ProcessIdentity: supervisorIdentity,
+		ProcessGroupID:  int64(groupID),
+		GroupIdentity:   anchorIdentity,
+	}); err != nil {
+		_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, 0)
+		_ = anchor.Wait()
+		return fmt.Errorf("report supervisor readiness: %w", err)
+	}
+
+	commands := make(chan string, 8)
+	controlErrors := make(chan error, 1)
+	go readSupervisorControl(control, commands, controlErrors)
+	leaseTimer := time.NewTimer(leaseStopDelay(protocol.LeaseDuration))
+	defer leaseTimer.Stop()
+
+	for {
+		select {
+		case command := <-commands:
+			action, duration, parseErr := parseControlCommand(command)
+			if parseErr != nil {
+				_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, 0)
+				_ = anchor.Wait()
+				return parseErr
+			}
+			switch action {
+			case "renew":
+				resetTimer(leaseTimer, leaseStopDelay(duration))
+			case "cancel":
+				_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, terminationGrace)
+				_ = anchor.Wait()
+				return writer.send(supervisorMessage{Type: "exit", Reason: "cancelled", Error: "attempt cancelled"})
+			case "lease_lost":
+				_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, terminationGrace)
+				_ = anchor.Wait()
+				return writer.send(supervisorMessage{Type: "exit", Reason: "lease_lost", Error: "control-plane lease was lost"})
+			case "fail":
+				_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, terminationGrace)
+				_ = anchor.Wait()
+				return writer.send(supervisorMessage{Type: "exit", Reason: "supervisor_error", Error: "attempt preparation failed"})
+			case "timeout":
+				_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, terminationGrace)
+				_ = anchor.Wait()
+				return writer.send(supervisorMessage{Type: "exit", Reason: "timeout", Error: "task timeout reached"})
+			case "start":
+				return superviseCodex(init, anchor, anchorIdentity, groupID, commands, controlErrors, leaseTimer, writer)
+			}
+		case err := <-controlErrors:
+			_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, terminationGrace)
+			_ = anchor.Wait()
+			if err != nil && !errors.Is(err, io.EOF) {
+				return fmt.Errorf("read supervisor control pipe: %w", err)
+			}
+			return nil
+		case <-leaseTimer.C:
+			_ = stopOwnedProcessGroup(anchorPID, anchorIdentity, terminationGrace)
+			_ = anchor.Wait()
+			return writer.send(supervisorMessage{Type: "exit", Reason: "lease_lost", Error: "control-plane lease renewal deadline passed"})
+		}
+	}
+}
+
+func superviseCodex(
+	init supervisorInit,
+	anchor *exec.Cmd,
+	anchorIdentity string,
+	groupID int,
+	commands <-chan string,
+	controlErrors <-chan error,
+	leaseTimer *time.Timer,
+	writer *synchronizedEncoder,
+) error {
+	command := exec.Command(init.CodexExecutable,
+		"exec", "--json", "--color", "never", "--output-last-message", init.ResultPath, "-")
+	command.Dir = init.Worktree
+	configureExistingProcessGroup(command, groupID)
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("open Codex stdin: %w", err))
+	}
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("open Codex stdout: %w", err))
+	}
+	stderr, err := command.StderrPipe()
+	if err != nil {
+		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("open Codex stderr: %w", err))
+	}
+	if err := command.Start(); err != nil {
+		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("start Codex: %w", err))
+	}
+	promptErrors := make(chan error, 1)
+	go func() {
+		_, writeErr := io.WriteString(stdin, init.Prompt)
+		closeErr := stdin.Close()
+		promptErrors <- errors.Join(writeErr, closeErr)
+	}()
+	stderrTail := &tailBuffer{limit: protocol.MaxErrorBytes}
+	readers := sync.WaitGroup{}
+	readers.Add(2)
+	go func() {
+		defer readers.Done()
+		streamSupervisorOutput(stdout, "stdout", writer, nil)
+	}()
+	go func() {
+		defer readers.Done()
+		streamSupervisorOutput(stderr, "stderr", writer, stderrTail)
+	}()
+	wait := make(chan error, 1)
+	go func() {
+		wait <- command.Wait()
+	}()
+	taskTimer := time.NewTimer(time.Duration(init.TimeoutSeconds) * time.Second)
+	defer taskTimer.Stop()
+
+	reason := "exited"
+	var waitErr error
+	running := true
+	for running {
+		select {
+		case command := <-commands:
+			action, duration, parseErr := parseControlCommand(command)
+			if parseErr != nil {
+				reason = "supervisor_error"
+				waitErr = parseErr
+				running = false
+				continue
+			}
+			switch action {
+			case "renew":
+				resetTimer(leaseTimer, leaseStopDelay(duration))
+			case "cancel":
+				reason = "cancelled"
+				running = false
+			case "lease_lost":
+				reason = "lease_lost"
+				running = false
+			case "fail":
+				reason = "supervisor_error"
+				running = false
+			case "timeout":
+				reason = "timeout"
+				running = false
+			case "start":
+			}
+		case controlErr := <-controlErrors:
+			reason = "parent_lost"
+			if controlErr != nil && !errors.Is(controlErr, io.EOF) {
+				waitErr = controlErr
+			}
+			running = false
+		case <-leaseTimer.C:
+			reason = "lease_lost"
+			running = false
+		case <-taskTimer.C:
+			reason = "timeout"
+			running = false
+		case waitErr = <-wait:
+			running = false
+		}
+	}
+
+	if reason == "exited" {
+		_ = stopOwnedProcessGroup(groupID, anchorIdentity, 0)
+	} else {
+		stopErr := stopOwnedProcessGroup(groupID, anchorIdentity, terminationGrace)
+		if stopErr != nil && waitErr == nil {
+			waitErr = stopErr
+		}
+		select {
+		case childErr := <-wait:
+			if waitErr == nil {
+				waitErr = childErr
+			}
+		case <-time.After(2 * time.Second):
+			if waitErr == nil {
+				waitErr = errors.New("Codex process did not reap after group termination")
+			}
+		}
+	}
+	_ = anchor.Wait()
+	readers.Wait()
+	select {
+	case promptErr := <-promptErrors:
+		if promptErr != nil && !errors.Is(promptErr, os.ErrClosed) && reason == "exited" && waitErr == nil {
+			waitErr = fmt.Errorf("send prompt to Codex: %w", promptErr)
+		}
+	default:
+	}
+
+	result, truncated, resultErr := readBoundedText(init.ResultPath, protocol.MaxResultBytes)
+	if resultErr != nil && reason == "exited" && waitErr == nil {
+		waitErr = resultErr
+	}
+	_ = os.Remove(init.ResultPath)
+	message := supervisorMessage{
+		Type:      "exit",
+		ExitCode:  exitCode(waitErr),
+		Reason:    reason,
+		Result:    result,
+		Truncated: truncated,
+	}
+	if reason != "exited" {
+		message.Error = map[string]string{
+			"cancelled":        "attempt cancelled",
+			"parent_lost":      "worker parent process exited",
+			"lease_lost":       "control-plane lease renewal deadline passed",
+			"timeout":          "task timeout reached",
+			"supervisor_error": "attempt supervisor failed",
+		}[reason]
+	}
+	if message.Error == "" && waitErr != nil {
+		message.Error = boundedText(waitErr.Error(), protocol.MaxErrorBytes)
+	}
+	if tail := stderrTail.String(); tail != "" && message.ExitCode != 0 && reason == "exited" {
+		if message.Error == "" {
+			message.Error = boundedText(tail, protocol.MaxErrorBytes)
+		} else {
+			message.Error = boundedText(message.Error+": "+tail, protocol.MaxErrorBytes)
+		}
+	}
+	return writer.send(message)
+}
+
+func finishSupervisorStartFailure(anchor *exec.Cmd, identity string, writer *synchronizedEncoder, cause error) error {
+	_ = stopOwnedProcessGroup(anchor.Process.Pid, identity, 0)
+	_ = anchor.Wait()
+	return writer.send(supervisorMessage{
+		Type: "exit", ExitCode: -1, Reason: "supervisor_error", Error: boundedText(cause.Error(), protocol.MaxErrorBytes),
+	})
+}
+
+type synchronizedEncoder struct {
+	mutex   sync.Mutex
+	encoder *json.Encoder
+}
+
+func (writer *synchronizedEncoder) send(message supervisorMessage) error {
+	writer.mutex.Lock()
+	defer writer.mutex.Unlock()
+	return writer.encoder.Encode(message)
+}
+
+func readSupervisorControl(control io.Reader, commands chan<- string, errorsChannel chan<- error) {
+	scanner := bufio.NewScanner(control)
+	for scanner.Scan() {
+		commands <- strings.TrimSpace(scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		errorsChannel <- err
+	} else {
+		errorsChannel <- io.EOF
+	}
+}
+
+func parseControlCommand(command string) (string, time.Duration, error) {
+	fields := strings.Fields(command)
+	if len(fields) == 1 {
+		switch fields[0] {
+		case "start", "cancel", "lease_lost", "fail", "timeout":
+			return fields[0], 0, nil
+		}
+	}
+	if len(fields) == 2 && fields[0] == "renew" {
+		milliseconds, err := strconv.ParseInt(fields[1], 10, 64)
+		if err == nil && milliseconds > 0 && milliseconds <= protocol.LeaseDuration.Milliseconds() {
+			return "renew", time.Duration(milliseconds) * time.Millisecond, nil
+		}
+	}
+	return "", 0, fmt.Errorf("unknown supervisor command %q", command)
+}
+
+func streamSupervisorOutput(reader io.Reader, stream string, writer *synchronizedEncoder, tail *tailBuffer) {
+	buffered := bufio.NewReaderSize(reader, 32<<10)
+	for {
+		line, prefix, err := buffered.ReadLine()
+		if len(line) > 0 {
+			if tail != nil {
+				_, _ = tail.Write(line)
+				_, _ = tail.Write([]byte{'\n'})
+			}
+			text := boundedText(string(line), maxSupervisorLineBytes)
+			_ = writer.send(supervisorMessage{Type: "output", Stream: stream, Text: text, Truncated: prefix})
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+type tailBuffer struct {
+	mutex sync.Mutex
+	bytes []byte
+	limit int
+}
+
+func (buffer *tailBuffer) Write(value []byte) (int, error) {
+	buffer.mutex.Lock()
+	defer buffer.mutex.Unlock()
+	buffer.bytes = append(buffer.bytes, value...)
+	if len(buffer.bytes) > buffer.limit {
+		buffer.bytes = append([]byte(nil), buffer.bytes[len(buffer.bytes)-buffer.limit:]...)
+	}
+	return len(value), nil
+}
+
+func (buffer *tailBuffer) String() string {
+	buffer.mutex.Lock()
+	defer buffer.mutex.Unlock()
+	return boundedText(string(buffer.bytes), buffer.limit)
+}
+
+func resetTimer(timer *time.Timer, duration time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(duration)
+}
+
+func leaseStopDelay(remaining time.Duration) time.Duration {
+	delay := remaining - terminationGrace
+	if delay < time.Millisecond {
+		return time.Millisecond
+	}
+	return delay
+}
+
+func exitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) {
+		return exitError.ExitCode()
+	}
+	return -1
+}
+
+func readBoundedText(path string, limit int) (string, bool, error) {
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read Codex result: %w", err)
+	}
+	defer file.Close()
+	body, err := io.ReadAll(io.LimitReader(file, int64(limit)+1))
+	if err != nil {
+		return "", false, fmt.Errorf("read Codex result: %w", err)
+	}
+	truncated := len(body) > limit
+	if truncated {
+		body = body[:limit]
+	}
+	return boundedText(string(body), limit), truncated, nil
+}
+
+func boundedText(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	value = value[:limit]
+	for !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+	return value
+}
+
+func startSupervisor(commandLine []string, init supervisorInit, errorOutput io.Writer) (*supervisorProcess, error) {
+	if len(commandLine) == 0 {
+		return nil, errors.New("supervisor command is empty")
+	}
+	controlRead, controlWrite, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create supervisor control pipe: %w", err)
+	}
+	command := exec.Command(commandLine[0], commandLine[1:]...)
+	command.ExtraFiles = []*os.File{controlRead}
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		controlRead.Close()
+		controlWrite.Close()
+		return nil, fmt.Errorf("open supervisor input: %w", err)
+	}
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		controlRead.Close()
+		controlWrite.Close()
+		return nil, fmt.Errorf("open supervisor output: %w", err)
+	}
+	stderr := newLimitBuffer(maxSupervisorErrorBytes)
+	command.Stderr = io.MultiWriter(errorOutput, stderr)
+	if err := command.Start(); err != nil {
+		controlRead.Close()
+		controlWrite.Close()
+		return nil, fmt.Errorf("start attempt supervisor: %w", err)
+	}
+	controlRead.Close()
+	process := &supervisorProcess{
+		command:      command,
+		control:      controlWrite,
+		messages:     make(chan supervisorMessage, 128),
+		decodeErrors: make(chan error, 1),
+		wait:         make(chan error, 1),
+		stderr:       stderr,
+	}
+	go func() {
+		encoder := json.NewEncoder(stdin)
+		err := encoder.Encode(init)
+		closeErr := stdin.Close()
+		if err != nil {
+			process.decodeErrors <- errors.Join(err, closeErr)
+		}
+	}()
+	go func() {
+		// Keep draining the supervisor protocol for the complete attempt. Progress
+		// is bounded downstream, while stopping reads here could block the
+		// supervisor before it reports or reaps a terminal process.
+		decoder := json.NewDecoder(stdout)
+		for {
+			var message supervisorMessage
+			if err := decoder.Decode(&message); err != nil {
+				process.decodeErrors <- err
+				return
+			}
+			process.messages <- message
+		}
+	}()
+	go func() {
+		process.wait <- command.Wait()
+	}()
+	return process, nil
+}
+
+func (process *supervisorProcess) awaitReady(ctx context.Context) error {
+	timer := time.NewTimer(supervisorReadyTimeout)
+	defer timer.Stop()
+	select {
+	case message := <-process.messages:
+		if message.Type != "ready" || message.SupervisorPID <= 0 || message.ProcessGroupID <= 0 ||
+			message.ProcessIdentity == "" || message.GroupIdentity == "" {
+			return errors.New("attempt supervisor returned invalid readiness data")
+		}
+		process.supervisorPID = message.SupervisorPID
+		process.supervisorIdentity = message.ProcessIdentity
+		process.processGroupID = message.ProcessGroupID
+		process.groupIdentity = message.GroupIdentity
+		return nil
+	case err := <-process.decodeErrors:
+		return fmt.Errorf("read attempt supervisor readiness: %w: %s", err, process.stderr.String())
+	case err := <-process.wait:
+		return fmt.Errorf("attempt supervisor exited before readiness: %w: %s", err, process.stderr.String())
+	case <-timer.C:
+		return errors.New("attempt supervisor did not become ready within ten seconds")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (process *supervisorProcess) send(command string) error {
+	process.controlMutex.Lock()
+	defer process.controlMutex.Unlock()
+	if process.control == nil {
+		return errors.New("attempt supervisor control pipe is closed")
+	}
+	_, err := io.WriteString(process.control, command+"\n")
+	return err
+}
+
+func (process *supervisorProcess) renew(expiry time.Time) error {
+	remaining := time.Until(expiry)
+	if remaining <= 0 {
+		return process.send("lease_lost")
+	}
+	if remaining > protocol.LeaseDuration {
+		remaining = protocol.LeaseDuration
+	}
+	milliseconds := remaining.Milliseconds()
+	if milliseconds < 1 {
+		milliseconds = 1
+	}
+	return process.send("renew " + strconv.FormatInt(milliseconds, 10))
+}
+
+func (process *supervisorProcess) closeControl() error {
+	process.controlMutex.Lock()
+	defer process.controlMutex.Unlock()
+	if process.control == nil {
+		return nil
+	}
+	err := process.control.Close()
+	process.control = nil
+	return err
+}
+
+func supervisorCommandLine(executable string) []string {
+	return []string{executable, supervisorCommand}
+}
+
+func resultPath(dataDirectory, attemptID string) (string, error) {
+	directory := filepath.Join(dataDirectory, "tmp")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return "", fmt.Errorf("create worker temporary directory: %w", err)
+	}
+	if info, err := os.Lstat(directory); err != nil {
+		return "", fmt.Errorf("inspect worker temporary directory: %w", err)
+	} else if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("worker temporary directory must be a real directory, not a symlink")
+	}
+	if err := os.Chmod(directory, 0o700); err != nil {
+		return "", fmt.Errorf("protect worker temporary directory: %w", err)
+	}
+	if !uuidPattern.MatchString(attemptID) {
+		return "", errors.New("invalid attempt ID for result path")
+	}
+	path := filepath.Join(directory, attemptID+"-result")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("create Codex result file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("close Codex result file: %w", err)
+	}
+	return path, nil
+}
+
+func supervisorStartRequest(process *supervisorProcess, token string) protocol.StartAttemptRequest {
+	supervisorPID := process.supervisorPID
+	processGroupID := process.processGroupID
+	return protocol.StartAttemptRequest{
+		LeaseToken:      token,
+		SupervisorPID:   &supervisorPID,
+		ProcessIdentity: process.supervisorIdentity,
+		ProcessGroupID:  &processGroupID,
+	}
+}
+
+func processSummary(process *supervisorProcess) string {
+	return "supervisor=" + strconv.FormatInt(process.supervisorPID, 10) +
+		" process_group=" + strconv.FormatInt(process.processGroupID, 10)
+}

--- a/internal/worker/supervisor.go
+++ b/internal/worker/supervisor.go
@@ -203,17 +203,29 @@ func superviseCodex(
 	if err != nil {
 		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("open Codex stdin: %w", err))
 	}
-	stdout, err := command.StdoutPipe()
+	stdout, stdoutWriter, err := os.Pipe()
 	if err != nil {
-		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("open Codex stdout: %w", err))
+		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("create Codex stdout pipe: %w", err))
 	}
-	stderr, err := command.StderrPipe()
+	stderr, stderrWriter, err := os.Pipe()
 	if err != nil {
-		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("open Codex stderr: %w", err))
+		stdout.Close()
+		stdoutWriter.Close()
+		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("create Codex stderr pipe: %w", err))
 	}
+	command.Stdout = stdoutWriter
+	command.Stderr = stderrWriter
 	if err := command.Start(); err != nil {
+		stdout.Close()
+		stdoutWriter.Close()
+		stderr.Close()
+		stderrWriter.Close()
 		return finishSupervisorStartFailure(anchor, anchorIdentity, writer, fmt.Errorf("start Codex: %w", err))
 	}
+	stdoutWriter.Close()
+	stderrWriter.Close()
+	defer stdout.Close()
+	defer stderr.Close()
 	promptErrors := make(chan error, 1)
 	go func() {
 		_, writeErr := io.WriteString(stdin, init.Prompt)
@@ -511,20 +523,24 @@ func startSupervisor(commandLine []string, init supervisorInit, errorOutput io.W
 		controlWrite.Close()
 		return nil, fmt.Errorf("open supervisor input: %w", err)
 	}
-	stdout, err := command.StdoutPipe()
+	stdout, stdoutWriter, err := os.Pipe()
 	if err != nil {
 		controlRead.Close()
 		controlWrite.Close()
-		return nil, fmt.Errorf("open supervisor output: %w", err)
+		return nil, fmt.Errorf("create supervisor output pipe: %w", err)
 	}
+	command.Stdout = stdoutWriter
 	stderr := newLimitBuffer(maxSupervisorErrorBytes)
 	command.Stderr = io.MultiWriter(errorOutput, stderr)
 	if err := command.Start(); err != nil {
 		controlRead.Close()
 		controlWrite.Close()
+		stdout.Close()
+		stdoutWriter.Close()
 		return nil, fmt.Errorf("start attempt supervisor: %w", err)
 	}
 	controlRead.Close()
+	stdoutWriter.Close()
 	process := &supervisorProcess{
 		command:      command,
 		control:      controlWrite,
@@ -542,6 +558,7 @@ func startSupervisor(commandLine []string, init supervisorInit, errorOutput io.W
 		}
 	}()
 	go func() {
+		defer stdout.Close()
 		// Keep draining the supervisor protocol for the complete attempt. Progress
 		// is bounded downstream, while stopping reads here could block the
 		// supervisor before it reports or reaps a terminal process.

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -89,6 +89,12 @@ case "$prompt" in
     trap '' TERM
     wait
     ;;
+  *FAKE_MODE=descendant*)
+    child="$FACTORY_TEST_CODEX_LOG/$attempt.child"
+    sh -c 'trap "" TERM; while :; do sleep 1; done' &
+    echo "$!" > "$child"
+    printf 'leader completed' > "$result"
+    ;;
   *)
     echo "missing fake mode" >&2
     exit 91
@@ -780,6 +786,27 @@ func TestCancellationStopsCompleteProcessGroup(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(manager.dataDirectory, "worktrees", detail.Attempts[0].ID)); err != nil {
 		t.Fatalf("cancelled worktree was not retained: %v", err)
 	}
+}
+
+func TestSuccessfulLeaderExitStopsDescendantHoldingOutputPipes(t *testing.T) {
+	repository := createRepository(t, "leader-exit")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"leader-exit": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy"
+	})
+	task := createTask(t, fixture.store, worker, "leader-exit", "descendant", 60)
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "succeeded")
+	if len(detail.Attempts) != 1 || detail.Attempts[0].Result != "leader completed" {
+		t.Fatalf("leader-exit attempt = %#v", detail.Attempts)
+	}
+	childPath := filepath.Join(os.Getenv("FACTORY_TEST_CODEX_LOG"), detail.Attempts[0].ID+".child")
+	childPID := readPID(t, childPath)
+	waitForProcessGone(t, childPID, 3*time.Second)
 }
 
 func TestTimeoutStopsIgnoringProcessGroup(t *testing.T) {

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -65,6 +65,12 @@ case "$prompt" in
     echo
     head -c 300000 /dev/zero | tr '\000' r > "$result"
     ;;
+  *FAKE_MODE=large-json*)
+    printf 'large JSON completed' > "$result"
+    printf '{"type":"item.completed","text":"'
+    head -c 40000 /dev/zero | tr '\000' x
+    printf '"}\n'
+    ;;
   *FAKE_MODE=fail*)
     echo "deterministic failure" >&2
     exit 17
@@ -378,6 +384,36 @@ func TestConfigurationStableIdentityLockAndHealthRecovery(t *testing.T) {
 	}
 }
 
+func TestRepositoryRejectedByGitCannotUseConfigFallback(t *testing.T) {
+	path := t.TempDir()
+	if err := os.Mkdir(filepath.Join(path, ".git"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	config := "[remote \"origin\"]\n\turl = https://github.com/example/not-a-repository.git\n"
+	if err := os.WriteFile(filepath.Join(path, ".git", "config"), []byte(config), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveRepository("invalid", path, "git"); err == nil ||
+		!strings.Contains(err.Error(), "verify Git repository") {
+		t.Fatalf("invalid repository error = %v", err)
+	}
+}
+
+func TestUnavailableGitExecutableUsesConfigFallback(t *testing.T) {
+	fixture := createRepository(t, "missing-git")
+	repository, err := resolveRepository("missing-git", fixture.path, filepath.Join(t.TempDir(), "git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected, err := normalizeRemoteIdentity(fixture.origin, fixture.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repository.RemoteIdentity != expected {
+		t.Fatalf("remote identity = %q; want %q", repository.RemoteIdentity, expected)
+	}
+}
+
 func TestMultiRepositorySuccessAndBoundedOutput(t *testing.T) {
 	first := createRepository(t, "first")
 	second := createRepository(t, "second")
@@ -444,6 +480,41 @@ func TestMultiRepositorySuccessAndBoundedOutput(t *testing.T) {
 			t.Fatalf("Codex prompt does not contain %q:\n%s", expected, prompt)
 		}
 	}
+}
+
+func TestLargeCodexJSONLineIsPreserved(t *testing.T) {
+	repository := createRepository(t, "large-json")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"large-json": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy"
+	})
+	task := createTask(t, fixture.store, worker, "large-json", "large-json", 60)
+	task = waitForTaskState(t, fixture.store, task.Task.ID, "succeeded")
+	events, err := fixture.store.Events(context.Background(), task.Attempts[0].ID, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		var payload struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload.Type == "item.completed" {
+			if payload.Text != strings.Repeat("x", 40000) {
+				t.Fatalf("large JSON text length = %d", len(payload.Text))
+			}
+			return
+		}
+	}
+	t.Fatal("large JSON event was not stored")
 }
 
 func TestRepositoryKeyRemapStopsStableWorkerFromClaiming(t *testing.T) {
@@ -887,6 +958,14 @@ func TestSupervisorCrashStopsRecordedProcessGroup(t *testing.T) {
 	if identity != attempt.ProcessIdentity {
 		t.Fatalf("stored supervisor identity does not match PID %d", *attempt.SupervisorPID)
 	}
+	group, err := processGroupID(int(*attempt.SupervisorPID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if group != int(*attempt.SupervisorPID) || group == unix.Getpgrp() {
+		t.Fatalf("supervisor process group = %d; supervisor PID = %d; worker group = %d",
+			group, *attempt.SupervisorPID, unix.Getpgrp())
+	}
 	childPath := filepath.Join(os.Getenv("FACTORY_TEST_CODEX_LOG"), attempt.ID+".child")
 	waitFor(t, 5*time.Second, func() bool {
 		_, err := os.Stat(childPath)
@@ -1172,6 +1251,38 @@ func TestEventPayloadIsAlwaysBoundedJSON(t *testing.T) {
 				t.Fatalf("payload length=%d valid=%v", len(payload), jsonValid(payload))
 			}
 		})
+	}
+}
+
+func TestSupervisorOutputBoundsOneLogicalLineAndPreservesNextLine(t *testing.T) {
+	first := strings.Repeat("x", maxSupervisorLineBytes+100)
+	second := `{"type":"item.completed","text":"next"}`
+	var output bytes.Buffer
+	writer := &synchronizedEncoder{encoder: json.NewEncoder(&output)}
+	streamSupervisorOutput(strings.NewReader(first+"\n"+second+"\n"), "stdout", writer, nil)
+
+	decoder := json.NewDecoder(&output)
+	var messages []supervisorMessage
+	for {
+		var message supervisorMessage
+		err := decoder.Decode(&message)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		messages = append(messages, message)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("supervisor output message count = %d", len(messages))
+	}
+	if len(messages[0].Text) != maxSupervisorLineBytes || !messages[0].Truncated {
+		t.Fatalf("oversized message length = %d; truncated = %v",
+			len(messages[0].Text), messages[0].Truncated)
+	}
+	if messages[1].Text != second || messages[1].Truncated {
+		t.Fatalf("following message = %#v", messages[1])
 	}
 }
 

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -1,0 +1,1207 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/owainlewis/factory/internal/controlplane"
+	"github.com/owainlewis/factory/internal/protocol"
+	"golang.org/x/sys/unix"
+)
+
+const fakeCodexScript = `#!/bin/sh
+set -eu
+if [ "${1:-}" = "--version" ]; then
+  echo "codex-cli test-1.0"
+  exit 0
+fi
+if [ "${1:-}" = "login" ] && [ "${2:-}" = "status" ]; then
+  echo "Logged in using test credentials"
+  exit 0
+fi
+if [ "${1:-}" != "exec" ]; then
+  echo "unexpected fake Codex arguments" >&2
+  exit 90
+fi
+result=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output-last-message" ]; then
+    result="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+prompt="$(cat)"
+attempt="$(basename "$PWD")"
+mkdir -p "$FACTORY_TEST_CODEX_LOG"
+printf '%s' "$prompt" > "$FACTORY_TEST_CODEX_LOG/$attempt.prompt"
+echo "$$" > "$FACTORY_TEST_CODEX_LOG/$attempt.pid"
+echo '{"type":"thread.started","thread_id":"test-thread"}'
+case "$prompt" in
+  *FAKE_MODE=success*)
+    printf 'completed by fake Codex' > "$result"
+    echo '{"type":"item.completed","item":{"type":"agent_message","text":"completed"}}'
+    ;;
+  *FAKE_MODE=long*)
+    head -c 68157440 /dev/zero | tr '\000' x
+    echo
+    head -c 300000 /dev/zero | tr '\000' r > "$result"
+    ;;
+  *FAKE_MODE=fail*)
+    echo "deterministic failure" >&2
+    exit 17
+    ;;
+  *FAKE_MODE=dirty*)
+    echo "dirty" > worker-output.txt
+    printf 'dirty success' > "$result"
+    ;;
+  *FAKE_MODE=unpublished*)
+    echo "unpublished" > worker-output.txt
+    git add worker-output.txt
+    git commit -m "fake unpublished result" >/dev/null
+    printf 'unpublished success' > "$result"
+    ;;
+  *FAKE_MODE=hang*)
+    trap '' TERM
+    while :; do sleep 1; done
+    ;;
+  *FAKE_MODE=fork*)
+    child="$FACTORY_TEST_CODEX_LOG/$attempt.child"
+    sh -c 'trap "" TERM; echo $$ > "$1"; while :; do sleep 1; done' sh "$child" &
+    trap '' TERM
+    wait
+    ;;
+  *)
+    echo "missing fake mode" >&2
+    exit 91
+    ;;
+esac
+`
+
+func TestWorkerSupervisorHelperProcess(t *testing.T) {
+	if os.Getenv("FACTORY_TEST_SUPERVISOR") != "1" {
+		return
+	}
+	control := os.NewFile(3, "factory-test-control")
+	err := RunSupervisor(control, os.Stdin, os.Stdout, os.Stderr)
+	runtime.KeepAlive(control)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+type serverFixture struct {
+	store  *controlplane.Store
+	server *httptest.Server
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func newServerFixture(t *testing.T, wrap func(http.Handler) http.Handler) *serverFixture {
+	t.Helper()
+	store, err := controlplane.Open(context.Background(), filepath.Join(t.TempDir(), "factory.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := controlplane.NewHandler(store, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if wrap != nil {
+		handler = wrap(handler)
+	}
+	server := httptest.NewServer(handler)
+	fixture := &serverFixture{store: store, server: server}
+	t.Cleanup(func() {
+		server.Close()
+		if err := store.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return fixture
+}
+
+type repositoryFixture struct {
+	path   string
+	origin string
+}
+
+func createRepository(t *testing.T, name string) repositoryFixture {
+	t.Helper()
+	root := t.TempDir()
+	origin := filepath.Join(root, name+"-origin.git")
+	path := filepath.Join(root, name)
+	runGitTest(t, "", "init", "--bare", "--initial-branch=main", origin)
+	runGitTest(t, "", "init", "--initial-branch=main", path)
+	runGitTest(t, path, "config", "user.name", "Factory Test")
+	runGitTest(t, path, "config", "user.email", "factory@example.invalid")
+	if err := os.WriteFile(filepath.Join(path, "README.md"), []byte(name+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, path, "add", "README.md")
+	runGitTest(t, path, "commit", "-m", "initial")
+	runGitTest(t, path, "remote", "add", "origin", origin)
+	runGitTest(t, path, "push", "-u", "origin", "main")
+	return repositoryFixture{path: path, origin: origin}
+}
+
+func runGitTest(t *testing.T, directory string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command("git", arguments...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", arguments, err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func writeFakeCodex(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(fakeCodexScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testOptions(codexPath string) Options {
+	return Options{
+		GitExecutable:        "git",
+		CodexExecutable:      codexPath,
+		SupervisorCommand:    []string{os.Args[0], "-test.run=TestWorkerSupervisorHelperProcess", "--"},
+		WorkerVersion:        "test",
+		PollInterval:         20 * time.Millisecond,
+		HealthInterval:       50 * time.Millisecond,
+		RegistrationInterval: 25 * time.Millisecond,
+		LeaseRenewInterval:   100 * time.Millisecond,
+		LeaseRetryInterval:   50 * time.Millisecond,
+		TransportBackoffMin:  20 * time.Millisecond,
+		TransportBackoffMax:  100 * time.Millisecond,
+		ShutdownTimeout:      15 * time.Second,
+	}
+}
+
+func newTestManager(
+	t *testing.T,
+	fixture *serverFixture,
+	codexPath string,
+	dataDirectory string,
+	repositories map[string]repositoryFixture,
+	maxConcurrent int,
+) *Manager {
+	t.Helper()
+	t.Setenv("FACTORY_TEST_SUPERVISOR", "1")
+	logDirectory := filepath.Join(t.TempDir(), "codex-log")
+	t.Setenv("FACTORY_TEST_CODEX_LOG", logDirectory)
+	configured := make(map[string]RepositoryConfig, len(repositories))
+	for key, repository := range repositories {
+		configured[key] = RepositoryConfig{Path: repository.path}
+	}
+	manager, err := New(Config{
+		Server: fixture.server.URL, Name: "test-worker", MaxConcurrent: maxConcurrent,
+		DataDirectory: dataDirectory, Repositories: configured,
+	}, testOptions(codexPath), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manager
+}
+
+func startManager(t *testing.T, manager *Manager) (context.CancelFunc, <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Run(ctx)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err, ok := <-done:
+			if ok && err != nil {
+				t.Errorf("worker stopped with error: %v", err)
+			}
+		case <-time.After(20 * time.Second):
+			t.Error("worker did not stop")
+		}
+	})
+	return cancel, done
+}
+
+func waitForWorker(t *testing.T, store *controlplane.Store, workerID string, predicate func(protocol.Worker) bool) protocol.Worker {
+	t.Helper()
+	var found protocol.Worker
+	waitFor(t, 15*time.Second, func() bool {
+		workers, err := store.Workers(context.Background())
+		if err != nil {
+			return false
+		}
+		for _, worker := range workers {
+			if worker.ID == workerID {
+				found = worker
+				return predicate(worker)
+			}
+		}
+		return false
+	})
+	return found
+}
+
+func createTask(t *testing.T, store *controlplane.Store, worker protocol.Worker, repositoryKey, mode string, timeout int) protocol.TaskDetail {
+	t.Helper()
+	var repositoryID string
+	for _, repository := range worker.Repositories {
+		if repository.Key == repositoryKey {
+			repositoryID = repository.ID
+		}
+	}
+	if repositoryID == "" {
+		t.Fatalf("worker did not advertise repository %q", repositoryKey)
+	}
+	task, _, err := store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+		RequestKey:  "request-" + repositoryKey + "-" + mode + "-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+		Title:       "Task " + mode,
+		Description: "Exercise worker behavior.\nFAKE_MODE=" + mode,
+		WorkerID:    worker.ID, RepositoryID: repositoryID, TimeoutSeconds: timeout,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return task
+}
+
+func waitForTaskState(t *testing.T, store *controlplane.Store, taskID string, states ...string) protocol.TaskDetail {
+	t.Helper()
+	expected := make(map[string]bool)
+	for _, state := range states {
+		expected[state] = true
+	}
+	var detail protocol.TaskDetail
+	waitFor(t, 75*time.Second, func() bool {
+		value, err := store.Task(context.Background(), taskID)
+		if err != nil {
+			return false
+		}
+		detail = value
+		if isTerminalState(value.Execution.State) && !expected[value.Execution.State] {
+			t.Fatalf("task reached unexpected terminal state %q: %#v", value.Execution.State, value.Attempts)
+		}
+		return expected[value.Execution.State]
+	})
+	return detail
+}
+
+func isTerminalState(state string) bool {
+	return state == "succeeded" || state == "failed" || state == "cancelled"
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("condition did not become true before timeout")
+}
+
+func TestConfigurationStableIdentityLockAndHealthRecovery(t *testing.T) {
+	repository := createRepository(t, "health")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	gitPath := filepath.Join(t.TempDir(), "git")
+	dataDirectory := filepath.Join(t.TempDir(), "worker")
+	manager := newTestManager(t, fixture, codexPath, dataDirectory, map[string]repositoryFixture{"health": repository}, 1)
+	manager.options.GitExecutable = gitPath
+	firstID := manager.ID()
+	lockedOptions := testOptions(codexPath)
+	lockedOptions.GitExecutable = gitPath
+	_, err := New(manager.config, lockedOptions, nil)
+	if err == nil || !strings.Contains(err.Error(), "already owns") {
+		t.Fatalf("second manager lock error = %v", err)
+	}
+	cancel, done := startManager(t, manager)
+	waitForWorker(t, fixture.store, firstID, func(worker protocol.Worker) bool {
+		return worker.Health == "unhealthy"
+	})
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gitShim := "#!/bin/sh\nexec " + strconv.Quote(realGit) + " \"$@\"\n"
+	if err := os.WriteFile(gitPath, []byte(gitShim), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeCodex(t, codexPath)
+	waitForWorker(t, fixture.store, firstID, func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" && worker.CodexVersion == "codex-cli test-1.0"
+	})
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	manager2 := newTestManager(t, fixture, codexPath, dataDirectory, map[string]repositoryFixture{"health": repository}, 1)
+	if manager2.ID() != firstID {
+		t.Fatalf("worker ID changed across restart: %s != %s", manager2.ID(), firstID)
+	}
+	if err := manager2.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMultiRepositorySuccessAndBoundedOutput(t *testing.T) {
+	first := createRepository(t, "first")
+	second := createRepository(t, "second")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"first": first, "second": second}, 2)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" && len(worker.Repositories) == 2
+	})
+	success := createTask(t, fixture.store, worker, "first", "success", 60)
+	long := createTask(t, fixture.store, worker, "second", "long", 60)
+	success = waitForTaskState(t, fixture.store, success.Task.ID, "succeeded")
+	long = waitForTaskState(t, fixture.store, long.Task.ID, "succeeded")
+	if len(success.Attempts) != 1 || len(long.Attempts) != 1 {
+		t.Fatalf("attempt counts = %d, %d", len(success.Attempts), len(long.Attempts))
+	}
+	if success.Attempts[0].Result != "completed by fake Codex" {
+		t.Fatalf("success result = %q", success.Attempts[0].Result)
+	}
+	if len(long.Attempts[0].Result) != protocol.MaxResultBytes {
+		t.Fatalf("bounded result length = %d", len(long.Attempts[0].Result))
+	}
+	events, err := fixture.store.Events(context.Background(), long.Attempts[0].ID, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 {
+		t.Fatal("long Codex output produced no stored events")
+	}
+	for _, event := range events {
+		if len(event.Payload) > protocol.MaxEventBytes {
+			t.Fatalf("event payload exceeded limit: %d", len(event.Payload))
+		}
+	}
+	for _, attempt := range []protocol.Attempt{success.Attempts[0], long.Attempts[0]} {
+		path := filepath.Join(manager.dataDirectory, "worktrees", attempt.ID)
+		waitFor(t, 5*time.Second, func() bool {
+			_, err := os.Stat(path)
+			return errors.Is(err, os.ErrNotExist)
+		})
+		branch := "factory-v2/" + map[string]string{
+			success.Attempts[0].ID: success.Task.ID,
+			long.Attempts[0].ID:    long.Task.ID,
+		}[attempt.ID][:12] + "-" + attempt.ID[:12]
+		runGitTest(t, map[string]string{
+			success.Attempts[0].ID: first.path,
+			long.Attempts[0].ID:    second.path,
+		}[attempt.ID], "show-ref", "--verify", "refs/heads/"+branch)
+	}
+	prompt, err := os.ReadFile(filepath.Join(os.Getenv("FACTORY_TEST_CODEX_LOG"), success.Attempts[0].ID+".prompt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"Factory V2 managed Git worktree",
+		"Task title: Task success",
+		"Repository: " + repositoryIdentity(t, first.path),
+		"FAKE_MODE=success",
+	} {
+		if !strings.Contains(string(prompt), expected) {
+			t.Fatalf("Codex prompt does not contain %q:\n%s", expected, prompt)
+		}
+	}
+}
+
+func TestRepositoryKeyRemapStopsStableWorkerFromClaiming(t *testing.T) {
+	first := createRepository(t, "first")
+	second := createRepository(t, "second")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	dataDirectory := filepath.Join(t.TempDir(), "worker")
+
+	firstManager := newTestManager(t, fixture, codexPath, dataDirectory,
+		map[string]repositoryFixture{"stable": first}, 1)
+	cancelFirst, firstDone := startManager(t, firstManager)
+	worker := waitForWorker(t, fixture.store, firstManager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" && len(worker.Repositories) == 1
+	})
+	cancelFirst()
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+
+	secondManager := newTestManager(t, fixture, codexPath, dataDirectory,
+		map[string]repositoryFixture{"stable": second}, 1)
+	startManager(t, secondManager)
+	waitFor(t, 5*time.Second, func() bool {
+		secondManager.stateMutex.Lock()
+		defer secondManager.stateMutex.Unlock()
+		return secondManager.fatalHealth != nil && !secondManager.registered
+	})
+
+	task := createTask(t, fixture.store, worker, "stable", "success", 60)
+	time.Sleep(250 * time.Millisecond)
+	detail, err := fixture.store.Task(context.Background(), task.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Execution.State != "queued" || len(detail.Attempts) != 0 {
+		t.Fatalf("worker claimed after rejected repository remap: state=%s attempts=%d",
+			detail.Execution.State, len(detail.Attempts))
+	}
+}
+
+func TestHealthFailureCancelsRetryingClaimBeforeServerRecovery(t *testing.T) {
+	claimStarted := make(chan struct{})
+	releaseClaim := make(chan struct{})
+	var blocked atomic.Bool
+	fixture := newServerFixture(t, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, "/claims") && blocked.CompareAndSwap(false, true) {
+				close(claimStarted)
+				<-releaseClaim
+			}
+			next.ServeHTTP(w, request)
+		})
+	})
+	repository := createRepository(t, "health-claim")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"health": repository}, 1)
+	manager.options.HealthInterval = 20 * time.Millisecond
+	manager.options.RegistrationInterval = 5 * time.Second
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy"
+	})
+	select {
+	case <-claimStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("claim did not start")
+	}
+	task := createTask(t, fixture.store, worker, "health", "success", 60)
+	if err := os.Remove(codexPath); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 5*time.Second, func() bool {
+		manager.stateMutex.Lock()
+		defer manager.stateMutex.Unlock()
+		return manager.health.State == "unhealthy"
+	})
+	close(releaseClaim)
+
+	time.Sleep(300 * time.Millisecond)
+	detail, err := fixture.store.Task(context.Background(), task.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Execution.State != "queued" || len(detail.Attempts) != 0 {
+		t.Fatalf("unhealthy worker completed a pending claim: state=%s attempts=%d",
+			detail.Execution.State, len(detail.Attempts))
+	}
+}
+
+func TestCommittedClaimBecomesFailedWhenHealthChangesBeforeResponse(t *testing.T) {
+	fixture := newServerFixture(t, nil)
+	repository := createRepository(t, "committed-claim")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"health": repository}, 1)
+	manager.options.HealthInterval = 20 * time.Millisecond
+	manager.options.RegistrationInterval = 5 * time.Second
+
+	claimCommitted := make(chan struct{})
+	releaseResponse := make(chan struct{})
+	var blocked atomic.Bool
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	t.Cleanup(transport.CloseIdleConnections)
+	manager.client.http = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		response, err := transport.RoundTrip(request)
+		if err != nil || !strings.HasSuffix(request.URL.Path, "/claims") ||
+			response.StatusCode != http.StatusOK || !blocked.CompareAndSwap(false, true) {
+			return response, err
+		}
+		body, readErr := io.ReadAll(response.Body)
+		response.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		response.Body = io.NopCloser(bytes.NewReader(body))
+		response.ContentLength = int64(len(body))
+		close(claimCommitted)
+		<-releaseResponse
+		return response, nil
+	})}
+
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy"
+	})
+	task := createTask(t, fixture.store, worker, "health", "success", 60)
+	select {
+	case <-claimCommitted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not commit a claim")
+	}
+	if err := os.Remove(codexPath); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, 5*time.Second, func() bool {
+		manager.stateMutex.Lock()
+		defer manager.stateMutex.Unlock()
+		return manager.health.State == "unhealthy"
+	})
+	close(releaseResponse)
+
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "failed")
+	if len(detail.Attempts) != 1 || detail.Attempts[0].State != "failed" ||
+		!strings.Contains(detail.Attempts[0].Error, "ineligible") {
+		t.Fatalf("committed ineligible claim was not failed precisely: %#v", detail.Attempts)
+	}
+	if _, err := os.Stat(filepath.Join(manager.dataDirectory, "worktrees", detail.Attempts[0].ID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ineligible claim created a worktree: %v", err)
+	}
+}
+
+func repositoryIdentity(t *testing.T, path string) string {
+	t.Helper()
+	repository, err := resolveRepository("test", path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repository.RemoteIdentity
+}
+
+func TestLostClaimAndCompletionResponsesAreIdempotent(t *testing.T) {
+	var droppedClaim atomic.Bool
+	var droppedCompletion atomic.Bool
+	fixture := newServerFixture(t, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			isClaim := strings.HasSuffix(request.URL.Path, "/claims") && !droppedClaim.Load()
+			isCompletion := strings.HasSuffix(request.URL.Path, "/complete") && !droppedCompletion.Load()
+			if isClaim || isCompletion {
+				recorder := httptest.NewRecorder()
+				next.ServeHTTP(recorder, request)
+				shouldDrop := recorder.Code == http.StatusOK &&
+					((isClaim && droppedClaim.CompareAndSwap(false, true)) ||
+						(isCompletion && droppedCompletion.CompareAndSwap(false, true)))
+				if shouldDrop {
+					hijacker, ok := writer.(http.Hijacker)
+					if !ok {
+						t.Error("test server cannot hijack connections")
+						return
+					}
+					connection, _, err := hijacker.Hijack()
+					if err != nil {
+						t.Error(err)
+						return
+					}
+					_ = connection.Close()
+					return
+				}
+				copyResponse(writer, recorder)
+				return
+			}
+			next.ServeHTTP(writer, request)
+		})
+	})
+	repository := createRepository(t, "replay")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"replay": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "replay", "success", 60)
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "succeeded")
+	if !droppedClaim.Load() || !droppedCompletion.Load() || len(detail.Attempts) != 1 {
+		t.Fatalf("dropped claim=%v completion=%v attempts=%d",
+			droppedClaim.Load(), droppedCompletion.Load(), len(detail.Attempts))
+	}
+}
+
+func TestCodexStartsOnlyAfterAttemptStartIsAccepted(t *testing.T) {
+	startReached := make(chan struct{}, 1)
+	releaseStart := make(chan struct{})
+	fixture := newServerFixture(t, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, "/start") {
+				select {
+				case startReached <- struct{}{}:
+				default:
+				}
+				select {
+				case <-releaseStart:
+				case <-request.Context().Done():
+					return
+				}
+			}
+			next.ServeHTTP(writer, request)
+		})
+	})
+	repository := createRepository(t, "start-order")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"start-order": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "start-order", "success", 60)
+	select {
+	case <-startReached:
+	case <-time.After(10 * time.Second):
+		t.Fatal("worker never requested attempt start")
+	}
+	if entries, err := os.ReadDir(os.Getenv("FACTORY_TEST_CODEX_LOG")); err == nil && len(entries) != 0 {
+		t.Fatalf("Codex started before the start request was accepted: %v", entries)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatal(err)
+	}
+	close(releaseStart)
+	waitForTaskState(t, fixture.store, task.Task.ID, "succeeded")
+}
+
+func copyResponse(writer http.ResponseWriter, recorder *httptest.ResponseRecorder) {
+	for key, values := range recorder.Header() {
+		for _, value := range values {
+			writer.Header().Add(key, value)
+		}
+	}
+	writer.WriteHeader(recorder.Code)
+	_, _ = writer.Write(recorder.Body.Bytes())
+}
+
+func TestFailureRetainsWorktree(t *testing.T) {
+	repository := createRepository(t, "failure")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"failure": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "failure", "fail", 60)
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "failed")
+	if len(detail.Attempts) != 1 ||
+		!strings.Contains(detail.Attempts[0].Error, "exit status 17") ||
+		!strings.Contains(detail.Attempts[0].Error, "deterministic failure") {
+		t.Fatalf("failed attempt = %#v", detail.Attempts)
+	}
+	if _, err := os.Stat(filepath.Join(manager.dataDirectory, "worktrees", detail.Attempts[0].ID)); err != nil {
+		t.Fatalf("failed worktree was not retained: %v", err)
+	}
+}
+
+func TestDirtyAndUnpublishedSuccessesAreRetained(t *testing.T) {
+	repository := createRepository(t, "unsafe-success")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"unsafe-success": repository}, 2)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	dirty := createTask(t, fixture.store, worker, "unsafe-success", "dirty", 60)
+	unpublished := createTask(t, fixture.store, worker, "unsafe-success", "unpublished", 60)
+	dirty = waitForTaskState(t, fixture.store, dirty.Task.ID, "succeeded")
+	unpublished = waitForTaskState(t, fixture.store, unpublished.Task.ID, "succeeded")
+	for _, attempt := range []protocol.Attempt{dirty.Attempts[0], unpublished.Attempts[0]} {
+		path := filepath.Join(manager.dataDirectory, "worktrees", attempt.ID)
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("unsafe successful worktree was removed: %v", err)
+		}
+		waitFor(t, 5*time.Second, func() bool {
+			manager.stateMutex.Lock()
+			defer manager.stateMutex.Unlock()
+			_, retained := manager.retained[attempt.ID]
+			return retained
+		})
+	}
+}
+
+func TestCancellationStopsCompleteProcessGroup(t *testing.T) {
+	repository := createRepository(t, "cancel")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"cancel": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "cancel", "fork", 60)
+	running := waitForTaskState(t, fixture.store, task.Task.ID, "running")
+	attemptID := running.Attempts[0].ID
+	childPath := filepath.Join(os.Getenv("FACTORY_TEST_CODEX_LOG"), attemptID+".child")
+	waitFor(t, 5*time.Second, func() bool {
+		_, err := os.Stat(childPath)
+		return err == nil
+	})
+	childPID := readPID(t, childPath)
+	started := time.Now()
+	if _, err := fixture.store.CancelTask(context.Background(), task.Task.ID); err != nil {
+		t.Fatal(err)
+	}
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "cancelled")
+	if elapsed := time.Since(started); elapsed > 15*time.Second {
+		t.Fatalf("cancellation took %s", elapsed)
+	}
+	waitForProcessGone(t, childPID, 3*time.Second)
+	if _, err := os.Stat(filepath.Join(manager.dataDirectory, "worktrees", detail.Attempts[0].ID)); err != nil {
+		t.Fatalf("cancelled worktree was not retained: %v", err)
+	}
+}
+
+func TestTimeoutStopsIgnoringProcessGroup(t *testing.T) {
+	repository := createRepository(t, "timeout")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"timeout": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "timeout", "fork", 1)
+	running := waitForTaskState(t, fixture.store, task.Task.ID, "running")
+	childPath := filepath.Join(os.Getenv("FACTORY_TEST_CODEX_LOG"), running.Attempts[0].ID+".child")
+	waitFor(t, 5*time.Second, func() bool {
+		_, err := os.Stat(childPath)
+		return err == nil
+	})
+	childPID := readPID(t, childPath)
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "failed")
+	if !strings.Contains(detail.Attempts[0].Error, "timeout") {
+		t.Fatalf("timeout error = %q", detail.Attempts[0].Error)
+	}
+	waitForProcessGone(t, childPID, 3*time.Second)
+}
+
+func TestTimeoutIncludesWorktreePreparation(t *testing.T) {
+	repository := createRepository(t, "preparation-timeout")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gitWrapper := filepath.Join(t.TempDir(), "git")
+	script := "#!/bin/sh\ncase \"$*\" in *\"worktree add\"*) sleep 3;; esac\nexec " +
+		strconv.Quote(realGit) + " \"$@\"\n"
+	if err := os.WriteFile(gitWrapper, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"preparation-timeout": repository}, 1)
+	manager.options.GitExecutable = gitWrapper
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "preparation-timeout", "success", 1)
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "failed")
+	if len(detail.Attempts) != 1 || !strings.Contains(detail.Attempts[0].Error, "task timeout") {
+		t.Fatalf("preparation timeout attempt = %#v", detail.Attempts)
+	}
+	if entries, err := os.ReadDir(os.Getenv("FACTORY_TEST_CODEX_LOG")); err == nil && len(entries) != 0 {
+		t.Fatalf("Codex started after the task timed out during preparation: %v", entries)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatal(err)
+	}
+}
+
+func TestSupervisorCrashStopsRecordedProcessGroup(t *testing.T) {
+	repository := createRepository(t, "supervisor-crash")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"supervisor-crash": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "supervisor-crash", "fork", 60)
+	running := waitForTaskState(t, fixture.store, task.Task.ID, "running")
+	attempt := running.Attempts[0]
+	if attempt.SupervisorPID == nil {
+		t.Fatal("control plane did not record the supervisor PID")
+	}
+	identity, err := processIdentity(int(*attempt.SupervisorPID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity != attempt.ProcessIdentity {
+		t.Fatalf("stored supervisor identity does not match PID %d", *attempt.SupervisorPID)
+	}
+	childPath := filepath.Join(os.Getenv("FACTORY_TEST_CODEX_LOG"), attempt.ID+".child")
+	waitFor(t, 5*time.Second, func() bool {
+		_, err := os.Stat(childPath)
+		return err == nil
+	})
+	childPID := readPID(t, childPath)
+	if err := unix.Kill(int(*attempt.SupervisorPID), unix.SIGKILL); err != nil {
+		t.Fatal(err)
+	}
+	waitForTaskState(t, fixture.store, task.Task.ID, "failed")
+	waitForProcessGone(t, childPID, 8*time.Second)
+}
+
+func TestServerLossStopsCodexBeforeLeaseExpiry(t *testing.T) {
+	repository := createRepository(t, "server-loss")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"server-loss": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "server-loss", "fork", 60)
+	running := waitForTaskState(t, fixture.store, task.Task.ID, "running")
+	childPath := filepath.Join(os.Getenv("FACTORY_TEST_CODEX_LOG"), running.Attempts[0].ID+".child")
+	waitFor(t, 5*time.Second, func() bool {
+		_, err := os.Stat(childPath)
+		return err == nil
+	})
+	childPID := readPID(t, childPath)
+	started := time.Now()
+	fixture.server.Close()
+	waitForProcessGone(t, childPID, 32*time.Second)
+	if elapsed := time.Since(started); elapsed > protocol.LeaseDuration+2*time.Second {
+		t.Fatalf("server-loss stop took %s", elapsed)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := fixture.store.SweepExpired(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "failed")
+	if detail.Attempts[0].State != "lost" {
+		t.Fatalf("server-loss attempt state = %s", detail.Attempts[0].State)
+	}
+}
+
+func TestGracefulShutdownStopsActiveGroup(t *testing.T) {
+	repository := createRepository(t, "shutdown")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"shutdown": repository}, 1)
+	cancel, done := startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "shutdown", "fork", 60)
+	running := waitForTaskState(t, fixture.store, task.Task.ID, "running")
+	queued := createTask(t, fixture.store, worker, "shutdown", "success", 60)
+	childPath := filepath.Join(os.Getenv("FACTORY_TEST_CODEX_LOG"), running.Attempts[0].ID+".child")
+	waitFor(t, 5*time.Second, func() bool {
+		_, err := os.Stat(childPath)
+		return err == nil
+	})
+	childPID := readPID(t, childPath)
+	started := time.Now()
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > 15*time.Second {
+		t.Fatalf("graceful shutdown took %s", elapsed)
+	}
+	waitForProcessGone(t, childPID, 3*time.Second)
+	detail := waitForTaskState(t, fixture.store, task.Task.ID, "cancelled")
+	if detail.Attempts[0].State != "cancelled" {
+		t.Fatalf("shutdown attempt state = %s", detail.Attempts[0].State)
+	}
+	queuedDetail, err := fixture.store.Task(context.Background(), queued.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if queuedDetail.Execution.State != "queued" || len(queuedDetail.Attempts) != 0 {
+		t.Fatalf("worker claimed new work during shutdown: %#v", queuedDetail)
+	}
+}
+
+func TestParentPipeLossStopsCodexGroup(t *testing.T) {
+	t.Setenv("FACTORY_TEST_SUPERVISOR", "1")
+	logDirectory := t.TempDir()
+	t.Setenv("FACTORY_TEST_CODEX_LOG", logDirectory)
+	repository := createRepository(t, "parent-loss")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	result := filepath.Join(t.TempDir(), "result")
+	process, err := startSupervisor(
+		[]string{os.Args[0], "-test.run=TestWorkerSupervisorHelperProcess", "--"},
+		supervisorInit{
+			CodexExecutable: codexPath, Worktree: repository.path, ResultPath: result,
+			Prompt: "FAKE_MODE=fork", TimeoutSeconds: 60,
+		}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := process.awaitReady(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.send("start"); err != nil {
+		t.Fatal(err)
+	}
+	attempt := filepath.Base(repository.path)
+	childPath := filepath.Join(logDirectory, attempt+".child")
+	waitFor(t, 5*time.Second, func() bool {
+		_, err := os.Stat(childPath)
+		return err == nil
+	})
+	childPID := readPID(t, childPath)
+	started := time.Now()
+	if err := process.closeControl(); err != nil {
+		t.Fatal(err)
+	}
+	waitForProcessGone(t, childPID, 8*time.Second)
+	if elapsed := time.Since(started); elapsed > 7*time.Second {
+		t.Fatalf("parent pipe loss took %s", elapsed)
+	}
+}
+
+func TestV1WorktreeAndStateIsolation(t *testing.T) {
+	repository := createRepository(t, "isolation")
+	v1Root := filepath.Join(t.TempDir(), ".factory", "v1-owned")
+	runGitTest(t, repository.path, "worktree", "add", "-b", "codex/v1-owned", v1Root, "HEAD")
+	marker := filepath.Join(v1Root, "v1-state.sqlite3")
+	if err := os.WriteFile(marker, []byte("v1-state"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), ".factory-v2", "worker"),
+		map[string]repositoryFixture{"isolation": repository}, 1)
+	startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool { return worker.Health == "healthy" })
+	task := createTask(t, fixture.store, worker, "isolation", "success", 60)
+	waitForTaskState(t, fixture.store, task.Task.ID, "succeeded")
+	body, err := os.ReadFile(marker)
+	if err != nil || string(body) != "v1-state" {
+		t.Fatalf("V1 state changed: %q, %v", body, err)
+	}
+	entries := runGitTest(t, repository.path, "worktree", "list", "--porcelain")
+	if !strings.Contains(entries, v1Root) || !strings.Contains(entries, "refs/heads/codex/v1-owned") {
+		t.Fatalf("V1 worktree registration changed:\n%s", entries)
+	}
+}
+
+func readPID(t *testing.T, path string) int {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pid
+}
+
+func waitForProcessGone(t *testing.T, pid int, timeout time.Duration) {
+	t.Helper()
+	waitFor(t, timeout, func() bool {
+		err := unix.Kill(pid, 0)
+		return errors.Is(err, unix.ESRCH)
+	})
+}
+
+func TestLoadConfigRejectsUnknownAndResolvesRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	repository := createRepository(t, "config")
+	configPath := filepath.Join(root, "worker.toml")
+	body := fmt.Sprintf(`server = "http://127.0.0.1:7337"
+name = "local"
+max_concurrent = 1
+data_directory = "data"
+
+[repositories.factory]
+path = %q
+`, repository.path)
+	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.DataDirectory != filepath.Join(root, "data") {
+		t.Fatalf("resolved data directory = %s", config.DataDirectory)
+	}
+	if err := os.WriteFile(configPath, []byte(body+"unsafe_shortcut = true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadConfig(configPath); err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("unknown field error = %v", err)
+	}
+}
+
+func TestServerURLRejectsNonLoopback(t *testing.T) {
+	for _, value := range []string{
+		"http://0.0.0.0:7337",
+		"http://example.com:7337",
+		"https://127.0.0.1:7337",
+		"http://127.0.0.1:7337/path",
+	} {
+		t.Run(value, func(t *testing.T) {
+			if err := validateServerURL(value); err == nil {
+				t.Fatalf("accepted %s", value)
+			}
+		})
+	}
+}
+
+func TestWorkerRefusesV1DataRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "factory.sqlite3"), []byte("v1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveDataDirectory(filepath.Join(root, "workers", "local")); err == nil ||
+		!strings.Contains(err.Error(), "V1 state") {
+		t.Fatalf("V1 data-root error = %v", err)
+	}
+}
+
+func TestProcessIdentityRefusesWrongOwner(t *testing.T) {
+	command := exec.Command("/bin/sh", "-c", "trap '' TERM; while :; do sleep 1; done")
+	configureNewProcessGroup(command)
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+	}()
+	if err := stopOwnedProcessGroup(command.Process.Pid, "wrong identity", 0); err == nil {
+		t.Fatal("signalled a process group with the wrong identity")
+	}
+	if err := unix.Kill(command.Process.Pid, 0); err != nil {
+		t.Fatalf("wrong-identity check stopped process: %v", err)
+	}
+}
+
+func TestEventPayloadIsAlwaysBoundedJSON(t *testing.T) {
+	cases := map[string]string{
+		"unicode":       strings.Repeat("é", protocol.MaxEventBytes),
+		"escaped":       strings.Repeat("\"\\\n\t", protocol.MaxEventBytes),
+		"control bytes": strings.Repeat("\x00\x01\x02", protocol.MaxEventBytes),
+		"invalid UTF-8": string(bytes.Repeat([]byte{0xff, 0xfe}, protocol.MaxEventBytes)),
+	}
+	for name, text := range cases {
+		t.Run(name, func(t *testing.T) {
+			payload := eventPayload("stderr", text, false)
+			if len(payload) > protocol.MaxEventBytes || !jsonValid(payload) {
+				t.Fatalf("payload length=%d valid=%v", len(payload), jsonValid(payload))
+			}
+		})
+	}
+}
+
+func TestEventSenderRetriesTransientFailureWithSameSequence(t *testing.T) {
+	requests := make(chan protocol.EventBatchRequest, 2)
+	var count atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		var input protocol.EventBatchRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Errorf("decode event request: %v", err)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		requests <- input
+		if count.Add(1) == 1 {
+			http.Error(w, "temporary failure", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sender := newEventSender(ctx, newClient(server.URL, nil), "attempt", "lease")
+	sender.enqueue("stderr", "retry me", false)
+	sender.closeAndWait(5 * time.Second)
+	if count.Load() != 2 {
+		t.Fatalf("event request count = %d", count.Load())
+	}
+	first := <-requests
+	second := <-requests
+	if len(first.Events) != 1 || len(second.Events) != 1 ||
+		first.Events[0].Sequence != 0 || second.Events[0].Sequence != 0 ||
+		!bytes.Equal(first.Events[0].Payload, second.Events[0].Payload) {
+		t.Fatalf("event retry changed content: first=%#v second=%#v", first.Events, second.Events)
+	}
+}
+
+func TestBoundedCompletionRequestFitsAfterJSONEscaping(t *testing.T) {
+	cases := map[string]protocol.CompleteAttemptRequest{
+		"control result": {
+			LeaseToken: strings.Repeat("l", 43),
+			State:      "succeeded",
+			Result:     strings.Repeat("\x00", protocol.MaxResultBytes),
+		},
+		"invalid UTF-8 result": {
+			LeaseToken: strings.Repeat("l", 43),
+			State:      "succeeded",
+			Result:     string(bytes.Repeat([]byte{0xff, 0xfe}, protocol.MaxResultBytes)),
+		},
+		"escaped result and invalid error": {
+			LeaseToken: strings.Repeat("l", 43),
+			State:      "failed",
+			Result:     strings.Repeat("\"\\\n", protocol.MaxResultBytes),
+			Error:      string(bytes.Repeat([]byte{0xff}, protocol.MaxErrorBytes)),
+		},
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			bounded := boundedCompletionRequest(input)
+			body, err := json.Marshal(bounded)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(body) > protocol.MaxBodyBytes {
+				t.Fatalf("encoded completion length = %d", len(body))
+			}
+			if len(bounded.Result) > protocol.MaxResultBytes || len(bounded.Error) > protocol.MaxErrorBytes {
+				t.Fatalf("raw bounds exceeded: result=%d error=%d", len(bounded.Result), len(bounded.Error))
+			}
+			if !utf8.ValidString(bounded.Result) || !utf8.ValidString(bounded.Error) {
+				t.Fatal("bounded completion retained invalid UTF-8")
+			}
+		})
+	}
+}
+
+func jsonValid(value []byte) bool {
+	decoder := json.NewDecoder(bytes.NewReader(value))
+	var decoded any
+	return decoder.Decode(&decoded) == nil
+}

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -1088,6 +1088,29 @@ func TestWorkerRefusesV1DataRoot(t *testing.T) {
 		!strings.Contains(err.Error(), "V1 state") {
 		t.Fatalf("V1 data-root error = %v", err)
 	}
+
+	linkRoot := t.TempDir()
+	link := filepath.Join(linkRoot, "v1-link")
+	if err := os.Symlink(root, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveDataDirectory(filepath.Join(link, "workers", "linked")); err == nil ||
+		!strings.Contains(err.Error(), "V1 state") {
+		t.Fatalf("symlinked V1 data-root error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "workers")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("V1 directory was mutated before refusal: %v", err)
+	}
+
+	cleanTarget := t.TempDir()
+	terminalLink := filepath.Join(t.TempDir(), "worker-link")
+	if err := os.Symlink(cleanTarget, terminalLink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveDataDirectory(terminalLink); err == nil ||
+		!strings.Contains(err.Error(), "not a symlink") {
+		t.Fatalf("terminal symlink error = %v", err)
+	}
 }
 
 func TestProcessIdentityRefusesWrongOwner(t *testing.T) {


### PR DESCRIPTION
## Problem

Factory V2 has a loopback control plane and UI but no production local worker that can safely execute assigned Codex tasks.

Closes #131.

## Changes

- add a strict TOML-configured Unix `factory-worker` with stable identity, exclusive data ownership, Git/Codex health, multi-repository registration, bounded capacity, and idempotent claim polling
- add V2-owned worktree creation and a supervisor-owned process-group lifecycle for Codex execution, lease renewal, cancellation, timeout, server loss, parent loss, and graceful shutdown
- bound and retry events and terminal results safely, including encoded HTTP limits and stale-health claim races
- remove only verified clean successful V2 worktrees while preserving branches; retain dirty, failed, cancelled, unpublished, or unverifiable worktrees without taking #132 manifest/reconciliation/cleanup scope
- preserve V1 isolation and enforce that `internal/worker` has no dependency on `internal/controlplane`
- document worker configuration and operations, and add worker coverage to CI

## Verification

- `go test -timeout 5m ./...`
- `go test -race -timeout 5m ./internal/worker`
- `go vet ./...`
- `test -z "$(gofmt -l cmd internal migrations web/*.go)"`
- `! go list -deps ./internal/worker | grep -qx 'github.com/owainlewis/factory/internal/controlplane'`
- `git diff --check`
- `GOOS=linux GOARCH=amd64 go build ./cmd/factory-worker`
- `GOOS=windows GOARCH=amd64 go build ./cmd/factory-worker`
- `cd web && npm ci && npm run lint && npm run typecheck && npm test && npm run build && npm run test:browser` (9 component tests and 7 real-server Chromium tests)
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`
- independent read-only review: approved after all event-bound, output-drain, registration, claim-health, completion-body, and committed-response findings were fixed and regression-tested

## Risks

The worker deliberately leaves restart reconciliation, durable manifests, retained-worktree limits, and cleanup commands to #132. Until then, prior-process worktrees are retained and never scanned or deleted. Unix process ownership and cleanup paths are covered with real process-group and real-Git integration tests.

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests and documentation cover changed behavior.
- [x] Logs, fixtures, and screenshots contain no secrets or private repository data.