### PR TITLE
build: separate V2 UI and operator builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,15 @@ jobs:
       - name: Build embedded UI
         env:
           FACTORY_V2_SKIP_INSTALL: "1"
-        run: ./scripts/build-v2.sh
+        run: ./scripts/build-v2-ui.sh
       - name: Check embedded UI is current
         run: |
           git diff --exit-code -- web/dist
           test -z "$(git status --porcelain --untracked-files=all -- web/dist)"
+      - name: Test Node-free operator build
+        run: ./scripts/test-build-v2.sh
+      - name: Build V2 Go binaries
+        run: ./scripts/build-v2.sh
       - name: Test local startup workflow
         run: ./scripts/test-run-v2-local.sh
       - name: Check Go formatting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,8 @@ git clone https://github.com/owainlewis/factory.git
 cd factory
 cargo build --locked
 go build ./...
-cd web
-npm ci
-npm run build
-cd ..
+./scripts/build-v2-ui.sh
+./scripts/build-v2.sh
 ```
 
 To exercise Factory against GitHub, install and authenticate the GitHub CLI.
@@ -68,7 +66,8 @@ screenshots under `web/test-results/screenshots/`. Install its Chromium runtime
 once with `cd web && npx playwright install chromium`.
 
 Run `./scripts/test-run-v2-local.sh` to check that the combined launcher refuses
-to report an unhealthy worker as ready.
+to report an unhealthy worker as ready. Run `./scripts/test-build-v2.sh` to
+prove the normal operator build does not invoke Node or npm.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ recovery, and cleanup.
 ## V2 control plane and local worker
 
 The local V2 server includes its web interface in the Go binary, and the Unix
-worker runs assigned Codex tasks in separate managed Git worktrees. Production
-does not need Node.js or cross-origin configuration:
+worker runs assigned Codex tasks in separate managed Git worktrees. Normal
+builds use the committed embedded UI and do not need Node.js:
 
 ```sh
 ./scripts/build-v2.sh

--- a/docs/v2-local.md
+++ b/docs/v2-local.md
@@ -9,10 +9,12 @@ repositories. V1 remains separate and unchanged.
 Install:
 
 - Go 1.24 or newer;
-- Node.js 22 and npm;
 - Git;
 - curl;
 - the Codex CLI.
+
+Node.js 22 and npm are needed only when changing the web UI. Normal builds use
+the reviewed `web/dist` assets committed to the repository.
 
 Authenticate Codex before starting the worker:
 
@@ -58,10 +60,17 @@ process.
 
 ## Build and start
 
-One command installs pinned UI dependencies, builds the production UI, and
-builds both Go binaries:
+One command builds both Go binaries from the committed embedded UI assets:
 
 ```sh
+./scripts/build-v2.sh
+```
+
+When changing the web UI, rebuild the committed assets explicitly before
+building the Go binaries:
+
+```sh
+./scripts/build-v2-ui.sh
 ./scripts/build-v2.sh
 ```
 
@@ -84,8 +93,8 @@ fails with a direct error when the config is missing, a repository is invalid,
 the port is already in use, the server cannot become healthy, or either process
 exits early.
 
-The production process model has no Node server. Node is used only to compile
-the UI that `factory-server` embeds.
+The production process model and normal local build do not need Node. Node is
+used only by contributors to rebuild the UI that `factory-server` embeds.
 
 ## Delegate and inspect work
 

--- a/scripts/build-v2-ui.sh
+++ b/scripts/build-v2-ui.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+web_directory="$root/web"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Factory V2 UI build requires $1 on PATH." >&2
+    exit 1
+  fi
+}
+
+require_command node
+require_command npm
+
+if [ "${FACTORY_V2_SKIP_INSTALL:-0}" != "1" ]; then
+  echo "Installing pinned UI dependencies..."
+  (cd "$web_directory" && npm ci)
+fi
+
+echo "Rebuilding the embedded Factory V2 UI assets..."
+(cd "$web_directory" && npm run build)
+
+echo "Factory V2 UI assets are current in $web_directory/dist."

