### PR TITLE
docs(v2): define reusable workflow contract

### DIFF
--- a/docs/v2-architecture/design.md
+++ b/docs/v2-architecture/design.md
@@ -26,6 +26,10 @@ automatic retry, or workflow synchronization. The main downside is that it does
 not yet deliver the full fleet architecture. It proves the control-plane
 boundary and preserves the hard reliability work before adding scale.
 
+The proposed [V2 workflow design](../v2-workflows/design.md) is the next
+control-plane extension. It keeps the implemented task and worker boundary,
+while defining a task as free-text context plus an optional reusable workflow.
+
 ## 2. Context and scope
 
 V1 combines source polling, scheduling, durable task storage, workspace

--- a/docs/v2-github-ingest/design.md
+++ b/docs/v2-github-ingest/design.md
@@ -242,8 +242,10 @@ exists because its destination is frozen. Otherwise, submitted episodes keep
 their current identity and do not refire while still matched.
 
 The workflow revision ID is a per-request snapshot, not a configured delivery
-setting. If the workflow receives a new current revision, pending episodes
-replay their stored old revision while new episodes use the new revision. A
+setting. Ingest resolves it once at startup. If the workflow receives a new
+current revision, pending episodes replay their stored revision and newly
+observed episodes in the running process continue using the startup revision.
+Episodes observed after the next restart use the new current revision. A
 workflow revision change does not refire a continuously matching submitted
 issue.
 
@@ -362,7 +364,8 @@ on-disk event history.
 - Changing delivery settings does not refire a continuously matching submitted
   issue and is rejected while a pending request exists.
 - A newer current workflow revision does not block pending recovery, change its
-  pinned request, or refire a continuously matching submitted issue.
+  pinned request, or refire a continuously matching submitted issue. It applies
+  to new episodes only after ingest restarts.
 - The existing UI shows the source-created task without UI changes.
 - A real smoke test can create a dedicated labeled issue, run `--once`, observe
   the configured local worker complete it, and verify the selected workflow
@@ -377,11 +380,12 @@ validation, authentication failure, workflow resolution, issue-context
 normalization and limits, control-plane worker and repository validation,
 trigger reconciliation, request-key idempotency, the lost-response plus label
 rearm crash window, replay after issue and workflow changes, trigger versus
-delivery configuration changes, lost-response recovery after workflow
-disablement, pre-creation failure followed by disablement and abandonment,
-permanent prompt-size abandonment, local oversized-context abandonment,
-submitted and abandoned absence transitions, malformed issue identities,
-truncation, the hard row limit, pruning, and clean shutdown.
+delivery configuration changes, workflow revision adoption only after restart,
+lost-response recovery after workflow disablement, pre-creation failure
+followed by disablement and abandonment, permanent prompt-size abandonment,
+local oversized-context abandonment, submitted and abandoned absence
+transitions, malformed issue identities, truncation, the hard row limit,
+pruning, and clean shutdown.
 
 An integration test runs a real control-plane store and API with a registered
 fake worker. It polls a fake issue, submits one task, repeats the poll, restarts

--- a/docs/v2-github-ingest/design.md
+++ b/docs/v2-github-ingest/design.md
@@ -2,6 +2,11 @@
 
 > **Status:** Proposed for review
 
+> **Workflow dependency:** This design uses the
+> [V2 workflow contract](../v2-workflows/design.md). Ingest pins a
+> control-plane workflow revision in each pending task request. The control
+> plane, not ingest, composes and snapshots the resolved prompt.
+
 ## 1. Executive summary
 
 Factory V2 can run manually delegated tasks, but it cannot watch GitHub for
@@ -10,18 +15,19 @@ adds a small Go process, `factory-ingest`, that polls one GitHub repository,
 turns each matching issue into the existing task shape, and assigns it to one
 configured worker.
 
-The process uses the authenticated `gh` CLI and the existing control-plane HTTP
-API. It keeps its own small SQLite database so restarts and repeated polls do
-not create duplicate tasks. A repository-owned prompt remains responsible for
-live issue checks, issue comments, branches, pull requests, and status changes.
-The main downside is that the first version has file-based configuration and
-supports one repository and one trigger.
+The process uses the authenticated `gh` CLI and the control-plane HTTP API. It
+keeps its own small SQLite database so restarts and repeated polls do not
+create duplicate tasks. A pinned control-plane workflow revision remains
+responsible for live issue checks, issue comments, branches, pull requests,
+and status changes. The main downside is that the first version has file-based
+configuration and supports one repository and one trigger.
 
 ## 2. Context and scope
 
-The Go control plane currently accepts `{title, description, worker_id,
-repository_id}` from the UI or API. Go workers claim those tasks and run Codex
-or Claude Code. They do not know whether a task came from a human, GitHub, or a
+The Go control plane accepts `{title, description, worker_id, repository_id}`
+from the UI or API. The proposed workflow extension adds an optional immutable
+`workflow_revision_id`. Go workers claim resolved task prompts and run Codex or
+Claude Code. They do not know whether a task came from a human, GitHub, or a
 future scheduler.
 
 The Rust application already polls command-backed sources, deduplicates trigger
