### PR TITLE
feat(worker): make V2 execution crash-safe

### DIFF
--- a/cmd/factory-worker/main.go
+++ b/cmd/factory-worker/main.go
@@ -33,6 +33,17 @@ func run() error {
 	if err != nil {
 		return err
 	}
+	if len(os.Args) > 1 && os.Args[1] == "cleanup" {
+		configPath, options, err := worker.ParseCleanupArguments(os.Args[2:], defaultConfig)
+		if err != nil {
+			return err
+		}
+		config, err := worker.LoadConfig(configPath)
+		if err != nil {
+			return err
+		}
+		return worker.Cleanup(config, options, os.Stdout)
+	}
 	flags := flag.NewFlagSet("factory-worker", flag.ContinueOnError)
 	configPath := flags.String("config", defaultConfig, "Factory V2 worker TOML configuration path")
 	if err := flags.Parse(os.Args[1:]); err != nil {

--- a/docs/v2-architecture/design.md
+++ b/docs/v2-architecture/design.md
@@ -653,9 +653,14 @@ Successful clean worktrees are removed after completion. Failed, cancelled,
 dirty, or unpublished worktrees are retained. The worker retains at most ten
 per repository. At a repository's limit it continues heartbeats and may claim
 work for other advertised repositories, but it does not claim more work for
-that repository. The Workers page groups retained attempt IDs and their cleanup
-commands by repository. The operator previews and confirms cleanup through
-`factory-worker cleanup`.
+that repository. Registration publishes both the retained snapshot and exact
+attempt IDs whose local processes have stopped and worktrees are durably
+absent. The control plane releases those attempt reservations without waiting
+for unrelated active work to finish. Disposed IDs use a durable worker-level
+journal until registration succeeds, then the corresponding manifests are
+marked acknowledged to bound later startup work. The Workers page groups
+retained attempt IDs and their cleanup commands by repository. The operator
+previews and confirms cleanup through `factory-worker cleanup`.
 
 ## 8. Security, privacy, and operations
 

--- a/docs/v2-architecture/design.md
+++ b/docs/v2-architecture/design.md
@@ -1,10 +1,11 @@
 # Factory V2 MVP
 
-> **Status:** Proposed for review
+> **Status:** Implemented
 
-> **Implementation:** The control plane, UI, and local Unix worker execution
-> core are implemented. Durable worker manifests, restart reconciliation,
-> retained-worktree limits, and the cleanup CLI remain in issue #132.
+> **Implementation:** The control plane, UI, and crash-safe local Unix worker
+> are implemented. The worker uses durable attempt manifests, startup
+> reconciliation, repository-scoped retained-worktree limits, and explicit
+> preview or confirmed cleanup.
 
 ## 1. Executive summary
 

--- a/docs/v2-architecture/design.md
+++ b/docs/v2-architecture/design.md
@@ -657,8 +657,8 @@ that repository. Registration publishes both the retained snapshot and exact
 attempt IDs whose local processes have stopped and worktrees are durably
 absent. The control plane releases those attempt reservations without waiting
 for unrelated active work to finish. Disposed IDs use a durable worker-level
-journal until registration succeeds, then the corresponding manifests are
-marked acknowledged to bound later startup work. The Workers page groups
+journal until registration succeeds, then absent manifests are durably pruned
+to bound later startup work. The Workers page groups
 retained attempt IDs and their cleanup commands by repository. The operator
 previews and confirms cleanup through `factory-worker cleanup`.
 

--- a/docs/v2-worker.md
+++ b/docs/v2-worker.md
@@ -179,6 +179,11 @@ durably records `cleaned`. It never deletes the branch. Because confirmation
 can remove a dirty retained worktree, copy or commit any uncommitted work you
 want to keep before using `--confirm`.
 
+The manifest distinguishes operator-confirmed cleanup from automatic cleanup.
+After an interruption, startup may force-remove only an operator-confirmed
+worktree. It revalidates an interrupted automatic cleanup and retains the
+worktree if it became dirty or gained unpublished commits.
+
 Cleanup fails closed for a missing manifest, a path outside the worker's V2
 worktree directory, a repository or branch identity mismatch, a partial
 worktree, or an unverified process identity. It never scans or removes Factory

--- a/docs/v2-worker.md
+++ b/docs/v2-worker.md
@@ -149,6 +149,9 @@ filesystem, and `git worktree list` and records one of these outcomes:
 An inconsistent or unproven identity makes the worker unhealthy and prevents
 claims. A missing or never-created worktree does not consume retained capacity.
 Only verified retained worktrees count toward the limit of ten per repository.
+A claimed attempt reserves one possible retained slot. After completion, the
+control plane keeps that reservation until a worker registration atomically
+publishes the repository's retained count and acknowledges the handoff.
 A full repository remains queued while the worker continues heartbeats and may
 claim work for another repository. Transient control-plane or Git failures
 during reconciliation are retried before the worker first registers; they are

--- a/docs/v2-worker.md
+++ b/docs/v2-worker.md
@@ -58,6 +58,12 @@ worker lifetime. The first start writes an owner-only `worker-id`; later starts
 reuse it. A second process cannot use the same data directory. The worker also
 refuses a data directory below a Factory V1 `factory.sqlite3` state root.
 
+Each claimed attempt has an owner-only manifest at
+`<data_directory>/attempts/<attempt-id>.json`. The worker writes the initial
+manifest before it creates the worktree. It atomically replaces the manifest
+and synchronizes both the file and parent directory for worktree, process,
+lease, completion, retention, and cleanup transitions.
+
 ## Run
 
 Start the server first, then:
@@ -123,11 +129,57 @@ worktree only when all live-attempt checks pass:
 - the worktree is clean;
 - its current commit is the original base or is reachable from a remote ref.
 
-Cleanup uses `git worktree remove` without force and never deletes the branch.
-Any mismatch or cleanup error retains the worktree. Failed, cancelled, dirty,
-and unpublished worktrees are also retained for inspection.
+Automatic successful cleanup uses `git worktree remove` without force and
+never deletes the branch. Any mismatch or cleanup error retains the worktree.
+Failed, cancelled, dirty, and unpublished worktrees are also retained for
+inspection.
 
-Durable attempt manifests, restart reconciliation, retained-worktree capacity,
-and preview or confirmed cleanup commands are intentionally delivered by issue
-#132. Until then, the worker does not scan, repair, or delete worktrees left by
-an earlier worker process.
+At startup, before registration or claims, the worker reads every attempt
+manifest. It stops any still-live process group only when the recorded process
+identity still matches. It never resumes Codex. It then compares the manifest,
+filesystem, and `git worktree list` and records one of these outcomes:
+
+- never created;
+- retained;
+- missing;
+- inconsistent;
+- cleanup in progress;
+- cleaned.
+
+An inconsistent or unproven identity makes the worker unhealthy and prevents
+claims. A missing or never-created worktree does not consume retained capacity.
+Only verified retained worktrees count toward the limit of ten per repository.
+A full repository remains queued while the worker continues heartbeats and may
+claim work for another repository. Transient control-plane or Git failures
+during reconciliation are retried before the worker first registers; they are
+not recorded as identity inconsistencies.
+
+## Inspect and clean retained worktrees
+
+Stop the worker before cleanup because the command takes the same exclusive
+data-directory lock. Preview is the default:
+
+```sh
+factory-worker cleanup ATTEMPT_ID --config /path/to/worker.toml
+```
+
+The preview prints the complete manifest, repository identity, worktree path,
+branch, commit, Git status, and retention reason. It does not change the
+manifest, worktree, or branch.
+
+After reviewing the preview, confirm cleanup explicitly:
+
+```sh
+factory-worker cleanup ATTEMPT_ID --confirm --config /path/to/worker.toml
+```
+
+Confirmed cleanup durably records `cleanup_started`, revalidates the
+manifest-owned V2 path and Git registration, removes that worktree, and then
+durably records `cleaned`. It never deletes the branch. Because confirmation
+can remove a dirty retained worktree, copy or commit any uncommitted work you
+want to keep before using `--confirm`.
+
+Cleanup fails closed for a missing manifest, a path outside the worker's V2
+worktree directory, a repository or branch identity mismatch, a partial
+worktree, or an unverified process identity. It never scans or removes Factory
+V1 paths, branches, or state.

--- a/docs/v2-worker.md
+++ b/docs/v2-worker.md
@@ -178,8 +178,8 @@ proof before an expired attempt is swept to `lost`; active-attempt capacity
 continues to apply until that state transition. A failed journal write makes the
 worker unhealthy and prevents terminal completion; the in-memory exact
 registration remains a recovery path while the process is running. Successful
-handoffs mark absent manifests as acknowledged, so later restarts do not rebuild
-or resend historical IDs.
+handoffs durably remove absent manifests before clearing the disposal journal,
+so later restarts do not scan or resend historical IDs.
 
 Historical attempts are acknowledged once by the schema migration because
 pre-manifest workers could not publish exact disposition evidence. The

--- a/docs/v2-worker.md
+++ b/docs/v2-worker.md
@@ -81,6 +81,18 @@ Healthy workers heartbeat their capacity and repositories, reserve a local
 slot, and poll for assigned work. Claim retries reuse the same request ID and
 lease secret, so a lost response cannot start a duplicate attempt.
 
+## Upgrade from the schema 1 V2 preview
+
+Drain all `preparing` and `running` attempts before starting the upgraded
+control plane. Schema 1 had no durable local evidence for active worktree
+disposition, so migration 002 fails transactionally with
+`drain_active_v2_attempts_before_upgrade` if active attempts remain. Restart the
+old control plane and workers, let or cancel those attempts to a terminal state,
+and wait for every worker to publish an idle registration with
+`active_count: 0` and its final retained snapshot. Then retry the upgrade.
+Terminal history and attributable retained summaries are migrated
+automatically.
+
 ## Execution and failure behavior
 
 Each claim is matched back to the configured repository key and normalized
@@ -152,10 +164,36 @@ Only verified retained worktrees count toward the limit of ten per repository.
 A claimed attempt reserves one possible retained slot. After completion, the
 control plane keeps that reservation until a worker registration atomically
 publishes the repository's retained count and acknowledges the handoff.
+The worker names attempts whose local process has stopped and whose worktree is
+durably absent in
+`disposed_attempt_ids`. It keeps those acknowledgments pending until the
+registration succeeds, including after startup reconciliation, so unrelated
+active work cannot delay capacity release. Pending IDs are stored atomically in
+`disposed-attempts.json` before completion is reported and are removed from the
+journal only after the server commits a registration.
+`capacity_handoff_version: 1`
+disables the legacy idle-worker bulk acknowledgment path; current workers use
+only exact retained or disposed attempt IDs. The server can record this local
+proof before an expired attempt is swept to `lost`; active-attempt capacity
+continues to apply until that state transition. A failed journal write makes the
+worker unhealthy and prevents terminal completion; the in-memory exact
+registration remains a recovery path while the process is running. Successful
+handoffs mark absent manifests as acknowledged, so later restarts do not rebuild
+or resend historical IDs.
+
+Historical attempts are acknowledged once by the schema migration because
+pre-manifest workers could not publish exact disposition evidence. The
+migration first derives their retained counts from complete legacy summaries.
+Active historical attempts are not pre-acknowledged: they reserve capacity by
+state before sweep and as unclassified terminal attempts afterward, until an
+exact retained or disposed handoff proves their local outcome.
 For upgrade compatibility, the control plane never trusts a reported count
-below the retained-worktree summaries in the same registration. An active
-legacy registration can acknowledge only terminal attempts named by those
-summaries; unlisted attempts remain reserved until an idle registration.
+below complete, uniquely attributable retained-worktree summaries in the same
+registration. Display-only summaries without an attempt or repository ID remain
+valid API input, but disable bulk idle-worker acknowledgment and do not
+acknowledge a capacity handoff themselves. An active legacy registration can
+acknowledge only terminal attempts named by complete summaries; unlisted
+attempts remain reserved until an idle registration.
 A full repository remains queued while the worker continues heartbeats and may
 claim work for another repository. Transient control-plane or Git failures
 during reconciliation are retried before the worker first registers; they are

--- a/docs/v2-worker.md
+++ b/docs/v2-worker.md
@@ -152,6 +152,10 @@ Only verified retained worktrees count toward the limit of ten per repository.
 A claimed attempt reserves one possible retained slot. After completion, the
 control plane keeps that reservation until a worker registration atomically
 publishes the repository's retained count and acknowledges the handoff.
+For upgrade compatibility, the control plane never trusts a reported count
+below the retained-worktree summaries in the same registration. An active
+legacy registration can acknowledge only terminal attempts named by those
+summaries; unlisted attempts remain reserved until an idle registration.
 A full repository remains queued while the worker continues heartbeats and may
 claim work for another repository. Transient control-plane or Git failures
 during reconciliation are retried before the worker first registers; they are

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -110,10 +110,28 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 		WHERE e.assigned_worker_id = ?
 		  AND e.state = 'queued'
 		  AND wr.advertised = 1
-		  AND wr.retained_count < ?
+		  AND wr.retained_count + (
+		      SELECT COUNT(*)
+		      FROM attempts active_attempt
+		      JOIN executions active_execution ON active_execution.id = active_attempt.execution_id
+		      JOIN tasks active_task ON active_task.id = active_execution.task_id
+		      WHERE active_attempt.worker_id = e.assigned_worker_id
+		        AND active_task.repository_id = t.repository_id
+		        AND active_attempt.state IN ('preparing', 'running')
+		        AND active_attempt.lease_expires_at > ?
+		  ) + (
+		      SELECT COUNT(*)
+		      FROM attempts terminal_attempt
+		      JOIN executions terminal_execution ON terminal_execution.id = terminal_attempt.execution_id
+		      JOIN tasks terminal_task ON terminal_task.id = terminal_execution.task_id
+		      WHERE terminal_attempt.worker_id = e.assigned_worker_id
+		        AND terminal_task.repository_id = t.repository_id
+		        AND terminal_attempt.state IN ('succeeded', 'failed', 'cancelled', 'lost')
+		        AND terminal_attempt.completed_at >= wr.updated_at
+		  ) < ?
 		ORDER BY e.created_at, e.id
 		LIMIT 1
-	`, workerID, protocol.MaxRetainedPerRepo).Scan(&executionID)
+	`, workerID, nowMillis, protocol.MaxRetainedPerRepo).Scan(&executionID)
 	if errors.Is(err, sql.ErrNoRows) {
 		if err := insertEmptyClaim(ctx, tx, workerID, input.RequestID, digest, nowMillis); err != nil {
 			return nil, err

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -86,8 +86,8 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 	var active int
 	if err := tx.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM attempts
-		WHERE worker_id = ? AND state IN ('preparing', 'running') AND lease_expires_at > ?
-	`, workerID, nowMillis).Scan(&active); err != nil {
+		WHERE worker_id = ? AND state IN ('preparing', 'running')
+	`, workerID).Scan(&active); err != nil {
 		return nil, unavailable(err)
 	}
 	if healthy == 0 || now.Sub(fromMillis(lastHeartbeat)) > protocol.WorkerOnlineWindow || active >= capacity {
@@ -118,7 +118,6 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 		      WHERE active_attempt.worker_id = e.assigned_worker_id
 		        AND active_task.repository_id = t.repository_id
 		        AND active_attempt.state IN ('preparing', 'running')
-		        AND active_attempt.lease_expires_at > ?
 		  ) + (
 		      SELECT COUNT(*)
 		      FROM attempts terminal_attempt
@@ -131,7 +130,7 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 		  ) < ?
 		ORDER BY e.created_at, e.id
 		LIMIT 1
-	`, workerID, nowMillis, protocol.MaxRetainedPerRepo).Scan(&executionID)
+	`, workerID, protocol.MaxRetainedPerRepo).Scan(&executionID)
 	if errors.Is(err, sql.ErrNoRows) {
 		if err := insertEmptyClaim(ctx, tx, workerID, input.RequestID, digest, nowMillis); err != nil {
 			return nil, err

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -127,7 +127,7 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 		      WHERE terminal_attempt.worker_id = e.assigned_worker_id
 		        AND terminal_task.repository_id = t.repository_id
 		        AND terminal_attempt.state IN ('succeeded', 'failed', 'cancelled', 'lost')
-		        AND terminal_attempt.completed_at >= wr.updated_at
+		        AND terminal_attempt.capacity_acknowledged = 0
 		  ) < ?
 		ORDER BY e.created_at, e.id
 		LIMIT 1

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -305,6 +305,10 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 	if input.Health != "healthy" && input.Health != "unhealthy" {
 		return protocol.Worker{}, invalid("invalid_health", "health must be healthy or unhealthy")
 	}
+	if input.CapacityHandoffVersion < 0 || input.CapacityHandoffVersion > 1 {
+		return protocol.Worker{}, invalid(
+			"invalid_capacity_handoff", "capacity_handoff_version must be 0 or 1")
+	}
 	if len(input.Repositories) == 0 {
 		return protocol.Worker{}, invalid("invalid_repositories", "at least one repository is required")
 	}
@@ -327,23 +331,42 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 	}
 	retainedCounts := make(map[string]int)
 	retainedAttemptIDs := make(map[string][]string)
-	seenRetainedAttempts := make(map[string]bool)
+	seenRetainedAttempts := make(map[string]string)
+	hasUnattributedRetainedSummary := false
 	for index := range input.RetainedWorktrees {
 		worktree := &input.RetainedWorktrees[index]
 		worktree.AttemptID = strings.TrimSpace(worktree.AttemptID)
 		worktree.RepositoryID = strings.TrimSpace(worktree.RepositoryID)
+		// Older API clients may send display-only summaries before they know the
+		// control-plane repository ID. Preserve those summaries, but do not use
+		// incomplete or duplicate entries as capacity-handoff evidence.
 		if worktree.AttemptID == "" || worktree.RepositoryID == "" {
-			return protocol.Worker{}, invalid(
-				"invalid_retained_worktrees", "retained worktree attempt_id and repository_id are required")
+			hasUnattributedRetainedSummary = true
+			continue
 		}
-		if seenRetainedAttempts[worktree.AttemptID] {
-			return protocol.Worker{}, invalid(
-				"invalid_retained_worktrees", "retained worktree attempt_id values must be unique")
+		if repositoryID, seen := seenRetainedAttempts[worktree.AttemptID]; seen {
+			if repositoryID != worktree.RepositoryID {
+				hasUnattributedRetainedSummary = true
+			}
+			continue
 		}
-		seenRetainedAttempts[worktree.AttemptID] = true
+		seenRetainedAttempts[worktree.AttemptID] = worktree.RepositoryID
 		retainedCounts[worktree.RepositoryID]++
 		retainedAttemptIDs[worktree.RepositoryID] = append(
 			retainedAttemptIDs[worktree.RepositoryID], worktree.AttemptID)
+	}
+	disposedAttemptIDs := make([]string, 0, len(input.DisposedAttemptIDs))
+	seenDisposedAttempts := make(map[string]bool, len(input.DisposedAttemptIDs))
+	for _, value := range input.DisposedAttemptIDs {
+		attemptID := strings.TrimSpace(value)
+		if attemptID == "" || len(attemptID) > 200 {
+			return protocol.Worker{}, invalid(
+				"invalid_disposed_attempts", "disposed attempt IDs must be non-empty and at most 200 bytes")
+		}
+		if !seenDisposedAttempts[attemptID] {
+			seenDisposedAttempts[attemptID] = true
+			disposedAttemptIDs = append(disposedAttemptIDs, attemptID)
+		}
 	}
 	retained, err := json.Marshal(input.RetainedWorktrees)
 	if err != nil || len(retained) > protocol.MaxBodyBytes {
@@ -435,6 +458,36 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		if err != nil {
 			return protocol.Worker{}, unavailable(err)
 		}
+	}
+	canBulkAcknowledge := input.CapacityHandoffVersion == 0 && !hasUnattributedRetainedSummary
+	for repositoryID := range retainedCounts {
+		if !advertisedRepositoryIDs[repositoryID] {
+			canBulkAcknowledge = false
+		}
+	}
+	for _, attemptID := range disposedAttemptIDs {
+		var ownerID string
+		err := tx.QueryRowContext(ctx, `
+			SELECT worker_id
+			FROM attempts
+			WHERE id = ?
+		`, attemptID).Scan(&ownerID)
+		if errors.Is(err, sql.ErrNoRows) || (err == nil && ownerID != workerID) {
+			return protocol.Worker{}, invalid(
+				"invalid_disposed_attempts", "disposed attempts must exist and be owned by this worker")
+		}
+		if err != nil {
+			return protocol.Worker{}, unavailable(err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE attempts
+			SET capacity_acknowledged = 1
+			WHERE id = ?
+		`, attemptID); err != nil {
+			return protocol.Worker{}, unavailable(err)
+		}
+	}
+	for repositoryID := range advertisedRepositoryIDs {
 		if _, err := tx.ExecContext(ctx, `
 			UPDATE attempts
 			SET capacity_acknowledged = 1
@@ -442,13 +495,14 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 			  AND capacity_acknowledged = 0
 			  AND state IN ('succeeded', 'failed', 'cancelled', 'lost')
 			  AND ? = 0
+			  AND ?
 			  AND execution_id IN (
 			      SELECT e.id
 			      FROM executions e
 			      JOIN tasks t ON t.id = e.task_id
 			      WHERE t.repository_id = ?
 			  )
-		`, workerID, input.ActiveCount, repositoryID); err != nil {
+		`, workerID, input.ActiveCount, canBulkAcknowledge, repositoryID); err != nil {
 			return protocol.Worker{}, unavailable(err)
 		}
 		for _, attemptID := range retainedAttemptIDs[repositoryID] {
@@ -467,12 +521,6 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 			`, attemptID, workerID, repositoryID); err != nil {
 				return protocol.Worker{}, unavailable(err)
 			}
-		}
-	}
-	for repositoryID := range retainedCounts {
-		if !advertisedRepositoryIDs[repositoryID] {
-			return protocol.Worker{}, invalid(
-				"invalid_retained_worktrees", "retained worktree repository_id must be advertised by this worker")
 		}
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -325,6 +325,26 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		}
 		seenKeys[repo.Key], seenRemotes[repo.RemoteIdentity] = true, true
 	}
+	retainedCounts := make(map[string]int)
+	retainedAttemptIDs := make(map[string][]string)
+	seenRetainedAttempts := make(map[string]bool)
+	for index := range input.RetainedWorktrees {
+		worktree := &input.RetainedWorktrees[index]
+		worktree.AttemptID = strings.TrimSpace(worktree.AttemptID)
+		worktree.RepositoryID = strings.TrimSpace(worktree.RepositoryID)
+		if worktree.AttemptID == "" || worktree.RepositoryID == "" {
+			return protocol.Worker{}, invalid(
+				"invalid_retained_worktrees", "retained worktree attempt_id and repository_id are required")
+		}
+		if seenRetainedAttempts[worktree.AttemptID] {
+			return protocol.Worker{}, invalid(
+				"invalid_retained_worktrees", "retained worktree attempt_id values must be unique")
+		}
+		seenRetainedAttempts[worktree.AttemptID] = true
+		retainedCounts[worktree.RepositoryID]++
+		retainedAttemptIDs[worktree.RepositoryID] = append(
+			retainedAttemptIDs[worktree.RepositoryID], worktree.AttemptID)
+	}
 	retained, err := json.Marshal(input.RetainedWorktrees)
 	if err != nil || len(retained) > protocol.MaxBodyBytes {
 		return protocol.Worker{}, invalid("invalid_retained_worktrees", "retained worktree summaries are too large")
@@ -335,6 +355,7 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		return protocol.Worker{}, unavailable(err)
 	}
 	defer tx.Rollback()
+	advertisedRepositoryIDs := make(map[string]bool, len(input.Repositories))
 	for _, repo := range input.Repositories {
 		var existingID string
 		err := tx.QueryRowContext(ctx, `
@@ -380,6 +401,11 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		if err != nil {
 			return protocol.Worker{}, unavailable(err)
 		}
+		advertisedRepositoryIDs[repositoryID] = true
+		effectiveRetainedCount := repo.RetainedCount
+		if retainedCounts[repositoryID] > effectiveRetainedCount {
+			effectiveRetainedCount = retainedCounts[repositoryID]
+		}
 		var existingKey string
 		mappingErr := tx.QueryRowContext(ctx, `
 			SELECT display_key FROM worker_repositories
@@ -391,18 +417,18 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 				UPDATE worker_repositories
 				SET display_key = ?, retained_count = ?, advertised = 1, updated_at = ?
 				WHERE worker_id = ? AND repository_id = ?
-			`, repo.Key, repo.RetainedCount, now, workerID, repositoryID)
+			`, repo.Key, effectiveRetainedCount, now, workerID, repositoryID)
 		case mappingErr == nil:
 			_, err = tx.ExecContext(ctx, `
 				UPDATE worker_repositories
 				SET retained_count = ?, advertised = 1, updated_at = ?
 				WHERE worker_id = ? AND repository_id = ?
-			`, repo.RetainedCount, now, workerID, repositoryID)
+			`, effectiveRetainedCount, now, workerID, repositoryID)
 		case errors.Is(mappingErr, sql.ErrNoRows):
 			_, err = tx.ExecContext(ctx, `
 				INSERT INTO worker_repositories(worker_id, display_key, repository_id, retained_count, advertised, updated_at)
 				VALUES (?, ?, ?, ?, 1, ?)
-			`, workerID, repo.Key, repositoryID, repo.RetainedCount, now)
+			`, workerID, repo.Key, repositoryID, effectiveRetainedCount, now)
 		default:
 			err = mappingErr
 		}
@@ -415,7 +441,7 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 			WHERE worker_id = ?
 			  AND capacity_acknowledged = 0
 			  AND state IN ('succeeded', 'failed', 'cancelled', 'lost')
-			  AND (state != 'lost' OR ? = 0)
+			  AND ? = 0
 			  AND execution_id IN (
 			      SELECT e.id
 			      FROM executions e
@@ -424,6 +450,29 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 			  )
 		`, workerID, input.ActiveCount, repositoryID); err != nil {
 			return protocol.Worker{}, unavailable(err)
+		}
+		for _, attemptID := range retainedAttemptIDs[repositoryID] {
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE attempts
+				SET capacity_acknowledged = 1
+				WHERE id = ?
+				  AND worker_id = ?
+				  AND state IN ('succeeded', 'failed', 'cancelled', 'lost')
+				  AND execution_id IN (
+				      SELECT e.id
+				      FROM executions e
+				      JOIN tasks t ON t.id = e.task_id
+				      WHERE t.repository_id = ?
+				  )
+			`, attemptID, workerID, repositoryID); err != nil {
+				return protocol.Worker{}, unavailable(err)
+			}
+		}
+	}
+	for repositoryID := range retainedCounts {
+		if !advertisedRepositoryIDs[repositoryID] {
+			return protocol.Worker{}, invalid(
+				"invalid_retained_worktrees", "retained worktree repository_id must be advertised by this worker")
 		}
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -409,6 +409,22 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		if err != nil {
 			return protocol.Worker{}, unavailable(err)
 		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE attempts
+			SET capacity_acknowledged = 1
+			WHERE worker_id = ?
+			  AND capacity_acknowledged = 0
+			  AND state IN ('succeeded', 'failed', 'cancelled', 'lost')
+			  AND (state != 'lost' OR ? = 0)
+			  AND execution_id IN (
+			      SELECT e.id
+			      FROM executions e
+			      JOIN tasks t ON t.id = e.task_id
+			      WHERE t.repository_id = ?
+			  )
+		`, workerID, input.ActiveCount, repositoryID); err != nil {
+			return protocol.Worker{}, unavailable(err)
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return protocol.Worker{}, unavailable(err)

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -426,6 +426,89 @@ func TestClaimOrderingRepositoryFilteringAndReplay(t *testing.T) {
 	}
 }
 
+func TestClaimReservesRepositoryRetainedHeadroom(t *testing.T) {
+	store := newTestStore(t)
+	fixed := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixed }
+	worker := registerTestWorker(t, store, workerA, 2,
+		protocol.RepositoryRegistration{
+			Key: "nearly-full", RemoteIdentity: "github.com/example/nearly-full",
+			RetainedCount: protocol.MaxRetainedPerRepo - 1,
+		},
+		protocol.RepositoryRegistration{Key: "open", RemoteIdentity: "github.com/example/open"},
+	)
+	repositories := map[string]string{}
+	for _, repository := range worker.Repositories {
+		repositories[repository.Key] = repository.ID
+	}
+	first := createTestTask(t, store, "nearly-full-first", workerA, repositories["nearly-full"])
+	fixed = fixed.Add(time.Millisecond)
+	createTestTask(t, store, "nearly-full-second", workerA, repositories["nearly-full"])
+	fixed = fixed.Add(time.Millisecond)
+	other := createTestTask(t, store, "open-while-reserved", workerA, repositories["open"])
+
+	claimedFirst := claimTestTask(t, store, workerA, "reserve-first", tokenA)
+	if claimedFirst.Task.ID != first.Task.ID {
+		t.Fatalf("first claim = %s; want %s", claimedFirst.Task.ID, first.Task.ID)
+	}
+	claimedOther := claimTestTask(t, store, workerA, "reserve-other", tokenB)
+	if claimedOther.Task.ID != other.Task.ID {
+		t.Fatalf("second claim = %s; want open repository task %s", claimedOther.Task.ID, other.Task.ID)
+	}
+}
+
+func TestTerminalAttemptReservesRetainedHeadroomUntilRegistration(t *testing.T) {
+	store := newTestStore(t)
+	fixed := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixed }
+	worker := registerTestWorker(t, store, workerA, 2,
+		protocol.RepositoryRegistration{
+			Key: "nearly-full", RemoteIdentity: "github.com/example/nearly-full",
+			RetainedCount: protocol.MaxRetainedPerRepo - 1,
+		},
+		protocol.RepositoryRegistration{Key: "open", RemoteIdentity: "github.com/example/open"},
+	)
+	repositories := map[string]string{}
+	for _, repository := range worker.Repositories {
+		repositories[repository.Key] = repository.ID
+	}
+	first := createTestTask(t, store, "terminal-reservation", workerA, repositories["nearly-full"])
+	fixed = fixed.Add(time.Millisecond)
+	blocked := createTestTask(t, store, "blocked-during-handoff", workerA, repositories["nearly-full"])
+	fixed = fixed.Add(time.Millisecond)
+	other := createTestTask(t, store, "other-during-handoff", workerA, repositories["open"])
+
+	claim := claimTestTask(t, store, workerA, "terminal-reservation", tokenA)
+	if claim.Task.ID != first.Task.ID {
+		t.Fatalf("first claim = %s; want %s", claim.Task.ID, first.Task.ID)
+	}
+	if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "failed", Error: "retained",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	next := claimTestTask(t, store, workerA, "other-repository", tokenB)
+	if next.Task.ID != other.Task.ID {
+		t.Fatalf("terminal handoff admitted %s; want other repository %s", next.Task.ID, other.Task.ID)
+	}
+	blockedDetail, err := store.Task(context.Background(), blocked.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blockedDetail.Execution.State != "queued" || len(blockedDetail.Attempts) != 0 {
+		t.Fatalf("terminal handoff failed to reserve capacity: %#v", blockedDetail)
+	}
+
+	fixed = fixed.Add(time.Millisecond)
+	registerTestWorker(t, store, workerA, 2,
+		protocol.RepositoryRegistration{
+			Key: "nearly-full", RemoteIdentity: "github.com/example/nearly-full",
+			RetainedCount: protocol.MaxRetainedPerRepo,
+		},
+		protocol.RepositoryRegistration{Key: "open", RemoteIdentity: "github.com/example/open"},
+	)
+}
+
 func TestConcurrentSQLiteClaimsCreateOneOwner(t *testing.T) {
 	store := newTestStore(t)
 	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -509,6 +509,99 @@ func TestTerminalAttemptReservesRetainedHeadroomUntilRegistration(t *testing.T) 
 	)
 }
 
+func TestRegistrationAcknowledgesSameMillisecondTerminalHandoff(t *testing.T) {
+	store := newTestStore(t)
+	fixed := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixed }
+	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+		Key: "nearly-full", RemoteIdentity: "github.com/example/same-millisecond",
+		RetainedCount: protocol.MaxRetainedPerRepo - 1,
+	})
+	first := createTestTask(t, store, "same-millisecond-first", workerA, worker.Repositories[0].ID)
+	fixed = fixed.Add(time.Millisecond)
+	second := createTestTask(t, store, "same-millisecond-second", workerA, worker.Repositories[0].ID)
+	fixed = fixed.Add(time.Millisecond)
+	claim := claimTestTask(t, store, workerA, "same-millisecond-first", tokenA)
+	if claim.Task.ID != first.Task.ID {
+		t.Fatalf("first claim = %s; want %s", claim.Task.ID, first.Task.ID)
+	}
+	if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "failed", Error: "no worktree was created",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+		RequestID: "same-millisecond-blocked", LeaseToken: tokenB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != nil {
+		t.Fatalf("terminal attempt was not reserved before registration: %#v", blocked)
+	}
+
+	registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+		Key: "nearly-full", RemoteIdentity: "github.com/example/same-millisecond",
+		RetainedCount: protocol.MaxRetainedPerRepo - 1,
+	})
+	next := claimTestTask(t, store, workerA, "same-millisecond-after-registration", tokenB)
+	if next.Task.ID != second.Task.ID {
+		t.Fatalf("same-millisecond registration left %s blocked; claimed %s", second.Task.ID, next.Task.ID)
+	}
+}
+
+func TestActiveRegistrationDoesNotAcknowledgeSweptAttempt(t *testing.T) {
+	store := newTestStore(t)
+	fixed := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixed }
+	repository := protocol.RepositoryRegistration{
+		Key: "nearly-full", RemoteIdentity: "github.com/example/swept-handoff",
+		RetainedCount: protocol.MaxRetainedPerRepo - 1,
+	}
+	worker := registerTestWorker(t, store, workerA, 2, repository)
+	first := createTestTask(t, store, "swept-handoff-first", workerA, worker.Repositories[0].ID)
+	fixed = fixed.Add(time.Millisecond)
+	second := createTestTask(t, store, "swept-handoff-second", workerA, worker.Repositories[0].ID)
+	claim := claimTestTask(t, store, workerA, "swept-handoff-first", tokenA)
+	if claim.Task.ID != first.Task.ID {
+		t.Fatalf("first claim = %s; want %s", claim.Task.ID, first.Task.ID)
+	}
+	fixed = fixed.Add(protocol.LeaseDuration + time.Millisecond)
+	expired, err := store.SweepExpired(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(expired) != 1 || expired[0].AttemptID != claim.Attempt.ID {
+		t.Fatalf("swept attempts = %#v", expired)
+	}
+	if _, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+		Name: "worker-a", WorkerVersion: "test", CodexVersion: "test",
+		Capacity: 2, ActiveCount: 1, Health: "healthy", Repositories: []protocol.RepositoryRegistration{repository},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+		RequestID: "swept-handoff-blocked", LeaseToken: tokenB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != nil {
+		t.Fatalf("active registration acknowledged an unclassified swept attempt: %#v", blocked)
+	}
+
+	if _, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+		Name: "worker-a", WorkerVersion: "test", CodexVersion: "test",
+		Capacity: 2, ActiveCount: 0, Health: "healthy", Repositories: []protocol.RepositoryRegistration{repository},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	next := claimTestTask(t, store, workerA, "swept-handoff-after-idle", tokenB)
+	if next.Task.ID != second.Task.ID {
+		t.Fatalf("idle registration left swept handoff blocked; claimed %s, want %s", next.Task.ID, second.Task.ID)
+	}
+}
+
 func TestConcurrentSQLiteClaimsCreateOneOwner(t *testing.T) {
 	store := newTestStore(t)
 	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -602,6 +602,149 @@ func TestActiveRegistrationDoesNotAcknowledgeSweptAttempt(t *testing.T) {
 	}
 }
 