--- a/scripts/build-v2.sh
+++ b/scripts/build-v2.sh
@@ -3,7 +3,6 @@
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-web_directory="$root/web"
 build_directory=${FACTORY_V2_BUILD_DIR:-"$root/.factory-v2/bin"}
 
 require_command() {
@@ -14,20 +13,10 @@ require_command() {
 }
 
 require_command go
-require_command node
-require_command npm
 
 mkdir -p "$build_directory"
 
-if [ "${FACTORY_V2_SKIP_INSTALL:-0}" != "1" ]; then
-  echo "Installing pinned UI dependencies..."
-  (cd "$web_directory" && npm ci)
-fi
-
-echo "Building the embedded Factory V2 UI..."
-(cd "$web_directory" && npm run build)
-
-echo "Building Factory V2 Go binaries..."
+echo "Building Factory V2 Go binaries from committed embedded UI assets..."
 (cd "$root" && go build -o "$build_directory/factory-server" ./cmd/factory-server)
 (cd "$root" && go build -o "$build_directory/factory-worker" ./cmd/factory-worker)
 

--- a/scripts/test-build-v2.sh
+++ b/scripts/test-build-v2.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+temporary=$(mktemp -d)
+trap 'rm -rf "$temporary"' EXIT
+mkdir -p "$temporary/bin"
+
+cat >"$temporary/bin/go" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"$FACTORY_V2_TEST_GO_LOG"
+output=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    shift
+    output=$1
+    break
+  fi
+  shift
+done
+if [ -z "$output" ]; then
+  echo "fake go did not receive -o" >&2
+  exit 1
+fi
+mkdir -p "$(dirname -- "$output")"
+case "$output" in
+  *factory-server)
+    cat >"$output" <<'SERVER'
+#!/bin/sh
+exit 0
+SERVER
+    ;;
+  *)
+    cat >"$output" <<'WORKER'
+#!/bin/sh
+exit 0
+WORKER
+    ;;
+esac
+chmod +x "$output"
+EOF
+
+for command in node npm; do
+  cat >"$temporary/bin/$command" <<'EOF'
+#!/bin/sh
+echo "$0 must not run during the operator build" >&2
+exit 99
+EOF
+done
+chmod +x "$temporary/bin/go" "$temporary/bin/node" "$temporary/bin/npm"
+
+FACTORY_V2_BUILD_DIR="$temporary/output" \
+FACTORY_V2_TEST_GO_LOG="$temporary/go.log" \
+PATH="$temporary/bin:/usr/bin:/bin" \
+  "$root/scripts/build-v2.sh"
+
+test -x "$temporary/output/factory-server"
+test -x "$temporary/output/factory-worker"
+test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "2"
+grep -q 'build -o .*factory-server ./cmd/factory-server' "$temporary/go.log"
+grep -q 'build -o .*factory-worker ./cmd/factory-worker' "$temporary/go.log"
+
+rm -rf "$temporary/output"
+: >"$temporary/go.log"
+: >"$temporary/worker.toml"
+
+set +e
+output=$(
+  FACTORY_V2_BUILD_DIR="$temporary/output" \
+    FACTORY_V2_DATA_HOME="$temporary/data" \
+    FACTORY_V2_LISTEN="127.0.0.1:1" \
+    FACTORY_V2_TEST_GO_LOG="$temporary/go.log" \
+    PATH="$temporary/bin:/usr/bin:/bin" \
+    "$root/scripts/run-v2-local.sh" "$temporary/worker.toml" 2>&1
+)
+status=$?
+set -e
+
+if [ "$status" -ne 1 ]; then
+  echo "launcher exit status = $status, want 1" >&2
+  echo "$output" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$output" |
+  grep -q "Factory V2 server exited before becoming ready"; then
+  echo "launcher did not reach the controlled server readiness failure" >&2
+  echo "$output" >&2
+  exit 1
+fi
+test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "2"
+
+echo "Factory V2 operator build and default launcher route require only Go."


### PR DESCRIPTION
Closes #141.

## Summary

Normal V2 builds and the local launcher now compile the Go binaries from the committed embedded UI assets without invoking Node or npm. Contributors rebuild `web/dist` explicitly with `scripts/build-v2-ui.sh`, while CI continues to prove the committed assets are current.

## Reviewer notes

- `scripts/build-v2.sh` is now the operator path and requires only Go.
- `scripts/build-v2-ui.sh` owns npm installation and the Vite build.
- The regression test traps Node and npm on both the direct build and default launcher route.
- Documentation distinguishes operator prerequisites from contributor UI tooling.

## Proof

- `go test ./...`
- `go vet ./...`
- `./scripts/build-v2-ui.sh` and `git diff --exit-code -- web/dist`
- `./scripts/build-v2.sh`
- `./scripts/test-build-v2.sh`
- `./scripts/test-run-v2-local.sh`
- `sh -n scripts/build-v2.sh scripts/build-v2-ui.sh scripts/test-build-v2.sh scripts/run-v2-local.sh scripts/test-run-v2-local.sh`
- Independent review: approved with no findings