@@ -40,7 +46,7 @@ matching GitHub issue -> V2 task -> selected worker -> agent-managed issue and P
 ```mermaid
 flowchart LR
     GH["GitHub Issues"] -->|"gh issue list"| I["factory-ingest"]
-    P["Repository prompt"] --> I
+    F["Pinned workflow revision"] --> CP
     I -->|"POST /api/v1/tasks"| CP["Factory control plane"]
     CP -->|"HTTP claim polling"| W["Configured worker"]
     W -->|"Codex or Claude Code"| A["Coding agent"]
@@ -54,16 +60,17 @@ The control plane owns task idempotency, assignment, execution history, and the
 UI. It does not store GitHub credentials or poll GitHub.
 
 The selected worker owns the runtime, local repository, worktree, and agent
-process. The repository prompt owns the engineering and GitHub workflow.
+process. The pinned workflow revision owns the engineering and GitHub process.
 
 ## 4. Proposed design
 
 ### How it works
 
 The operator configures one GitHub repository, one required label, one worker
-ID, one repository key advertised by that worker, and one prompt file. The
-operator starts `factory-ingest` continuously or runs `factory-ingest --once`
-for a bounded test.
+ID, one repository key advertised by that worker, and one workflow ID. At
+startup ingest fetches and validates the workflow's current enabled revision.
+The operator starts `factory-ingest` continuously or runs
+`factory-ingest --once` for a bounded test.
 
 On each successful poll, ingest asks `gh issue list` for up to 100 open issues
 with the configured label. It validates the result and compares it with its
@@ -71,30 +78,33 @@ local trigger state.
 
 The first time an issue appears in a continuous matching period, ingest creates
 a random episode ID and a stable request key. It stores that pending episode
-and the exact normalized `CreateTaskRequest` JSON before submitting the task.
-The task title is the trusted static text `GitHub issue #<number>`. The
-description contains the trusted repository prompt first, then a delimiter and
-the untrusted issue number, URL, title, and body.
+and the exact normalized `CreateTaskRequest` JSON before submitting a valid
+task. The task title is the trusted static text `GitHub issue #<number>`. The
+description is free-text context containing a clear untrusted-data label plus
+the issue number, URL, title, and body. The request pins the workflow revision
+ID resolved at startup. If this context already exceeds the task API limit,
+ingest stores the episode as abandoned with `invalid_description` and does not
+create or submit a pending request.
 
 Ingest posts the task through `POST /api/v1/tasks`. A lost response is safe:
 the next attempt uses the same request key, and the control plane returns the
 task it already created. A pending episode cannot be rearmed. Ingest must replay
 its request key until a `200` or `201` response supplies the task ID, even when
 the issue has stopped matching. The agent may receive a stale task in that
-crash window, so the trusted prompt must revalidate the live label and stop
+crash window, so the pinned workflow must revalidate the live label and stop
 without mutation when it is absent. The task appears in the existing UI and is
 claimed by the configured worker.
 
-The repository prompt tells the agent to reread the live issue and confirm that
-the trigger label is still present before making changes. The prompt also owns
-removing the trigger label, commenting on the issue, pushing a branch, opening
-or updating a pull request, and reporting blockers. Ingest does not duplicate
+The workflow tells the agent to reread the live issue and confirm that the
+trigger label is still present before making changes. It also owns removing
+the trigger label, commenting on the issue, pushing a branch, opening or
+updating a pull request, and reporting blockers. Ingest does not duplicate
 those actions.
 
-Only a submitted issue may become absent. When it is absent from a complete
-successful poll, its episode is rearmed. If the label is applied again later,
-ingest creates a new episode and task. Edits and agent comments while the issue
-remains continuously matched do not create another task.
+Only a submitted or abandoned issue may become absent. When it is absent from
+a complete successful poll, its episode is rearmed. If the label is applied
+again later, ingest creates a new episode and task. Edits and agent comments
+while the issue remains continuously matched do not create another task.
 
 ### Components and responsibilities
 
@@ -102,13 +112,16 @@ remains continuously matched do not create another task.
 operator output. It depends on the ingest package and does not import worker or
 control-plane storage.
 
-`internal/ingest` owns config validation, GitHub polling, prompt composition,
-episode reconciliation, API submission, retry decisions, and SQLite state. It
-depends on `gh`, the control-plane HTTP API, and a local data directory. It does
-not own worker execution or GitHub mutations after submission.
+`internal/ingest` owns config validation, GitHub polling, issue-context
+normalization, episode reconciliation, API submission, retry decisions, and
+SQLite state. It depends on `gh`, the control-plane workflow and task APIs, and
+a local data directory. It does not compose workflow prompts, own worker
+execution, or perform GitHub mutations after submission.
 
-The existing control plane and worker keep their current contracts. No new
-control-plane table, endpoint, runtime interface, or UI framework is added.
+The worker keeps its existing claim contract. Ingest depends on the workflow
+tables and endpoints defined by the V2 workflow design, but adds no
+ingest-specific control-plane table, endpoint, runtime interface, or UI
+framework.
 
 ### Decisions
 
@@ -135,8 +148,7 @@ the MVP larger.
 1. One continuous matching period creates at most one control-plane task.
 2. A crash before, during, or after task submission cannot create a duplicate.
 3. An incomplete or failed GitHub poll never rearms an issue.