+func TestLegacyRegistrationDerivesRetainedCountBeforeAcknowledgingHandoff(t *testing.T) {
+	store := newTestStore(t)
+	fixed := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixed }
+	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/example/legacy-worker",
+	})
+	first := createTestTask(t, store, "legacy-worker-first", workerA, worker.Repositories[0].ID)
+	fixed = fixed.Add(time.Millisecond)
+	second := createTestTask(t, store, "legacy-worker-second", workerA, worker.Repositories[0].ID)
+	claim := claimTestTask(t, store, workerA, "legacy-worker-first", tokenA)
+	if claim.Task.ID != first.Task.ID {
+		t.Fatalf("first claim = %s; want %s", claim.Task.ID, first.Task.ID)
+	}
+	if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "failed", Error: "legacy retained worktree",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	retained := make([]protocol.RetainedWorktree, protocol.MaxRetainedPerRepo)
+	for index := range retained {
+		retained[index] = protocol.RetainedWorktree{
+			AttemptID:    fmt.Sprintf("legacy-attempt-%d", index),
+			RepositoryID: worker.Repositories[0].ID,
+			Path:         fmt.Sprintf("/tmp/legacy-%d", index),
+			Reason:       "legacy retained worktree",
+		}
+	}
+	registered, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+		Name: "legacy-worker", WorkerVersion: "legacy", CodexVersion: "test",
+		Capacity: 2, ActiveCount: 0, Health: "healthy",
+		Repositories: []protocol.RepositoryRegistration{{
+			Key: "factory", RemoteIdentity: "github.com/example/legacy-worker",
+			RetainedCount: 0,
+		}},
+		RetainedWorktrees: retained,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if registered.Repositories[0].RetainedCount != protocol.MaxRetainedPerRepo {
+		t.Fatalf("derived retained count = %d", registered.Repositories[0].RetainedCount)
+	}
+	blocked, err := store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+		RequestID: "legacy-worker-blocked", LeaseToken: tokenB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != nil {
+		t.Fatalf("legacy registration bypassed retained capacity: %#v", blocked)
+	}
+	detail, err := store.Task(context.Background(), second.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Execution.State != "queued" || len(detail.Attempts) != 0 {
+		t.Fatalf("legacy retained capacity did not keep task queued: %#v", detail)
+	}
+}
+
+func TestActiveLegacyRegistrationCannotAcknowledgeUnlistedHandoff(t *testing.T) {
+	store := newTestStore(t)
+	fixed := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixed }
+	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/example/legacy-overlap",
+	})
+	retained := make([]protocol.RetainedWorktree, protocol.MaxRetainedPerRepo-1)
+	for index := range retained {
+		retained[index] = protocol.RetainedWorktree{
+			AttemptID:    fmt.Sprintf("legacy-existing-%d", index),
+			RepositoryID: worker.Repositories[0].ID,
+			Path:         fmt.Sprintf("/tmp/legacy-existing-%d", index),
+			Reason:       "legacy retained worktree",
+		}
+	}
+	legacyRegistration := protocol.WorkerRegistration{
+		Name: "legacy-worker", WorkerVersion: "legacy", CodexVersion: "test",
+		Capacity: 2, ActiveCount: 0, Health: "healthy",
+		Repositories: []protocol.RepositoryRegistration{{
+			Key: "factory", RemoteIdentity: "github.com/example/legacy-overlap",
+		}},
+		RetainedWorktrees: retained,
+	}
+	if _, err := store.RegisterWorker(context.Background(), workerA, legacyRegistration); err != nil {
+		t.Fatal(err)
+	}
+	first := createTestTask(t, store, "legacy-overlap-first", workerA, worker.Repositories[0].ID)
+	fixed = fixed.Add(time.Millisecond)
+	second := createTestTask(t, store, "legacy-overlap-second", workerA, worker.Repositories[0].ID)
+	claim := claimTestTask(t, store, workerA, "legacy-overlap-first", tokenA)
+	if claim.Task.ID != first.Task.ID {
+		t.Fatalf("first claim = %s; want %s", claim.Task.ID, first.Task.ID)
+	}
+	if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "failed", Error: "legacy worktree not yet summarized",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	legacyRegistration.ActiveCount = 1
+	if _, err := store.RegisterWorker(context.Background(), workerA, legacyRegistration); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+		RequestID: "legacy-overlap-blocked", LeaseToken: tokenB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != nil {
+		t.Fatalf("active legacy snapshot acknowledged an unlisted handoff: %#v", blocked)
+	}
+
+	legacyRegistration.RetainedWorktrees = append(legacyRegistration.RetainedWorktrees, protocol.RetainedWorktree{
+		AttemptID: claim.Attempt.ID, RepositoryID: worker.Repositories[0].ID,
+		Path: "/tmp/legacy-new", Reason: "legacy retained worktree",
+	})
+	registered, err := store.RegisterWorker(context.Background(), workerA, legacyRegistration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if registered.Repositories[0].RetainedCount != protocol.MaxRetainedPerRepo {
+		t.Fatalf("legacy retained count after handoff = %d", registered.Repositories[0].RetainedCount)
+	}
+	blocked, err = store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+		RequestID: "legacy-overlap-still-full", LeaseToken: tokenB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != nil {
+		t.Fatalf("legacy retained repository exceeded capacity: %#v", blocked)
+	}
+	detail, err := store.Task(context.Background(), second.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Execution.State != "queued" || len(detail.Attempts) != 0 {
+		t.Fatalf("legacy overlap task did not remain queued: %#v", detail)
+	}
+}
+
 func TestConcurrentSQLiteClaimsCreateOneOwner(t *testing.T) {
 	store := newTestStore(t)
 	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/owainlewis/factory/internal/protocol"
+	"github.com/owainlewis/factory/migrations"
 )
 
 const (
@@ -34,6 +36,268 @@ func newTestStore(t *testing.T) *Store {
 		}
 	})
 	return store
