### PR TITLE
Isolate worker attempts from remote base branches

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -226,17 +226,24 @@ use its installed provider CLI to update the issue and open a pull request.
 
 1. The worker validates the claim identity, assignment, runtime, repository ID,
    and remote identity.
-2. It uses a compatible legacy checkout or serially clones/fetches the managed
-   repository. Managed work starts at the fetched remote default-branch commit.
-3. It creates a branch named
+2. It uses a compatible legacy checkout or serially clones/acquires the managed
+   repository cache.
+3. It discovers the origin default branch or uses a legacy repository's
+   configured `base_branch`, fetches it, and freezes its exact commit.
+4. It creates a branch named
    `factory/<task-prefix>-<attempt-prefix>` and an owned worktree.
-4. It writes a protected attempt manifest before starting the runtime.
-5. The internal supervisor starts, then the worker transitions the attempt to
+5. It writes a protected attempt manifest before starting the runtime.
+6. The internal supervisor starts, then the worker transitions the attempt to
    `running`.
-6. Runtime output is sent as ordered, idempotent event batches.
-7. The worker renews the 30-second lease while the supervisor is active.
-8. Completion records a bounded result, error, and outcome, and moves the
+7. Runtime output is sent as ordered, idempotent event batches.
+8. The worker renews the 30-second lease while the supervisor is active.
+9. Completion records a bounded result, error, and outcome, and moves the
    execution to `succeeded`, `failed`, or `cancelled`.
+
+The configured checkout is repository metadata and a shared Git object store;
+agent work never runs inside it. Worktrees isolate Git state, not process,
+network, credential, or host filesystem access. A future sandbox may contain
+the prepared worktree without changing task or execution identity.
 
 ### Cancellation and lease expiry
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -228,8 +228,9 @@ use its installed provider CLI to update the issue and open a pull request.
    and remote identity.
 2. It uses a compatible legacy checkout or serially clones/acquires the managed
    repository cache.
-3. It discovers the origin default branch or uses a legacy repository's
-   configured `base_branch`, fetches it, and freezes its exact commit.
+3. It revalidates the registered origin identity, discovers the origin default
+   branch or uses a legacy repository's configured `base_branch`, fetches it,
+   freezes its exact commit, and checks the origin identity again.
 4. It creates a branch named
    `factory/<task-prefix>-<attempt-prefix>` and an owned worktree.
 5. It writes a protected attempt manifest before starting the runtime.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,10 +241,10 @@ use its installed provider CLI to update the issue and open a pull request.
 9. Completion records a bounded result, error, and outcome, and moves the
    execution to `succeeded`, `failed`, or `cancelled`.
 
-The configured checkout is repository metadata and a shared Git object store;
-agent work never runs inside it. Worktrees isolate Git state, not process,
-network, credential, or host filesystem access. A future sandbox may contain
-the prepared worktree without changing task or execution identity.
+The legacy checkout or managed cache is repository metadata and a shared Git
+object store; agent work never runs inside it. Worktrees isolate Git state, not
+process, network, credential, or host filesystem access. A future sandbox may
+contain the prepared worktree without changing task or execution identity.
 
 ### Cancellation and lease expiry
 

--- a/docs/local.md
+++ b/docs/local.md
@@ -38,8 +38,15 @@ selects the state directory.
 
 No worker repository list is required. Factory detects local GitHub access with
 `gh auth status` and clones centrally managed repositories on demand. Optional
-legacy repository paths still resolve from the worker TOML directory and remain
-available for manual UI delegation.
+legacy repository paths remain available for manual UI delegation. Relative
+paths resolve from the worker TOML directory, and each path must be a real,
+non-bare Git checkout with an `origin` remote. Factory starts legacy work from
+the origin default branch without changing the checkout. To use another base,
+configure it under that repository:
+
+```toml
+base_branch = "release/2026.07"
+```
 
 For Claude Code, use another config and identity:
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -32,6 +32,9 @@ ability to acquire centrally managed GitHub repositories. It contains no token.
 
 The legacy `[repositories.<key>]` map remains optional for manual delegation to
 an existing non-bare checkout. Its paths resolve relative to the worker TOML.
+Each repository must have an `origin`. `base_branch` is an optional short branch
+name such as `main`, `develop`, or `release/2026.07`; when omitted, Factory uses
+the branch advertised as the origin default.
 Newly discovered legacy checkouts enter the catalog disabled and support only
 explicit assignment until an operator adds or enables them centrally. Reposting
 a centrally managed repository does not override an explicit disable.
@@ -85,16 +88,24 @@ lease expires.
 The worker prepares a task as follows:
 
 1. validate the repository ID and canonical `github.com/owner/repository`