-4. GitHub issue content, including its title, is marked untrusted and cannot
-   precede the trusted repository prompt.
+4. GitHub issue content, including its title, is marked as untrusted context.
 5. Ingest never opens, edits, labels, comments on, or closes a GitHub issue.
 6. Ingest never opens the control-plane SQLite database.
 7. A task is submitted only to the configured worker and the advertised
@@ -149,8 +161,9 @@ the MVP larger.
   summary, and exits.
 - Continuous mode polls at the configured interval, which must be between 10
   seconds and 24 hours.
-- Startup validates the config, prompt, `gh` availability and authentication,
-  control-plane health, worker registration, and advertised repository.
+- Startup validates the config, enabled workflow and current revision, `gh`
+  availability and authentication, control-plane health, worker registration,
+  and advertised repository.
 - The advertised repository remote must equal
   `github.com/<owner>/<repository>` using an ASCII case-insensitive comparison.
 - A worker may be offline when ingest starts. Its registration and repository
@@ -185,7 +198,7 @@ repository = "owner/repository"
 label = "factory:ready-to-implement"
 worker_id = "61b30338-95dc-4704-80bd-8a4c63aa3037"
 repository_key = "repository"
-prompt = "/absolute/path/to/repository/.factory/workflows/implement.md"
+workflow_id = "9ec13fe1-4f41-49e2-94c9-5bb4b7f3c807"
 ```
 
 Unknown fields are errors. The first slice always polls open issues. The server
@@ -197,7 +210,7 @@ stores one current episode per repository, trigger, and issue:
 
 - issue number and URL;
 - random episode ID and derived request key;
-- state: `pending`, `submitted`, or `absent`;
+- state: `pending`, `submitted`, `abandoned`, or `absent`;
 - exact normalized `CreateTaskRequest` JSON used for every pending replay;
 - control-plane task ID when submitted;
 - first-seen, last-seen, submitted, and absent timestamps.
@@ -222,17 +235,24 @@ github:<uuid>
 The ingest database stores the human-readable repository, trigger, and issue
 identity. Changing the repository or label creates a new trigger identity.
 
-The server, worker ID, repository key, prompt path, and prompt content digest
-are delivery settings, not trigger identity. Their stored fingerprint detects a
-change at startup. A delivery change is rejected while any pending episode
-exists because its exact request and destination are frozen. Otherwise,
-submitted episodes keep their current identity and do not refire while still
-matched. Only episodes created after the change use the new delivery settings.
+The server, worker ID, repository key, and workflow ID are delivery settings,
+not trigger identity. Their stored fingerprint detects a config change at
+startup. A configured delivery change is rejected while any pending episode
+exists because its destination is frozen. Otherwise, submitted episodes keep
+their current identity and do not refire while still matched.
+
+The workflow revision ID is a per-request snapshot, not a configured delivery
+setting. If the workflow receives a new current revision, pending episodes
+replay their stored old revision while new episodes use the new revision. A
+workflow revision change does not refire a continuously matching submitted
+issue.
 
 ## 7. Failure behavior and lifecycle
 
-Config, authentication, database, prompt, or control-plane validation failures
-stop startup with a direct error. No task is submitted.
+Config, authentication, database, workflow, or control-plane validation
+failures stop startup with a direct error. Pending task recovery is the one
+exception: it runs before validation of the workflow's current enabled
+revision because every pending request already pins an immutable revision.
 
 A `gh` timeout, nonzero exit, or malformed JSON response records the source poll
 failure and leaves all existing episode states unchanged. Continuous mode tries
@@ -248,29 +268,48 @@ between those writes, the same POST is repeated and control-plane request-key
 idempotency returns the original task. Pending recovery happens before absence
 reconciliation. A pending episode never becomes absent, even if the issue no
 longer appears in the source result. Recovery sends the exact stored request
-bytes; later edits to the issue or prompt cannot change a pending request.
+bytes, including its immutable workflow revision ID. Later edits to the issue
+or workflow cannot change a pending request.
+
+If the original POST created a task but its response was lost, exact
+request-key replay returns that task before the control plane checks current
+workflow state. Disabling the workflow therefore cannot hide a task that
+already exists.
+
+If no task was created and recovery receives `workflow_disabled`,
+`workflow_revision_not_found`, `resolved_prompt_too_large`, or
+`agent_prompt_too_large`, or `invalid_description`, ingest atomically marks the
+episode `abandoned`, records the stable error, and does not retry or create
+another episode while the issue remains continuously matched. A later complete
+poll moves an abandoned issue that no longer matches to `absent`; applying the
+label again after the workflow or context is corrected creates a new episode.
+Transport, temporary server, and rate-limit failures leave the episode pending
+for bounded retry.
 
 Absence reconciliation requires a successful result with fewer than 100 issues
 and a valid issue number for every entry. Other invalid fields suppress the
 entry's submission but preserve its number as seen. An entry without a usable
 number suppresses all absence transitions for that poll.
 
-The config and prompt are read at startup. Changes require a restart. In-flight
-control-plane tasks continue independently when ingest stops or its config
-changes.
+The config and current enabled workflow revision are read at startup. Config
+changes require a restart. A new current workflow revision is adopted at the
+next restart. Pending recovery still uses each stored request's pinned
+revision. In-flight control-plane tasks continue independently when ingest
+stops or its config changes.
 
 ## 8. Security, privacy, and operations
 
 `gh` owns GitHub credentials. Ingest never requests, stores, prints, or forwards
 the token. The pending request and control-plane task description store the
-issue body and trusted prompt, so operators must treat both databases as
-sensitive. Existing task deletion and retention policy apply. The ingest
-database removes absent rows after 30 days and has the 1,000-row hard limit.
+issue body, while the control-plane task also stores the resolved workflow
+prompt. Operators must treat both databases as sensitive. Existing task
+deletion and retention policy apply. The ingest database removes absent rows
+after 30 days and has the 1,000-row hard limit.
 
-Issue content is untrusted input. Ingest validates JSON types and sizes, places
-the trusted workflow before issue content, and labels the issue section as
-untrusted context. The worker safety preamble remains the highest Factory-owned
-instruction.
+Issue content is untrusted input. Ingest validates JSON types and sizes and
+labels its description as untrusted context. The control plane places the
+pinned workflow before that context. The worker safety preamble remains the
+highest Factory-owned instruction.
 
 The control-plane URL is restricted to loopback HTTP. The SQLite directory and
 files are owner-only. Ingest takes an exclusive process lock so two processes
@@ -295,7 +334,16 @@ on-disk event history.
   restarting still creates only the original task until pending recovery
   records its task ID.
 - Pending recovery replays the exact stored request after the issue disappears,
-  its content changes, or the prompt file changes.
+  its content changes, or the workflow receives a newer revision.
+- A lost-response task is recovered after workflow disablement. A request that
+  never created a task becomes abandoned after disablement and does not retry
+  or duplicate work while the issue remains matched.
+- A permanently oversized pinned request becomes abandoned and is not retried
+  every poll.
+- An issue whose normalized context exceeds the task description limit is
+  abandoned before submission and is not retried while continuously matched.
+- A complete poll moves a submitted or abandoned episode that no longer
+  matches to absent; a later match creates one new episode.
 - Removing the label rearms the issue only after a complete successful poll;
   applying it again creates exactly one new task.
 - Failed, malformed, timed-out, or truncated GitHub polls do not rearm missing
@@ -307,15 +355,17 @@ on-disk event history.
 - Request keys remain below the control-plane 200-byte limit for every valid
   GitHub repository and issue.
 - The static task title contains no GitHub-controlled text. The task description
-  contains the exact trusted prompt before a clearly delimited untrusted issue
-  section.
+  is clearly labelled untrusted issue context, and the stored request pins the
+  enabled workflow revision resolved at startup.
 - The 1,000-row hard limit rejects new episodes without losing or rewriting
   existing state.
 - Changing delivery settings does not refire a continuously matching submitted
   issue and is rejected while a pending request exists.
+- A newer current workflow revision does not block pending recovery, change its
+  pinned request, or refire a continuously matching submitted issue.
 - The existing UI shows the source-created task without UI changes.
 - A real smoke test can create a dedicated labeled issue, run `--once`, observe
-  the configured local worker complete it, and verify the repository prompt
+  the configured local worker complete it, and verify the selected workflow
   updates the issue and opens or updates a pull request.
 - Normal Go binary builds continue to use committed UI assets and do not
   require Node.
@@ -323,12 +373,15 @@ on-disk event history.
 ## 10. Test approach
 
 Focused tests use fake `gh` and HTTP executables or servers. They cover config
-validation, authentication failure, issue normalization, prompt ordering and
-limits, control-plane worker and repository validation, trigger reconciliation,
-request-key idempotency, the lost-response plus label rearm crash window,
-replay after issue and prompt changes, trigger versus delivery configuration
-changes, malformed issue identities, truncation, the hard row limit, pruning,
-and clean shutdown.
+validation, authentication failure, workflow resolution, issue-context
+normalization and limits, control-plane worker and repository validation,
+trigger reconciliation, request-key idempotency, the lost-response plus label
+rearm crash window, replay after issue and workflow changes, trigger versus
+delivery configuration changes, lost-response recovery after workflow
+disablement, pre-creation failure followed by disablement and abandonment,
+permanent prompt-size abandonment, local oversized-context abandonment,
+submitted and abandoned absence transitions, malformed issue identities,
+truncation, the hard row limit, pruning, and clean shutdown.
 
 An integration test runs a real control-plane store and API with a registered
 fake worker. It polls a fake issue, submits one task, repeats the poll, restarts
@@ -341,11 +394,11 @@ GitHub.
 
 ## 11. Risks and tradeoffs
 
-- A prompt may fail to update GitHub after the task succeeds. The task result
+- A workflow may fail to update GitHub after the task succeeds. The task result
   and issue remain available for operator diagnosis; ingest does not guess a
   recovery mutation.
-- A label can be removed after polling but before execution. The trusted prompt
-  must revalidate live issue state before acting.
+- A label can be removed after polling but before execution. The pinned
+  workflow must revalidate live issue state before acting.
 - File-based worker IDs are not friendly. The first slice favors explicit,
   stable assignment; UI-based ingest configuration can follow later.
 - The issue body is retained in task history. Existing deletion controls and a

--- a/docs/v2-workflows/design.md
+++ b/docs/v2-workflows/design.md
@@ -181,7 +181,8 @@ small runtime-specific data plane.
 - Workflow name is required, ASCII case-insensitively unique, and limited to
   100 Unicode characters. Non-ASCII bytes are compared exactly.
 - Workflow summary is optional and limited to 500 Unicode characters.
-- Workflow instructions are required and limited to 64 KiB.
+- Workflow instructions are required and limited to 48 KiB. This reserves at
+  least 16 KiB for composition labels and useful task context.
 - Manual context is required and remains limited to 64 KiB.
 - The complete resolved prompt is limited to 64 KiB after UTF-8 composition.
 - The final agent input, including the safety preamble, title, repository
@@ -347,9 +348,10 @@ and separate editor or runner roles must be designed before hosted access.
 Prompts may contain private engineering policy and ticket context. They remain
 in the control-plane SQLite database and task detail API, must not enter normal
 server logs, and follow the existing task retention or deletion policy.
-Workflow revision text is bounded to 64 KiB, resolved prompts are bounded to 64
-KiB, server-validated final agent input is bounded to 72 KiB, workflow listing
-is paginated, and revision history is capped at 100 records per workflow.
+Workflow revision instructions are bounded to 48 KiB, resolved prompts are
+bounded to 64 KiB, server-validated final agent input is bounded to 72 KiB,
+workflow listing is paginated, and revision history is capped at 100 records
+per workflow.
 
 Workflows standardize instructions, not machines. Operators remain responsible
 for installing any tool and credential that a workflow expects. The first

--- a/docs/v2-workflows/design.md
+++ b/docs/v2-workflows/design.md
@@ -1,0 +1,435 @@
+# Reusable workflows for Factory V2
+
+> **Status:** Proposed for review
+
+## 1. Executive summary
+
+Factory V2 can delegate a free-text task to a worker, but every operator must
+remember and rewrite the team's implementation, review, and maintenance
+process. This makes the result depend on personal agent skills and local
+habits. V2 will add reusable workflows: named, versioned prompts stored by the
+control plane. A task becomes free-text context plus an optional workflow. The
+control plane saves the exact resolved prompt, and the worker runs it through
+its existing agent contract. The main downside is that prompts standardize the
+agent's process but cannot guarantee that every worker has the same tools or
+credentials.
+
+## 2. Context and scope
+
+The implemented [V2 architecture](../v2-architecture/design.md) accepts a
+title, description, worker, repository, and timeout. The description becomes
+the agent prompt. This is a useful normalized execution contract, but it has no
+shared place for team instructions such as coding standards, sub-agent review,
+ticket updates, verification, and pull-request templates.
+
+This change adds a control-plane workflow library and lets manual delegation,
+future source pollers, and future schedules use the same workflow. Manual
+context remains free text. It may contain a Jira ticket, merge-request URL,
+branch, repository request, or ordinary instructions. Factory does not require
+the operator to classify or parse that text.
+
+This design changes prompt creation in the control plane. It does not change
+worker assignment, leases, attempts, worktrees, runtime selection, or
+cancellation.
+
+## 3. System context
+
+```mermaid
+flowchart LR
+    M["Manual free-text context"] --> T["Task creation"]
+    I["Jira or GitHub ingest"] --> T
+    S["Future schedule"] --> T
+    F["Optional pinned workflow revision"] --> T
+    T --> P["Immutable resolved prompt"]
+    P --> CP["Control plane task"]
+    CP --> W["Unchanged worker contract"]
+    W --> A["Codex or Claude Code"]
+```
+
+The control plane owns workflow definitions, revisions, prompt composition,
+and task snapshots. A workflow record owns stable identity, enabled state, and
+its current revision. Each immutable revision contains the workflow name,
+summary, and instructions. The worker receives one resolved prompt and does
+not fetch, interpret, or synchronize workflows. External systems may add
+provenance for deduplication, but that metadata is not part of the agent
+execution contract.
+
+## 4. Proposed design
+
+### How it works
+
+An operator creates a workflow named `Implement a ticket`. Its instructions
+tell the agent to read the live ticket, inspect the repository, implement the
+change, run checks, request an independent review, address findings, open a
+pull request, and update the ticket. Saving creates revision 1.
+
+The operator opens Delegate task, selects that workflow, chooses a worker and
+repository, and enters:
+
+```text
+Work on JIRA-123:
+https://jira.example.com/browse/JIRA-123
+```
+
+The UI selects the workflow's current revision and submits that immutable
+revision ID. In one transaction, the server verifies that the revision belongs
+to an enabled workflow, stores the free-text context, composes the resolved
+prompt, and creates the task and execution. The resolved prompt has stable
+sections:
+
+```text
+Follow this workflow:
+
+<workflow instructions>
+
+Work on this context:
+
+<free-text context>
+```
+
+The worker adds its existing fixed Factory safety preamble, title, and
+repository identity, then runs the resolved prompt. Task detail shows the
+workflow name and revision, the original context, and the resolved prompt.
+
+Choosing `Blank task` stores no workflow reference. In that case the context is
+also the resolved prompt, preserving current behavior.
+
+### Components and responsibilities
+
+#### Control-plane store and API
+
+The control plane owns workflow identity, immutable revisions, enabled state,
+prompt composition, size validation, and task snapshots. It depends on SQLite.
+It does not execute workflows or inspect the meaning of their instructions.
+
+#### React UI
+
+The UI owns workflow management, workflow selection, and free-text context
+entry. It depends on the control-plane API. It does not compose prompts or
+store workflow state outside the server.
+
+#### Worker
+
+The worker owns agent execution exactly as it does today. It depends on the
+resolved prompt included in a claim. It does not know whether the task used a
+workflow or came from a person, poller, or schedule.
+
+#### Pollers and schedules
+
+A poller or schedule creates a normal task with context and an optional pinned
+workflow revision ID. It may attach source metadata for deduplication and
+display. It does not copy workflow text or compose the final prompt.
+
+### Decisions
+
+#### Context stays free text
+
+Manual context is one free-text field. Factory does not require ticket, merge
+request, branch, or repository target types. Typed work-item schemas were
+rejected because agents already understand these references and the schemas
+would add provider-specific UI and validation before it is needed. Automated
+sources may store structured provenance without changing manual delegation.
+
+#### Workflows are prompts, not programs
+
+A workflow is Markdown instructions. There is no template language, step
+graph, condition, shell action, tool installer, or runtime override. This keeps
+policy in a readable prompt and execution mechanism in Factory. Deterministic
+approval or deployment stages require a separate design if they become
+necessary.
+
+#### Tasks snapshot the resolved prompt
+
+Workflow edits affect only tasks created after the edit. Every task stores its
+workflow name, revision number, context, and resolved prompt. An execution
+retry uses the existing task snapshot. This was chosen over resolving a
+workflow at claim time because late resolution would make queued work change
+without an operator action.
+
+#### Workflows are shared across repositories
+
+The first workflow library belongs to the control plane, not one repository.
+The same implementation or review process can therefore be used across a
+fleet. Repository-specific instructions remain in the repository and may be
+referenced by the workflow. Repository scoping and workflow import or export
+are deferred.
+
+#### The server composes prompts
+
+The server, not the browser, poller, or worker, creates the resolved prompt.
+This gives every task source the same behavior and lets the worker remain a
+small runtime-specific data plane.
+
+## 5. Invariants and requirements
+
+### Invariants
+
+1. A workflow revision never changes after it is created.
+2. A task's context and resolved prompt never change after task creation.
+3. A task with a workflow records the exact workflow name and revision used.
+4. Workflow edits and disables do not change queued, running, or terminal
+   tasks.
+5. Blank tasks resolve to their free-text context without added workflow text.
+6. The control plane is the only component that composes workflow and context.
+7. Workers receive a resolved prompt and do not read workflow records.
+8. A disabled workflow cannot be used for a new task.
+9. Context is stored separately and never overwrites workflow instructions.
+10. Existing tasks created before this feature keep their original prompt.
+
+### Requirements
+
+- Workflow name is required, ASCII case-insensitively unique, and limited to
+  100 Unicode characters. Non-ASCII bytes are compared exactly.
+- Workflow summary is optional and limited to 500 Unicode characters.
+- Workflow instructions are required and limited to 64 KiB.
+- Manual context is required and remains limited to 64 KiB.
+- The complete resolved prompt is limited to 64 KiB after UTF-8 composition.
+- The final agent input, including the safety preamble, title, repository
+  identity, and resolved prompt, is limited to 72 KiB and is validated by the
+  control plane before task creation.
+- Editing a workflow's name, summary, or instructions creates the next integer
+  revision rather than updating text in place.
+- Workflow lists are paginated with the existing task-list limits: 50 by
+  default and 200 at most.
+- A workflow retains at most 100 revisions. Creating another revision at that
+  limit is rejected; revisions are not pruned while external requests may
+  still refer to them.
+- The UI offers `Blank task` and every enabled workflow in Delegate task.
+- Task detail shows context separately from the workflow snapshot.
+- Exact execution retry continues using the task's stored resolved prompt.
+- Disabling a workflow takes effect for new task creation immediately and does
+  not cancel work.
+
+## 6. Interfaces and data
+
+The API adds:
+
+- `GET /api/v1/workflows?limit=N&cursor=C` lists bounded workflow summaries.
+- `POST /api/v1/workflows` creates a workflow and revision 1. Its body includes
+  a client mutation key.
+- `GET /api/v1/workflows/{id}` returns metadata and the current revision.
+- `POST /api/v1/workflows/{id}/revisions` creates and activates a new revision.
+  Its body includes a client mutation key and the expected current revision ID.
+- `PUT /api/v1/workflows/{id}/enabled` idempotently enables or disables use.
+
+Task creation keeps `description` as the free-text context for API
+compatibility and adds an optional pinned `workflow_revision_id`:
+
+```json
+{
+  "request_key": "4a11cc72-2bb7-4f5e-92d6-e1d2087f6d94",
+  "title": "Implement JIRA-123",
+  "description": "Work on JIRA-123: https://jira.example.com/browse/JIRA-123",
+  "workflow_revision_id": "9ec13fe1-4f41-49e2-94c9-5bb4b7f3c807",
+  "worker_id": "3f441724-98c3-43ac-97f7-f87c92cbb9a8",
+  "repository_id": "b3195042-65f3-47b8-80e2-a5d09db33a31",
+  "timeout_seconds": 7200
+}
+```
+
+The UI gets the current immutable revision ID from the workflow response and
+sends that exact ID, so a concurrent edit cannot change the selected
+instructions. The server validates the revision and enabled workflow inside
+the task-creation transaction. An exact task request-key replay returns the
+original task before revalidating workflow state.
+
+The stored task adds nullable workflow ID and revision ID, workflow-name and
+revision-number snapshots, and a required resolved prompt. Browser list and
+detail projections keep `task.description` as the original free-text context;
+task detail also returns `resolved_prompt`.
+
+The claim projection deliberately keeps the existing worker contract:
+`claim.task.description` contains the resolved prompt. Current worker binaries
+already treat this field as their complete task instructions, so a server
+upgrade does not require a coordinated worker rollout or workflow-specific
+worker code.
+
+The canonical fixed prompt formatting and 72 KiB limit live in the shared
+protocol package used by the control plane and updated workers. The package
+does not read workflow storage or execute a runtime.
+
+Existing task rows are migrated with no workflow, their current description as
+context, and the same description as their resolved prompt. Existing API
+clients that omit `workflow_revision_id` therefore keep current behavior.
+
+Optional source provenance is a later additive task field. It may hold a
+provider, external key, URL, and revision for deduplication, but it does not
+participate in prompt composition in this feature.
+
+Workflow creation accepts:
+
+```json
+{
+  "request_key": "e3f257f6-bb5d-47cd-b903-8966c4bd36d8",
+  "name": "Implement a ticket",
+  "summary": "Implement, verify, review, and open a pull request.",
+  "instructions": "Read the live ticket..."
+}
+```
+
+Creating a revision accepts the same editable fields, a new `request_key`, and
+`expected_revision_id`. The server stores each mutation key and request digest
+on the workflow or revision record it created. Exact replay returns that
+record before checking current state. Reusing a key with different input
+returns `request_key_conflict`. A non-replay edit whose expected revision is no
+longer current returns `workflow_revision_conflict`.
+
+### Naming and identity
+
+The server creates one stable `workflow_id` UUID and one immutable
+`workflow_revision_id` UUID for each revision. The workflow ID survives
+rename. Revision numbers are display values and are not API identity.
+
+The server trims each name and maps ASCII `A` through `Z` to lowercase for its
+unique lookup key. Other UTF-8 bytes remain unchanged; V2 does not perform
+Unicode case folding or canonical-equivalence normalization. A blank,
+duplicate, or overlong name is rejected without creating a record.
+
+Revision numbers start at 1 and increase by one in the same transaction that
+stores the immutable revision and updates the current revision. Tasks snapshot
+the workflow name and revision number, so later rename, disable, deletion, or
+revision-library changes do not make task history unclear.
+
+## 7. Failure behavior and lifecycle
+
+Creating or editing a workflow is atomic. Validation or database failure
+leaves the previous current revision unchanged. Exact mutation-key replay
+returns its first result. Concurrent non-replay edits use
+`expected_revision_id`; only one can advance the current revision and the
+other receives `workflow_revision_conflict`.
+
+Task creation fails with `workflow_revision_not_found` when the revision ID is
+unknown, `workflow_disabled` when its workflow is disabled,
+`resolved_prompt_too_large` when composition exceeds 64 KiB, and
+`agent_prompt_too_large` when the complete worker input exceeds 72 KiB. No task
+or execution is created in those cases. The operator can correct the input and
+submit again with the same request key because failed validation does not
+reserve that key.
+
+A control-plane restart requires no workflow recovery beyond normal SQLite
+startup. A task committed before a crash contains its complete prompt. A
+worker that already claimed a task continues with that snapshot. Server
+shutdown does not modify workflows or tasks.
+
+Disabling a workflow blocks subsequent task creation as soon as the disable
+transaction commits. Existing executions, retries of those executions, and
+task history remain valid. Re-enabling restores use of the same current
+revision. Hard deletion is not exposed in the first version.
+
+Creating a 101st revision returns `workflow_revision_limit` and leaves the
+current revision unchanged. Revisions are not pruned because a pending source
+request may hold an immutable revision ID outside the control-plane database.
+One hundred revisions is enough for the MVP and provides an explicit storage
+bound.
+
+The control plane and worker share one canonical agent-prompt formatter. Before
+creating a task, the control plane formats the exact input using the selected
+repository identity and rejects more than 72 KiB. Existing worker binaries use
+the same current fixed format, so this server-side guarantee protects them
+without a coordinated rollout. Updated workers also check the 72 KiB limit
+before starting the runtime as defense in depth. A future format or preamble
+change must remain within this contract or introduce an explicit worker
+protocol version gate.
+
+## 8. Security, privacy, and operations
+
+Workflow instructions are trusted operator policy. Free-text context, ticket
+bodies, merge-request text, and linked content are untrusted. The resolved
+prompt places trusted workflow instructions before a clearly delimited context
+section. The fixed worker safety preamble remains first. This structure reduces
+ambiguity but does not remove model prompt-injection risk.
+
+V2 is still a local, unauthenticated control plane bound to loopback. Any local
+caller that can create tasks can also read workflow instructions. Workflow
+editing requires the same local trust as worker configuration. Authentication
+and separate editor or runner roles must be designed before hosted access.
+
+Prompts may contain private engineering policy and ticket context. They remain
+in the control-plane SQLite database and task detail API, must not enter normal
+server logs, and follow the existing task retention or deletion policy.
+Workflow revision text is bounded to 64 KiB, resolved prompts are bounded to 64
+KiB, server-validated final agent input is bounded to 72 KiB, workflow listing
+is paginated, and revision history is capped at 100 records per workflow.
+
+Workflows standardize instructions, not machines. Operators remain responsible
+for installing any tool and credential that a workflow expects. The first
+version adds no worker capability matching.
+
+## 9. Acceptance criteria
+
+- An operator can create, edit, disable, enable, and list workflows in the UI.
+- Editing a workflow creates an immutable numbered revision.
+- Delegate task can run blank context or combine context with an enabled
+  workflow.
+- Jira text, a merge-request URL, a branch name, and a repository-wide request
+  are all accepted as ordinary context without target-type fields.
+- Task detail shows the original context, workflow name and revision, and exact
+  resolved prompt.
+- Delegate task uses the pinned workflow revision selected by the operator even
+  when another operator edits the workflow before submission completes.
+- Editing or disabling a workflow after task creation does not change that
+  task's claim payload.
+- A Codex worker and a Claude Code worker both run workflow tasks without
+  workflow-specific worker code.
+- Existing clients that create tasks without `workflow_revision_id` behave as
+  before, and already registered worker binaries receive the resolved prompt
+  through their existing claim field.
+- Invalid, disabled, duplicate, and oversized workflow operations return stable
+  API errors and create no partial records.
+- Lost workflow-create and edit responses are recovered by exact
+  mutation-key replay, and concurrent edits cannot overwrite one another.
+- The revision limit rejects a new edit without removing revisions used by
+  tasks or pending sources.
+
+## 10. Test approach
+
+Store and HTTP tests will cover name normalization, immutable revision
+increments, lost-response replay, mutation-key conflict, concurrent edit
+conflict, enable and disable behavior, pinned prompt composition, UTF-8 byte
+limits, atomic task snapshots, migration backfill, pagination, the revision
+limit, and stable errors.
+
+Worker protocol tests will prove that claims carry the stored resolved prompt
+in `task.description` for blank and workflow tasks, including a worker built
+before the workflow migration. Store and worker tests will prove that the
+shared formatter produces identical bytes and that the server rejects final
+input over 72 KiB before creating a task. Existing lease, retry, cancellation,
+and reconciliation tests must continue to pass unchanged.
+
+React unit tests will cover workflow management, workflow selection, context
+preservation during polling, validation, and task detail. A real browser test
+will create a workflow, delegate Jira-style context through it, edit the
+workflow while the task is queued, and prove that a real worker receives the
+original resolved prompt.
+
+## 11. Risks and tradeoffs
+
+- Prompt-only workflows cannot enforce every step. Human review, worker
+  credentials, and repository controls remain required.
+- A global workflow may not fit every repository. Workflows should direct the
+  agent to read repository-owned instructions, and repository scoping can be
+  added after real use.
+- Saving context and the resolved prompt duplicates some text. The duplication
+  is intentional because it preserves both the human input and exact execution
+  record.
+- A workflow cannot receive more than 100 revisions in the MVP. The server
+  rejects further edits rather than invalidating pinned requests.
+- A provider URL can change after submission. The workflow should reread live
+  state when freshness matters, while the stored context preserves what
+  Factory received.
+
+## 12. Open questions
+
+- None block task breakdown. Hosted authorization, repository scoping, and
+  workflow import or export require separate designs when they enter scope.
+
+## 13. Out of scope
+
+- A workflow graph, conditional steps, approvals, or a general job engine.
+- Prompt variables, interpolation, or provider-specific input forms.
+- Automatic URL parsing or typed ticket, merge-request, branch, and repository
+  targets.
+- Installing skills, tools, models, or credentials on workers.
+- Repository-scoped workflow synchronization.
+- Source pollers, scheduled triggers, and structured provenance storage.
+- Hosted authentication and workflow editor roles.


### PR DESCRIPTION
## Problem

Factory V2 has no shared way to encode team implementation, review, or maintenance practices. Manual prompts therefore depend on each operator and their personal agent setup.

## Changes

Defines a task as free-text context plus an optional pinned workflow revision. The control plane owns immutable workflow revisions and resolved prompt snapshots, while existing workers continue receiving one prompt through their current claim field. The GitHub ingest design now pins workflow revisions and has explicit recovery behavior for disabled, invalid, and oversized work.

## Verification

- `git diff --check`
- Confirmed both design documents contain all 13 required sections.
- Confirmed referenced design files exist.
- Independent design review approved the final task, worker, ingest recovery, idempotency, identity, and prompt-bound contracts.
- No runtime tests were run because this pull request changes design documentation only.

## Risks

This is a proposed design, not an implementation. Prompt-only workflows cannot enforce every step, the MVP remains local-trust only, and workflow history is capped at 100 revisions.

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests and documentation cover changed behavior.
- [x] Logs, fixtures, and screenshots contain no secrets or private repository data.