+}
+
+func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing.T) {
+	database, err := sql.Open("sqlite", t.TempDir()+"/migration.sqlite3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	schema, err := migrations.Files.ReadFile("001_controlplane.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(string(schema)); err != nil {
+		t.Fatal(err)
+	}
+	retained := make([]protocol.RetainedWorktree, protocol.MaxRetainedPerRepo-1)
+	for index := range retained {
+		retained[index] = protocol.RetainedWorktree{
+			AttemptID:    fmt.Sprintf("00000000-0000-4000-8000-%012d", index),
+			RepositoryID: "legacy-repository",
+			Path:         fmt.Sprintf("/tmp/legacy-%d", index),
+			Reason:       "legacy retained worktree",
+		}
+	}
+	retainedJSON, err := json.Marshal(retained)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`
+		INSERT INTO workers(
+			id, name, worker_version, codex_version, capacity, active_count, health,
+			retained_worktrees_json, registered_at, last_heartbeat
+		) VALUES ('worker-a', 'legacy', 'legacy', 'legacy', 2, 0, 'healthy', ?, 100, 100)
+	`, retainedJSON); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`
+		INSERT INTO workers(
+			id, name, worker_version, codex_version, capacity, active_count, health,
+			retained_worktrees_json, registered_at, last_heartbeat
+		) VALUES (
+			'worker-b', 'legacy-invalid', 'legacy', 'legacy', 1, 0, 'healthy',
+			'[{"attempt_id":"stale-attempt","repository_id":"stale-repository"}]',
+			100, 100
+		)
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`
+		INSERT INTO workers(
+			id, name, worker_version, codex_version, capacity, active_count, health,
+			retained_worktrees_json, registered_at, last_heartbeat
+		) VALUES (
+			'worker-c', 'legacy-malformed', 'legacy', 'legacy', 1, 0, 'healthy',
+			'not-json', 100, 100
+		)
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`
+		INSERT INTO schema_migrations(version, applied_at) VALUES (1, 1);
+		INSERT INTO repositories(id, remote_identity, created_at)
+		VALUES ('legacy-repository', 'github.com/example/migration', 1);
+		INSERT INTO repositories(id, remote_identity, created_at)
+		VALUES ('invalid-repository', 'github.com/example/invalid-migration', 1);
+		INSERT INTO repositories(id, remote_identity, created_at)
+		VALUES ('malformed-repository', 'github.com/example/malformed-migration', 1);
+		INSERT INTO worker_repositories(
+			worker_id, display_key, repository_id, retained_count, advertised, updated_at
+		) VALUES ('worker-a', 'factory', 'legacy-repository', 0, 1, 1);
+		INSERT INTO worker_repositories(
+			worker_id, display_key, repository_id, retained_count, advertised, updated_at
+		) VALUES ('worker-b', 'invalid', 'invalid-repository', 0, 1, 1);
+		INSERT INTO worker_repositories(
+			worker_id, display_key, repository_id, retained_count, advertised, updated_at
+		) VALUES ('worker-c', 'malformed', 'malformed-repository', 0, 1, 1);
+		INSERT INTO tasks(
+			id, request_key, title, description, repository_id, timeout_seconds, created_at
+		) VALUES ('historical-task', 'historical-task', 'historical', '', 'legacy-repository', 60, 1);
+		INSERT INTO tasks(
+			id, request_key, title, description, repository_id, timeout_seconds, created_at
+		) VALUES (
+			'invalid-task', 'invalid-task', 'invalid', '', 'invalid-repository', 60, 3
+		);
+		INSERT INTO tasks(
+			id, request_key, title, description, repository_id, timeout_seconds, created_at
+		) VALUES (
+			'malformed-task', 'malformed-task', 'malformed', '', 'malformed-repository', 60, 4
+		);
+		INSERT INTO executions(
+			id, task_id, assigned_worker_id, required_runtime, state,
+			cancellation_requested, created_at, updated_at
+		) VALUES ('historical-execution', 'historical-task', 'worker-a', 'codex', 'failed', 0, 1, 1);
+		INSERT INTO executions(
+			id, task_id, assigned_worker_id, required_runtime, state,
+			cancellation_requested, created_at, updated_at
+		) VALUES (
+			'invalid-execution', 'invalid-task', 'worker-b', 'codex', 'failed', 0, 3, 3
+		);
+		INSERT INTO executions(
+			id, task_id, assigned_worker_id, required_runtime, state,
+			cancellation_requested, created_at, updated_at
+		) VALUES (
+			'malformed-execution', 'malformed-task', 'worker-c', 'codex', 'failed', 0, 4, 4
+		);
+		INSERT INTO attempts(
+			id, execution_id, worker_id, attempt_number, state, lease_digest,
+			lease_expires_at, error, completed_at, created_at
+		) VALUES (
+			'historical-attempt', 'historical-execution', 'worker-a', 1, 'failed',
+			X'00', 1, 'legacy failure', 1, 1
+		);
+		INSERT INTO attempts(
+			id, execution_id, worker_id, attempt_number, state, lease_digest,
+			lease_expires_at, error, completed_at, created_at
+		) VALUES (
+			'invalid-attempt', 'invalid-execution', 'worker-b', 1, 'failed',
+			X'00', 1, 'legacy invalid snapshot', 3, 3
+		);
+		INSERT INTO attempts(
+			id, execution_id, worker_id, attempt_number, state, lease_digest,
+			lease_expires_at, error, completed_at, created_at
+		) VALUES (
+			'malformed-attempt', 'malformed-execution', 'worker-c', 1, 'failed',
+			X'00', 1, 'legacy malformed snapshot', 4, 4
+		);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	now := time.UnixMilli(100)
+	store := &Store{db: database, now: func() time.Time { return now }, sweepEvery: 5 * time.Second}
+	if err := store.migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	var retainedCount, acknowledged int
+	if err := database.QueryRow(`
+		SELECT retained_count FROM worker_repositories
+		WHERE worker_id = 'worker-a' AND repository_id = 'legacy-repository'
+	`).Scan(&retainedCount); err != nil {
+		t.Fatal(err)
+	}
+	if retainedCount != protocol.MaxRetainedPerRepo-1 {
+		t.Fatalf("migrated retained count = %d", retainedCount)
+	}
+	if err := database.QueryRow(`
+		SELECT COUNT(*) FROM attempts WHERE capacity_acknowledged = 1
+	`).Scan(&acknowledged); err != nil {
+		t.Fatal(err)
+	}
+	if acknowledged != 1 {
+		t.Fatalf("migrated acknowledged attempts = %d; want 1", acknowledged)
+	}
+	createTestTask(t, store, "post-migration-task", workerA, "legacy-repository")
+	claim := claimTestTask(t, store, workerA, "post-migration-claim", tokenA)
+	if claim.Task.RequestKey != "post-migration-task" {
+		t.Fatalf("post-migration claim selected %q", claim.Task.RequestKey)
+	}
+}
+
+func TestCapacityMigrationRequiresDrainedLegacyWorkers(t *testing.T) {
+	database, err := sql.Open("sqlite", t.TempDir()+"/active-migration.sqlite3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	schema, err := migrations.Files.ReadFile("001_controlplane.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(string(schema)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(`
+		INSERT INTO schema_migrations(version, applied_at) VALUES (1, 1);
+		INSERT INTO workers(
+			id, name, worker_version, codex_version, capacity, active_count, health,
+			retained_worktrees_json, registered_at, last_heartbeat
+		) VALUES ('worker-a', 'legacy', 'legacy', 'legacy', 1, 1, 'healthy', '[]', 1, 1);
+		INSERT INTO repositories(id, remote_identity, created_at)
+		VALUES ('legacy-repository', 'github.com/example/active-migration', 1);
+		INSERT INTO tasks(
+			id, request_key, title, description, repository_id, timeout_seconds, created_at
+		) VALUES ('active-task', 'active-task', 'active', '', 'legacy-repository', 60, 1);
+		INSERT INTO executions(
+			id, task_id, assigned_worker_id, required_runtime, state,
+			cancellation_requested, created_at, updated_at
+		) VALUES ('active-execution', 'active-task', 'worker-a', 'codex', 'running', 0, 1, 1);
+		INSERT INTO attempts(
+			id, execution_id, worker_id, attempt_number, state, lease_digest,
+			lease_expires_at, started_at, created_at
+		) VALUES (
+			'active-attempt', 'active-execution', 'worker-a', 1, 'running',
+			X'00', 100, 1, 1
+		);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	store := &Store{db: database, now: time.Now, sweepEvery: 5 * time.Second}
+	err = store.migrate(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "drain_active_v2_attempts_before_upgrade") {
+		t.Fatalf("active migration error = %v", err)
+	}
+	var capacityColumn int
+	rows, err := database.Query(`PRAGMA table_info(attempts)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatal(err)
+		}
+		if name == "capacity_acknowledged" {
+			capacityColumn++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if capacityColumn != 0 {
+		t.Fatal("failed drain guard left a partial capacity migration")
+	}
+	if _, err := database.Exec(`
+		UPDATE attempts
+		SET state = 'failed', error = 'legacy terminal result', completed_at = 2
+		WHERE id = 'active-attempt';
+		UPDATE executions
+		SET state = 'failed', updated_at = 2
+		WHERE id = 'active-execution';
+	`); err != nil {
+		t.Fatal(err)
+	}
+	err = store.migrate(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "drain_active_v2_attempts_before_upgrade") {
+		t.Fatalf("stale active-count migration error = %v", err)
+	}
+	if _, err := database.Exec(`UPDATE workers SET active_count = 0 WHERE id = 'worker-a'`); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRow(`
+		SELECT COUNT(*) FROM pragma_table_info('attempts')
+		WHERE name = 'capacity_acknowledged'
+	`).Scan(&capacityColumn); err != nil {
+		t.Fatal(err)
+	}
+	if capacityColumn != 1 {
+		t.Fatalf("drained retry capacity columns = %d; want 1", capacityColumn)
+	}
 }
 
 func registerTestWorker(t *testing.T, store *Store, id string, capacity int, repositories ...protocol.RepositoryRegistration) protocol.Worker {
@@ -742,6 +1006,219 @@ func TestActiveLegacyRegistrationCannotAcknowledgeUnlistedHandoff(t *testing.T) 
 	}
 	if detail.Execution.State != "queued" || len(detail.Attempts) != 0 {
 		t.Fatalf("legacy overlap task did not remain queued: %#v", detail)
+	}
+}
+
+func TestActiveRegistrationAcknowledgesExplicitDisposedAttempt(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/example/explicit-disposal",
+	})
+	first := createTestTask(t, store, "explicit-disposal-first", workerA, worker.Repositories[0].ID)
+	claim := claimTestTask(t, store, workerA, "explicit-disposal-first", tokenA)
+	if claim.Task.ID != first.Task.ID {
+		t.Fatalf("first claim = %s; want %s", claim.Task.ID, first.Task.ID)
+	}
+	if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "failed", Error: "disposed without a worktree",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second := createTestTask(t, store, "explicit-disposal-second", workerA, worker.Repositories[0].ID)
+
+	if _, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+		Name: "modern-worker", WorkerVersion: "test", CodexVersion: "test",
+		Capacity: 2, ActiveCount: 1, Health: "healthy",
+		Repositories: []protocol.RepositoryRegistration{{
+			Key: "factory", RemoteIdentity: "github.com/example/explicit-disposal",
+			RetainedCount: protocol.MaxRetainedPerRepo - 1,
+		}},
+		DisposedAttemptIDs: []string{claim.Attempt.ID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	next := claimTestTask(t, store, workerA, "explicit-disposal-second", tokenB)
+	if next.Task.ID != second.Task.ID {
+		t.Fatalf("claim after disposal = %s; want %s", next.Task.ID, second.Task.ID)
+	}
+}
+
+func TestVersionedRegistrationDoesNotBulkAcknowledgeUnlistedAttempt(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/example/versioned-handoff",
+	})
+	createTestTask(t, store, "versioned-handoff-first", workerA, worker.Repositories[0].ID)
+	claim := claimTestTask(t, store, workerA, "versioned-handoff-first", tokenA)
+	if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "failed", Error: "disposition not published",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	createTestTask(t, store, "versioned-handoff-second", workerA, worker.Repositories[0].ID)
+
+	if _, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+		Name: "modern-worker", WorkerVersion: "test", CodexVersion: "test",
+		Capacity: 2, ActiveCount: 0, Health: "healthy", CapacityHandoffVersion: 1,
+		Repositories: []protocol.RepositoryRegistration{{
+			Key: "factory", RemoteIdentity: "github.com/example/versioned-handoff",
+			RetainedCount: protocol.MaxRetainedPerRepo - 1,
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+		RequestID: "versioned-handoff-blocked", LeaseToken: tokenB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != nil {
+		t.Fatalf("versioned snapshot bulk-acknowledged an unlisted attempt: %#v", blocked)
+	}
+}
+
+func TestRegistrationCanPreAcknowledgeDisposedAttemptBeforeLeaseSweep(t *testing.T) {
+	store := newTestStore(t)
+	fixed := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return fixed }
+	worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/example/preacknowledged-disposal",
+	})
+	createTestTask(t, store, "preacknowledged-first", workerA, worker.Repositories[0].ID)
+	claim := claimTestTask(t, store, workerA, "preacknowledged-first", tokenA)
+	second := createTestTask(t, store, "preacknowledged-second", workerA, worker.Repositories[0].ID)
+
+	registration := protocol.WorkerRegistration{
+		Name: "modern-worker", WorkerVersion: "test", CodexVersion: "test",
+		Capacity: 2, ActiveCount: 1, Health: "healthy", CapacityHandoffVersion: 1,
+		Repositories: []protocol.RepositoryRegistration{{
+			Key: "factory", RemoteIdentity: "github.com/example/preacknowledged-disposal",
+			RetainedCount: protocol.MaxRetainedPerRepo - 1,
+		}},
+		DisposedAttemptIDs: []string{claim.Attempt.ID},
+	}
+	if _, err := store.RegisterWorker(context.Background(), workerA, registration); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+		RequestID: "preacknowledged-active-blocked", LeaseToken: tokenB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != nil {
+		t.Fatalf("disposed active attempt stopped reserving active capacity: %#v", blocked)
+	}
+
+	fixed = fixed.Add(protocol.LeaseDuration + time.Millisecond)
+	blocked, err = store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+		RequestID: "preacknowledged-expired-blocked", LeaseToken: tokenB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blocked != nil {
+		t.Fatalf("expired attempt stopped reserving capacity before sweep: %#v", blocked)
+	}
+	if _, err := store.SweepExpired(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	registration.ActiveCount = 0
+	registration.DisposedAttemptIDs = nil
+	if _, err := store.RegisterWorker(context.Background(), workerA, registration); err != nil {
+		t.Fatal(err)
+	}
+	next := claimTestTask(t, store, workerA, "preacknowledged-after-sweep", tokenB)
+	if next.Task.ID != second.Task.ID {
+		t.Fatalf("claim after sweep = %s; want %s", next.Task.ID, second.Task.ID)
+	}
+}
+
+func TestRegistrationRejectsUnknownDisposedAttempt(t *testing.T) {
+	store := newTestStore(t)
+	registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/example/unproven-disposal",
+	})
+
+	_, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+		Name: "modern-worker", WorkerVersion: "test", CodexVersion: "test",
+		Capacity: 2, ActiveCount: 1, Health: "healthy",
+		Repositories: []protocol.RepositoryRegistration{{
+			Key: "factory", RemoteIdentity: "github.com/example/unproven-disposal",
+		}},
+		DisposedAttemptIDs: []string{"missing-attempt"},
+	})
+	assertErrorCode(t, err, "invalid_disposed_attempts")
+}
+
+func TestUnattributedRetainedSummaryPreservesRegistrationContractWithoutAcknowledgingHandoff(t *testing.T) {
+	testCases := []struct {
+		name         string
+		repositoryID string
+	}{
+		{name: "display-only"},
+		{name: "unadvertised-repository", repositoryID: "stale-repository-id"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			store := newTestStore(t)
+			remote := "github.com/example/" + testCase.name
+			worker := registerTestWorker(t, store, workerA, 2, protocol.RepositoryRegistration{
+				Key: "factory", RemoteIdentity: remote,
+			})
+			first := createTestTask(t, store, testCase.name+"-first", workerA, worker.Repositories[0].ID)
+			claim := claimTestTask(t, store, workerA, testCase.name+"-first", tokenA)
+			if claim.Task.ID != first.Task.ID {
+				t.Fatalf("first claim = %s; want %s", claim.Task.ID, first.Task.ID)
+			}
+			if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+				LeaseToken: tokenA, State: "failed", Error: "retained before repository attribution",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			second := createTestTask(t, store, testCase.name+"-second", workerA, worker.Repositories[0].ID)
+
+			registered, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+				Name: "legacy-display-client", WorkerVersion: "legacy", CodexVersion: "test",
+				Capacity: 2, ActiveCount: 0, Health: "healthy",
+				Repositories: []protocol.RepositoryRegistration{{
+					Key: "factory", RemoteIdentity: remote,
+					RetainedCount: protocol.MaxRetainedPerRepo - 1,
+				}},
+				RetainedWorktrees: []protocol.RetainedWorktree{{
+					AttemptID:    claim.Attempt.ID,
+					RepositoryID: testCase.repositoryID,
+					Path:         "/tmp/" + testCase.name,
+					Reason:       "repository ID is not attributable",
+				}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(registered.RetainedWorktrees) != 1 {
+				t.Fatalf("unattributed summaries = %d; want 1", len(registered.RetainedWorktrees))
+			}
+			if registered.Repositories[0].RetainedCount != protocol.MaxRetainedPerRepo-1 {
+				t.Fatalf("unattributed summary changed retained count to %d", registered.Repositories[0].RetainedCount)
+			}
+			blocked, err := store.Claim(context.Background(), workerA, protocol.ClaimRequest{
+				RequestID: testCase.name + "-blocked", LeaseToken: tokenB,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if blocked != nil {
+				t.Fatalf("unattributed summary acknowledged the handoff: %#v", blocked)
+			}
+			detail, err := store.Task(context.Background(), second.Task.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if detail.Execution.State != "queued" || len(detail.Attempts) != 0 {
+				t.Fatalf("unattributed summary did not keep task queued: %#v", detail)
+			}
+		})
 	}
 }
 

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -37,14 +37,16 @@ type RetainedWorktree struct {
 }
 
 type WorkerRegistration struct {
-	Name              string                   `json:"name"`
-	WorkerVersion     string                   `json:"worker_version"`
-	CodexVersion      string                   `json:"codex_version"`
-	Capacity          int                      `json:"capacity"`
-	ActiveCount       int                      `json:"active_count"`
-	Health            string                   `json:"health"`
-	Repositories      []RepositoryRegistration `json:"repositories"`
-	RetainedWorktrees []RetainedWorktree       `json:"retained_worktrees"`
+	Name                   string                   `json:"name"`
+	WorkerVersion          string                   `json:"worker_version"`
+	CodexVersion           string                   `json:"codex_version"`
+	Capacity               int                      `json:"capacity"`
+	ActiveCount            int                      `json:"active_count"`
+	Health                 string                   `json:"health"`
+	Repositories           []RepositoryRegistration `json:"repositories"`
+	RetainedWorktrees      []RetainedWorktree       `json:"retained_worktrees"`
+	CapacityHandoffVersion int                      `json:"capacity_handoff_version,omitempty"`
+	DisposedAttemptIDs     []string                 `json:"disposed_attempt_ids,omitempty"`
 }
 
 type Repository struct {

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -109,14 +109,13 @@ func Cleanup(config Config, options CleanupOptions, output io.Writer) error {
 	if !inspection.PathExists {
 		return errors.New("refuse cleanup because the retained worktree is absent")
 	}
-	if manifest.Lifecycle != manifestCleanupStarted {
-		if _, err := store.update(manifest.AttemptID, func(value *attemptManifest) error {
-			value.Lifecycle = manifestCleanupStarted
-			value.CleanupResult = "operator confirmed cleanup"
-			return nil
-		}); err != nil {
-			return err
-		}
+	if _, err := store.update(manifest.AttemptID, func(value *attemptManifest) error {
+		value.Lifecycle = manifestCleanupStarted
+		value.CleanupIntent = cleanupIntentOperator
+		value.CleanupResult = "operator confirmed cleanup"
+		return nil
+	}); err != nil {
+		return err
 	}
 	manifest, err = store.load(options.AttemptID)
 	if err != nil {

--- a/internal/worker/cleanup.go
+++ b/internal/worker/cleanup.go
@@ -1,0 +1,187 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type CleanupOptions struct {
+	AttemptID     string
+	Confirm       bool
+	GitExecutable string
+}
+
+type cleanupPreview struct {
+	Manifest           attemptManifest `json:"manifest"`
+	RepositoryIdentity string          `json:"repository_identity"`
+	Branch             string          `json:"branch"`
+	Commit             string          `json:"commit,omitempty"`
+	GitStatus          string          `json:"git_status"`
+	Reason             string          `json:"reason"`
+	PathExists         bool            `json:"path_exists"`
+	GitRegistered      bool            `json:"git_registered"`
+}
+
+func Cleanup(config Config, options CleanupOptions, output io.Writer) error {
+	if err := ensureSupportedPlatform(); err != nil {
+		return err
+	}
+	if err := validateConfig(config); err != nil {
+		return err
+	}
+	if !uuidPattern.MatchString(options.AttemptID) {
+		return errors.New("cleanup requires a valid attempt ID")
+	}
+	if options.GitExecutable == "" {
+		options.GitExecutable = "git"
+	}
+	if output == nil {
+		output = os.Stdout
+	}
+	dataDirectory, err := resolveDataDirectory(config.DataDirectory)
+	if err != nil {
+		return err
+	}
+	lock, err := lockDataDirectory(dataDirectory)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	workerID, err := loadWorkerID(dataDirectory)
+	if err != nil {
+		return err
+	}
+	store := newManifestStore(dataDirectory, workerID)
+	manifest, err := store.load(options.AttemptID)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*gitCommandTimeout)
+	defer cancel()
+	inspection, inspectErr := inspectManifestWorktree(ctx, options.GitExecutable, dataDirectory, manifest)
+	preview := cleanupPreview{
+		Manifest: manifest, RepositoryIdentity: manifest.RemoteIdentity, Branch: manifest.Branch,
+		Reason: manifest.RetentionReason, PathExists: inspection.PathExists,
+		GitRegistered: inspection.Registered,
+	}
+	if inspection.Registered {
+		preview.Commit = inspection.Entry.Head
+	}
+	if inspectErr != nil || !inspection.PathExists || !inspection.Registered {
+		preview.GitStatus = "unavailable"
+	} else if inspection.Status == "" {
+		preview.GitStatus = "clean"
+	} else {
+		preview.GitStatus = inspection.Status
+	}
+	if err := writeCleanupPreview(output, preview); err != nil {
+		return err
+	}
+	if inspectErr != nil {
+		return inspectErr
+	}
+	if !options.Confirm {
+		return nil
+	}
+	if manifest.ProcessActive {
+		return errors.New("refuse cleanup while the manifest has unreconciled process identity")
+	}
+	if manifest.Lifecycle != manifestRetained && manifest.Lifecycle != manifestCleanupStarted {
+		return fmt.Errorf("attempt lifecycle %q is not eligible for cleanup", manifest.Lifecycle)
+	}
+	if !inspection.PathExists && !inspection.Registered && manifest.Lifecycle == manifestCleanupStarted {
+		_, err := store.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = manifestCleaned
+			value.CleanupResult = "confirmed cleanup found the worktree already absent"
+			value.RetentionReason = ""
+			return nil
+		})
+		return err
+	}
+	if inspection.PathExists != inspection.Registered {
+		return errors.New("refuse cleanup because filesystem and Git worktree identity disagree")
+	}
+	if !inspection.PathExists {
+		return errors.New("refuse cleanup because the retained worktree is absent")
+	}
+	if manifest.Lifecycle != manifestCleanupStarted {
+		if _, err := store.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = manifestCleanupStarted
+			value.CleanupResult = "operator confirmed cleanup"
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	manifest, err = store.load(options.AttemptID)
+	if err != nil {
+		return err
+	}
+	inspection, err = inspectManifestWorktree(ctx, options.GitExecutable, dataDirectory, manifest)
+	if err != nil {
+		return err
+	}
+	if err := removeInspectedWorktree(ctx, options.GitExecutable, inspection, true); err != nil {
+		return err
+	}
+	_, err = store.update(manifest.AttemptID, func(value *attemptManifest) error {
+		value.Lifecycle = manifestCleaned
+		value.CleanupResult = "operator cleanup completed"
+		value.RetentionReason = ""
+		return nil
+	})
+	if err == nil {
+		_, _ = fmt.Fprintf(output, "cleanup confirmed for attempt %s; branch %s was preserved\n",
+			manifest.AttemptID, manifest.Branch)
+	}
+	return err
+}
+
+func writeCleanupPreview(output io.Writer, preview cleanupPreview) error {
+	body, err := json.MarshalIndent(preview, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode cleanup preview: %w", err)
+	}
+	if _, err := output.Write(append(body, '\n')); err != nil {
+		return fmt.Errorf("write cleanup preview: %w", err)
+	}
+	return nil
+}
+
+func ParseCleanupArguments(arguments []string, defaultConfig string) (string, CleanupOptions, error) {
+	configPath := defaultConfig
+	options := CleanupOptions{}
+	for index := 0; index < len(arguments); index++ {
+		argument := arguments[index]
+		switch {
+		case argument == "--confirm":
+			options.Confirm = true
+		case argument == "--config":
+			index++
+			if index >= len(arguments) {
+				return "", CleanupOptions{}, errors.New("--config requires a path")
+			}
+			configPath = arguments[index]
+		case strings.HasPrefix(argument, "--config="):
+			configPath = strings.TrimPrefix(argument, "--config=")
+			if configPath == "" {
+				return "", CleanupOptions{}, errors.New("--config requires a path")
+			}
+		case strings.HasPrefix(argument, "-"):
+			return "", CleanupOptions{}, fmt.Errorf("unknown cleanup option %q", argument)
+		case options.AttemptID == "":
+			options.AttemptID = argument
+		default:
+			return "", CleanupOptions{}, fmt.Errorf("unexpected cleanup argument %q", argument)
+		}
+	}
+	if options.AttemptID == "" {
+		return "", CleanupOptions{}, errors.New("usage: factory-worker cleanup ATTEMPT_ID [--confirm] [--config PATH]")
+	}
+	return configPath, options, nil
+}

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -72,6 +72,12 @@ func (client *client) heartbeat(ctx context.Context, attemptID, token string) (p
 	return heartbeat, err
 }
 
+func (client *client) attempt(ctx context.Context, attemptID string) (protocol.Attempt, error) {
+	var attempt protocol.Attempt
+	_, err := client.request(ctx, http.MethodGet, "/api/v1/attempts/"+url.PathEscape(attemptID), nil, &attempt)
+	return attempt, err
+}
+
 func (client *client) events(ctx context.Context, attemptID string, input protocol.EventBatchRequest) error {
 	_, err := client.request(ctx, http.MethodPost, "/api/v1/attempts/"+url.PathEscape(attemptID)+"/events", input, nil)
 	return err

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	MaxConcurrent int                         `toml:"max_concurrent"`
 	DataDirectory string                      `toml:"data_directory"`
 	Repositories  map[string]RepositoryConfig `toml:"repositories"`
+	path          string
 }
 
 type Repository struct {
@@ -68,6 +69,10 @@ func LoadConfig(path string) (Config, error) {
 			repository.Path = filepath.Join(filepath.Dir(path), repository.Path)
 			config.Repositories[key] = repository
 		}
+	}
+	config.path, err = filepath.Abs(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve worker configuration path: %w", err)
 	}
 	return config, validateConfig(config)
 }

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -217,6 +217,17 @@ func normalizeHostPath(host, path string) string {
 }
 
 func createWorktree(ctx context.Context, gitExecutable, root string, repository Repository, taskID, attemptID string) (worktree, error) {
+	value, err := prepareWorktree(ctx, gitExecutable, root, repository, taskID, attemptID)
+	if err != nil {
+		return value, err
+	}
+	if err := addPreparedWorktree(ctx, gitExecutable, repository, value); err != nil {
+		return value, err
+	}
+	return value, nil
+}
+
+func prepareWorktree(ctx context.Context, gitExecutable, root string, repository Repository, taskID, attemptID string) (worktree, error) {
 	if !uuidPattern.MatchString(taskID) || !uuidPattern.MatchString(attemptID) {
 		return worktree{}, errors.New("server returned an invalid task or attempt ID")
 	}
@@ -248,12 +259,16 @@ func createWorktree(ctx context.Context, gitExecutable, root string, repository 
 	}
 	branch := "factory-v2/" + taskID[:12] + "-" + attemptID[:12]
 	value := worktree{Path: path, Branch: branch, BaseCommit: base, HeadCommit: base}
-	stdout, stderr, err = runGitCommand(ctx, gitExecutable, repository.Path, 256<<10,
-		"worktree", "add", "-b", branch, path, base)
-	if err != nil {
-		return value, commandFailure("create managed worktree", stdout, stderr, err)
-	}
 	return value, nil
+}
+
+func addPreparedWorktree(ctx context.Context, gitExecutable string, repository Repository, value worktree) error {
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 256<<10,
+		"worktree", "add", "-b", value.Branch, value.Path, value.BaseCommit)
+	if err != nil {
+		return commandFailure("create managed worktree", stdout, stderr, err)
+	}
+	return nil
 }
 
 type gitWorktreeEntry struct {

--- a/internal/worker/identity.go
+++ b/internal/worker/identity.go
@@ -51,21 +51,7 @@ func (lock *dataLock) Close() error {
 func loadOrCreateWorkerID(directory string, random io.Reader) (string, error) {
 	path := filepath.Join(directory, "worker-id")
 	if info, err := os.Lstat(path); err == nil {
-		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-			return "", errors.New("worker-id must be a regular non-symlink file")
-		}
-		if info.Mode().Perm()&0o077 != 0 {
-			return "", errors.New("worker-id permissions must not allow group or other access")
-		}
-		body, err := os.ReadFile(path)
-		if err != nil {
-			return "", fmt.Errorf("read worker ID: %w", err)
-		}
-		id := strings.TrimSpace(string(body))
-		if !uuidPattern.MatchString(id) {
-			return "", errors.New("worker-id does not contain a valid UUID")
-		}
-		return id, nil
+		return readWorkerID(path, info)
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("inspect worker ID: %w", err)
 	}
@@ -93,6 +79,36 @@ func loadOrCreateWorkerID(directory string, random io.Reader) (string, error) {
 	}
 	if err := syncDirectory(directory); err != nil {
 		return "", fmt.Errorf("sync worker ID directory: %w", err)
+	}
+	return id, nil
+}
+
+func loadWorkerID(directory string) (string, error) {
+	path := filepath.Join(directory, "worker-id")
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", errors.New("worker-id does not exist")
+		}
+		return "", fmt.Errorf("inspect worker ID: %w", err)
+	}
+	return readWorkerID(path, info)
+}
+
+func readWorkerID(path string, info os.FileInfo) (string, error) {
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("worker-id must be a regular non-symlink file")
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return "", errors.New("worker-id permissions must not allow group or other access")
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read worker ID: %w", err)
+	}
+	id := strings.TrimSpace(string(body))
+	if !uuidPattern.MatchString(id) {
+		return "", errors.New("worker-id does not contain a valid UUID")
 	}
 	return id, nil
 }

--- a/internal/worker/manager.go
+++ b/internal/worker/manager.go
@@ -81,6 +81,11 @@ type attemptHandle struct {
 	context context.Context
 	cancel  context.CancelFunc
 	done    chan struct{}
+	// heartbeatDone is closed after the heartbeat goroutine has stopped all
+	// manifest writes. doneOnce lets terminal handoff join it before runAttempt
+	// performs its final deferred cleanup.
+	heartbeatDone chan struct{}
+	doneOnce      sync.Once
 
 	mutex         sync.Mutex
 	reason        string
@@ -467,7 +472,8 @@ func (manager *Manager) cancelPendingClaimsLocked() {
 func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim, token string) {
 	attemptContext, cancel := context.WithCancel(parent)
 	handle := &attemptHandle{
-		context: attemptContext, cancel: cancel, done: make(chan struct{}), expiry: claim.Attempt.LeaseExpiresAt,
+		context: attemptContext, cancel: cancel, done: make(chan struct{}),
+		heartbeatDone: make(chan struct{}), expiry: claim.Attempt.LeaseExpiresAt,
 	}
 	manager.stateMutex.Lock()
 	manager.active[claim.Attempt.ID] = handle
@@ -476,7 +482,7 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 		handle.stop("cancelled")
 	}
 	defer func() {
-		close(handle.done)
+		handle.stopHeartbeat()
 		cancel()
 		manager.stateMutex.Lock()
 		delete(manager.active, claim.Attempt.ID)
@@ -666,6 +672,7 @@ func (manager *Manager) validateClaim(claim protocol.Claim) (Repository, error) 
 }
 
 func (manager *Manager) heartbeatAttempt(handle *attemptHandle, attemptID, token string) {
+	defer close(handle.heartbeatDone)
 	delay := manager.options.LeaseRenewInterval
 	for {
 		timer := time.NewTimer(delay)
@@ -707,6 +714,18 @@ func (manager *Manager) heartbeatAttempt(handle *attemptHandle, attemptID, token
 			return
 		}
 		delay = manager.options.LeaseRetryInterval
+	}
+}
+
+func (handle *attemptHandle) stopHeartbeat() {
+	if handle.done == nil {
+		return
+	}
+	handle.doneOnce.Do(func() {
+		close(handle.done)
+	})
+	if handle.heartbeatDone != nil {
+		<-handle.heartbeatDone
 	}
 }
 
@@ -842,11 +861,7 @@ func (manager *Manager) finishWithoutWorktree(
 ) {
 	manager.registrationMutex.Lock()
 	defer manager.registrationMutex.Unlock()
-	defer func() {
-		registerContext, cancel := context.WithTimeout(context.Background(), requestTimeout)
-		defer cancel()
-		manager.registerLocked(registerContext)
-	}()
+	defer manager.registerAfterAttempt(handle)
 
 	errorText := ""
 	if cause != nil {
@@ -880,11 +895,7 @@ func (manager *Manager) finishWithWorktree(
 ) {
 	manager.registrationMutex.Lock()
 	defer manager.registrationMutex.Unlock()
-	defer func() {
-		registerContext, cancel := context.WithTimeout(context.Background(), requestTimeout)
-		defer cancel()
-		manager.registerLocked(registerContext)
-	}()
+	defer manager.registerAfterAttempt(handle)
 
 	result = boundedText(result, protocol.MaxResultBytes)
 	errorText = boundedText(errorText, protocol.MaxErrorBytes)
@@ -914,6 +925,13 @@ func (manager *Manager) finishWithWorktree(
 	}
 	reason := firstNonEmpty(errorText, state+" attempt retained for inspection")
 	manager.retain(claim, repository, value, reason)
+}
+
+func (manager *Manager) registerAfterAttempt(handle *attemptHandle) {
+	handle.stopHeartbeat()
+	registerContext, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	manager.registerLocked(registerContext)
 }
 
 func (handle *attemptHandle) processStillActive() bool {

--- a/internal/worker/manager.go
+++ b/internal/worker/manager.go
@@ -352,7 +352,7 @@ func (manager *Manager) registerLocked(ctx context.Context) {
 		manager.logger.Warn("worker_registration_failed", "error_class", apiErrorClass(err))
 		return
 	}
-	if err := manager.manifests.markDisposalsAcknowledged(registration.DisposedAttemptIDs); err != nil {
+	if err := manager.manifests.removeDisposedManifests(registration.DisposedAttemptIDs); err != nil {
 		manager.markUnhealthy("attempt_manifest", err)
 		return
 	}

--- a/internal/worker/manager.go
+++ b/internal/worker/manager.go
@@ -55,20 +55,25 @@ type Manager struct {
 	repositories      []Repository
 	repositoriesByKey map[string]Repository
 	client            *client
+	manifests         *manifestStore
 	slots             chan struct{}
 
-	stateMutex  sync.Mutex
-	health      health
-	active      map[string]*attemptHandle
-	seen        map[string]bool
-	retained    map[string]protocol.RetainedWorktree
-	pending     map[string]context.CancelFunc
-	fatalHealth error
-	registered  bool
-	closed      bool
+	stateMutex     sync.Mutex
+	health         health
+	active         map[string]*attemptHandle
+	seen           map[string]bool
+	retained       map[string]protocol.RetainedWorktree
+	retainedCounts map[string]int
+	pending        map[string]context.CancelFunc
+	fatalHealth    error
+	registered     bool
+	closed         bool
 
 	randomMutex sync.Mutex
-	waitGroup   sync.WaitGroup
+	// registrationMutex keeps a periodic registration from overtaking the
+	// terminal-attempt to retained-worktree capacity handoff.
+	registrationMutex sync.Mutex
+	waitGroup         sync.WaitGroup
 }
 
 type attemptHandle struct {
@@ -76,10 +81,11 @@ type attemptHandle struct {
 	cancel  context.CancelFunc
 	done    chan struct{}
 
-	mutex      sync.Mutex
-	reason     string
-	expiry     time.Time
-	supervisor *supervisorProcess
+	mutex         sync.Mutex
+	reason        string
+	expiry        time.Time
+	supervisor    *supervisorProcess
+	manifestReady bool
 }
 
 func New(config Config, options Options, logger *slog.Logger) (*Manager, error) {
@@ -133,11 +139,13 @@ func New(config Config, options Options, logger *slog.Logger) (*Manager, error) 
 		repositories:      repositories,
 		repositoriesByKey: byKey,
 		client:            newClient(config.Server, options.HTTPClient),
+		manifests:         newManifestStore(dataDirectory, id),
 		slots:             make(chan struct{}, config.MaxConcurrent),
 		health:            health{State: "unhealthy"},
 		active:            make(map[string]*attemptHandle),
 		seen:              make(map[string]bool),
 		retained:          make(map[string]protocol.RetainedWorktree),
+		retainedCounts:    make(map[string]int),
 		pending:           make(map[string]context.CancelFunc),
 	}, nil
 }
@@ -192,6 +200,24 @@ func (manager *Manager) ID() string { return manager.id }
 
 func (manager *Manager) Run(ctx context.Context) error {
 	defer manager.Close()
+	for {
+		err := manager.reconcile(ctx)
+		if err == nil {
+			break
+		}
+		if !reconciliationNeedsRetry(err) {
+			manager.markUnhealthy("startup_reconciliation", err)
+			break
+		}
+		manager.logger.Warn("startup_reconciliation_retry", "error_class", "transient", "error", err)
+		timer := time.NewTimer(manager.options.LeaseRetryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		case <-timer.C:
+		}
+	}
 	manager.setHealth(checkHealth(ctx, manager.options.GitExecutable, manager.options.CodexExecutable))
 	manager.register(ctx)
 
@@ -281,6 +307,7 @@ func (manager *Manager) registration() protocol.WorkerRegistration {
 	for _, repository := range manager.repositories {
 		repositories = append(repositories, protocol.RepositoryRegistration{
 			Key: repository.Key, RemoteIdentity: repository.RemoteIdentity,
+			RetainedCount: manager.retainedCounts[repository.RemoteIdentity],
 		})
 	}
 	return protocol.WorkerRegistration{
@@ -296,6 +323,12 @@ func (manager *Manager) registration() protocol.WorkerRegistration {
 }
 
 func (manager *Manager) register(ctx context.Context) {
+	manager.registrationMutex.Lock()
+	defer manager.registrationMutex.Unlock()
+	manager.registerLocked(ctx)
+}
+
+func (manager *Manager) registerLocked(ctx context.Context) {
 	requestContext, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
 	if _, err := manager.client.register(requestContext, manager.id, manager.registration()); err != nil {
@@ -442,21 +475,62 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 	})
 	defer taskTimer.Stop()
 	worktreeRoot := filepath.Join(manager.dataDirectory, "worktrees")
-	value, err := createWorktree(handle.context, manager.options.GitExecutable, worktreeRoot,
+	value, err := prepareWorktree(handle.context, manager.options.GitExecutable, worktreeRoot,
 		repository, claim.Task.ID, claim.Attempt.ID)
 	if err != nil {
+		manager.finishWithoutWorktree(claim, token, handle, terminalForStop(handle), stoppedAttemptError(handle, err))
+		return
+	}
+	manifest := attemptManifest{
+		TaskID: claim.Task.ID, ExecutionID: claim.Execution.ID, AttemptID: claim.Attempt.ID,
+		RepositoryID: claim.Repository.ID, RepositoryKey: repository.Key,
+		RepositoryPath: repository.Path, RemoteIdentity: repository.RemoteIdentity,
+		BaseCommit: value.BaseCommit, WorktreePath: value.Path, Branch: value.Branch,
+		LeaseDeadline: claim.Attempt.LeaseExpiresAt, Lifecycle: manifestPreparing,
+	}
+	if err := manager.manifests.create(manifest); err != nil {
+		manager.markUnhealthy("manifest_write", err)
+		manager.finishWithoutWorktree(claim, token, handle, "failed", err)
+		return
+	}
+	handle.setManifestReady()
+	if err := addPreparedWorktree(handle.context, manager.options.GitExecutable, repository, value); err != nil {
 		state := "failed"
 		if handle.stopReason() == "cancelled" {
 			state = "cancelled"
 		}
 		err = stoppedAttemptError(handle, err)
-		if value.Path != "" {
-			if _, pathErr := os.Lstat(value.Path); pathErr == nil {
-				manager.finishWithWorktree(claim, token, handle, repository, value, state, "", err.Error())
-				return
-			}
+		persisted, loadErr := manager.manifests.load(claim.Attempt.ID)
+		inspection, inspectErr := inspectManifestWorktree(
+			context.Background(), manager.options.GitExecutable, manager.dataDirectory, persisted)
+		if loadErr != nil || inspectErr != nil {
+			identityErr := errors.Join(loadErr, inspectErr)
+			_ = manager.persistLifecycle(claim.Attempt.ID, manifestInconsistent, func(manifest *attemptManifest) {
+				manifest.RetentionReason = boundedText(identityErr.Error(), 1000)
+			})
+			manager.markUnhealthy("worktree_identity", identityErr)
+			manager.complete(claim.Attempt.ID, token, state, "", err.Error(), handle)
+			return
+		}
+		if inspection.PathExists && inspection.Registered {
+			manager.finishWithWorktree(claim, token, handle, repository, value, state, "", err.Error())
+			return
+		}
+		if inspection.PathExists || inspection.Registered {
+			identityErr := errors.New("worktree creation left partial filesystem or Git registration state")
+			_ = manager.persistLifecycle(claim.Attempt.ID, manifestInconsistent, func(manifest *attemptManifest) {
+				manifest.RetentionReason = identityErr.Error()
+			})
+			manager.markUnhealthy("worktree_identity", identityErr)
+			manager.complete(claim.Attempt.ID, token, state, "", err.Error(), handle)
+			return
 		}
 		manager.finishWithoutWorktree(claim, token, handle, state, err)
+		return
+	}
+	if err := manager.persistLifecycle(claim.Attempt.ID, manifestWorktreeCreated, nil); err != nil {
+		manager.markUnhealthy("manifest_write", err)
+		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", "", err.Error())
 		return
 	}
 
@@ -481,6 +555,21 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 		_ = process.closeControl()
 		manager.finishWithWorktree(claim, token, handle, repository, value,
 			terminalForStop(handle), "", stoppedAttemptError(handle, err).Error())
+		return
+	}
+	if _, err := manager.manifests.update(claim.Attempt.ID, func(manifest *attemptManifest) error {
+		manifest.SupervisorPID = process.supervisorPID
+		manifest.SupervisorIdentity = process.supervisorIdentity
+		manifest.ProcessGroupID = process.processGroupID
+		manifest.ProcessGroupIdentity = process.groupIdentity
+		manifest.ProcessActive = true
+		manifest.LeaseDeadline = handle.leaseExpiry()
+		manifest.Lifecycle = manifestSupervisorReady
+		return nil
+	}); err != nil {
+		manager.emergencyStop(process, err)
+		manager.markUnhealthy("manifest_write", err)
+		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", "", err.Error())
 		return
 	}
 	handle.setSupervisor(process)
@@ -510,6 +599,13 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 		message := manager.waitForSupervisor(process)
 		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", message.Result,
 			"control plane did not accept the running transition")
+		return
+	}
+	if err := manager.persistLifecycle(claim.Attempt.ID, manifestRunning, nil); err != nil {
+		handle.stop("failed")
+		manager.emergencyStop(process, err)
+		manager.markUnhealthy("manifest_write", err)
+		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", "", err.Error())
 		return
 	}
 	if err := process.send("start"); err != nil {
@@ -563,6 +659,16 @@ func (manager *Manager) heartbeatAttempt(handle *attemptHandle, attemptID, token
 		heartbeat, err := manager.client.heartbeat(requestContext, attemptID, token)
 		cancel()
 		if err == nil {
+			if handle.hasManifest() {
+				if _, persistErr := manager.manifests.update(attemptID, func(manifest *attemptManifest) error {
+					manifest.LeaseDeadline = heartbeat.LeaseExpiresAt
+					return nil
+				}); persistErr != nil {
+					manager.markUnhealthy("manifest_write", persistErr)
+					handle.stop("failed")
+					return
+				}
+			}
 			handle.updateExpiry(heartbeat.LeaseExpiresAt)
 			if heartbeat.CancellationRequested {
 				handle.stop("cancelled")
@@ -595,6 +701,18 @@ func (handle *attemptHandle) setSupervisor(process *supervisorProcess) {
 	} else {
 		_ = process.renew(expiry)
 	}
+}
+
+func (handle *attemptHandle) setManifestReady() {
+	handle.mutex.Lock()
+	handle.manifestReady = true
+	handle.mutex.Unlock()
+}
+
+func (handle *attemptHandle) hasManifest() bool {
+	handle.mutex.Lock()
+	defer handle.mutex.Unlock()
+	return handle.manifestReady
 }
 
 func (handle *attemptHandle) updateExpiry(expiry time.Time) {
@@ -661,6 +779,7 @@ func (manager *Manager) waitForSupervisorMessage(process *supervisorProcess) sup
 			if message.Type == "exit" || message.Type == "output" {
 				if message.Type == "exit" {
 					_ = process.closeControl()
+					process.markStopped()
 				}
 				return message
 			}
@@ -668,11 +787,15 @@ func (manager *Manager) waitForSupervisorMessage(process *supervisorProcess) sup
 			select {
 			case message := <-process.messages:
 				if message.Type == "exit" || message.Type == "output" {
+					if message.Type == "exit" {
+						process.markStopped()
+					}
 					return message
 				}
 			default:
 			}
 			manager.emergencyStop(process, err)
+			manager.markUnhealthy("attempt_supervisor", err)
 			return supervisorMessage{Type: "exit", Reason: "supervisor_error", ExitCode: -1,
 				Error: "attempt supervisor output ended unexpectedly"}
 		}
@@ -684,7 +807,9 @@ func (manager *Manager) emergencyStop(process *supervisorProcess, cause error) {
 	if process.processGroupID > 0 && process.groupIdentity != "" {
 		if err := stopOwnedProcessGroup(int(process.processGroupID), process.groupIdentity, terminationGrace); err != nil {
 			manager.markUnhealthy("process_group_stop", errors.Join(cause, err))
+			return
 		}
+		process.markStopped()
 	}
 }
 
@@ -699,6 +824,15 @@ func (manager *Manager) finishWithoutWorktree(
 	if cause != nil {
 		errorText = boundedText(cause.Error(), protocol.MaxErrorBytes)
 	}
+	if _, err := manager.manifests.load(claim.Attempt.ID); err == nil {
+		if persistErr := manager.persistLifecycle(claim.Attempt.ID, manifestNotCreated, func(manifest *attemptManifest) {
+			manifest.TerminalState = state
+			manifest.RetentionReason = ""
+			manifest.ProcessActive = false
+		}); persistErr != nil {
+			manager.markUnhealthy("manifest_write", persistErr)
+		}
+	}
 	manager.complete(claim.Attempt.ID, token, state, "", errorText, handle)
 }
 
@@ -712,22 +846,46 @@ func (manager *Manager) finishWithWorktree(
 	result string,
 	errorText string,
 ) {
+	manager.registrationMutex.Lock()
+	defer manager.registrationMutex.Unlock()
+	defer func() {
+		registerContext, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		manager.registerLocked(registerContext)
+	}()
+
 	result = boundedText(result, protocol.MaxResultBytes)
 	errorText = boundedText(errorText, protocol.MaxErrorBytes)
+	if err := manager.persistLifecycle(claim.Attempt.ID, manifestCompleted, func(manifest *attemptManifest) {
+		manifest.TerminalState = state
+		manifest.ProcessActive = handle.processStillActive()
+	}); err != nil {
+		manager.markUnhealthy("manifest_write", err)
+		errorText = firstNonEmpty(errorText, err.Error())
+	}
 	completed := manager.complete(claim.Attempt.ID, token, state, result, errorText, handle)
 	if completed && state == "succeeded" {
-		cleanupContext, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
-		err := cleanupSuccessfulWorktree(cleanupContext, manager.options.GitExecutable,
-			filepath.Join(manager.dataDirectory, "worktrees"), repository, value)
-		cancel()
+		err := manager.cleanCompletedWorktree(claim.Attempt.ID)
 		if err == nil {
 			manager.logger.Info("attempt_worktree_cleaned", "attempt_id", claim.Attempt.ID, "repository", repository.Key)
+			return
+		}
+		if manifest, loadErr := manager.manifests.load(claim.Attempt.ID); loadErr == nil &&
+			manifest.Lifecycle == manifestCleanupStarted {
+			manager.markUnhealthy("worktree_cleanup", err)
 			return
 		}
 		errorText = err.Error()
 	}
 	reason := firstNonEmpty(errorText, state+" attempt retained for inspection")
 	manager.retain(claim, repository, value, reason)
+}
+
+func (handle *attemptHandle) processStillActive() bool {
+	handle.mutex.Lock()
+	process := handle.supervisor
+	handle.mutex.Unlock()
+	return process != nil && !process.isStopped()
 }
 
 func (manager *Manager) complete(
@@ -760,12 +918,34 @@ func (manager *Manager) complete(
 }
 
 func (manager *Manager) retain(claim protocol.Claim, repository Repository, value worktree, reason string) {
-	manager.stateMutex.Lock()
-	manager.retained[claim.Attempt.ID] = protocol.RetainedWorktree{
-		AttemptID: claim.Attempt.ID, RepositoryID: claim.Repository.ID,
-		Path: value.Path, Reason: boundedText(reason, 1000),
+	manifest, err := manager.manifests.load(claim.Attempt.ID)
+	if err != nil {
+		manager.markUnhealthy("manifest_read", err)
+		return
 	}
-	manager.stateMutex.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*gitCommandTimeout)
+	inspection, inspectErr := inspectManifestWorktree(ctx, manager.options.GitExecutable, manager.dataDirectory, manifest)
+	cancel()
+	if inspectErr != nil || !inspection.PathExists || !inspection.Registered {
+		if inspectErr == nil {
+			inspectErr = errors.New("worktree exists in only one of the filesystem and Git worktree registry")
+		}
+		_ = manager.persistLifecycle(claim.Attempt.ID, manifestInconsistent, func(value *attemptManifest) {
+			value.RetentionReason = boundedText(inspectErr.Error(), 1000)
+		})
+		manager.markUnhealthy("worktree_identity", inspectErr)
+		return
+	}
+	updated, err := manager.manifests.update(claim.Attempt.ID, func(manifest *attemptManifest) error {
+		manifest.Lifecycle = manifestRetained
+		manifest.RetentionReason = boundedText(reason, 1000)
+		return nil
+	})
+	if err != nil {
+		manager.markUnhealthy("manifest_write", err)
+		return
+	}
+	manager.recordRetained(updated)
 	manager.logger.Info("attempt_worktree_retained", "attempt_id", claim.Attempt.ID, "repository", repository.Key)
 }
 

--- a/internal/worker/manager.go
+++ b/internal/worker/manager.go
@@ -64,6 +64,7 @@ type Manager struct {
 	seen           map[string]bool
 	retained       map[string]protocol.RetainedWorktree
 	retainedCounts map[string]int
+	disposed       map[string]bool
 	pending        map[string]context.CancelFunc
 	fatalHealth    error
 	registered     bool
@@ -146,6 +147,7 @@ func New(config Config, options Options, logger *slog.Logger) (*Manager, error) 
 		seen:              make(map[string]bool),
 		retained:          make(map[string]protocol.RetainedWorktree),
 		retainedCounts:    make(map[string]int),
+		disposed:          make(map[string]bool),
 		pending:           make(map[string]context.CancelFunc),
 	}, nil
 }
@@ -301,8 +303,12 @@ func (manager *Manager) registration() protocol.WorkerRegistration {
 	defer manager.stateMutex.Unlock()
 	repositories := make([]protocol.RepositoryRegistration, 0, len(manager.repositories))
 	retained := make([]protocol.RetainedWorktree, 0, len(manager.retained))
+	disposedAttemptIDs := make([]string, 0, len(manager.disposed))
 	for _, value := range manager.retained {
 		retained = append(retained, value)
+	}
+	for attemptID := range manager.disposed {
+		disposedAttemptIDs = append(disposedAttemptIDs, attemptID)
 	}
 	for _, repository := range manager.repositories {
 		repositories = append(repositories, protocol.RepositoryRegistration{
@@ -311,14 +317,16 @@ func (manager *Manager) registration() protocol.WorkerRegistration {
 		})
 	}
 	return protocol.WorkerRegistration{
-		Name:              strings.TrimSpace(manager.config.Name),
-		WorkerVersion:     manager.options.WorkerVersion,
-		CodexVersion:      manager.health.CodexVersion,
-		Capacity:          manager.config.MaxConcurrent,
-		ActiveCount:       len(manager.slots),
-		Health:            manager.health.State,
-		Repositories:      repositories,
-		RetainedWorktrees: retained,
+		Name:                   strings.TrimSpace(manager.config.Name),
+		WorkerVersion:          manager.options.WorkerVersion,
+		CodexVersion:           manager.health.CodexVersion,
+		Capacity:               manager.config.MaxConcurrent,
+		ActiveCount:            len(manager.slots),
+		Health:                 manager.health.State,
+		Repositories:           repositories,
+		RetainedWorktrees:      retained,
+		CapacityHandoffVersion: 1,
+		DisposedAttemptIDs:     disposedAttemptIDs,
 	}
 }
 
@@ -331,7 +339,8 @@ func (manager *Manager) register(ctx context.Context) {
 func (manager *Manager) registerLocked(ctx context.Context) {
 	requestContext, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
-	if _, err := manager.client.register(requestContext, manager.id, manager.registration()); err != nil {
+	registration := manager.registration()
+	if _, err := manager.client.register(requestContext, manager.id, registration); err != nil {
 		manager.stateMutex.Lock()
 		manager.registered = false
 		manager.cancelPendingClaimsLocked()
@@ -343,7 +352,18 @@ func (manager *Manager) registerLocked(ctx context.Context) {
 		manager.logger.Warn("worker_registration_failed", "error_class", apiErrorClass(err))
 		return
 	}
+	if err := manager.manifests.markDisposalsAcknowledged(registration.DisposedAttemptIDs); err != nil {
+		manager.markUnhealthy("attempt_manifest", err)
+		return
+	}
+	if err := manager.manifests.clearDisposals(registration.DisposedAttemptIDs); err != nil {
+		manager.markUnhealthy("disposal_journal", err)
+		return
+	}
 	manager.stateMutex.Lock()
+	for _, attemptID := range registration.DisposedAttemptIDs {
+		delete(manager.disposed, attemptID)
+	}
 	manager.registered = true
 	manager.stateMutex.Unlock()
 }
@@ -399,8 +419,8 @@ func (manager *Manager) claimOnce(ctx context.Context) {
 	}
 	if !eligible {
 		handle := &attemptHandle{expiry: claim.Attempt.LeaseExpiresAt}
-		manager.complete(claim.Attempt.ID, token, "failed", "",
-			"worker became ineligible before attempt start", handle)
+		manager.finishWithoutWorktree(*claim, token, handle, "failed",
+			errors.New("worker became ineligible before attempt start"))
 		return
 	}
 	manager.stateMutex.Lock()
@@ -820,9 +840,21 @@ func (manager *Manager) finishWithoutWorktree(
 	state string,
 	cause error,
 ) {
+	manager.registrationMutex.Lock()
+	defer manager.registrationMutex.Unlock()
+	defer func() {
+		registerContext, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		manager.registerLocked(registerContext)
+	}()
+
 	errorText := ""
 	if cause != nil {
 		errorText = boundedText(cause.Error(), protocol.MaxErrorBytes)
+	}
+	if err := manager.recordDisposed(claim.Attempt.ID); err != nil {
+		manager.markUnhealthy("disposal_journal", err)
+		return
 	}
 	if _, err := manager.manifests.load(claim.Attempt.ID); err == nil {
 		if persistErr := manager.persistLifecycle(claim.Attempt.ID, manifestNotCreated, func(manifest *attemptManifest) {
@@ -867,6 +899,9 @@ func (manager *Manager) finishWithWorktree(
 	if completed && state == "succeeded" {
 		err := manager.cleanCompletedWorktree(claim.Attempt.ID)
 		if err == nil {
+			if err := manager.recordDisposed(claim.Attempt.ID); err != nil {
+				manager.markUnhealthy("disposal_journal", err)
+			}
 			manager.logger.Info("attempt_worktree_cleaned", "attempt_id", claim.Attempt.ID, "repository", repository.Key)
 			return
 		}

--- a/internal/worker/manifest.go
+++ b/internal/worker/manifest.go
@@ -30,6 +30,11 @@ const (
 	manifestCleaned         = "cleaned"
 )
 
+const (
+	cleanupIntentAutomatic = "automatic"
+	cleanupIntentOperator  = "operator_confirmed"
+)
+
 type attemptManifest struct {
 	SchemaVersion int `json:"schema_version"`
 
@@ -56,6 +61,7 @@ type attemptManifest struct {
 	Lifecycle       string    `json:"lifecycle"`
 	TerminalState   string    `json:"terminal_state,omitempty"`
 	RetentionReason string    `json:"retention_reason,omitempty"`
+	CleanupIntent   string    `json:"cleanup_intent,omitempty"`
 	CleanupResult   string    `json:"cleanup_result,omitempty"`
 	CreatedAt       time.Time `json:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at"`
@@ -370,6 +376,11 @@ func (store *manifestStore) validate(manifest attemptManifest) error {
 	}
 	if !allowedLifecycle[manifest.Lifecycle] {
 		return fmt.Errorf("attempt manifest lifecycle %q is invalid", manifest.Lifecycle)
+	}
+	if manifest.CleanupIntent != "" &&
+		manifest.CleanupIntent != cleanupIntentAutomatic &&
+		manifest.CleanupIntent != cleanupIntentOperator {
+		return fmt.Errorf("attempt manifest cleanup intent %q is invalid", manifest.CleanupIntent)
 	}
 	processEmpty := manifest.SupervisorPID == 0 && manifest.SupervisorIdentity == "" &&
 		manifest.ProcessGroupID == 0 && manifest.ProcessGroupIdentity == ""

--- a/internal/worker/manifest.go
+++ b/internal/worker/manifest.go
@@ -15,6 +15,7 @@ import (
 )
 
 const manifestSchemaVersion = 1
+const disposalJournalSchemaVersion = 1
 
 const (
 	manifestPreparing       = "preparing"
@@ -58,13 +59,20 @@ type attemptManifest struct {
 	ProcessActive        bool      `json:"process_active"`
 	LeaseDeadline        time.Time `json:"lease_deadline,omitempty"`
 
-	Lifecycle       string    `json:"lifecycle"`
-	TerminalState   string    `json:"terminal_state,omitempty"`
-	RetentionReason string    `json:"retention_reason,omitempty"`
-	CleanupIntent   string    `json:"cleanup_intent,omitempty"`
-	CleanupResult   string    `json:"cleanup_result,omitempty"`
-	CreatedAt       time.Time `json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	Lifecycle            string    `json:"lifecycle"`
+	TerminalState        string    `json:"terminal_state,omitempty"`
+	CapacityAcknowledged bool      `json:"capacity_acknowledged,omitempty"`
+	RetentionReason      string    `json:"retention_reason,omitempty"`
+	CleanupIntent        string    `json:"cleanup_intent,omitempty"`
+	CleanupResult        string    `json:"cleanup_result,omitempty"`
+	CreatedAt            time.Time `json:"created_at"`
+	UpdatedAt            time.Time `json:"updated_at"`
+}
+
+type disposalJournal struct {
+	SchemaVersion int      `json:"schema_version"`
+	WorkerID      string   `json:"worker_id"`
+	AttemptIDs    []string `json:"attempt_ids"`
 }
 
 type manifestStore struct {
@@ -74,6 +82,7 @@ type manifestStore struct {
 
 	mutex          sync.Mutex
 	hook           func(string) error
+	disposalHook   func(string) error
 	directoryReady bool
 }
 
@@ -208,6 +217,225 @@ func (store *manifestStore) loadAll() ([]attemptManifest, error) {
 		return manifests[i].AttemptID < manifests[j].AttemptID
 	})
 	return manifests, errors.Join(loadErrors...)
+}
+
+func (store *manifestStore) loadDisposals() ([]string, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	journal, err := store.readDisposalsLocked()
+	if err != nil {
+		return nil, err
+	}
+	return append([]string(nil), journal.AttemptIDs...), nil
+}
+
+func (store *manifestStore) addDisposal(attemptID string) error {
+	if !uuidPattern.MatchString(attemptID) {
+		return errors.New("invalid disposed attempt ID")
+	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	journal, err := store.readDisposalsLocked()
+	if err != nil {
+		return err
+	}
+	for _, existing := range journal.AttemptIDs {
+		if existing == attemptID {
+			return nil
+		}
+	}
+	if store.disposalHook != nil {
+		if err := store.disposalHook("before_add"); err != nil {
+			return err
+		}
+	}
+	journal.AttemptIDs = append(journal.AttemptIDs, attemptID)
+	sort.Strings(journal.AttemptIDs)
+	return store.writeDisposalsLocked(journal)
+}
+
+func (store *manifestStore) clearDisposals(attemptIDs []string) error {
+	if len(attemptIDs) == 0 {
+		return nil
+	}
+	cleared := make(map[string]bool, len(attemptIDs))
+	for _, attemptID := range attemptIDs {
+		if !uuidPattern.MatchString(attemptID) {
+			return errors.New("invalid disposed attempt ID")
+		}
+		cleared[attemptID] = true
+	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	journal, err := store.readDisposalsLocked()
+	if err != nil {
+		return err
+	}
+	remaining := journal.AttemptIDs[:0]
+	for _, attemptID := range journal.AttemptIDs {
+		if !cleared[attemptID] {
+			remaining = append(remaining, attemptID)
+		}
+	}
+	journal.AttemptIDs = remaining
+	return store.writeDisposalsLocked(journal)
+}
+
+func (store *manifestStore) markDisposalsAcknowledged(attemptIDs []string) error {
+	if len(attemptIDs) == 0 {
+		return nil
+	}
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	for _, attemptID := range attemptIDs {
+		path, err := store.path(attemptID)
+		if err != nil {
+			return err
+		}
+		if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("inspect acknowledged attempt manifest: %w", err)
+		}
+		manifest, err := store.readLocked(path)
+		if err != nil {
+			return err
+		}
+		if manifest.CapacityAcknowledged {
+			continue
+		}
+		manifest.CapacityAcknowledged = true
+		manifest.UpdatedAt = store.now().UTC()
+		if err := store.validate(manifest); err != nil {
+			return err
+		}
+		if err := store.writeLocked(path, manifest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (store *manifestStore) disposalJournalPath() string {
+	return filepath.Join(store.dataDirectory, "disposed-attempts.json")
+}
+
+func (store *manifestStore) readDisposalsLocked() (disposalJournal, error) {
+	journal := disposalJournal{
+		SchemaVersion: disposalJournalSchemaVersion,
+		WorkerID:      store.workerID,
+		AttemptIDs:    []string{},
+	}
+	entries, err := os.ReadDir(store.dataDirectory)
+	if err != nil {
+		return disposalJournal{}, fmt.Errorf("read worker data directory for disposal journal: %w", err)
+	}
+	removedTemporary := false
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".disposed-attempts-") ||
+			!strings.HasSuffix(entry.Name(), ".tmp") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return disposalJournal{}, fmt.Errorf("inspect stale disposal journal: %w", err)
+		}
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return disposalJournal{}, fmt.Errorf("unsafe stale disposal journal entry: %s", entry.Name())
+		}
+		if err := os.Remove(filepath.Join(store.dataDirectory, entry.Name())); err != nil {
+			return disposalJournal{}, fmt.Errorf("remove stale disposal journal: %w", err)
+		}
+		removedTemporary = true
+	}
+	if removedTemporary {
+		if err := syncDirectory(store.dataDirectory); err != nil {
+			return disposalJournal{}, fmt.Errorf("sync stale disposal journal cleanup: %w", err)
+		}
+	}
+	path := store.disposalJournalPath()
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return journal, nil
+	}
+	if err != nil {
+		return disposalJournal{}, fmt.Errorf("inspect disposal journal: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return disposalJournal{}, errors.New("disposal journal must be a regular non-symlink file")
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return disposalJournal{}, errors.New("disposal journal permissions must not allow group or other access")
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return disposalJournal{}, fmt.Errorf("read disposal journal: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&journal); err != nil {
+		return disposalJournal{}, fmt.Errorf("decode disposal journal: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return disposalJournal{}, errors.New("disposal journal contains trailing JSON")
+	}
+	if journal.SchemaVersion != disposalJournalSchemaVersion {
+		return disposalJournal{}, fmt.Errorf(
+			"unsupported disposal journal schema version %d", journal.SchemaVersion)
+	}
+	if journal.WorkerID != store.workerID {
+		return disposalJournal{}, errors.New("disposal journal belongs to a different worker")
+	}
+	seen := make(map[string]bool, len(journal.AttemptIDs))
+	for _, attemptID := range journal.AttemptIDs {
+		if !uuidPattern.MatchString(attemptID) || seen[attemptID] {
+			return disposalJournal{}, errors.New("disposal journal attempt IDs must be unique UUIDs")
+		}
+		seen[attemptID] = true
+	}
+	sort.Strings(journal.AttemptIDs)
+	return journal, nil
+}
+
+func (store *manifestStore) writeDisposalsLocked(journal disposalJournal) error {
+	body, err := json.MarshalIndent(journal, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode disposal journal: %w", err)
+	}
+	body = append(body, '\n')
+	file, err := os.CreateTemp(store.dataDirectory, ".disposed-attempts-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary disposal journal: %w", err)
+	}
+	temporary := file.Name()
+	removeTemporary := true
+	defer func() {
+		_ = file.Close()
+		if removeTemporary {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		return fmt.Errorf("protect temporary disposal journal: %w", err)
+	}
+	if _, err := file.Write(body); err != nil {
+		return fmt.Errorf("write temporary disposal journal: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync temporary disposal journal: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temporary disposal journal: %w", err)
+	}
+	if err := os.Rename(temporary, store.disposalJournalPath()); err != nil {
+		return fmt.Errorf("replace disposal journal: %w", err)
+	}
+	removeTemporary = false
+	if err := syncDirectory(store.dataDirectory); err != nil {
+		return fmt.Errorf("sync worker data directory after disposal journal update: %w", err)
+	}
+	return nil
 }
 
 func (store *manifestStore) readLocked(path string) (attemptManifest, error) {

--- a/internal/worker/manifest.go
+++ b/internal/worker/manifest.go
@@ -1,0 +1,388 @@
+package worker
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const manifestSchemaVersion = 1
+
+const (
+	manifestPreparing       = "preparing"
+	manifestWorktreeCreated = "worktree_created"
+	manifestSupervisorReady = "supervisor_ready"
+	manifestRunning         = "running"
+	manifestCompleted       = "completed"
+	manifestRetained        = "retained"
+	manifestNotCreated      = "not_created"
+	manifestInconsistent    = "inconsistent"
+	manifestMissing         = "missing"
+	manifestCleanupStarted  = "cleanup_started"
+	manifestCleaned         = "cleaned"
+)
+
+type attemptManifest struct {
+	SchemaVersion int `json:"schema_version"`
+
+	WorkerID    string `json:"worker_id"`
+	TaskID      string `json:"task_id"`
+	ExecutionID string `json:"execution_id"`
+	AttemptID   string `json:"attempt_id"`
+
+	RepositoryID   string `json:"repository_id"`
+	RepositoryKey  string `json:"repository_key"`
+	RepositoryPath string `json:"repository_path"`
+	RemoteIdentity string `json:"remote_identity"`
+	BaseCommit     string `json:"base_commit"`
+	WorktreePath   string `json:"worktree_path"`
+	Branch         string `json:"branch"`
+
+	SupervisorPID        int64     `json:"supervisor_pid,omitempty"`
+	SupervisorIdentity   string    `json:"supervisor_identity,omitempty"`
+	ProcessGroupID       int64     `json:"process_group_id,omitempty"`
+	ProcessGroupIdentity string    `json:"process_group_identity,omitempty"`
+	ProcessActive        bool      `json:"process_active"`
+	LeaseDeadline        time.Time `json:"lease_deadline,omitempty"`
+
+	Lifecycle       string    `json:"lifecycle"`
+	TerminalState   string    `json:"terminal_state,omitempty"`
+	RetentionReason string    `json:"retention_reason,omitempty"`
+	CleanupResult   string    `json:"cleanup_result,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+type manifestStore struct {
+	dataDirectory string
+	workerID      string
+	now           func() time.Time
+
+	mutex          sync.Mutex
+	hook           func(string) error
+	directoryReady bool
+}
+
+func newManifestStore(dataDirectory, workerID string) *manifestStore {
+	return &manifestStore{dataDirectory: dataDirectory, workerID: workerID, now: time.Now}
+}
+
+func (store *manifestStore) attemptsDirectory() string {
+	return filepath.Join(store.dataDirectory, "attempts")
+}
+
+func (store *manifestStore) path(attemptID string) (string, error) {
+	if !uuidPattern.MatchString(attemptID) {
+		return "", errors.New("invalid attempt ID")
+	}
+	return filepath.Join(store.attemptsDirectory(), attemptID+".json"), nil
+}
+
+func (store *manifestStore) create(manifest attemptManifest) error {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	path, err := store.path(manifest.AttemptID)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(path); err == nil {
+		return errors.New("attempt manifest already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect attempt manifest: %w", err)
+	}
+	now := store.now().UTC()
+	manifest.SchemaVersion = manifestSchemaVersion
+	manifest.WorkerID = store.workerID
+	manifest.CreatedAt = now
+	manifest.UpdatedAt = now
+	if err := store.validate(manifest); err != nil {
+		return err
+	}
+	return store.writeLocked(path, manifest)
+}
+
+func (store *manifestStore) update(attemptID string, change func(*attemptManifest) error) (attemptManifest, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	path, err := store.path(attemptID)
+	if err != nil {
+		return attemptManifest{}, err
+	}
+	manifest, err := store.readLocked(path)
+	if err != nil {
+		return attemptManifest{}, err
+	}
+	if err := change(&manifest); err != nil {
+		return attemptManifest{}, err
+	}
+	manifest.UpdatedAt = store.now().UTC()
+	if err := store.validate(manifest); err != nil {
+		return attemptManifest{}, err
+	}
+	if err := store.writeLocked(path, manifest); err != nil {
+		return attemptManifest{}, err
+	}
+	return manifest, nil
+}
+
+func (store *manifestStore) load(attemptID string) (attemptManifest, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	path, err := store.path(attemptID)
+	if err != nil {
+		return attemptManifest{}, err
+	}
+	return store.readLocked(path)
+}
+
+func (store *manifestStore) loadAll() ([]attemptManifest, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	directory, err := store.ensureDirectory()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, fmt.Errorf("read attempt manifests: %w", err)
+	}
+	manifests := make([]attemptManifest, 0, len(entries))
+	removedTemporary := false
+	var loadErrors []error
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") && strings.HasSuffix(entry.Name(), ".tmp") {
+			info, infoErr := entry.Info()
+			if infoErr != nil {
+				loadErrors = append(loadErrors, fmt.Errorf("inspect stale temporary manifest: %w", infoErr))
+				continue
+			}
+			if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+				loadErrors = append(loadErrors, fmt.Errorf("unsafe stale temporary manifest entry: %s", entry.Name()))
+				continue
+			}
+			if err := os.Remove(filepath.Join(directory, entry.Name())); err != nil {
+				loadErrors = append(loadErrors, fmt.Errorf("remove stale temporary manifest: %w", err))
+				continue
+			}
+			removedTemporary = true
+			continue
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			loadErrors = append(loadErrors,
+				fmt.Errorf("unexpected entry in attempt manifest directory: %s", entry.Name()))
+			continue
+		}
+		attemptID := strings.TrimSuffix(entry.Name(), ".json")
+		path, pathErr := store.path(attemptID)
+		if pathErr != nil {
+			loadErrors = append(loadErrors, fmt.Errorf("invalid attempt manifest filename %q", entry.Name()))
+			continue
+		}
+		manifest, readErr := store.readLocked(path)
+		if readErr != nil {
+			loadErrors = append(loadErrors, fmt.Errorf("%s: %w", entry.Name(), readErr))
+			continue
+		}
+		manifests = append(manifests, manifest)
+	}
+	if removedTemporary {
+		if err := syncDirectory(directory); err != nil {
+			loadErrors = append(loadErrors, fmt.Errorf("sync stale manifest cleanup: %w", err))
+		}
+	}
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].AttemptID < manifests[j].AttemptID
+	})
+	return manifests, errors.Join(loadErrors...)
+}
+
+func (store *manifestStore) readLocked(path string) (attemptManifest, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return attemptManifest{}, errors.New("attempt manifest does not exist")
+		}
+		return attemptManifest{}, fmt.Errorf("inspect attempt manifest: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return attemptManifest{}, errors.New("attempt manifest must be a regular non-symlink file")
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return attemptManifest{}, errors.New("attempt manifest permissions must not allow group or other access")
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return attemptManifest{}, fmt.Errorf("read attempt manifest: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.DisallowUnknownFields()
+	var manifest attemptManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return attemptManifest{}, fmt.Errorf("decode attempt manifest: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return attemptManifest{}, errors.New("attempt manifest contains trailing JSON")
+	}
+	if err := store.validate(manifest); err != nil {
+		return attemptManifest{}, err
+	}
+	return manifest, nil
+}
+
+func (store *manifestStore) writeLocked(path string, manifest attemptManifest) error {
+	directory, err := store.ensureDirectory()
+	if err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode attempt manifest: %w", err)
+	}
+	body = append(body, '\n')
+	file, err := os.CreateTemp(directory, "."+manifest.AttemptID+"-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temporary attempt manifest: %w", err)
+	}
+	temporary := file.Name()
+	removeTemporary := true
+	defer func() {
+		_ = file.Close()
+		if removeTemporary {
+			_ = os.Remove(temporary)
+		}
+	}()
+	if err := file.Chmod(0o600); err != nil {
+		return fmt.Errorf("protect temporary attempt manifest: %w", err)
+	}
+	if _, err := file.Write(body); err != nil {
+		return fmt.Errorf("write temporary attempt manifest: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync temporary attempt manifest: %w", err)
+	}
+	if err := store.callHook("after_file_sync"); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close temporary attempt manifest: %w", err)
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		return fmt.Errorf("replace attempt manifest: %w", err)
+	}
+	removeTemporary = false
+	if err := store.callHook("after_rename"); err != nil {
+		return err
+	}
+	if err := syncDirectory(directory); err != nil {
+		return fmt.Errorf("sync attempt manifest directory: %w", err)
+	}
+	return store.callHook("after_directory_sync")
+}
+
+func (store *manifestStore) ensureDirectory() (string, error) {
+	directory := store.attemptsDirectory()
+	if _, err := os.Lstat(directory); errors.Is(err, os.ErrNotExist) {
+		if err := os.Mkdir(directory, 0o700); err != nil {
+			return "", fmt.Errorf("create attempt manifest directory: %w", err)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("inspect attempt manifest directory: %w", err)
+	}
+	info, err := os.Lstat(directory)
+	if err != nil {
+		return "", fmt.Errorf("inspect attempt manifest directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("attempt manifest directory must be a real directory, not a symlink")
+	}
+	if err := os.Chmod(directory, 0o700); err != nil {
+		return "", fmt.Errorf("protect attempt manifest directory: %w", err)
+	}
+	if !store.directoryReady {
+		if err := store.callHook("before_attempts_parent_sync"); err != nil {
+			return "", err
+		}
+		if err := syncDirectory(store.dataDirectory); err != nil {
+			return "", fmt.Errorf("sync worker data directory after creating attempts: %w", err)
+		}
+		if err := store.callHook("after_attempts_parent_sync"); err != nil {
+			return "", err
+		}
+		store.directoryReady = true
+	}
+	return directory, nil
+}
+
+func (store *manifestStore) callHook(stage string) error {
+	if store.hook == nil {
+		return nil
+	}
+	return store.hook(stage)
+}
+
+func (store *manifestStore) validate(manifest attemptManifest) error {
+	if manifest.SchemaVersion != manifestSchemaVersion {
+		return fmt.Errorf("unsupported attempt manifest schema version %d", manifest.SchemaVersion)
+	}
+	for name, value := range map[string]string{
+		"worker_id": manifest.WorkerID, "task_id": manifest.TaskID,
+		"execution_id": manifest.ExecutionID, "attempt_id": manifest.AttemptID,
+		"repository_id": manifest.RepositoryID,
+	} {
+		if !uuidPattern.MatchString(value) {
+			return fmt.Errorf("attempt manifest %s is not a valid UUID", name)
+		}
+	}
+	if manifest.WorkerID != store.workerID {
+		return errors.New("attempt manifest belongs to a different worker")
+	}
+	if strings.TrimSpace(manifest.RepositoryKey) == "" || strings.TrimSpace(manifest.RemoteIdentity) == "" {
+		return errors.New("attempt manifest repository identity is incomplete")
+	}
+	if !filepath.IsAbs(manifest.RepositoryPath) || filepath.Clean(manifest.RepositoryPath) != manifest.RepositoryPath {
+		return errors.New("attempt manifest repository path is not canonical")
+	}
+	if !commitPattern.MatchString(manifest.BaseCommit) {
+		return errors.New("attempt manifest base commit is invalid")
+	}
+	expectedPath := filepath.Join(store.dataDirectory, "worktrees", manifest.AttemptID)
+	if manifest.WorktreePath != expectedPath {
+		return errors.New("attempt manifest worktree path is not the owned V2 path")
+	}
+	expectedBranch := "factory-v2/" + manifest.TaskID[:12] + "-" + manifest.AttemptID[:12]
+	if manifest.Branch != expectedBranch {
+		return errors.New("attempt manifest branch does not match its task and attempt")
+	}
+	allowedLifecycle := map[string]bool{
+		manifestPreparing: true, manifestWorktreeCreated: true, manifestSupervisorReady: true,
+		manifestRunning: true, manifestCompleted: true, manifestRetained: true,
+		manifestNotCreated: true, manifestInconsistent: true, manifestMissing: true,
+		manifestCleanupStarted: true, manifestCleaned: true,
+	}
+	if !allowedLifecycle[manifest.Lifecycle] {
+		return fmt.Errorf("attempt manifest lifecycle %q is invalid", manifest.Lifecycle)
+	}
+	processEmpty := manifest.SupervisorPID == 0 && manifest.SupervisorIdentity == "" &&
+		manifest.ProcessGroupID == 0 && manifest.ProcessGroupIdentity == ""
+	processComplete := manifest.SupervisorPID > 0 && manifest.SupervisorIdentity != "" &&
+		manifest.ProcessGroupID > 0 && manifest.ProcessGroupIdentity != ""
+	if !processEmpty && !processComplete {
+		return errors.New("attempt manifest process identity is partial")
+	}
+	if manifest.ProcessActive && !processComplete {
+		return errors.New("attempt manifest active process identity is incomplete")
+	}
+	if manifest.CreatedAt.IsZero() || manifest.UpdatedAt.IsZero() {
+		return errors.New("attempt manifest timestamps are incomplete")
+	}
+	return nil
+}

--- a/internal/worker/manifest.go
+++ b/internal/worker/manifest.go
@@ -59,14 +59,13 @@ type attemptManifest struct {
 	ProcessActive        bool      `json:"process_active"`
 	LeaseDeadline        time.Time `json:"lease_deadline,omitempty"`
 
-	Lifecycle            string    `json:"lifecycle"`
-	TerminalState        string    `json:"terminal_state,omitempty"`
-	CapacityAcknowledged bool      `json:"capacity_acknowledged,omitempty"`
-	RetentionReason      string    `json:"retention_reason,omitempty"`
-	CleanupIntent        string    `json:"cleanup_intent,omitempty"`
-	CleanupResult        string    `json:"cleanup_result,omitempty"`
-	CreatedAt            time.Time `json:"created_at"`
-	UpdatedAt            time.Time `json:"updated_at"`
+	Lifecycle       string    `json:"lifecycle"`
+	TerminalState   string    `json:"terminal_state,omitempty"`
+	RetentionReason string    `json:"retention_reason,omitempty"`
+	CleanupIntent   string    `json:"cleanup_intent,omitempty"`
+	CleanupResult   string    `json:"cleanup_result,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 type disposalJournal struct {
@@ -281,12 +280,13 @@ func (store *manifestStore) clearDisposals(attemptIDs []string) error {
 	return store.writeDisposalsLocked(journal)
 }
 
-func (store *manifestStore) markDisposalsAcknowledged(attemptIDs []string) error {
+func (store *manifestStore) removeDisposedManifests(attemptIDs []string) error {
 	if len(attemptIDs) == 0 {
 		return nil
 	}
 	store.mutex.Lock()
 	defer store.mutex.Unlock()
+	removed := false
 	for _, attemptID := range attemptIDs {
 		path, err := store.path(attemptID)
 		if err != nil {
@@ -301,16 +301,20 @@ func (store *manifestStore) markDisposalsAcknowledged(attemptIDs []string) error
 		if err != nil {
 			return err
 		}
-		if manifest.CapacityAcknowledged {
-			continue
+		switch manifest.Lifecycle {
+		case manifestCleaned, manifestNotCreated, manifestMissing:
+		default:
+			return fmt.Errorf(
+				"refusing to remove disposal manifest in lifecycle %q", manifest.Lifecycle)
 		}
-		manifest.CapacityAcknowledged = true
-		manifest.UpdatedAt = store.now().UTC()
-		if err := store.validate(manifest); err != nil {
-			return err
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("remove acknowledged disposal manifest: %w", err)
 		}
-		if err := store.writeLocked(path, manifest); err != nil {
-			return err
+		removed = true
+	}
+	if removed {
+		if err := syncDirectory(store.attemptsDirectory()); err != nil {
+			return fmt.Errorf("sync acknowledged disposal manifest removal: %w", err)
 		}
 	}
 	return nil

--- a/internal/worker/manifest_integration_test.go
+++ b/internal/worker/manifest_integration_test.go
@@ -1,0 +1,951 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestWorkerManagerHelperProcess(t *testing.T) {
+	if os.Getenv("FACTORY_TEST_MANAGER_HELPER") != "1" {
+		return
+	}
+	config, err := LoadConfig(os.Getenv("FACTORY_TEST_MANAGER_CONFIG"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	options := testOptions(os.Getenv("FACTORY_TEST_MANAGER_CODEX"))
+	options.SupervisorCommand = []string{os.Args[0], "-test.run=TestWorkerSupervisorHelperProcess", "--"}
+	manager, err := New(config, options, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	if err := manager.Run(context.Background()); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func fixtureUUID(value int) string {
+	return fmt.Sprintf("00000000-0000-4000-8000-%012x", value)
+}
+
+func fixtureManifest(dataDirectory, workerID string, value int) attemptManifest {
+	taskID := fixtureUUID(value + 1)
+	attemptID := fixtureUUID(value + 2)
+	return attemptManifest{
+		SchemaVersion:  manifestSchemaVersion,
+		WorkerID:       workerID,
+		TaskID:         taskID,
+		ExecutionID:    fixtureUUID(value + 3),
+		AttemptID:      attemptID,
+		RepositoryID:   fixtureUUID(value + 4),
+		RepositoryKey:  "factory",
+		RepositoryPath: filepath.Join(dataDirectory, "source"),
+		RemoteIdentity: "example.invalid/factory",
+		BaseCommit:     strings.Repeat("a", 40),
+		WorktreePath:   filepath.Join(dataDirectory, "worktrees", attemptID),
+		Branch:         "factory-v2/" + taskID[:12] + "-" + attemptID[:12],
+		Lifecycle:      manifestPreparing,
+		CreatedAt:      time.Unix(100, 0).UTC(),
+		UpdatedAt:      time.Unix(100, 0).UTC(),
+	}
+}
+
+func TestManifestWritesAreAtomicAndDurable(t *testing.T) {
+	dataDirectory := t.TempDir()
+	workerID := fixtureUUID(1)
+	store := newManifestStore(dataDirectory, workerID)
+	store.now = func() time.Time { return time.Unix(200, 0) }
+	manifest := fixtureManifest(dataDirectory, workerID, 10)
+	store.hook = func(stage string) error {
+		if stage == "before_attempts_parent_sync" {
+			return errors.New("simulated crash before attempts parent sync")
+		}
+		return nil
+	}
+	if err := store.create(manifest); err == nil {
+		t.Fatal("initial manifest proceeded before attempts directory parent sync")
+	}
+	path, _ := store.path(manifest.AttemptID)
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("manifest exists before attempts directory was durable: %v", err)
+	}
+	store.hook = nil
+	if err := store.create(manifest); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("manifest permissions = %o", info.Mode().Perm())
+	}
+
+	store.hook = func(stage string) error {
+		if stage == "after_file_sync" {
+			return errors.New("simulated crash before rename")
+		}
+		return nil
+	}
+	if _, err := store.update(manifest.AttemptID, func(value *attemptManifest) error {
+		value.Lifecycle = manifestWorktreeCreated
+		return nil
+	}); err == nil {
+		t.Fatal("manifest update unexpectedly survived pre-rename crash")
+	}
+	persisted, err := store.load(manifest.AttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Lifecycle != manifestPreparing {
+		t.Fatalf("pre-rename crash persisted lifecycle %q", persisted.Lifecycle)
+	}
+
+	store.hook = func(stage string) error {
+		if stage == "after_rename" {
+			return errors.New("simulated crash before directory sync")
+		}
+		return nil
+	}
+	if _, err := store.update(manifest.AttemptID, func(value *attemptManifest) error {
+		value.Lifecycle = manifestWorktreeCreated
+		return nil
+	}); err == nil {
+		t.Fatal("manifest update unexpectedly reported a completed directory sync")
+	}
+	persisted, err = store.load(manifest.AttemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Lifecycle != manifestWorktreeCreated {
+		t.Fatalf("post-rename manifest is not complete JSON: %#v", persisted)
+	}
+
+	store.hook = nil
+	for _, lifecycle := range []string{
+		manifestSupervisorReady, manifestRunning, manifestCompleted, manifestRetained,
+		manifestCleanupStarted, manifestCleaned,
+	} {
+		if _, err := store.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = lifecycle
+			return nil
+		}); err != nil {
+			t.Fatalf("persist lifecycle %s: %v", lifecycle, err)
+		}
+		persisted, err = store.load(manifest.AttemptID)
+		if err != nil || persisted.Lifecycle != lifecycle {
+			t.Fatalf("lifecycle %s persisted as %q: %v", lifecycle, persisted.Lifecycle, err)
+		}
+	}
+	entries, err := os.ReadDir(store.attemptsDirectory())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != manifest.AttemptID+".json" {
+		t.Fatalf("manifest directory contains temporary debris: %v", entries)
+	}
+	stale := filepath.Join(store.attemptsDirectory(), "."+manifest.AttemptID+"-stale.tmp")
+	if err := os.WriteFile(stale, []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.loadAll(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stale); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale temporary manifest was not reconciled: %v", err)
+	}
+}
+
+func TestStartupReconciliationClassifiesManifestAndFilesystemState(t *testing.T) {
+	cases := []struct {
+		name          string
+		initial       string
+		createGit     bool
+		createPartial bool
+		want          string
+		wantError     bool
+	}{
+		{name: "never created", initial: manifestPreparing, want: manifestNotCreated},
+		{name: "missing", initial: manifestWorktreeCreated, want: manifestMissing},
+		{name: "cleaned", initial: manifestCleaned, want: manifestCleaned},
+		{name: "retained", initial: manifestWorktreeCreated, createGit: true, want: manifestRetained},
+		{name: "cleanup already absent", initial: manifestCleanupStarted, want: manifestCleaned},
+		{name: "cleanup still present", initial: manifestCleanupStarted, createGit: true, want: manifestCleaned},
+		{name: "partial", initial: manifestWorktreeCreated, createPartial: true, want: manifestInconsistent, wantError: true},
+	}
+	for index, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newServerFixture(t, nil)
+			repository := createRepository(t, "reconcile")
+			dataDirectory := filepath.Join(t.TempDir(), "worker")
+			manager := newTestManager(t, fixture, filepath.Join(t.TempDir(), "codex"), dataDirectory,
+				map[string]repositoryFixture{"factory": repository}, 1)
+			t.Cleanup(func() { _ = manager.Close() })
+			workerValue, err := fixture.store.RegisterWorker(context.Background(), manager.ID(), protocol.WorkerRegistration{
+				Name: "test-worker", WorkerVersion: "test", CodexVersion: "test", Capacity: 1,
+				Health: "healthy", Repositories: []protocol.RepositoryRegistration{{
+					Key: "factory", RemoteIdentity: repositoryIdentity(t, repository.path),
+				}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			task, _, err := fixture.store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+				RequestKey: fmt.Sprintf("reconcile-%d", index), Title: "reconcile",
+				Description: "reconcile", WorkerID: manager.ID(),
+				RepositoryID: workerValue.Repositories[0].ID, TimeoutSeconds: 60,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim, err := fixture.store.Claim(context.Background(), manager.ID(), protocol.ClaimRequest{
+				RequestID: fmt.Sprintf("claim-%d", index), LeaseToken: strings.Repeat("l", 43),
+			})
+			if err != nil || claim == nil {
+				t.Fatalf("claim = %#v, %v", claim, err)
+			}
+			value, err := prepareWorktree(context.Background(), "git",
+				filepath.Join(dataDirectory, "worktrees"), manager.repositories[0], task.Task.ID, claim.Attempt.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			manifest := attemptManifest{
+				TaskID: task.Task.ID, ExecutionID: claim.Execution.ID, AttemptID: claim.Attempt.ID,
+				RepositoryID: workerValue.Repositories[0].ID, RepositoryKey: "factory",
+				RepositoryPath: manager.repositories[0].Path, RemoteIdentity: manager.repositories[0].RemoteIdentity,
+				BaseCommit: value.BaseCommit, WorktreePath: value.Path, Branch: value.Branch,
+				LeaseDeadline: claim.Attempt.LeaseExpiresAt, Lifecycle: test.initial,
+			}
+			if err := manager.manifests.create(manifest); err != nil {
+				t.Fatal(err)
+			}
+			if test.createGit {
+				if err := addPreparedWorktree(context.Background(), "git", manager.repositories[0], value); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.createPartial {
+				if err := os.MkdirAll(value.Path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			persisted, _ := manager.manifests.load(claim.Attempt.ID)
+			err = manager.reconcileManifest(context.Background(), persisted)
+			if test.wantError != (err != nil) {
+				t.Fatalf("reconciliation error = %v; wantError=%v", err, test.wantError)
+			}
+			persisted, loadErr := manager.manifests.load(claim.Attempt.ID)
+			if loadErr != nil {
+				t.Fatal(loadErr)
+			}
+			if persisted.Lifecycle != test.want {
+				t.Fatalf("lifecycle = %q; want %q", persisted.Lifecycle, test.want)
+			}
+			_, retained := manager.retained[claim.Attempt.ID]
+			if retained != (test.want == manifestRetained) {
+				t.Fatalf("retained=%v for lifecycle %s", retained, persisted.Lifecycle)
+			}
+			if test.initial == manifestCleanupStarted && test.createGit {
+				if _, err := os.Stat(value.Path); !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("startup cleanup left worktree: %v", err)
+				}
+				runGitTest(t, repository.path, "show-ref", "--verify", "refs/heads/"+value.Branch)
+			}
+		})
+	}
+}
+
+func seedReconciliationManifest(
+	t *testing.T,
+	fixture *serverFixture,
+	manager *Manager,
+	lifecycle string,
+) protocol.Claim {
+	t.Helper()
+	repository := manager.repositories[0]
+	workerValue, err := fixture.store.RegisterWorker(context.Background(), manager.ID(), protocol.WorkerRegistration{
+		Name: "test-worker", WorkerVersion: "test", CodexVersion: "test", Capacity: manager.config.MaxConcurrent,
+		Health: "healthy", Repositories: []protocol.RepositoryRegistration{{
+			Key: repository.Key, RemoteIdentity: repository.RemoteIdentity,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, _, err := fixture.store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+		RequestKey: fmt.Sprintf("reconcile-retry-%d", time.Now().UnixNano()), Title: "reconcile retry",
+		Description: "reconcile retry", WorkerID: manager.ID(),
+		RepositoryID: workerValue.Repositories[0].ID, TimeoutSeconds: 60,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := fixture.store.Claim(context.Background(), manager.ID(), protocol.ClaimRequest{
+		RequestID:  fmt.Sprintf("reconcile-retry-claim-%d", time.Now().UnixNano()),
+		LeaseToken: strings.Repeat("r", 43),
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+	value, err := prepareWorktree(context.Background(), "git",
+		filepath.Join(manager.dataDirectory, "worktrees"), repository, task.Task.ID, claim.Attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := attemptManifest{
+		TaskID: task.Task.ID, ExecutionID: claim.Execution.ID, AttemptID: claim.Attempt.ID,
+		RepositoryID: workerValue.Repositories[0].ID, RepositoryKey: repository.Key,
+		RepositoryPath: repository.Path, RemoteIdentity: repository.RemoteIdentity,
+		BaseCommit: value.BaseCommit, WorktreePath: value.Path, Branch: value.Branch,
+		LeaseDeadline: claim.Attempt.LeaseExpiresAt, Lifecycle: lifecycle,
+	}
+	if err := manager.manifests.create(manifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := addPreparedWorktree(context.Background(), "git", repository, value); err != nil {
+		t.Fatal(err)
+	}
+	return *claim
+}
+
+func TestStartupReconciliationRetriesControlPlaneInterruptionBeforeRegistration(t *testing.T) {
+	var unavailable atomic.Bool
+	unavailable.Store(true)
+	fixture := newServerFixture(t, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if unavailable.Load() && request.Method == http.MethodGet &&
+				strings.HasPrefix(request.URL.Path, "/api/v1/attempts/") {
+				http.Error(writer, "temporarily unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			next.ServeHTTP(writer, request)
+		})
+	})
+	repository := createRepository(t, "server-recovery")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"factory": repository}, 1)
+	seedReconciliationManifest(t, fixture, manager, manifestWorktreeCreated)
+	startManager(t, manager)
+	time.Sleep(250 * time.Millisecond)
+	manager.stateMutex.Lock()
+	registered := manager.registered
+	fatal := manager.fatalHealth
+	manager.stateMutex.Unlock()
+	if registered || fatal != nil {
+		t.Fatalf("transient reconciliation registered=%v fatal=%v", registered, fatal)
+	}
+	unavailable.Store(false)
+	waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" && len(worker.RetainedWorktrees) == 1
+	})
+}
+
+func TestStartupReconciliationRetriesGitInterruptionBeforeRegistration(t *testing.T) {
+	fixture := newServerFixture(t, nil)
+	repository := createRepository(t, "git-recovery")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"factory": repository}, 1)
+	seedReconciliationManifest(t, fixture, manager, manifestWorktreeCreated)
+	gitPath := filepath.Join(t.TempDir(), "git")
+	manager.options.GitExecutable = gitPath
+	startManager(t, manager)
+	time.Sleep(250 * time.Millisecond)
+	manager.stateMutex.Lock()
+	registered := manager.registered
+	fatal := manager.fatalHealth
+	manager.stateMutex.Unlock()
+	if registered || fatal != nil {
+		t.Fatalf("transient Git reconciliation registered=%v fatal=%v", registered, fatal)
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realGit, gitPath); err != nil {
+		t.Fatal(err)
+	}
+	waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" && len(worker.RetainedWorktrees) == 1
+	})
+}
+
+func TestCleanupPreviewAndConfirmationAreSafe(t *testing.T) {
+	repository := createRepository(t, "cleanup")
+	dataDirectory, err := resolveDataDirectory(filepath.Join(t.TempDir(), "worker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerID, err := loadOrCreateWorkerID(dataDirectory, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newManifestStore(dataDirectory, workerID)
+	taskID := fixtureUUID(100)
+	attemptID := fixtureUUID(101)
+	resolved, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := createWorktree(context.Background(), "git", filepath.Join(dataDirectory, "worktrees"),
+		resolved,
+		taskID, attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := attemptManifest{
+		TaskID: taskID, ExecutionID: fixtureUUID(102), AttemptID: attemptID,
+		RepositoryID: fixtureUUID(103), RepositoryKey: "factory", RepositoryPath: resolved.Path,
+		RemoteIdentity: resolved.RemoteIdentity, BaseCommit: value.BaseCommit,
+		WorktreePath: value.Path, Branch: value.Branch, Lifecycle: manifestRetained,
+		RetentionReason: "failed attempt retained for inspection",
+	}
+	if err := store.create(manifest); err != nil {
+		t.Fatal(err)
+	}
+	config := Config{
+		Server: "http://127.0.0.1:7337", Name: "cleanup", MaxConcurrent: 1,
+		DataDirectory: dataDirectory,
+		Repositories:  map[string]RepositoryConfig{"factory": {Path: repository.path}},
+	}
+	path, _ := store.path(attemptID)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var preview bytes.Buffer
+	if err := Cleanup(config, CleanupOptions{AttemptID: attemptID}, &preview); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{attemptID, value.Branch, resolved.RemoteIdentity,
+		"failed attempt retained for inspection", `"git_status": "clean"`} {
+		if !strings.Contains(preview.String(), expected) {
+			t.Fatalf("cleanup preview does not contain %q:\n%s", expected, preview.String())
+		}
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("cleanup preview mutated the manifest")
+	}
+	if _, err := os.Stat(value.Path); err != nil {
+		t.Fatalf("cleanup preview mutated the worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(value.Path, "uncommitted.txt"), []byte("operator reviewed\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var confirmed bytes.Buffer
+	if err := Cleanup(config, CleanupOptions{AttemptID: attemptID, Confirm: true}, &confirmed); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(value.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("confirmed cleanup left worktree: %v", err)
+	}
+	runGitTest(t, repository.path, "show-ref", "--verify", "refs/heads/"+value.Branch)
+	cleaned, err := store.load(attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleaned.Lifecycle != manifestCleaned || !strings.Contains(cleaned.CleanupResult, "completed") {
+		t.Fatalf("cleaned manifest = %#v", cleaned)
+	}
+}
+
+func TestCleanupFailsClosedOnIdentityMismatchAndPathEscape(t *testing.T) {
+	repository := createRepository(t, "cleanup-unsafe")
+	dataDirectory, err := resolveDataDirectory(filepath.Join(t.TempDir(), "worker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerID, err := loadOrCreateWorkerID(dataDirectory, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := newManifestStore(dataDirectory, workerID)
+	taskID, attemptID := fixtureUUID(200), fixtureUUID(201)
+	repo, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := createWorktree(context.Background(), "git", filepath.Join(dataDirectory, "worktrees"),
+		repo, taskID, attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := attemptManifest{
+		TaskID: taskID, ExecutionID: fixtureUUID(202), AttemptID: attemptID,
+		RepositoryID: fixtureUUID(203), RepositoryKey: "factory", RepositoryPath: repo.Path,
+		RemoteIdentity: repo.RemoteIdentity, BaseCommit: value.BaseCommit, WorktreePath: value.Path,
+		Branch: value.Branch, Lifecycle: manifestRetained, RetentionReason: "inspect",
+	}
+	if err := store.create(manifest); err != nil {
+		t.Fatal(err)
+	}
+	config := Config{
+		Server: "http://127.0.0.1:7337", Name: "cleanup", MaxConcurrent: 1,
+		DataDirectory: dataDirectory,
+		Repositories:  map[string]RepositoryConfig{"factory": {Path: repository.path}},
+	}
+	if err := Cleanup(config, CleanupOptions{AttemptID: fixtureUUID(999), Confirm: true}, io.Discard); err == nil {
+		t.Fatal("cleanup accepted a missing manifest")
+	}
+	if _, err := store.update(attemptID, func(value *attemptManifest) error {
+		value.SupervisorPID = 123
+		value.SupervisorIdentity = "unreconciled supervisor"
+		value.ProcessGroupID = 456
+		value.ProcessGroupIdentity = "unreconciled group"
+		value.ProcessActive = true
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Cleanup(config, CleanupOptions{AttemptID: attemptID, Confirm: true}, io.Discard); err == nil ||
+		!strings.Contains(err.Error(), "unreconciled process identity") {
+		t.Fatalf("cleanup process identity error = %v", err)
+	}
+	if _, err := store.update(attemptID, func(value *attemptManifest) error {
+		value.ProcessActive = false
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.update(attemptID, func(value *attemptManifest) error {
+		value.RemoteIdentity = "example.invalid/different"
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Cleanup(config, CleanupOptions{AttemptID: attemptID, Confirm: true}, io.Discard); err == nil {
+		t.Fatal("cleanup accepted a repository identity mismatch")
+	}
+	if _, err := os.Stat(value.Path); err != nil {
+		t.Fatalf("identity mismatch changed worktree: %v", err)
+	}
+
+	if _, err := store.update(attemptID, func(value *attemptManifest) error {
+		value.RemoteIdentity = repo.RemoteIdentity
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	current, err := store.load(attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.WorktreePath = filepath.Join(t.TempDir(), "escaped")
+	body, err := json.MarshalIndent(current, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, _ := store.path(attemptID)
+	if err := os.WriteFile(path, append(body, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Cleanup(config, CleanupOptions{AttemptID: attemptID, Confirm: true}, io.Discard); err == nil {
+		t.Fatal("cleanup accepted an escaped manifest path")
+	}
+	if _, err := os.Stat(value.Path); err != nil {
+		t.Fatalf("path escape changed worktree: %v", err)
+	}
+	current.WorktreePath = value.Path
+	body, err = json.MarshalIndent(current, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(body, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, repository.path, "worktree", "remove", "--force", value.Path)
+	if err := os.MkdirAll(value.Path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := Cleanup(config, CleanupOptions{AttemptID: attemptID, Confirm: true}, io.Discard); err == nil ||
+		!strings.Contains(err.Error(), "filesystem and Git worktree identity disagree") {
+		t.Fatalf("cleanup partial worktree error = %v", err)
+	}
+}
+
+func TestParseCleanupArgumentsAcceptsDocumentedOrder(t *testing.T) {
+	attemptID := fixtureUUID(300)
+	configPath, options, err := ParseCleanupArguments(
+		[]string{attemptID, "--confirm", "--config", "/tmp/worker.toml"}, "/default.toml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if configPath != "/tmp/worker.toml" || options.AttemptID != attemptID || !options.Confirm {
+		t.Fatalf("parsed cleanup arguments = %q, %#v", configPath, options)
+	}
+	if _, _, err := ParseCleanupArguments([]string{attemptID, "--unsafe"}, "/default.toml"); err == nil {
+		t.Fatal("cleanup parser accepted an unknown option")
+	}
+}
+
+func TestRepositoryRetainedCapacityDoesNotBlockAnotherRepository(t *testing.T) {
+	first := createRepository(t, "full")
+	second := createRepository(t, "open")
+	fixture := newServerFixture(t, nil)
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"full": first, "open": second}, 1)
+	manager.retainedCounts[repositoryIdentity(t, first.path)] = protocol.MaxRetainedPerRepo
+	startManager(t, manager)
+	registered := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		if worker.Health != "healthy" {
+			return false
+		}
+		for _, repository := range worker.Repositories {
+			if repository.Key == "full" {
+				return repository.RetainedCount == protocol.MaxRetainedPerRepo
+			}
+		}
+		return false
+	})
+	full := createTask(t, fixture.store, registered, "full", "success", 60)
+	open := createTask(t, fixture.store, registered, "open", "success", 60)
+	waitForTaskState(t, fixture.store, open.Task.ID, "succeeded")
+	time.Sleep(250 * time.Millisecond)
+	fullDetail, err := fixture.store.Task(context.Background(), full.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fullDetail.Execution.State != "queued" || len(fullDetail.Attempts) != 0 {
+		t.Fatalf("full repository was claimed: %#v", fullDetail)
+	}
+}
+
+func TestPeriodicRegistrationCannotOvertakeRetainedCapacityHandoff(t *testing.T) {
+	var blockNextRegistration atomic.Bool
+	registrationReached := make(chan struct{}, 1)
+	releaseRegistration := make(chan struct{})
+	fixture := newServerFixture(t, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if request.Method == http.MethodPut &&
+				strings.HasPrefix(request.URL.Path, "/api/v1/workers/") &&
+				blockNextRegistration.CompareAndSwap(true, false) {
+				registrationReached <- struct{}{}
+				<-releaseRegistration
+			}
+			next.ServeHTTP(writer, request)
+		})
+	})
+	repository := createRepository(t, "registration-handoff")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"factory": repository}, 2)
+	t.Cleanup(func() { _ = manager.Close() })
+	manager.setHealth(health{State: "healthy", GitVersion: "test", CodexVersion: "test"})
+	manager.stateMutex.Lock()
+	manager.retainedCounts[manager.repositories[0].RemoteIdentity] = protocol.MaxRetainedPerRepo - 1
+	manager.stateMutex.Unlock()
+	manager.register(context.Background())
+	workerValue := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" &&
+			worker.Repositories[0].RetainedCount == protocol.MaxRetainedPerRepo-1
+	})
+	task := createTask(t, fixture.store, workerValue, "factory", "fail", 60)
+	claim, err := fixture.store.Claim(context.Background(), manager.ID(), protocol.ClaimRequest{
+		RequestID: "registration-handoff-claim", LeaseToken: strings.Repeat("h", 43),
+	})
+	if err != nil || claim == nil || claim.Task.ID != task.Task.ID {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+	value, err := prepareWorktree(context.Background(), "git",
+		filepath.Join(manager.dataDirectory, "worktrees"), manager.repositories[0], task.Task.ID, claim.Attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.manifests.create(attemptManifest{
+		TaskID: claim.Task.ID, ExecutionID: claim.Execution.ID, AttemptID: claim.Attempt.ID,
+		RepositoryID: claim.Repository.ID, RepositoryKey: manager.repositories[0].Key,
+		RepositoryPath: manager.repositories[0].Path, RemoteIdentity: manager.repositories[0].RemoteIdentity,
+		BaseCommit: value.BaseCommit, WorktreePath: value.Path, Branch: value.Branch,
+		LeaseDeadline: claim.Attempt.LeaseExpiresAt, Lifecycle: manifestPreparing,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := addPreparedWorktree(context.Background(), "git", manager.repositories[0], value); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.persistLifecycle(claim.Attempt.ID, manifestWorktreeCreated, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	blockNextRegistration.Store(true)
+	registrationDone := make(chan struct{})
+	go func() {
+		manager.register(context.Background())
+		close(registrationDone)
+	}()
+	select {
+	case <-registrationReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("periodic registration did not reach the server")
+	}
+	finishDone := make(chan struct{})
+	go func() {
+		manager.finishWithWorktree(*claim, strings.Repeat("h", 43), &attemptHandle{
+			expiry: claim.Attempt.LeaseExpiresAt,
+		}, manager.repositories[0], value, "failed", "", "retained")
+		close(finishDone)
+	}()
+	select {
+	case <-finishDone:
+		t.Fatal("capacity handoff overtook an in-flight registration")
+	case <-time.After(100 * time.Millisecond):
+	}
+	attempt, err := fixture.store.Attempt(context.Background(), claim.Attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.State != "preparing" {
+		t.Fatalf("attempt completed before registration serialization: %s", attempt.State)
+	}
+	close(releaseRegistration)
+	select {
+	case <-registrationDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("periodic registration did not finish")
+	}
+	select {
+	case <-finishDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("capacity handoff did not finish")
+	}
+	registered := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Repositories[0].RetainedCount == protocol.MaxRetainedPerRepo &&
+			len(worker.RetainedWorktrees) == 1
+	})
+	blocked := createTask(t, fixture.store, registered, "factory", "fail", 60)
+	next, err := fixture.store.Claim(context.Background(), manager.ID(), protocol.ClaimRequest{
+		RequestID: "registration-handoff-blocked", LeaseToken: strings.Repeat("i", 43),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != nil {
+		t.Fatalf("claim exceeded retained-worktree cap: %#v", next)
+	}
+	blockedDetail, err := fixture.store.Task(context.Background(), blocked.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blockedDetail.Execution.State != "queued" {
+		t.Fatalf("capacity-blocked task state = %s", blockedDetail.Execution.State)
+	}
+}
+
+func TestManifestProcessIdentityIsDurableBeforeCodexStarts(t *testing.T) {
+	startReached := make(chan struct{}, 1)
+	releaseStart := make(chan struct{})
+	fixture := newServerFixture(t, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, "/start") {
+				select {
+				case startReached <- struct{}{}:
+				default:
+				}
+				<-releaseStart
+			}
+			next.ServeHTTP(writer, request)
+		})
+	})
+	repository := createRepository(t, "manifest-start")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager := newTestManager(t, fixture, codexPath, filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"factory": repository}, 1)
+	startManager(t, manager)
+	workerValue := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy"
+	})
+	task := createTask(t, fixture.store, workerValue, "factory", "success", 60)
+	select {
+	case <-startReached:
+	case <-time.After(10 * time.Second):
+		t.Fatal("worker did not reach attempt start")
+	}
+	detail, err := fixture.store.Task(context.Background(), task.Task.ID)
+	if err != nil || len(detail.Attempts) != 1 {
+		t.Fatalf("task detail = %#v, %v", detail, err)
+	}
+	manifest, err := manager.manifests.load(detail.Attempts[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.Lifecycle != manifestSupervisorReady || !manifest.ProcessActive ||
+		manifest.SupervisorPID <= 0 || manifest.ProcessGroupID <= 0 ||
+		manifest.SupervisorIdentity == "" || manifest.ProcessGroupIdentity == "" {
+		t.Fatalf("process identity was not durable before start: %#v", manifest)
+	}
+	if entries, err := os.ReadDir(os.Getenv("FACTORY_TEST_CODEX_LOG")); err == nil && len(entries) != 0 {
+		t.Fatalf("Codex started before durable identity and accepted start: %v", entries)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatal(err)
+	}
+	close(releaseStart)
+	waitForTaskState(t, fixture.store, task.Task.ID, "succeeded")
+}
+
+func TestKillingMainWorkerStopsCodexAndRestartDoesNotOverlap(t *testing.T) {
+	fixture := newServerFixture(t, nil)
+	repository := createRepository(t, "worker-crash")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	dataDirectory := filepath.Join(t.TempDir(), "worker")
+	configPath := filepath.Join(t.TempDir(), "worker.toml")
+	configBody := fmt.Sprintf(`server = %q
+name = "crash-worker"
+max_concurrent = 1
+data_directory = %q
+
+[repositories.factory]
+path = %q
+`, fixture.server.URL, dataDirectory, repository.path)
+	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FACTORY_TEST_SUPERVISOR", "1")
+	logDirectory := filepath.Join(t.TempDir(), "codex-log")
+	t.Setenv("FACTORY_TEST_CODEX_LOG", logDirectory)
+	initializer, err := New(config, testOptions(codexPath), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerID := initializer.ID()
+	if err := initializer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	command := exec.Command(os.Args[0], "-test.run=TestWorkerManagerHelperProcess", "--")
+	command.Env = append(os.Environ(),
+		"FACTORY_TEST_MANAGER_HELPER=1",
+		"FACTORY_TEST_MANAGER_CONFIG="+configPath,
+		"FACTORY_TEST_MANAGER_CODEX="+codexPath,
+	)
+	var childOutput bytes.Buffer
+	command.Stdout = &childOutput
+	command.Stderr = &childOutput
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	childReaped := false
+	t.Cleanup(func() {
+		if !childReaped {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+		}
+	})
+	workerValue := waitForWorker(t, fixture.store, workerID, func(worker protocol.Worker) bool {
+		return worker.Health == "healthy"
+	})
+	task := createTask(t, fixture.store, workerValue, "factory", "fork", 60)
+	running := waitForTaskState(t, fixture.store, task.Task.ID, "running")
+	childPath := filepath.Join(logDirectory, running.Attempts[0].ID+".child")
+	waitFor(t, 5*time.Second, func() bool {
+		_, err := os.Stat(childPath)
+		return err == nil
+	})
+	codexChildPID := readPID(t, childPath)
+	if err := command.Process.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Wait(); err == nil {
+		t.Fatal("killed worker process exited successfully")
+	}
+	childReaped = true
+	waitForProcessGone(t, codexChildPID, 8*time.Second)
+
+	restarted, err := New(config, testOptions(codexPath), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, restartedDone := startManager(t, restarted)
+	waitForWorker(t, fixture.store, workerID, func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" && len(worker.RetainedWorktrees) == 1 &&
+			strings.Contains(worker.RetainedWorktrees[0].CleanupCommand, "--config") &&
+			strings.Contains(worker.RetainedWorktrees[0].CleanupCommand, configPath)
+	})
+	time.Sleep(300 * time.Millisecond)
+	detail, err := fixture.store.Task(context.Background(), task.Task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Attempts) != 1 {
+		t.Fatalf("worker restart created overlapping attempts: %#v", detail.Attempts)
+	}
+	_ = restartedDone
+}
+
+func TestSupervisorStopsAtLastRenewalWithoutPipeClosure(t *testing.T) {
+	t.Setenv("FACTORY_TEST_SUPERVISOR", "1")
+	logDirectory := t.TempDir()
+	t.Setenv("FACTORY_TEST_CODEX_LOG", logDirectory)
+	repository := createRepository(t, "renewal-deadline")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	process, err := startSupervisor(
+		[]string{os.Args[0], "-test.run=TestWorkerSupervisorHelperProcess", "--"},
+		supervisorInit{
+			CodexExecutable: codexPath, Worktree: repository.path,
+			ResultPath: filepath.Join(t.TempDir(), "result"),
+			Prompt:     "FAKE_MODE=fork", TimeoutSeconds: 60,
+		}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := process.awaitReady(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.renew(time.Now().Add(6 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.send("start"); err != nil {
+		t.Fatal(err)
+	}
+	childPath := filepath.Join(logDirectory, filepath.Base(repository.path)+".child")
+	waitFor(t, 5*time.Second, func() bool {
+		_, err := os.Stat(childPath)
+		return err == nil
+	})
+	childPID := readPID(t, childPath)
+	started := time.Now()
+	waitForProcessGone(t, childPID, 8*time.Second)
+	if elapsed := time.Since(started); elapsed > 7*time.Second {
+		t.Fatalf("supervisor exceeded the last renewal deadline and grace: %s", elapsed)
+	}
+	if process.control == nil {
+		t.Fatal("test closed the parent control pipe before deadline enforcement")
+	}
+	_ = process.closeControl()
+}

--- a/internal/worker/manifest_integration_test.go
+++ b/internal/worker/manifest_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -882,6 +883,125 @@ func TestAcknowledgedDisposedManifestIsPrunedBeforeSecondRestart(t *testing.T) {
 	}
 	if got := secondRestart.registration().DisposedAttemptIDs; len(got) != 0 {
 		t.Fatalf("second restart republished acknowledged disposals: %#v", got)
+	}
+}
+
+func TestDisposedManifestWaitsForHeartbeatBeforePruning(t *testing.T) {
+	var blockHeartbeat atomic.Bool
+	var watchRegistration atomic.Bool
+	heartbeatReached := make(chan struct{}, 1)
+	releaseHeartbeat := make(chan struct{}, 1)
+	defer func() {
+		select {
+		case releaseHeartbeat <- struct{}{}:
+		default:
+		}
+	}()
+	registrationReached := make(chan struct{}, 1)
+	fixture := newServerFixture(t, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if strings.HasSuffix(request.URL.Path, "/heartbeat") && blockHeartbeat.Load() {
+				response := httptest.NewRecorder()
+				next.ServeHTTP(response, request)
+				heartbeatReached <- struct{}{}
+				<-releaseHeartbeat
+				for key, values := range response.Header() {
+					writer.Header()[key] = append([]string(nil), values...)
+				}
+				writer.WriteHeader(response.Code)
+				_, _ = writer.Write(response.Body.Bytes())
+				return
+			}
+			if request.Method == http.MethodPut &&
+				strings.HasPrefix(request.URL.Path, "/api/v1/workers/") &&
+				watchRegistration.Load() {
+				registrationReached <- struct{}{}
+			}
+			next.ServeHTTP(writer, request)
+		})
+	})
+	repository := createRepository(t, "heartbeat-pruning")
+	manager := newTestManager(t, fixture, filepath.Join(t.TempDir(), "codex"),
+		filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"factory": repository}, 1)
+	t.Cleanup(func() { _ = manager.Close() })
+	claim := seedReconciliationManifest(t, fixture, manager, manifestWorktreeCreated)
+	manifest, err := manager.manifests.load(claim.Attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := inspectManifestWorktree(context.Background(), "git", manager.dataDirectory, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := removeInspectedWorktree(context.Background(), "git", inspection, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.persistLifecycle(claim.Attempt.ID, manifestCleaned, func(value *attemptManifest) {
+		value.TerminalState = "failed"
+		value.ProcessActive = false
+	}); err != nil {
+		t.Fatal(err)
+	}
+	manager.setHealth(health{State: "healthy", GitVersion: "test", CodexVersion: "test"})
+	manager.options.LeaseRenewInterval = time.Millisecond
+	attemptContext, cancel := context.WithCancel(context.Background())
+	handle := &attemptHandle{
+		context: attemptContext, cancel: cancel, done: make(chan struct{}),
+		heartbeatDone: make(chan struct{}), expiry: claim.Attempt.LeaseExpiresAt,
+		manifestReady: true,
+	}
+	defer cancel()
+	blockHeartbeat.Store(true)
+	go manager.heartbeatAttempt(handle, claim.Attempt.ID, strings.Repeat("r", 43))
+	select {
+	case <-heartbeatReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("heartbeat did not reach the server")
+	}
+	if _, err := fixture.store.CompleteAttempt(context.Background(), claim.Attempt.ID,
+		protocol.CompleteAttemptRequest{
+			LeaseToken: strings.Repeat("r", 43), State: "failed", Error: "complete",
+		}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.recordDisposed(claim.Attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	watchRegistration.Store(true)
+	registrationDone := make(chan struct{})
+	go func() {
+		manager.registrationMutex.Lock()
+		defer manager.registrationMutex.Unlock()
+		manager.registerAfterAttempt(handle)
+		close(registrationDone)
+	}()
+	select {
+	case <-registrationReached:
+		t.Fatal("registration pruned the manifest before the heartbeat stopped")
+	case <-time.After(100 * time.Millisecond):
+	}
+	releaseHeartbeat <- struct{}{}
+	select {
+	case <-registrationReached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("registration did not proceed after the heartbeat stopped")
+	}
+	select {
+	case <-registrationDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("registration did not finish")
+	}
+	if _, err := manager.manifests.load(claim.Attempt.ID); err == nil {
+		t.Fatal("acknowledged manifest was not pruned")
+	}
+	manager.stateMutex.Lock()
+	workerHealth := manager.health.State
+	fatalHealth := manager.fatalHealth
+	manager.stateMutex.Unlock()
+	if workerHealth != "healthy" || fatalHealth != nil {
+		t.Fatalf("late heartbeat made worker unhealthy: health=%s error=%v", workerHealth, fatalHealth)
 	}
 }
 

--- a/internal/worker/manifest_integration_test.go
+++ b/internal/worker/manifest_integration_test.go
@@ -179,7 +179,9 @@ func TestStartupReconciliationClassifiesManifestAndFilesystemState(t *testing.T)
 	cases := []struct {
 		name          string
 		initial       string
+		cleanupIntent string
 		createGit     bool
+		makeDirty     bool
 		createPartial bool
 		want          string
 		wantError     bool
@@ -189,7 +191,22 @@ func TestStartupReconciliationClassifiesManifestAndFilesystemState(t *testing.T)
 		{name: "cleaned", initial: manifestCleaned, want: manifestCleaned},
 		{name: "retained", initial: manifestWorktreeCreated, createGit: true, want: manifestRetained},
 		{name: "cleanup already absent", initial: manifestCleanupStarted, want: manifestCleaned},
-		{name: "cleanup still present", initial: manifestCleanupStarted, createGit: true, want: manifestCleaned},
+		{
+			name: "operator cleanup still present", initial: manifestCleanupStarted,
+			cleanupIntent: cleanupIntentOperator, createGit: true, want: manifestCleaned,
+		},
+		{
+			name: "automatic cleanup still eligible", initial: manifestCleanupStarted,
+			cleanupIntent: cleanupIntentAutomatic, createGit: true, want: manifestCleaned,
+		},
+		{
+			name: "automatic cleanup became dirty", initial: manifestCleanupStarted,
+			cleanupIntent: cleanupIntentAutomatic, createGit: true, makeDirty: true, want: manifestRetained,
+		},
+		{
+			name: "ambiguous cleanup remains safe", initial: manifestCleanupStarted,
+			createGit: true, want: manifestRetained,
+		},
 		{name: "partial", initial: manifestWorktreeCreated, createPartial: true, want: manifestInconsistent, wantError: true},
 	}
 	for index, test := range cases {
@@ -234,12 +251,18 @@ func TestStartupReconciliationClassifiesManifestAndFilesystemState(t *testing.T)
 				RepositoryPath: manager.repositories[0].Path, RemoteIdentity: manager.repositories[0].RemoteIdentity,
 				BaseCommit: value.BaseCommit, WorktreePath: value.Path, Branch: value.Branch,
 				LeaseDeadline: claim.Attempt.LeaseExpiresAt, Lifecycle: test.initial,
+				CleanupIntent: test.cleanupIntent,
 			}
 			if err := manager.manifests.create(manifest); err != nil {
 				t.Fatal(err)
 			}
 			if test.createGit {
 				if err := addPreparedWorktree(context.Background(), "git", manager.repositories[0], value); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.makeDirty {
+				if err := os.WriteFile(filepath.Join(value.Path, "dirty.txt"), []byte("retain me\n"), 0o600); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -265,8 +288,12 @@ func TestStartupReconciliationClassifiesManifestAndFilesystemState(t *testing.T)
 				t.Fatalf("retained=%v for lifecycle %s", retained, persisted.Lifecycle)
 			}
 			if test.initial == manifestCleanupStarted && test.createGit {
-				if _, err := os.Stat(value.Path); !errors.Is(err, os.ErrNotExist) {
-					t.Fatalf("startup cleanup left worktree: %v", err)
+				_, statErr := os.Stat(value.Path)
+				if test.want == manifestCleaned && !errors.Is(statErr, os.ErrNotExist) {
+					t.Fatalf("startup cleanup left worktree: %v", statErr)
+				}
+				if test.want == manifestRetained && statErr != nil {
+					t.Fatalf("startup cleanup removed retained worktree: %v", statErr)
 				}
 				runGitTest(t, repository.path, "show-ref", "--verify", "refs/heads/"+value.Branch)
 			}
@@ -471,7 +498,8 @@ func TestCleanupPreviewAndConfirmationAreSafe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cleaned.Lifecycle != manifestCleaned || !strings.Contains(cleaned.CleanupResult, "completed") {
+	if cleaned.Lifecycle != manifestCleaned || cleaned.CleanupIntent != cleanupIntentOperator ||
+		!strings.Contains(cleaned.CleanupResult, "completed") {
 		t.Fatalf("cleaned manifest = %#v", cleaned)
 	}
 }

--- a/internal/worker/manifest_integration_test.go
+++ b/internal/worker/manifest_integration_test.go
@@ -829,7 +829,7 @@ func TestDisposalJournalFailureDoesNotCompleteAttempt(t *testing.T) {
 	}
 }
 
-func TestAcknowledgedDisposedManifestIsNotRepublishedOnSecondRestart(t *testing.T) {
+func TestAcknowledgedDisposedManifestIsPrunedBeforeSecondRestart(t *testing.T) {
 	fixture := newServerFixture(t, nil)
 	repository := createRepository(t, "disposed-compaction")
 	dataDirectory := filepath.Join(t.TempDir(), "worker")
@@ -867,12 +867,8 @@ func TestAcknowledgedDisposedManifestIsNotRepublishedOnSecondRestart(t *testing.
 		t.Fatalf("first restart disposals = %#v", got)
 	}
 	firstRestart.register(context.Background())
-	manifest, err = firstRestart.manifests.load(claim.Attempt.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !manifest.CapacityAcknowledged {
-		t.Fatal("successful registration did not compact the disposed manifest")
+	if _, err := firstRestart.manifests.load(claim.Attempt.ID); err == nil {
+		t.Fatal("successful registration left the disposed manifest on disk")
 	}
 	if err := firstRestart.Close(); err != nil {
 		t.Fatal(err)

--- a/internal/worker/manifest_integration_test.go
+++ b/internal/worker/manifest_integration_test.go
@@ -667,6 +667,228 @@ func TestRepositoryRetainedCapacityDoesNotBlockAnotherRepository(t *testing.T) {
 	}
 }
 
+func TestDisposedAttemptHandoffDoesNotWaitForIdleWorker(t *testing.T) {
+	repository := createRepository(t, "disposed-handoff")
+	fixture := newServerFixture(t, nil)
+	manager := newTestManager(t, fixture, filepath.Join(t.TempDir(), "codex"),
+		filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"factory": repository}, 2)
+	t.Cleanup(func() { _ = manager.Close() })
+	manager.setHealth(health{State: "healthy", GitVersion: "test", CodexVersion: "test"})
+	manager.stateMutex.Lock()
+	manager.retainedCounts[manager.repositories[0].RemoteIdentity] = protocol.MaxRetainedPerRepo - 1
+	manager.stateMutex.Unlock()
+	manager.register(context.Background())
+	workerValue := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" &&
+			worker.Repositories[0].RetainedCount == protocol.MaxRetainedPerRepo-1
+	})
+	first := createTask(t, fixture.store, workerValue, "factory", "fail", 60)
+	claim, err := fixture.store.Claim(context.Background(), manager.ID(), protocol.ClaimRequest{
+		RequestID: "disposed-handoff-first", LeaseToken: strings.Repeat("j", 43),
+	})
+	if err != nil || claim == nil || claim.Task.ID != first.Task.ID {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+
+	manager.slots <- struct{}{}
+	manager.finishWithoutWorktree(*claim, strings.Repeat("j", 43), &attemptHandle{
+		expiry: claim.Attempt.LeaseExpiresAt,
+	}, "failed", errors.New("failed before worktree creation"))
+	if len(manager.disposed) != 0 {
+		t.Fatalf("successful registration left disposed attempts pending: %#v", manager.disposed)
+	}
+	second := createTask(t, fixture.store, workerValue, "factory", "success", 60)
+	next, err := fixture.store.Claim(context.Background(), manager.ID(), protocol.ClaimRequest{
+		RequestID: "disposed-handoff-second", LeaseToken: strings.Repeat("k", 43),
+	})
+	if err != nil || next == nil || next.Task.ID != second.Task.ID {
+		t.Fatalf("claim after disposal = %#v, %v", next, err)
+	}
+	<-manager.slots
+}
+
+func TestDisposedAttemptHandoffSurvivesFailedRegistrationAndRestart(t *testing.T) {
+	var failNextRegistration atomic.Bool
+	fixture := newServerFixture(t, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			if request.Method == http.MethodPut &&
+				strings.HasPrefix(request.URL.Path, "/api/v1/workers/") &&
+				failNextRegistration.CompareAndSwap(true, false) {
+				http.Error(writer, "control plane interrupted", http.StatusServiceUnavailable)
+				return
+			}
+			next.ServeHTTP(writer, request)
+		})
+	})
+	repository := createRepository(t, "durable-disposed-handoff")
+	dataDirectory := filepath.Join(t.TempDir(), "worker")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	firstManager := newTestManager(t, fixture, codexPath, dataDirectory,
+		map[string]repositoryFixture{"factory": repository}, 2)
+	firstManager.setHealth(health{State: "healthy", GitVersion: "test", CodexVersion: "test"})
+	firstManager.stateMutex.Lock()
+	firstManager.retainedCounts[firstManager.repositories[0].RemoteIdentity] = protocol.MaxRetainedPerRepo - 1
+	firstManager.stateMutex.Unlock()
+	firstManager.register(context.Background())
+	workerValue := waitForWorker(t, fixture.store, firstManager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" &&
+			worker.Repositories[0].RetainedCount == protocol.MaxRetainedPerRepo-1
+	})
+	createTask(t, fixture.store, workerValue, "factory", "fail", 60)
+	claim, err := fixture.store.Claim(context.Background(), firstManager.ID(), protocol.ClaimRequest{
+		RequestID: "durable-disposed-first", LeaseToken: strings.Repeat("m", 43),
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+
+	firstManager.slots <- struct{}{}
+	failNextRegistration.Store(true)
+	firstManager.finishWithoutWorktree(*claim, strings.Repeat("m", 43), &attemptHandle{
+		expiry: claim.Attempt.LeaseExpiresAt,
+	}, "failed", errors.New("failed before manifest creation"))
+	<-firstManager.slots
+	pending, err := firstManager.manifests.loadDisposals()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 || pending[0] != claim.Attempt.ID {
+		t.Fatalf("durable pending disposals = %#v", pending)
+	}
+	if err := firstManager.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	secondManager := newTestManager(t, fixture, codexPath, dataDirectory,
+		map[string]repositoryFixture{"factory": repository}, 2)
+	t.Cleanup(func() { _ = secondManager.Close() })
+	secondManager.setHealth(health{State: "healthy", GitVersion: "test", CodexVersion: "test"})
+	secondManager.stateMutex.Lock()
+	secondManager.retainedCounts[secondManager.repositories[0].RemoteIdentity] = protocol.MaxRetainedPerRepo - 1
+	secondManager.stateMutex.Unlock()
+	if err := secondManager.reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	secondManager.register(context.Background())
+	pending, err = secondManager.manifests.loadDisposals()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("successful restart registration left pending disposals: %#v", pending)
+	}
+	second := createTask(t, fixture.store, workerValue, "factory", "success", 60)
+	next, err := fixture.store.Claim(context.Background(), secondManager.ID(), protocol.ClaimRequest{
+		RequestID: "durable-disposed-second", LeaseToken: strings.Repeat("n", 43),
+	})
+	if err != nil || next == nil || next.Task.ID != second.Task.ID {
+		t.Fatalf("claim after restart handoff = %#v, %v", next, err)
+	}
+}
+
+func TestDisposalJournalFailureDoesNotCompleteAttempt(t *testing.T) {
+	repository := createRepository(t, "disposal-journal-failure")
+	fixture := newServerFixture(t, nil)
+	manager := newTestManager(t, fixture, filepath.Join(t.TempDir(), "codex"),
+		filepath.Join(t.TempDir(), "worker"),
+		map[string]repositoryFixture{"factory": repository}, 1)
+	t.Cleanup(func() { _ = manager.Close() })
+	manager.setHealth(health{State: "healthy", GitVersion: "test", CodexVersion: "test"})
+	manager.register(context.Background())
+	workerValue := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy"
+	})
+	createTask(t, fixture.store, workerValue, "factory", "fail", 60)
+	claim, err := fixture.store.Claim(context.Background(), manager.ID(), protocol.ClaimRequest{
+		RequestID: "disposal-journal-failure", LeaseToken: strings.Repeat("o", 43),
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, %v", claim, err)
+	}
+	manager.manifests.disposalHook = func(string) error {
+		return errors.New("simulated disposal journal failure")
+	}
+	manager.slots <- struct{}{}
+	manager.finishWithoutWorktree(*claim, strings.Repeat("o", 43), &attemptHandle{
+		expiry: claim.Attempt.LeaseExpiresAt,
+	}, "failed", errors.New("failed before manifest creation"))
+	<-manager.slots
+	attempt, err := fixture.store.Attempt(context.Background(), claim.Attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.State != "preparing" {
+		t.Fatalf("journal failure completed attempt as %s", attempt.State)
+	}
+	manager.stateMutex.Lock()
+	pending := len(manager.disposed)
+	manager.stateMutex.Unlock()
+	if pending != 0 {
+		t.Fatalf("successful in-memory fallback left %d disposal acknowledgments pending", pending)
+	}
+}
+
+func TestAcknowledgedDisposedManifestIsNotRepublishedOnSecondRestart(t *testing.T) {
+	fixture := newServerFixture(t, nil)
+	repository := createRepository(t, "disposed-compaction")
+	dataDirectory := filepath.Join(t.TempDir(), "worker")
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	seedManager := newTestManager(t, fixture, codexPath, dataDirectory,
+		map[string]repositoryFixture{"factory": repository}, 1)
+	claim := seedReconciliationManifest(t, fixture, seedManager, manifestCleanupStarted)
+	if _, err := fixture.store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: strings.Repeat("r", 43), State: "failed", Error: "disposed during restart",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := seedManager.manifests.load(claim.Attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := inspectManifestWorktree(context.Background(), "git", seedManager.dataDirectory, manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := removeInspectedWorktree(context.Background(), "git", inspection, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := seedManager.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	firstRestart := newTestManager(t, fixture, codexPath, dataDirectory,
+		map[string]repositoryFixture{"factory": repository}, 1)
+	firstRestart.setHealth(health{State: "healthy", GitVersion: "test", CodexVersion: "test"})
+	if err := firstRestart.reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := firstRestart.registration().DisposedAttemptIDs; len(got) != 1 || got[0] != claim.Attempt.ID {
+		t.Fatalf("first restart disposals = %#v", got)
+	}
+	firstRestart.register(context.Background())
+	manifest, err = firstRestart.manifests.load(claim.Attempt.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !manifest.CapacityAcknowledged {
+		t.Fatal("successful registration did not compact the disposed manifest")
+	}
+	if err := firstRestart.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	secondRestart := newTestManager(t, fixture, codexPath, dataDirectory,
+		map[string]repositoryFixture{"factory": repository}, 1)
+	t.Cleanup(func() { _ = secondRestart.Close() })
+	if err := secondRestart.reconcile(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := secondRestart.registration().DisposedAttemptIDs; len(got) != 0 {
+		t.Fatalf("second restart republished acknowledged disposals: %#v", got)
+	}
+}
+
 func TestPeriodicRegistrationCannotOvertakeRetainedCapacityHandoff(t *testing.T) {
 	var blockNextRegistration atomic.Bool
 	registrationReached := make(chan struct{}, 1)

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -133,7 +133,7 @@ func (manager *Manager) reconcileManifest(ctx context.Context, manifest attemptM
 			value.RetentionReason = ""
 			return nil
 		})
-		if err == nil && !manifest.CapacityAcknowledged {
+		if err == nil {
 			err = manager.recordDisposed(manifest.AttemptID)
 		}
 		return retryReconciliation(err)
@@ -182,7 +182,7 @@ func (manager *Manager) reconcileManifest(ctx context.Context, manifest attemptM
 			value.RetentionReason = ""
 			return nil
 		})
-		if err == nil && !manifest.CapacityAcknowledged {
+		if err == nil {
 			err = manager.recordDisposed(manifest.AttemptID)
 		}
 		return retryReconciliation(err)
@@ -212,7 +212,7 @@ func (manager *Manager) reconcileManifest(ctx context.Context, manifest attemptM
 			value.RetentionReason = reason
 			return nil
 		})
-		if err == nil && !manifest.CapacityAcknowledged {
+		if err == nil {
 			err = manager.recordDisposed(manifest.AttemptID)
 		}
 		return retryReconciliation(err)

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -128,7 +128,42 @@ func (manager *Manager) reconcileManifest(ctx context.Context, manifest attemptM
 		})
 		return retryReconciliation(err)
 	case manifest.Lifecycle == manifestCleanupStarted && inspection.PathExists && inspection.Registered:
-		if err := removeInspectedWorktree(ctx, manager.options.GitExecutable, inspection, true); err != nil {
+		force := false
+		switch manifest.CleanupIntent {
+		case cleanupIntentAutomatic:
+			if eligibilityErr := automaticCleanupEligible(
+				ctx, manager.options.GitExecutable, manifest, inspection,
+			); eligibilityErr != nil {
+				reason := "interrupted automatic cleanup retained after revalidation: " + eligibilityErr.Error()
+				updated, updateErr := manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+					value.Lifecycle = manifestRetained
+					value.RetentionReason = boundedText(reason, 1000)
+					value.CleanupResult = "automatic cleanup stopped without removing the worktree"
+					return nil
+				})
+				if updateErr != nil {
+					return retryReconciliation(updateErr)
+				}
+				manager.recordRetained(updated)
+				return nil
+			}
+		case cleanupIntentOperator:
+			force = true
+		default:
+			reason := "cleanup intent was not durable; worktree retained for operator inspection"
+			updated, updateErr := manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+				value.Lifecycle = manifestRetained
+				value.RetentionReason = reason
+				value.CleanupResult = "startup refused ambiguous interrupted cleanup"
+				return nil
+			})
+			if updateErr != nil {
+				return retryReconciliation(updateErr)
+			}
+			manager.recordRetained(updated)
+			return nil
+		}
+		if err := removeInspectedWorktree(ctx, manager.options.GitExecutable, inspection, force); err != nil {
 			return retryReconciliation(err)
 		}
 		_, err = manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
@@ -371,6 +406,7 @@ func (manager *Manager) cleanCompletedWorktree(attemptID string) error {
 		return err
 	}
 	if err := manager.persistLifecycle(attemptID, manifestCleanupStarted, func(value *attemptManifest) {
+		value.CleanupIntent = cleanupIntentAutomatic
 		value.CleanupResult = "automatic cleanup started after successful completion"
 	}); err != nil {
 		return err

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -1,0 +1,428 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+type worktreeInspection struct {
+	Repository Repository
+	PathExists bool
+	Registered bool
+	Entry      gitWorktreeEntry
+	Status     string
+}
+
+type reconciliationRetryError struct{ error }
+type reconciliationUnsafeError struct{ error }
+type worktreeMismatchError struct{ error }
+
+func retryReconciliation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return reconciliationRetryError{error: err}
+}
+
+func unsafeReconciliation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return reconciliationUnsafeError{error: err}
+}
+
+func worktreeMismatch(message string) error {
+	return worktreeMismatchError{error: errors.New(message)}
+}
+
+func reconciliationNeedsRetry(err error) bool {
+	var retry reconciliationRetryError
+	return errors.As(err, &retry)
+}
+
+func isWorktreeMismatch(err error) bool {
+	var mismatch worktreeMismatchError
+	return errors.As(err, &mismatch)
+}
+
+func (manager *Manager) reconcile(ctx context.Context) error {
+	manifests, err := manager.manifests.loadAll()
+	var reconciliationErrors []error
+	if err != nil {
+		reconciliationErrors = append(reconciliationErrors, unsafeReconciliation(err))
+	}
+	for _, manifest := range manifests {
+		if err := manager.reconcileManifest(ctx, manifest); err != nil {
+			reconciliationErrors = append(reconciliationErrors,
+				fmt.Errorf("attempt %s: %w", manifest.AttemptID, err))
+		}
+	}
+	return errors.Join(reconciliationErrors...)
+}
+
+func (manager *Manager) reconcileManifest(ctx context.Context, manifest attemptManifest) error {
+	if manifest.ProcessActive {
+		if err := stopManifestProcesses(manifest); err != nil {
+			_, _ = manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+				value.Lifecycle = manifestInconsistent
+				value.RetentionReason = boundedText(err.Error(), 1000)
+				return nil
+			})
+			return unsafeReconciliation(err)
+		}
+		updated, err := manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.ProcessActive = false
+			return nil
+		})
+		if err != nil {
+			return retryReconciliation(fmt.Errorf("record stopped process group: %w", err))
+		}
+		manifest = updated
+	}
+
+	requestContext, cancel := context.WithTimeout(ctx, requestTimeout)
+	attempt, err := manager.client.attempt(requestContext, manifest.AttemptID)
+	cancel()
+	if err != nil {
+		var apiError *APIError
+		if errors.As(err, &apiError) && apiError.Status < 500 {
+			return unsafeReconciliation(fmt.Errorf("read control-plane attempt during reconciliation: %w", err))
+		}
+		return retryReconciliation(fmt.Errorf("read control-plane attempt during reconciliation: %w", err))
+	}
+	if err := verifyServerAttempt(manifest, attempt); err != nil {
+		_, persistErr := manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = manifestInconsistent
+			value.RetentionReason = boundedText(err.Error(), 1000)
+			return nil
+		})
+		return errors.Join(unsafeReconciliation(err), retryReconciliation(persistErr))
+	}
+
+	inspection, inspectErr := inspectManifestWorktree(ctx, manager.options.GitExecutable, manager.dataDirectory, manifest)
+	if inspectErr != nil {
+		if !isWorktreeMismatch(inspectErr) {
+			return retryReconciliation(inspectErr)
+		}
+		_, persistErr := manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = manifestInconsistent
+			value.RetentionReason = boundedText(inspectErr.Error(), 1000)
+			return nil
+		})
+		return errors.Join(unsafeReconciliation(inspectErr), retryReconciliation(persistErr))
+	}
+
+	switch {
+	case manifest.Lifecycle == manifestCleanupStarted && !inspection.PathExists && !inspection.Registered:
+		_, err = manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = manifestCleaned
+			value.CleanupResult = "worktree was already absent during startup cleanup recovery"
+			value.RetentionReason = ""
+			return nil
+		})
+		return retryReconciliation(err)
+	case manifest.Lifecycle == manifestCleanupStarted && inspection.PathExists && inspection.Registered:
+		if err := removeInspectedWorktree(ctx, manager.options.GitExecutable, inspection, true); err != nil {
+			return retryReconciliation(err)
+		}
+		_, err = manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = manifestCleaned
+			value.CleanupResult = "startup finished interrupted cleanup"
+			value.RetentionReason = ""
+			return nil
+		})
+		return retryReconciliation(err)
+	case inspection.PathExists != inspection.Registered:
+		reason := "worktree exists in only one of the filesystem and Git worktree registry"
+		_, err = manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = manifestInconsistent
+			value.RetentionReason = reason
+			return nil
+		})
+		if err != nil {
+			return retryReconciliation(err)
+		}
+		return unsafeReconciliation(errors.New(reason))
+	case !inspection.PathExists && !inspection.Registered:
+		lifecycle := manifestMissing
+		reason := "previously created worktree is absent"
+		if manifest.Lifecycle == manifestPreparing || manifest.Lifecycle == manifestNotCreated {
+			lifecycle = manifestNotCreated
+			reason = "worktree was never created"
+		} else if manifest.Lifecycle == manifestCleaned {
+			lifecycle = manifestCleaned
+			reason = ""
+		}
+		_, err = manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = lifecycle
+			value.RetentionReason = reason
+			return nil
+		})
+		return retryReconciliation(err)
+	default:
+		if manifest.Lifecycle == manifestCleaned || manifest.Lifecycle == manifestNotCreated {
+			reason := "worktree exists for a manifest recorded as absent"
+			_, err = manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+				value.Lifecycle = manifestInconsistent
+				value.RetentionReason = reason
+				return nil
+			})
+			if err != nil {
+				return retryReconciliation(err)
+			}
+			return unsafeReconciliation(errors.New(reason))
+		}
+		reason := firstNonEmpty(manifest.RetentionReason, "worktree retained after worker restart")
+		updated, err := manager.manifests.update(manifest.AttemptID, func(value *attemptManifest) error {
+			value.Lifecycle = manifestRetained
+			value.RetentionReason = reason
+			return nil
+		})
+		if err != nil {
+			return retryReconciliation(err)
+		}
+		manager.recordRetained(updated)
+		return nil
+	}
+}
+
+func verifyServerAttempt(manifest attemptManifest, attempt protocol.Attempt) error {
+	if attempt.ID != manifest.AttemptID || attempt.ExecutionID != manifest.ExecutionID ||
+		attempt.WorkerID != manifest.WorkerID {
+		return errors.New("control-plane attempt identity does not match the manifest")
+	}
+	if attempt.SupervisorPID != nil {
+		if manifest.SupervisorPID != *attempt.SupervisorPID ||
+			manifest.SupervisorIdentity != attempt.ProcessIdentity ||
+			attempt.ProcessGroupID == nil || manifest.ProcessGroupID != *attempt.ProcessGroupID {
+			return errors.New("control-plane process identity does not match the manifest")
+		}
+	} else if attempt.ProcessIdentity != "" || attempt.ProcessGroupID != nil {
+		return errors.New("control-plane process identity is partial")
+	}
+	return nil
+}
+
+func stopManifestProcesses(manifest attemptManifest) error {
+	var stopErrors []error
+	if processGroupAlive(int(manifest.ProcessGroupID)) {
+		if err := stopOwnedProcessGroup(int(manifest.ProcessGroupID), manifest.ProcessGroupIdentity, terminationGrace); err != nil {
+			stopErrors = append(stopErrors, fmt.Errorf("stop recorded Codex process group: %w", err))
+		}
+	}
+	if processGroupAlive(int(manifest.SupervisorPID)) {
+		if err := stopOwnedProcessGroup(int(manifest.SupervisorPID), manifest.SupervisorIdentity, terminationGrace); err != nil {
+			stopErrors = append(stopErrors, fmt.Errorf("stop recorded supervisor process group: %w", err))
+		}
+	}
+	return errors.Join(stopErrors...)
+}
+
+func inspectManifestWorktree(
+	ctx context.Context,
+	gitExecutable string,
+	dataDirectory string,
+	manifest attemptManifest,
+) (worktreeInspection, error) {
+	expectedPath := filepath.Join(dataDirectory, "worktrees", manifest.AttemptID)
+	if manifest.WorktreePath != expectedPath {
+		return worktreeInspection{}, worktreeMismatch("manifest worktree path escapes the V2 worktree root")
+	}
+	repository, err := resolveRepository(manifest.RepositoryKey, manifest.RepositoryPath, gitExecutable)
+	if err != nil {
+		return worktreeInspection{}, fmt.Errorf("verify manifest repository: %w", err)
+	}
+	if repository.Path != manifest.RepositoryPath || repository.RemoteIdentity != manifest.RemoteIdentity {
+		return worktreeInspection{}, worktreeMismatch("manifest repository identity no longer matches")
+	}
+	inspection := worktreeInspection{Repository: repository}
+	info, err := os.Lstat(manifest.WorktreePath)
+	switch {
+	case err == nil:
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return inspection, worktreeMismatch("manifest worktree path is not a real directory")
+		}
+		canonical, canonicalErr := filepath.EvalSymlinks(manifest.WorktreePath)
+		if canonicalErr != nil || canonical != manifest.WorktreePath {
+			return inspection, worktreeMismatch("manifest worktree path is not canonical")
+		}
+		inspection.PathExists = true
+	case errors.Is(err, os.ErrNotExist):
+	default:
+		return inspection, fmt.Errorf("inspect manifest worktree path: %w", err)
+	}
+
+	entries, err := listGitWorktrees(ctx, gitExecutable, repository.Path)
+	if err != nil {
+		return inspection, err
+	}
+	for _, entry := range entries {
+		entryPath, pathErr := filepath.Abs(entry.Path)
+		if pathErr != nil {
+			continue
+		}
+		entryPath = filepath.Clean(entryPath)
+		if entryPath != manifest.WorktreePath {
+			continue
+		}
+		if inspection.Registered {
+			return inspection, worktreeMismatch("Git lists the manifest worktree more than once")
+		}
+		inspection.Registered = true
+		inspection.Entry = entry
+	}
+	if inspection.Registered {
+		if inspection.Entry.Branch != manifest.Branch {
+			return inspection, worktreeMismatch("Git worktree branch does not match the manifest")
+		}
+		if !commitPattern.MatchString(inspection.Entry.Head) {
+			return inspection, worktreeMismatch("Git worktree commit identity is invalid")
+		}
+	}
+	if inspection.PathExists && inspection.Registered {
+		stdout, stderr, statusErr := runGitCommand(ctx, gitExecutable, manifest.WorktreePath, 1<<20,
+			"--no-optional-locks", "status", "--porcelain=v1")
+		if statusErr != nil {
+			return inspection, commandFailure("inspect retained worktree status", stdout, stderr, statusErr)
+		}
+		inspection.Status = strings.TrimSpace(string(stdout))
+	}
+	return inspection, nil
+}
+
+func removeInspectedWorktree(
+	ctx context.Context,
+	gitExecutable string,
+	inspection worktreeInspection,
+	force bool,
+) error {
+	if !inspection.PathExists || !inspection.Registered {
+		return errors.New("refuse cleanup without matching filesystem and Git worktree identity")
+	}
+	arguments := []string{"worktree", "remove"}
+	if force {
+		arguments = append(arguments, "--force")
+	}
+	arguments = append(arguments, inspection.Entry.Path)
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, inspection.Repository.Path, 256<<10, arguments...)
+	if err != nil {
+		return commandFailure("remove manifest-owned worktree", stdout, stderr, err)
+	}
+	if _, err := os.Lstat(inspection.Entry.Path); !errors.Is(err, os.ErrNotExist) {
+		return errors.New("Git reported cleanup success but the worktree path remains")
+	}
+	entries, err := listGitWorktrees(ctx, gitExecutable, inspection.Repository.Path)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		path, pathErr := filepath.Abs(entry.Path)
+		if pathErr == nil && filepath.Clean(path) == inspection.Entry.Path {
+			return errors.New("Git reported cleanup success but the worktree registration remains")
+		}
+	}
+	return nil
+}
+
+func automaticCleanupEligible(
+	ctx context.Context,
+	gitExecutable string,
+	manifest attemptManifest,
+	inspection worktreeInspection,
+) error {
+	if !inspection.PathExists || !inspection.Registered {
+		return errors.New("worktree identity is incomplete")
+	}
+	if inspection.Status != "" {
+		return errors.New("worktree is dirty")
+	}
+	if inspection.Entry.Head == manifest.BaseCommit {
+		return nil
+	}
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, manifest.WorktreePath, 256<<10,
+		"for-each-ref", "--format=%(refname)", "--contains", inspection.Entry.Head, "refs/remotes")
+	if err != nil {
+		return commandFailure("inspect published refs", stdout, stderr, err)
+	}
+	if strings.TrimSpace(string(stdout)) == "" {
+		return errors.New("worktree contains unpublished commits")
+	}
+	return nil
+}
+
+func (manager *Manager) cleanCompletedWorktree(attemptID string) error {
+	manifest, err := manager.manifests.load(attemptID)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*gitCommandTimeout)
+	defer cancel()
+	inspection, err := inspectManifestWorktree(ctx, manager.options.GitExecutable, manager.dataDirectory, manifest)
+	if err != nil {
+		return err
+	}
+	if err := automaticCleanupEligible(ctx, manager.options.GitExecutable, manifest, inspection); err != nil {
+		return err
+	}
+	if err := manager.persistLifecycle(attemptID, manifestCleanupStarted, func(value *attemptManifest) {
+		value.CleanupResult = "automatic cleanup started after successful completion"
+	}); err != nil {
+		return err
+	}
+	manifest, err = manager.manifests.load(attemptID)
+	if err != nil {
+		return err
+	}
+	inspection, err = inspectManifestWorktree(ctx, manager.options.GitExecutable, manager.dataDirectory, manifest)
+	if err != nil {
+		return err
+	}
+	if err := automaticCleanupEligible(ctx, manager.options.GitExecutable, manifest, inspection); err != nil {
+		return err
+	}
+	if err := removeInspectedWorktree(ctx, manager.options.GitExecutable, inspection, false); err != nil {
+		return err
+	}
+	return manager.persistLifecycle(attemptID, manifestCleaned, func(value *attemptManifest) {
+		value.CleanupResult = "automatic cleanup completed"
+		value.RetentionReason = ""
+	})
+}
+
+func (manager *Manager) recordRetained(manifest attemptManifest) {
+	cleanupCommand := "factory-worker cleanup " + manifest.AttemptID
+	if manager.config.path != "" {
+		cleanupCommand += " --config " + shellQuote(manager.config.path)
+	}
+	manager.stateMutex.Lock()
+	if _, exists := manager.retained[manifest.AttemptID]; !exists {
+		manager.retainedCounts[manifest.RemoteIdentity]++
+	}
+	manager.retained[manifest.AttemptID] = protocol.RetainedWorktree{
+		AttemptID: manifest.AttemptID, RepositoryID: manifest.RepositoryID,
+		Path: manifest.WorktreePath, Reason: boundedText(manifest.RetentionReason, 1000),
+		CleanupCommand: cleanupCommand,
+	}
+	manager.stateMutex.Unlock()
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func (manager *Manager) persistLifecycle(attemptID, lifecycle string, change func(*attemptManifest)) error {
+	_, err := manager.manifests.update(attemptID, func(manifest *attemptManifest) error {
+		manifest.Lifecycle = lifecycle
+		if change != nil {
+			change(manifest)
+		}
+		return nil
+	})
+	return err
+}

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -52,6 +52,13 @@ func isWorktreeMismatch(err error) bool {
 }
 
 func (manager *Manager) reconcile(ctx context.Context) error {
+	disposedAttemptIDs, err := manager.manifests.loadDisposals()
+	if err != nil {
+		return unsafeReconciliation(err)
+	}
+	for _, attemptID := range disposedAttemptIDs {
+		manager.rememberDisposed(attemptID)
+	}
 	manifests, err := manager.manifests.loadAll()
 	var reconciliationErrors []error
 	if err != nil {
@@ -126,6 +133,9 @@ func (manager *Manager) reconcileManifest(ctx context.Context, manifest attemptM
 			value.RetentionReason = ""
 			return nil
 		})
+		if err == nil && !manifest.CapacityAcknowledged {
+			err = manager.recordDisposed(manifest.AttemptID)
+		}
 		return retryReconciliation(err)
 	case manifest.Lifecycle == manifestCleanupStarted && inspection.PathExists && inspection.Registered:
 		force := false
@@ -172,6 +182,9 @@ func (manager *Manager) reconcileManifest(ctx context.Context, manifest attemptM
 			value.RetentionReason = ""
 			return nil
 		})
+		if err == nil && !manifest.CapacityAcknowledged {
+			err = manager.recordDisposed(manifest.AttemptID)
+		}
 		return retryReconciliation(err)
 	case inspection.PathExists != inspection.Registered:
 		reason := "worktree exists in only one of the filesystem and Git worktree registry"
@@ -199,6 +212,9 @@ func (manager *Manager) reconcileManifest(ctx context.Context, manifest attemptM
 			value.RetentionReason = reason
 			return nil
 		})
+		if err == nil && !manifest.CapacityAcknowledged {
+			err = manager.recordDisposed(manifest.AttemptID)
+		}
 		return retryReconciliation(err)
 	default:
 		if manifest.Lifecycle == manifestCleaned || manifest.Lifecycle == manifestNotCreated {
@@ -445,6 +461,21 @@ func (manager *Manager) recordRetained(manifest attemptManifest) {
 		Path: manifest.WorktreePath, Reason: boundedText(manifest.RetentionReason, 1000),
 		CleanupCommand: cleanupCommand,
 	}
+	manager.stateMutex.Unlock()
+}
+
+func (manager *Manager) recordDisposed(attemptID string) error {
+	if err := manager.manifests.addDisposal(attemptID); err != nil {
+		manager.rememberDisposed(attemptID)
+		return err
+	}
+	manager.rememberDisposed(attemptID)
+	return nil
+}
+
+func (manager *Manager) rememberDisposed(attemptID string) {
+	manager.stateMutex.Lock()
+	manager.disposed[attemptID] = true
 	manager.stateMutex.Unlock()
 }
 

--- a/internal/worker/supervisor.go
+++ b/internal/worker/supervisor.go
@@ -58,6 +58,8 @@ type supervisorProcess struct {
 	wait               chan error
 	stderr             *limitBuffer
 	controlMutex       sync.Mutex
+	stateMutex         sync.Mutex
+	stoppedVerified    bool
 	supervisorPID      int64
 	supervisorIdentity string
 	processGroupID     int64
@@ -658,6 +660,18 @@ func (process *supervisorProcess) closeControl() error {
 	err := process.control.Close()
 	process.control = nil
 	return err
+}
+
+func (process *supervisorProcess) markStopped() {
+	process.stateMutex.Lock()
+	process.stoppedVerified = true
+	process.stateMutex.Unlock()
+}
+
+func (process *supervisorProcess) isStopped() bool {
+	process.stateMutex.Lock()
+	defer process.stateMutex.Unlock()
+	return process.stoppedVerified
 }
 
 func supervisorCommandLine(executable string) []string {

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -977,6 +977,11 @@ func TestSupervisorCrashStopsRecordedProcessGroup(t *testing.T) {
 	}
 	waitForTaskState(t, fixture.store, task.Task.ID, "failed")
 	waitForProcessGone(t, childPID, 8*time.Second)
+	waitFor(t, 5*time.Second, func() bool {
+		manager.stateMutex.Lock()
+		defer manager.stateMutex.Unlock()
+		return manager.fatalHealth != nil && manager.health.State == "unhealthy"
+	})
 }
 
 func TestServerLossStopsCodexBeforeLeaseExpiry(t *testing.T) {

--- a/migrations/002_attempt_capacity_handoff.sql
+++ b/migrations/002_attempt_capacity_handoff.sql
@@ -1,6 +1,146 @@
+-- Schema 1 had no durable local record for an active attempt. Refuse to guess
+-- whether its worktree would be retained or disposed after interruption.
+CREATE TABLE migration_002_active_attempt_guard (
+    active_count INTEGER
+        CONSTRAINT drain_active_v2_attempts_before_upgrade
+        CHECK (active_count = 0)
+);
+
+INSERT INTO migration_002_active_attempt_guard(active_count)
+SELECT
+    (
+        SELECT COUNT(*)
+        FROM attempts
+        WHERE state IN ('preparing', 'running')
+    )
+    +
+    (
+        SELECT COUNT(*)
+        FROM workers
+        WHERE active_count <> 0
+    );
+
+DROP TABLE migration_002_active_attempt_guard;
+
 ALTER TABLE attempts
 ADD COLUMN capacity_acknowledged INTEGER NOT NULL DEFAULT 0
 CHECK (capacity_acknowledged IN (0, 1));
+
+-- Schema 1 had no durable per-attempt local disposition. Preserve its existing
+-- retained-worktree snapshot instead of treating historical terminal rows as
+-- new reservations that no upgraded worker can acknowledge. Schema 1 workers
+-- left retained_count at zero, so derive it from complete unique summaries.
+UPDATE worker_repositories AS wr
+SET retained_count = MAX(
+    retained_count,
+    COALESCE((
+        SELECT COUNT(DISTINCT CASE
+            WHEN retained.type = 'object'
+            THEN json_extract(retained.value, '$.attempt_id')
+        END)
+        FROM workers AS w,
+             json_each(
+                 CASE
+                     WHEN json_valid(w.retained_worktrees_json)
+                     THEN CASE
+                         WHEN json_type(w.retained_worktrees_json) = 'array'
+                         THEN w.retained_worktrees_json
+                         ELSE '[]'
+                     END
+                     ELSE '[]'
+                 END
+             ) AS retained
+        WHERE w.id = wr.worker_id
+          AND retained.type = 'object'
+          AND TRIM(COALESCE(json_extract(retained.value, '$.attempt_id'), '')) <> ''
+          AND json_extract(retained.value, '$.repository_id') = wr.repository_id
+    ), 0)
+);
+
+UPDATE attempts AS historical
+SET capacity_acknowledged = 1
+WHERE state IN ('succeeded', 'failed', 'cancelled', 'lost')
+  AND EXISTS (
+      SELECT 1
+      FROM workers AS w
+      WHERE w.id = historical.worker_id
+        AND json_valid(w.retained_worktrees_json)
+        AND json_type(
+            CASE
+                WHEN json_valid(w.retained_worktrees_json)
+                THEN w.retained_worktrees_json
+                ELSE 'null'
+            END
+        ) = 'array'
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM workers AS w,
+           json_each(
+               CASE
+                   WHEN json_valid(w.retained_worktrees_json)
+                   THEN CASE
+                       WHEN json_type(w.retained_worktrees_json) = 'array'
+                       THEN w.retained_worktrees_json
+                       ELSE '[]'
+                   END
+                   ELSE '[]'
+               END
+           ) AS retained
+      WHERE w.id = historical.worker_id
+        AND (
+            retained.type <> 'object'
+            OR TRIM(COALESCE(
+                CASE WHEN retained.type = 'object'
+                     THEN json_extract(retained.value, '$.attempt_id')
+                END,
+                ''
+            )) = ''
+            OR TRIM(COALESCE(
+                CASE WHEN retained.type = 'object'
+                     THEN json_extract(retained.value, '$.repository_id')
+                END,
+                ''
+            )) = ''
+            OR NOT EXISTS (
+                SELECT 1
+                FROM worker_repositories AS attributed
+                WHERE attributed.worker_id = historical.worker_id
+                  AND attributed.advertised = 1
+                  AND attributed.repository_id = CASE
+                      WHEN retained.type = 'object'
+                      THEN json_extract(retained.value, '$.repository_id')
+                  END
+            )
+        )
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM (
+          SELECT
+              CASE WHEN retained.type = 'object'
+                   THEN json_extract(retained.value, '$.attempt_id')
+              END AS attempt_id
+          FROM workers AS w,
+               json_each(
+                   CASE
+                       WHEN json_valid(w.retained_worktrees_json)
+                       THEN CASE
+                           WHEN json_type(w.retained_worktrees_json) = 'array'
+                           THEN w.retained_worktrees_json
+                           ELSE '[]'
+                       END
+                       ELSE '[]'
+                   END
+               ) AS retained
+          WHERE w.id = historical.worker_id
+          GROUP BY attempt_id
+          HAVING COUNT(DISTINCT CASE
+              WHEN retained.type = 'object'
+              THEN json_extract(retained.value, '$.repository_id')
+          END) > 1
+      ) AS conflicting_summary
+  );
 
 CREATE INDEX attempts_unacknowledged_capacity
 ON attempts(worker_id, capacity_acknowledged, state);

--- a/migrations/002_attempt_capacity_handoff.sql
+++ b/migrations/002_attempt_capacity_handoff.sql
@@ -1,0 +1,6 @@
+ALTER TABLE attempts
+ADD COLUMN capacity_acknowledged INTEGER NOT NULL DEFAULT 0
+CHECK (capacity_acknowledged IN (0, 1));
+
+CREATE INDEX attempts_unacknowledged_capacity
+ON attempts(worker_id, capacity_acknowledged, state);


### PR DESCRIPTION
Closes #132

## Summary

- persist and fsync versioned per-attempt manifests before side effects
- reconcile interrupted attempts and owned process groups before registration or claims
- enforce retained-worktree capacity per repository with an atomic terminal handoff
- add fail-closed cleanup preview and confirmation behavior while preserving branches
- document the recovery and operator workflow

## Verification

- `test -z "$(gofmt -l cmd internal migrations web/*.go)"`
- `go vet ./...`
- worker/control-plane dependency boundary check
- `go test -count=1 -timeout 5m ./...`
- `go test -race -count=1 -timeout 8m ./internal/worker ./internal/controlplane`
- `npm ci && npm run lint && npm run typecheck && npm test && npm run build`
- embedded UI freshness check
- `npm run test:browser` (7 passed)
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets`

## Review

Fresh independent review: approved with no blocker or important findings.