-   identity;
-2. clone a missing repository with `gh repo clone` or fetch its existing cache,
-   then resolve the current remote default-branch commit;
-3. create an owned worktree below its data directory;
-4. create a `factory/<task-prefix>-<attempt-prefix>` branch;
-5. write a protected, durable attempt manifest;
-6. launch the selected runtime in the worktree;
-7. stream bounded lifecycle and output events;
-8. report the result and outcome;
-9. inspect final Git state locally to decide whether cleanup is safe.
+   identity, or validate a compatible legacy checkout;
+2. clone a missing managed repository with `gh repo clone` or use its existing
+   cache;
+3. discover the origin default branch or use a legacy repository's configured
+   `base_branch`, fetch it, and freeze its exact commit;
+4. create an owned worktree below its data directory;
+5. create a `factory/<task-prefix>-<attempt-prefix>` branch;
+6. write a protected, durable attempt manifest;
+7. launch the selected runtime in the worktree;
+8. stream bounded lifecycle and output events;
+9. report the result and outcome;
+10. inspect final Git state locally to decide whether cleanup is safe.
+
+The registered checkout is never switched to the base branch and agent work
+never runs in it. A worktree isolates Git state but is not a security sandbox:
+the runtime still has the worker process's filesystem, network, and credential
+access. A later sandbox can contain this same prepared workspace without
+changing the task contract.
 
 Codex is launched non-interactively with structured result output. Claude Code
 is launched non-interactively with JSON output. The worker normalizes both into

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -41,6 +41,10 @@ a centrally managed repository does not override an explicit disable.
 Repositories already known before this migration remain enabled for routing
 compatibility.
 
+The worker pins the normalized `origin` identity at startup and revalidates it
+before and after resolving each attempt base. An intentional origin change
+requires a worker restart; an unexpected change fails before agent launch.
+
 ## Identity and registration
 
 The first start creates a protected `worker-id` file in the worker data

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -105,11 +105,11 @@ The worker prepares a task as follows:
 9. report the result and outcome;
 10. inspect final Git state locally to decide whether cleanup is safe.
 
-The registered checkout is never switched to the base branch and agent work
-never runs in it. A worktree isolates Git state but is not a security sandbox:
-the runtime still has the worker process's filesystem, network, and credential
-access. A later sandbox can contain this same prepared workspace without
-changing the task contract.
+The legacy checkout and managed cache are never switched to the base branch,
+and agent work never runs in either. A worktree isolates Git state but is not a
+security sandbox: the runtime still has the worker process's filesystem,
+network, and credential access. A later sandbox can contain this same prepared
+workspace without changing the task contract.
 
 Codex is launched non-interactively with structured result output. Claude Code
 is launched non-interactively with JSON output. The worker normalizes both into

--- a/examples/worker.toml
+++ b/examples/worker.toml
@@ -14,3 +14,5 @@ max_concurrent = 1
 # Legacy manual delegation may still point a worker at an existing checkout:
 # [repositories.factory]
 # path = "/absolute/path/to/factory"
+# Optional. When omitted, Factory uses the origin default branch.
+# base_branch = "release/2026.07"

--- a/internal/worker/attempt_lifecycle.go
+++ b/internal/worker/attempt_lifecycle.go
@@ -75,7 +75,8 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 		TaskID: claim.Task.ID, ExecutionID: claim.Execution.ID, AttemptID: claim.Attempt.ID,
 		RepositoryID: claim.Repository.ID, RepositoryKey: repository.Key,
 		RepositoryPath: repository.Path, RemoteIdentity: repository.RemoteIdentity,
-		BaseCommit: value.BaseCommit, WorktreePath: value.Path, Branch: value.Branch,
+		BaseBranch: value.BaseBranch, BaseCommit: value.BaseCommit,
+		WorktreePath: value.Path, Branch: value.Branch,
 		LeaseDeadline: claim.Attempt.LeaseExpiresAt, Lifecycle: manifestPreparing,
 	}
 	if err := manager.manifests.create(manifest); err != nil {
@@ -135,7 +136,7 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 		RuntimeExecutable: manager.options.RuntimeExecutable,
 		Worktree:          value.Path,
 		ResultPath:        path,
-		Prompt:            buildPrompt(claim),
+		Prompt:            buildPrompt(claim, value),
 		TimeoutSeconds:    remainingTimeoutSeconds(taskDeadline),
 	}, os.Stderr)
 	if err != nil {
@@ -617,12 +618,14 @@ func terminalState(message supervisorMessage) string {
 	return "failed"
 }
 
-func buildPrompt(claim protocol.Claim) string {
+func buildPrompt(claim protocol.Claim, value worktree) string {
 	return "You are running in a Factory managed Git worktree.\n" +
-		"Work only on the assigned task and repository. Preserve unrelated changes and do not touch Factory state or unrelated worktrees, " +
-		"and do not delete worktrees or branches. Complete and verify the task before returning a concise result.\n\n" +
+		"Work only on the assigned task and repository. Preserve unrelated changes and do not touch Factory state or unrelated worktrees. " +
+		"Do not switch, create, rename, or delete branches or worktrees. Complete and verify the task before returning a concise result.\n\n" +
 		"Task title: " + claim.Task.Title + "\n" +
-		"Repository: " + claim.Repository.RemoteIdentity + "\n\n" +
+		"Repository: " + claim.Repository.RemoteIdentity + "\n" +
+		"Working branch: " + value.Branch + "\n" +
+		"Target base branch: " + value.BaseBranch + "\n\n" +
 		claim.Task.Description
 }
 

--- a/internal/worker/attempt_lifecycle_test.go
+++ b/internal/worker/attempt_lifecycle_test.go
@@ -14,15 +14,18 @@ func TestBuildPromptIncludesGrammaticalSafetyInstruction(t *testing.T) {
 		},
 		Repository: protocol.Repository{RemoteIdentity: "github.com/owainlewis/factory"},
 	}
+	value := worktree{Branch: "factory/123456789abc-abcdef123456", BaseBranch: "main"}
 
 	want := "You are running in a Factory managed Git worktree.\n" +
-		"Work only on the assigned task and repository. Preserve unrelated changes and do not touch Factory state or unrelated worktrees, " +
-		"and do not delete worktrees or branches. Complete and verify the task before returning a concise result.\n\n" +
+		"Work only on the assigned task and repository. Preserve unrelated changes and do not touch Factory state or unrelated worktrees. " +
+		"Do not switch, create, rename, or delete branches or worktrees. Complete and verify the task before returning a concise result.\n\n" +
 		"Task title: Fix the prompt\n" +
-		"Repository: github.com/owainlewis/factory\n\n" +
+		"Repository: github.com/owainlewis/factory\n" +
+		"Working branch: factory/123456789abc-abcdef123456\n" +
+		"Target base branch: main\n\n" +
 		"Keep the change focused."
 
-	if got := buildPrompt(claim); got != want {
+	if got := buildPrompt(claim, value); got != want {
 		t.Fatalf("buildPrompt() = %q, want %q", got, want)
 	}
 }

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -22,7 +22,8 @@ const (
 )
 
 type RepositoryConfig struct {
-	Path string `toml:"path"`
+	Path       string `toml:"path"`
+	BaseBranch string `toml:"base_branch"`
 }
 
 type Config struct {
@@ -41,6 +42,7 @@ type Repository struct {
 	Path           string
 	RemoteIdentity string
 	BaseCommit     string
+	BaseBranch     string
 }
 
 func LoadConfig(path string) (Config, error) {
@@ -132,6 +134,12 @@ func validateConfig(config Config) error {
 		}
 		if strings.TrimSpace(repository.Path) == "" {
 			return fmt.Errorf("repository %q path is required", key)
+		}
+		if repository.BaseBranch != strings.TrimSpace(repository.BaseBranch) {
+			return fmt.Errorf("repository %q base_branch must not have surrounding whitespace", key)
+		}
+		if len(repository.BaseBranch) > 244 {
+			return fmt.Errorf("repository %q base_branch must be at most 244 bytes", key)
 		}
 	}
 	return nil

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -314,7 +314,7 @@ func resolveBaseCommit(
 		"rev-parse", "--verify", base+"^{commit}")
 	if localErr != nil || strings.TrimSpace(string(stdout)) != base {
 		stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 256<<10,
-			"fetch", "--no-tags", "origin", "refs/heads/"+branch)
+			"fetch", "--no-tags", "--refmap=", "origin", "refs/heads/"+branch)
 		if err != nil {
 			return "", "", commandFailure("fetch base branch origin/"+branch, stdout, stderr, err)
 		}

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -271,9 +271,14 @@ func prepareWorktree(ctx context.Context, gitExecutable, root string, repository
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return worktree{}, fmt.Errorf("inspect attempt worktree path: %w", err)
 	}
-	baseBranch, base, err := resolveBaseCommit(ctx, gitExecutable, repository)
-	if err != nil {
-		return worktree{}, err
+	baseBranch, base := repository.BaseBranch, repository.BaseCommit
+	if base == "" {
+		baseBranch, base, err = resolveBaseCommit(ctx, gitExecutable, repository)
+		if err != nil {
+			return worktree{}, err
+		}
+	} else if baseBranch == "" || !commitPattern.MatchString(base) {
+		return worktree{}, errors.New("pre-resolved repository base must include a branch and full commit ID")
 	}
 	branch := "factory/" + taskID[:12] + "-" + attemptID[:12]
 	value := worktree{
@@ -346,7 +351,7 @@ func validateRegisteredOrigin(ctx context.Context, gitExecutable string, reposit
 	if err != nil {
 		return fmt.Errorf("revalidate repository origin: %w", err)
 	}
-	if identity != repository.RemoteIdentity {
+	if !sameRemoteIdentity(identity, repository.RemoteIdentity) {
 		return errors.New("repository origin changed since worker registration")
 	}
 	return nil

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -288,8 +288,6 @@ func resolveBaseCommit(
 	gitExecutable string,
 	repository Repository,
 ) (string, string, error) {
-	ctx, cancel := context.WithTimeout(ctx, gitCommandTimeout)
-	defer cancel()
 	branch := repository.BaseBranch
 	var base string
 	if branch == "" {

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -288,6 +288,9 @@ func resolveBaseCommit(
 	gitExecutable string,
 	repository Repository,
 ) (string, string, error) {
+	if err := validateRegisteredOrigin(ctx, gitExecutable, repository); err != nil {
+		return "", "", err
+	}
 	branch := repository.BaseBranch
 	var base string
 	if branch == "" {
@@ -327,7 +330,26 @@ func resolveBaseCommit(
 	if !commitPattern.MatchString(base) {
 		return "", "", errors.New("base branch did not resolve to a full commit ID")
 	}
+	if err := validateRegisteredOrigin(ctx, gitExecutable, repository); err != nil {
+		return "", "", err
+	}
 	return branch, base, nil
+}
+
+func validateRegisteredOrigin(ctx context.Context, gitExecutable string, repository Repository) error {
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10,
+		"remote", "get-url", "origin")
+	if err != nil {
+		return commandFailure("revalidate repository origin", stdout, stderr, err)
+	}
+	identity, err := normalizeRemoteIdentity(strings.TrimSpace(string(stdout)), repository.Path)
+	if err != nil {
+		return fmt.Errorf("revalidate repository origin: %w", err)
+	}
+	if identity != repository.RemoteIdentity {
+		return errors.New("repository origin changed since worker registration")
+	}
+	return nil
 }
 
 func validateBaseBranch(

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -319,7 +319,7 @@ func resolveBaseCommit(
 		"rev-parse", "--verify", base+"^{commit}")
 	if localErr != nil || strings.TrimSpace(string(stdout)) != base {
 		stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 256<<10,
-			"fetch", "--no-tags", "--refmap=", "origin", "refs/heads/"+branch)
+			"fetch", "--no-tags", "--no-write-fetch-head", "--refmap=", "origin", "refs/heads/"+branch)
 		if err != nil {
 			return "", "", commandFailure("fetch base branch origin/"+branch, stdout, stderr, err)
 		}

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -22,6 +22,7 @@ var commitPattern = regexp.MustCompile(`^[0-9a-f]{40}([0-9a-f]{24})?$`)
 type worktree struct {
 	Path       string
 	Branch     string
+	BaseBranch string
 	BaseCommit string
 	HeadCommit string
 }
@@ -39,6 +40,15 @@ func resolveRepositories(config Config, gitExecutable string) ([]Repository, err
 		repository, err := resolveRepository(key, config.Repositories[key].Path, gitExecutable)
 		if err != nil {
 			return nil, fmt.Errorf("repository %q: %w", key, err)
+		}
+		repository.BaseBranch = config.Repositories[key].BaseBranch
+		if repository.BaseBranch != "" {
+			ctx, cancel := context.WithTimeout(context.Background(), gitCommandTimeout)
+			err = validateBaseBranch(ctx, gitExecutable, repository, repository.BaseBranch)
+			cancel()
+			if err != nil {
+				return nil, fmt.Errorf("repository %q: %w", key, err)
+			}
 		}
 		if previous := paths[repository.Path]; previous != "" {
 			return nil, fmt.Errorf("repositories %q and %q resolve to the same path", previous, key)
@@ -261,20 +271,127 @@ func prepareWorktree(ctx context.Context, gitExecutable, root string, repository
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return worktree{}, fmt.Errorf("inspect attempt worktree path: %w", err)
 	}
-	base := repository.BaseCommit
-	if base == "" {
-		stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10, "rev-parse", "HEAD")
-		if err != nil {
-			return worktree{}, commandFailure("resolve repository HEAD", stdout, stderr, err)
-		}
-		base = strings.TrimSpace(string(stdout))
-	}
-	if !commitPattern.MatchString(base) {
-		return worktree{}, errors.New("repository HEAD is not a full commit ID")
+	baseBranch, base, err := resolveBaseCommit(ctx, gitExecutable, repository)
+	if err != nil {
+		return worktree{}, err
 	}
 	branch := "factory/" + taskID[:12] + "-" + attemptID[:12]
-	value := worktree{Path: path, Branch: branch, BaseCommit: base, HeadCommit: base}
+	value := worktree{
+		Path: path, Branch: branch, BaseBranch: baseBranch,
+		BaseCommit: base, HeadCommit: base,
+	}
 	return value, nil
+}
+
+func resolveBaseCommit(
+	ctx context.Context,
+	gitExecutable string,
+	repository Repository,
+) (string, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, gitCommandTimeout)
+	defer cancel()
+	branch := repository.BaseBranch
+	var base string
+	if branch == "" {
+		var err error
+		branch, base, err = discoverRemoteDefaultBranch(ctx, gitExecutable, repository)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	if err := validateBaseBranch(ctx, gitExecutable, repository, branch); err != nil {
+		return "", "", err
+	}
+	if base == "" {
+		var err error
+		base, err = remoteBranchCommit(ctx, gitExecutable, repository, branch)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	stdout, _, localErr := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10,
+		"rev-parse", "--verify", base+"^{commit}")
+	if localErr != nil || strings.TrimSpace(string(stdout)) != base {
+		stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 256<<10,
+			"fetch", "--no-tags", "origin", "refs/heads/"+branch)
+		if err != nil {
+			return "", "", commandFailure("fetch base branch origin/"+branch, stdout, stderr, err)
+		}
+		stdout, stderr, err = runGitCommand(ctx, gitExecutable, repository.Path, 64<<10,
+			"rev-parse", "--verify", base+"^{commit}")
+		if err != nil || strings.TrimSpace(string(stdout)) != base {
+			if err == nil {
+				err = errors.New("fetched branch did not contain the advertised commit")
+			}
+			return "", "", commandFailure("resolve fetched base branch origin/"+branch, stdout, stderr, err)
+		}
+	}
+	if !commitPattern.MatchString(base) {
+		return "", "", errors.New("base branch did not resolve to a full commit ID")
+	}
+	return branch, base, nil
+}
+
+func validateBaseBranch(
+	ctx context.Context,
+	gitExecutable string,
+	repository Repository,
+	branch string,
+) error {
+	if branch == "HEAD" || strings.HasPrefix(branch, "refs/") || strings.HasPrefix(branch, "origin/") {
+		return errors.New("base_branch must be a short branch name such as main or release/2026.07")
+	}
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10,
+		"check-ref-format", "refs/heads/"+branch)
+	if err != nil {
+		return commandFailure("validate base_branch", stdout, stderr, err)
+	}
+	return nil
+}
+
+func discoverRemoteDefaultBranch(
+	ctx context.Context,
+	gitExecutable string,
+	repository Repository,
+) (string, string, error) {
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10,
+		"ls-remote", "--symref", "origin", "HEAD")
+	if err != nil {
+		return "", "", commandFailure("discover origin default branch", stdout, stderr, err)
+	}
+	var branch, commit string
+	for _, line := range strings.Split(string(stdout), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 3 && fields[0] == "ref:" && fields[2] == "HEAD" {
+			if value, found := strings.CutPrefix(fields[1], "refs/heads/"); found {
+				branch = value
+			}
+		} else if len(fields) == 2 && fields[1] == "HEAD" && commitPattern.MatchString(fields[0]) {
+			commit = fields[0]
+		}
+	}
+	if branch == "" || commit == "" {
+		return "", "", errors.New("origin did not advertise a default branch; set base_branch for this repository")
+	}
+	return branch, commit, nil
+}
+
+func remoteBranchCommit(
+	ctx context.Context,
+	gitExecutable string,
+	repository Repository,
+	branch string,
+) (string, error) {
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10,
+		"ls-remote", "--refs", "origin", "refs/heads/"+branch)
+	if err != nil {
+		return "", commandFailure("resolve base branch origin/"+branch, stdout, stderr, err)
+	}
+	fields := strings.Fields(string(stdout))
+	if len(fields) != 2 || fields[1] != "refs/heads/"+branch || !commitPattern.MatchString(fields[0]) {
+		return "", errors.New("base branch origin/" + branch + " does not exist")
+	}
+	return fields[0], nil
 }
 
 func addPreparedWorktree(ctx context.Context, gitExecutable string, repository Repository, value worktree) error {

--- a/internal/worker/manifest.go
+++ b/internal/worker/manifest.go
@@ -48,6 +48,7 @@ type attemptManifest struct {
 	RepositoryKey  string `json:"repository_key"`
 	RepositoryPath string `json:"repository_path"`
 	RemoteIdentity string `json:"remote_identity"`
+	BaseBranch     string `json:"base_branch,omitempty"`
 	BaseCommit     string `json:"base_commit"`
 	WorktreePath   string `json:"worktree_path"`
 	Branch         string `json:"branch"`

--- a/internal/worker/repository_cache.go
+++ b/internal/worker/repository_cache.go
@@ -115,39 +115,11 @@ func (manager *Manager) acquireManagedRepository(
 	if !strings.EqualFold(repository.RemoteIdentity, identity) {
 		return Repository{}, errors.New("managed repository cache origin does not match the assigned repository")
 	}
-	stdout, stderr, err := runCommand(
-		acquisitionContext,
-		manager.options.GitExecutable,
-		repository.Path,
-		256<<10,
-		"fetch", "--prune", "origin",
+	repository.BaseBranch, repository.BaseCommit, err = resolveBaseCommit(
+		acquisitionContext, manager.options.GitExecutable, repository,
 	)
 	if err != nil {
-		return Repository{}, commandFailure("fetch managed repository", stdout, stderr, err)
-	}
-	stdout, stderr, err = runCommand(
-		acquisitionContext,
-		manager.options.GitExecutable,
-		repository.Path,
-		64<<10,
-		"remote", "set-head", "origin", "--auto",
-	)
-	if err != nil {
-		return Repository{}, commandFailure("refresh managed repository default branch", stdout, stderr, err)
-	}
-	stdout, stderr, err = runCommand(
-		acquisitionContext,
-		manager.options.GitExecutable,
-		repository.Path,
-		64<<10,
-		"rev-parse", "refs/remotes/origin/HEAD^{commit}",
-	)
-	if err != nil {
-		return Repository{}, commandFailure("resolve managed repository default branch", stdout, stderr, err)
-	}
-	repository.BaseCommit = strings.TrimSpace(string(stdout))
-	if !commitPattern.MatchString(repository.BaseCommit) {
-		return Repository{}, errors.New("managed repository default branch is not a full commit ID")
+		return Repository{}, fmt.Errorf("resolve managed repository base: %w", err)
 	}
 	return repository, nil
 }

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -214,6 +214,113 @@ func createRepository(t *testing.T, name string) repositoryFixture {
 	return repositoryFixture{path: path, origin: origin}
 }
 
+func TestWorktreeUsesRemoteDefaultBranchWithoutChangingCheckout(t *testing.T) {
+	repository := createRepository(t, "remote-default")
+	runGitTest(t, repository.path, "checkout", "-b", "local-only")
+	if err := os.WriteFile(filepath.Join(repository.path, "local-only.txt"), []byte("local\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, repository.path, "add", "local-only.txt")
+	runGitTest(t, repository.path, "commit", "-m", "local only")
+	localCommit := runGitTest(t, repository.path, "rev-parse", "HEAD")
+
+	publisher := filepath.Join(t.TempDir(), "publisher")
+	runGitTest(t, "", "clone", repository.origin, publisher)
+	runGitTest(t, publisher, "config", "user.name", "Factory Publisher")
+	runGitTest(t, publisher, "config", "user.email", "publisher@example.invalid")
+	if err := os.WriteFile(filepath.Join(publisher, "remote-only.txt"), []byte("remote\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, publisher, "add", "remote-only.txt")
+	runGitTest(t, publisher, "commit", "-m", "advance remote")
+	runGitTest(t, publisher, "push", "origin", "main")
+	mainCommit := runGitTest(t, publisher, "rev-parse", "HEAD")
+	if stale := runGitTest(t, repository.path, "rev-parse", "refs/remotes/origin/main"); stale == mainCommit {
+		t.Fatal("registered checkout unexpectedly observed the remote commit before workspace preparation")
+	}
+
+	resolved, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := createWorktree(
+		context.Background(), "git", filepath.Join(t.TempDir(), "worktrees"),
+		resolved, fixtureUUID(700), fixtureUUID(701),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value.BaseBranch != "main" || value.BaseCommit != mainCommit || value.BaseCommit == localCommit {
+		t.Fatalf("worktree base = %q %q; want main %q, not local %q",
+			value.BaseBranch, value.BaseCommit, mainCommit, localCommit)
+	}
+	if branch := runGitTest(t, repository.path, "branch", "--show-current"); branch != "local-only" {
+		t.Fatalf("configured checkout branch = %q; want local-only", branch)
+	}
+	if _, err := os.Stat(filepath.Join(value.Path, "local-only.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("isolated worktree contains local-only change: %v", err)
+	}
+	if body, err := os.ReadFile(filepath.Join(value.Path, "remote-only.txt")); err != nil || string(body) != "remote\n" {
+		t.Fatalf("isolated worktree did not fetch the authoritative remote commit: %q, %v", body, err)
+	}
+}
+
+func TestWorktreeUsesConfiguredBaseBranch(t *testing.T) {
+	repository := createRepository(t, "configured-base")
+	runGitTest(t, repository.path, "checkout", "-b", "release/2026.07")
+	if err := os.WriteFile(filepath.Join(repository.path, "release.txt"), []byte("release\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, repository.path, "add", "release.txt")
+	runGitTest(t, repository.path, "commit", "-m", "release")
+	runGitTest(t, repository.path, "push", "origin", "release/2026.07")
+	releaseCommit := runGitTest(t, repository.path, "rev-parse", "HEAD")
+	runGitTest(t, repository.path, "checkout", "main")
+
+	resolved, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved.BaseBranch = "release/2026.07"
+	value, err := createWorktree(
+		context.Background(), "git", filepath.Join(t.TempDir(), "worktrees"),
+		resolved, fixtureUUID(702), fixtureUUID(703),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value.BaseBranch != "release/2026.07" || value.BaseCommit != releaseCommit {
+		t.Fatalf("worktree base = %q %q; want release/2026.07 %q",
+			value.BaseBranch, value.BaseCommit, releaseCommit)
+	}
+	if body, err := os.ReadFile(filepath.Join(value.Path, "release.txt")); err != nil || string(body) != "release\n" {
+		t.Fatalf("release worktree file = %q, %v", body, err)
+	}
+	if branch := runGitTest(t, repository.path, "branch", "--show-current"); branch != "main" {
+		t.Fatalf("configured checkout branch = %q; want main", branch)
+	}
+}
+
+func TestWorktreeRejectsMissingConfiguredBaseBranch(t *testing.T) {
+	repository := createRepository(t, "missing-base")
+	resolved, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved.BaseBranch = "release/missing"
+	root := filepath.Join(t.TempDir(), "worktrees")
+	attemptID := fixtureUUID(705)
+	_, err = prepareWorktree(
+		context.Background(), "git", root, resolved, fixtureUUID(704), attemptID,
+	)
+	if err == nil || !strings.Contains(err.Error(), "base branch origin/release/missing does not exist") {
+		t.Fatalf("missing base branch error = %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(root, attemptID)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("missing base branch created a worktree path: %v", statErr)
+	}
+}
+
 func runGitTest(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
 	command := exec.Command("git", arguments...)
@@ -1602,6 +1709,7 @@ source_access = ["github"]
 
 [repositories.factory]
 path = %q
+base_branch = "release/2026.07"
 `, repository.path)
 	if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
@@ -1615,6 +1723,9 @@ path = %q
 	}
 	if config.Runtime != protocol.RuntimeClaudeCode {
 		t.Fatalf("runtime = %q", config.Runtime)
+	}
+	if config.Repositories["factory"].BaseBranch != "release/2026.07" {
+		t.Fatalf("base branch = %q", config.Repositories["factory"].BaseBranch)
 	}
 	if !reflect.DeepEqual(config.SourceAccess, []string{"github"}) {
 		t.Fatalf("source access = %#v", config.SourceAccess)

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -577,10 +577,7 @@ if [ "${1:-}" = "remote" ] && [ "${2:-}" = "get-url" ] && [ "${3:-}" = "origin" 
       ;;
   esac
 fi
-if [ "${1:-}" = "fetch" ]; then
-  exec "$FACTORY_TEST_REAL_GIT" -c "url.$FACTORY_TEST_GH_ORIGIN.insteadOf=https://github.com/example/cattle.git" "$@"
-fi
-if [ "${1:-}" = "remote" ] && [ "${2:-}" = "set-head" ]; then
+if [ "${1:-}" = "fetch" ] || [ "${1:-}" = "ls-remote" ]; then
   exec "$FACTORY_TEST_REAL_GIT" -c "url.$FACTORY_TEST_GH_ORIGIN.insteadOf=https://github.com/example/cattle.git" "$@"
 fi
 exec "$FACTORY_TEST_REAL_GIT" "$@"
@@ -633,6 +630,9 @@ exec "$FACTORY_TEST_REAL_GIT" "$@"
 	if info, err := os.Stat(cachePath); err != nil || !info.IsDir() {
 		t.Fatalf("managed repository cache = %v, err %v", info, err)
 	}
+	sentinel := runGitTest(t, cachePath, "rev-parse", "HEAD")
+	runGitTest(t, cachePath, "branch", "vendor/main", sentinel)
+	runGitTest(t, cachePath, "config", "remote.origin.fetch", "+refs/heads/*:refs/heads/vendor/*")
 	if err := os.WriteFile(filepath.Join(upstream.path, "SECOND.md"), []byte("second\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -645,8 +645,11 @@ exec "$FACTORY_TEST_REAL_GIT" "$@"
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := runGitTest(t, upstream.path, "rev-parse", "HEAD"); refreshed.BaseCommit != want {
-		t.Fatalf("refreshed base commit = %q, want %q", refreshed.BaseCommit, want)
+	if want := runGitTest(t, upstream.path, "rev-parse", "HEAD"); refreshed.BaseBranch != "main" || refreshed.BaseCommit != want {
+		t.Fatalf("refreshed base = %q %q, want main %q", refreshed.BaseBranch, refreshed.BaseCommit, want)
+	}
+	if branchCommit := runGitTest(t, cachePath, "rev-parse", "refs/heads/vendor/main"); branchCommit != sentinel {
+		t.Fatalf("managed fetch mapping changed vendor/main from %q to %q", sentinel, branchCommit)
 	}
 	worker = waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
 		return len(worker.Repositories) == 1 && worker.Repositories[0].ID == managed.ID

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -382,6 +382,12 @@ exit "$status"
 func TestWorktreeFetchDoesNotApplyConfiguredOriginRefmap(t *testing.T) {
 	repository := createRepository(t, "custom-refmap")
 	sentinel := runGitTest(t, repository.path, "rev-parse", "HEAD")
+	runGitTest(t, repository.path, "fetch", "origin", "main")
+	fetchHeadPath := filepath.Join(repository.path, ".git", "FETCH_HEAD")
+	fetchHead, err := os.ReadFile(fetchHeadPath)
+	if err != nil {
+		t.Fatal(err)
+	}
 	runGitTest(t, repository.path, "branch", "vendor/main", sentinel)
 	runGitTest(t, repository.path, "config", "remote.origin.fetch", "+refs/heads/*:refs/heads/vendor/*")
 
@@ -413,6 +419,9 @@ func TestWorktreeFetchDoesNotApplyConfiguredOriginRefmap(t *testing.T) {
 	}
 	if branchCommit := runGitTest(t, repository.path, "rev-parse", "refs/heads/vendor/main"); branchCommit != sentinel {
 		t.Fatalf("configured fetch mapping changed vendor/main from %q to %q", sentinel, branchCommit)
+	}
+	if currentFetchHead, err := os.ReadFile(fetchHeadPath); err != nil || string(currentFetchHead) != string(fetchHead) {
+		t.Fatalf("Factory base fetch changed FETCH_HEAD from %q to %q: %v", fetchHead, currentFetchHead, err)
 	}
 }
 

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -321,6 +321,64 @@ func TestWorktreeRejectsMissingConfiguredBaseBranch(t *testing.T) {
 	}
 }
 
+func TestWorktreeRejectsOriginChangedAfterRegistration(t *testing.T) {
+	repository := createRepository(t, "registered-origin")
+	other := createRepository(t, "replacement-origin")
+	resolved, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, repository.path, "remote", "set-url", "origin", other.origin)
+	root := filepath.Join(t.TempDir(), "worktrees")
+	attemptID := fixtureUUID(707)
+	_, err = prepareWorktree(
+		context.Background(), "git", root, resolved, fixtureUUID(706), attemptID,
+	)
+	if err == nil || !strings.Contains(err.Error(), "repository origin changed since worker registration") {
+		t.Fatalf("changed origin error = %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(root, attemptID)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("changed origin created a worktree path: %v", statErr)
+	}
+}
+
+func TestWorktreeRejectsOriginChangedDuringBaseResolution(t *testing.T) {
+	repository := createRepository(t, "origin-race")
+	other := createRepository(t, "origin-race-replacement")
+	resolved, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FACTORY_TEST_REAL_GIT", realGit)
+	t.Setenv("FACTORY_TEST_REPLACEMENT_ORIGIN", other.origin)
+	wrapper := filepath.Join(t.TempDir(), "git")
+	if err := os.WriteFile(wrapper, []byte(`#!/bin/sh
+"$FACTORY_TEST_REAL_GIT" "$@"
+status=$?
+if [ "$status" -eq 0 ] && [ "$1" = "ls-remote" ] && [ "$2" = "--symref" ]; then
+  "$FACTORY_TEST_REAL_GIT" remote set-url origin "$FACTORY_TEST_REPLACEMENT_ORIGIN"
+fi
+exit "$status"
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(t.TempDir(), "worktrees")
+	attemptID := fixtureUUID(709)
+	_, err = prepareWorktree(
+		context.Background(), wrapper, root, resolved, fixtureUUID(708), attemptID,
+	)
+	if err == nil || !strings.Contains(err.Error(), "repository origin changed since worker registration") {
+		t.Fatalf("concurrent origin change error = %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(root, attemptID)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("concurrent origin change created a worktree path: %v", statErr)
+	}
+}
+
 func runGitTest(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
 	command := exec.Command("git", arguments...)

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -379,6 +379,43 @@ exit "$status"
 	}
 }
 
+func TestWorktreeFetchDoesNotApplyConfiguredOriginRefmap(t *testing.T) {
+	repository := createRepository(t, "custom-refmap")
+	sentinel := runGitTest(t, repository.path, "rev-parse", "HEAD")
+	runGitTest(t, repository.path, "branch", "vendor/main", sentinel)
+	runGitTest(t, repository.path, "config", "remote.origin.fetch", "+refs/heads/*:refs/heads/vendor/*")
+
+	publisher := filepath.Join(t.TempDir(), "publisher")
+	runGitTest(t, "", "clone", repository.origin, publisher)
+	runGitTest(t, publisher, "config", "user.name", "Factory Publisher")
+	runGitTest(t, publisher, "config", "user.email", "publisher@example.invalid")
+	if err := os.WriteFile(filepath.Join(publisher, "remote-refmap.txt"), []byte("remote\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, publisher, "add", "remote-refmap.txt")
+	runGitTest(t, publisher, "commit", "-m", "advance refmap remote")
+	runGitTest(t, publisher, "push", "origin", "main")
+	remoteCommit := runGitTest(t, publisher, "rev-parse", "HEAD")
+
+	resolved, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := createWorktree(
+		context.Background(), "git", filepath.Join(t.TempDir(), "worktrees"),
+		resolved, fixtureUUID(710), fixtureUUID(711),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if value.BaseCommit != remoteCommit {
+		t.Fatalf("worktree base = %q; want remote %q", value.BaseCommit, remoteCommit)
+	}
+	if branchCommit := runGitTest(t, repository.path, "rev-parse", "refs/heads/vendor/main"); branchCommit != sentinel {
+		t.Fatalf("configured fetch mapping changed vendor/main from %q to %q", sentinel, branchCommit)
+	}
+}
+
 func runGitTest(t *testing.T, directory string, arguments ...string) string {
 	t.Helper()
 	command := exec.Command("git", arguments...)


### PR DESCRIPTION
## Problem

Workers could previously create attempt branches from a local or stale checkout state. PR #168 also needed to compose safely with the centrally managed repository cache added on `main`.

## Changes

Workers now acquire either a compatible legacy checkout or a cattle-worker managed cache, resolve the authoritative origin default branch or configured `base_branch`, and freeze its exact commit before creating the deterministic Factory branch and owned worktree. Managed acquisition uses the same origin-validated base resolver, so an empty fetch refmap protects custom local mappings and `--no-write-fetch-head` preserves operator fetch metadata while the cache lock serializes base acquisition.

The source checkout or cache is never switched or used as the agent workspace. Attempt manifests and prompts record the resolved base branch and commit, and the documentation distinguishes Git worktree isolation from a security sandbox.

## Verification

- Rebased linearly onto `origin/main` at `d601b0b`
- `just check` passed on the final tree, including the worker suite, 40 UI tests, builds, and launcher checks
- Focused prompt, remote-default, release-base, missing-base, origin-mutation, custom-refmap, FETCH_HEAD, and cattle-worker tests passed
- Three fresh independent diff reviews approved with no findings; the final review covered the FETCH_HEAD fix
- Hosted `check` passed on `b83b7cb`, including real-server browser tests
- GitHub Codex reviewed `b83b7cb` and found no major issues
- The latest P2 was fixed in `b83b7cb`, replied to with proof in its original thread, and resolved; all review threads are resolved

## Risks

Workspace preparation contacts `origin` to resolve the current base. An unavailable, missing, or identity-mismatched origin fails the attempt before a worktree or agent process starts. Existing worker configs remain compatible because `base_branch` is optional. Base acquisition relies on Git fetch safety flags to avoid modifying custom refs or `FETCH_HEAD`.

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests and documentation cover changed behavior.
- [x] Logs, fixtures, and screenshots contain no secrets or private repository data.