### PR TITLE
feat: add centrally managed repository fleet

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > **Status:** Current implementation
 >
-> **Verification basis:** Working tree based on commit `88a5093`
+> **Verification basis:** Working tree based on commit `2d732ec`
 
 ## 1. Executive summary
 
@@ -12,16 +12,17 @@ It separates durable coordination from agent execution:
 - `factory-server` stores work, assigns it, exposes the HTTP API, and serves the
   embedded browser UI.
 - `factory-worker` has one stable identity and one agent runtime. It advertises
-  allowed repositories, polls for work, and runs attempts in isolated Git
-  worktrees.
+  runtime capacity and provider access, acquires centrally managed repositories
+  on demand, and runs attempts in isolated Git worktrees.
 - `factory-poller` lists configured issue queues through provider CLIs and
   submits matching tickets as ordinary control-plane tasks.
 - Codex or Claude Code performs the repository work as a child process of the
   worker.
 
 The current task contract is a title, prompt, assigned worker, repository, and
-timeout. The scheduler is part of the control plane. The deployment is limited
-to a trusted user and loopback HTTP on one host.
+timeout. Callers may name the assignment directly or ask the control-plane
+scheduler to choose from cattle workers. The deployment is limited to a trusted
+user and loopback HTTP on one host.
 
 ## 2. System context
 
@@ -38,7 +39,8 @@ factory-server
            | registration, polling, leases, events, completion
            |
 factory-worker (one identity and one runtime)
-   |-- repository allowlist
+   |-- bounded on-demand repository cache
+   |-- optional legacy static checkouts
    |-- attempt manifests and owned Git worktrees
    `-- Codex CLI or Claude Code CLI
 
@@ -57,8 +59,8 @@ the system does not use WebSockets.
 
 1. One worker identity has one immutable runtime, either `codex` or
    `claude-code`.
-2. Tasks are assigned to a specific worker and one repository currently
-   advertised by that worker.
+2. Every task freezes one worker and one control-plane repository. Routed work
+   may select a cattle worker before that repository exists in its local cache.
 3. Only a healthy, recently registered worker with free capacity can claim its
    queued work.
 4. A lease token owns one active attempt. Active operations require a matching,
@@ -116,11 +118,13 @@ credentials and API clients outside Factory.
 
 For GitHub, the poller submits the repository remote and a GitHub source-access
 requirement. In the task-creation transaction, the control plane chooses the
-healthy online repository advertiser with the lowest
-`(active + queued) / capacity` load, breaking an exact tie by worker ID. It
-excludes repositories without retained-worktree headroom, then freezes the
-selected worker and repository on the execution. The poller writes the exact
-task request to its own SQLite ledger, submits through
+healthy online cattle worker with GitHub access and the lowest `(active +
+queued) / capacity` load, breaking an exact tie by worker ID. A legacy worker
+that already advertises the checkout is also eligible. It excludes repositories
+without retained-worktree headroom and excludes a cattle worker without cache
+headroom unless that repository is already cached. It then freezes the selected
+worker and repository on the execution. The poller writes the exact task request
+to its own SQLite ledger, submits through
 `POST /api/v1/tasks`, and records the returned task ID. Its default state is
 `~/.factory/poller/poller.sqlite3`.
 
@@ -131,8 +135,11 @@ manual cleanup, or starts the internal attempt supervisor. The manager:
 
 - resolves and locks its data directory;
 - creates or loads a durable worker ID;
-- resolves repository paths and normalizes their `origin` identities;
-- checks Git and runtime health;
+- resolves any optional legacy repository paths and normalizes their `origin`
+  identities;
+- checks Git and runtime health and automatically probes local GitHub access;
+- clones or fetches assigned managed repositories into a bounded cache before
+  agent startup;
 - registers every ten seconds and polls for claims every two seconds with
   jitter;
 - renews active leases every ten seconds;
@@ -171,19 +178,24 @@ Node.js is a contributor dependency only when UI source changes.
 
 1. The server validates its data root, opens SQLite, applies migrations, and
    marks already expired attempts as `lost`.
-2. The worker validates its TOML, data directory, runtime, and repositories.
+2. The worker validates its TOML, data directory, runtime, and any optional
+   legacy repositories.
 3. The worker reconciles durable attempt manifests before accepting new work.
-4. A healthy worker registers its identity, runtime, capacity, repositories,
-   retained worktrees, and disposed attempt IDs.
+4. A healthy worker registers its identity, runtime, capacity, provider access,
+   managed-repository acquisition capability, optional legacy repositories,
+   bounded cached repository IDs, retained worktrees, and disposed attempt IDs.
 5. A worker is shown as offline when its last registration is more than 30
    seconds old.
 
 ### Task creation and claiming
 
-1. An operator submits a unique `request_key`, title, description, worker ID,
-   repository ID, and optional timeout.
-2. The control plane creates one task and one queued execution. Reusing the
-   request key returns the original task.
+1. A caller submits a unique `request_key`, title, description, optional timeout,
+   and either an explicit worker/repository pair or a repository remote plus
+   source-access route.
+2. For a route, the control plane requires an enabled managed repository,
+   chooses an eligible worker by fair load, and freezes both IDs. It then
+   creates one task and one queued execution. Reusing the request key returns
+   the original task.
 3. The assigned worker polls its claim endpoint with a unique request ID and
    lease token.
 4. The control plane verifies worker health, recency, capacity, runtime,
@@ -212,8 +224,10 @@ use its installed provider CLI to update the issue and open a pull request.
 
 ### Attempt execution
 
-1. The worker validates the claim against its identity and repository allowlist.
-2. It reads the configured checkout's current `HEAD`.
+1. The worker validates the claim identity, assignment, runtime, repository ID,
+   and remote identity.
+2. It uses a compatible legacy checkout or serially clones/fetches the managed
+   repository. Managed work starts at the fetched remote default-branch commit.
 3. It creates a branch named
    `factory/<task-prefix>-<attempt-prefix>` and an owned worktree.
 4. It writes a protected attempt manifest before starting the runtime.
@@ -261,6 +275,10 @@ GET    /healthz
 GET    /api/v1/metrics/summary?window=24h|7d|30d|all
 GET    /api/v1/workers
 GET    /api/v1/workers/{worker_id}
+GET    /api/v1/repositories
+POST   /api/v1/repositories
+GET    /api/v1/repositories/{repository_id}
+PUT    /api/v1/repositories/{repository_id}/enabled
 GET    /api/v1/tasks?limit={1..200}&cursor={cursor}
 POST   /api/v1/tasks
 GET    /api/v1/tasks/{task_id}
@@ -296,6 +314,10 @@ Task   1 --- 1 Execution       1 --- * Attempt 1 --- * AttemptEvent
 ```
 
 - A task stores the operator request and repository.
+- A repository is the central fleet record. Its enabled flag gates new routed
+  work but does not rewrite existing assignments.
+- A worker-repository row may be a legacy static advertisement or the dynamic
+  association frozen when a cattle worker is selected.
 - An execution stores its assigned worker, required runtime, state,
   cancellation flag, and explicit retry count.
 - An attempt stores one claim, lease, process identity, result, and outcome.
@@ -321,6 +343,8 @@ task list.
 | Completion result | 256 KiB |
 | Completion error | 64 KiB |
 | Retained and reserved worktrees per worker repository | 10 |
+| Managed repositories | 1,000 |
+| Cached repositories per worker | 100 |
 | Task page | 50 by default, 200 maximum |
 | Event page | 100 by default, 500 maximum |
 | Issues per queue pass | 100 |
@@ -347,6 +371,7 @@ task list.
   workers/<worker>/
     worker-id
     worker.lock
+    repositories/<repository-id>/
     attempts/
     disposed-attempts.json
     worktrees/
@@ -362,9 +387,9 @@ preview storage format. They do not represent a second application.
 names remain migration aliases in code and the local launcher, but are not
 operator-facing configuration.
 
-Relative worker data and repository paths are resolved from the directory that
-contains the worker TOML. Repositories must resolve to real Git checkouts with
-an `origin` remote.
+Relative worker data and optional legacy repository paths are resolved from the
+directory that contains the worker TOML. Managed repositories are configured by
+the control-plane API and cached below the worker data directory.
 
 ## 7. Security and trust boundaries
 
@@ -375,11 +400,12 @@ The current trust boundary is one trusted user on one host:
 - worker IDs identify local state but are not secrets;
 - the agent process has the worker OS user's permissions and can access anything
   available to that user;
-- the repository allowlist controls assignment and worktree creation, but it is
-  not a filesystem sandbox;
+- the enabled central repository catalog controls routed assignment. Workers
+  accept only canonical GitHub identities from that catalog and never clone an
+  arbitrary URL supplied by a ticket. This is not a filesystem sandbox;
 - provider CLIs own their credentials; the poller does not request, store, or
   pass provider tokens;
-- workers advertise GitHub source access only after an explicit opt-in and a
+- workers advertise GitHub source access and managed acquisition only after a
   successful local `gh auth status` probe; registrations contain no token;
 - configured source commands and queue prompts are trusted operator policy;
 - issue fields are stored in the poller ledger and task prompt as untrusted
@@ -490,7 +516,7 @@ designs.
 | Shared contracts and limits | `internal/protocol` |
 | Worker orchestration | `internal/worker/manager.go`, `registration.go`, `claiming.go`, `attempt_lifecycle.go` |
 | Runtime supervision | `internal/worker/supervisor.go` |
-| Git worktrees and cleanup | `internal/worker/git.go`, `reconcile.go`, `cleanup.go` |
+| Repository acquisition, Git worktrees, and cleanup | `internal/worker/repository_cache.go`, `git.go`, `reconcile.go`, `cleanup.go` |
 | Durable worker state | `internal/worker/identity.go`, `manifest.go` |
 | Issue sources and dispatch ledger | `internal/poller` |
 | State path compatibility | `internal/statepath` |

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Requirements:
 Node.js is only needed when changing the UI. Normal builds use the committed,
 embedded UI assets.
 
-GitHub issue polling is optional, but it depends on the GitHub CLI, `gh`.
-Factory does not include a separate GitHub API client. Install and authenticate
-[`gh`](https://cli.github.com/) on the poller host before configuring a GitHub
-queue:
+GitHub issue polling and on-demand worker checkout are optional, but both depend
+on the GitHub CLI, `gh`. Factory does not include a separate GitHub API client.
+Install and authenticate [`gh`](https://cli.github.com/) on the poller host and
+each eligible worker host before configuring a GitHub queue:
 
 ```sh
 gh --version
@@ -44,8 +44,9 @@ mkdir -p ~/.factory
 cp examples/worker.toml ~/.factory/worker.toml
 ```
 
-Edit `~/.factory/worker.toml` to select `codex` or `claude-code` and add the
-repositories this worker may use. Then start the server and worker:
+Edit `~/.factory/worker.toml` to select `codex` or `claude-code`. Workers need
+no repository list. They probe local `gh` access and acquire centrally managed
+GitHub repositories on demand. Then start the server and worker:
 
 ```sh
 just run
@@ -87,7 +88,7 @@ Go control plane <--- Issue poller
    | registration, claim, heartbeat, events, completion
    |
 Go workers
-  one identity + one runtime + allowed repositories
+  one identity + one runtime + on-demand repository cache
    |
    +-- Codex CLI
    `-- Claude Code CLI
@@ -121,7 +122,8 @@ Implemented:
 - Codex and Claude Code workers;
 - configurable issue queues with GitHub CLI polling and a normalized command
   contract for other provider CLIs;
-- repository allowlists and isolated Git worktrees;
+- a central managed-repository catalog, bounded worker caches, and isolated Git
+  worktrees;
 - bounded list APIs and retained-data metrics;
 - automatic cleanup of clean unchanged or published work and preservation of
   unpublished branches.

--- a/docs/local.md
+++ b/docs/local.md
@@ -9,6 +9,7 @@ This guide starts one control plane and one worker on macOS or Linux.
 - `curl`
 - `just`
 - an authenticated Codex CLI or Claude Code CLI
+- an authenticated `gh` CLI for centrally managed GitHub repositories
 
 Node.js is not required for normal startup.
 
@@ -30,14 +31,12 @@ name = "local-codex"
 runtime = "codex"
 max_concurrent = 1
 data_directory = "workers/local-codex"
-
-[repositories.factory]
-path = "/absolute/path/to/factory"
 ```
 
-Relative repository paths resolve from the directory containing the worker TOML.
-Each path must resolve to a real, non-bare Git checkout with an `origin` remote.
-The map key is the repository name shown in the UI.
+No worker repository list is required. Factory detects local GitHub access with
+`gh auth status` and clones centrally managed repositories on demand. Optional
+legacy repository paths still resolve from the worker TOML directory and remain
+available for manual UI delegation.
 
 For Claude Code, use another config and identity:
 
@@ -47,9 +46,6 @@ name = "local-claude"
 runtime = "claude-code"
 max_concurrent = 1
 data_directory = "workers/local-claude"
-
-[repositories.factory]
-path = "/absolute/path/to/factory"
 ```
 
 Do not share a `data_directory` between worker identities.
@@ -67,6 +63,20 @@ Open [http://127.0.0.1:7337](http://127.0.0.1:7337).
 
 Stop both processes with Ctrl+C.
 
+Add a GitHub repository to the central fleet once:
+
+```sh
+curl --fail --silent --show-error \
+  -H 'Content-Type: application/json' \
+  -d '{"remote_identity":"github.com/OWNER/REPOSITORY"}' \
+  http://127.0.0.1:7337/api/v1/repositories
+```
+
+List the current fleet with `GET /api/v1/repositories`. Set
+`{"enabled":false}` with `PUT /api/v1/repositories/REPOSITORY_ID/enabled` to
+stop new routed work without interrupting an execution whose worker assignment
+is already frozen.
+
 To start with a different worker config:
 
 ```sh
@@ -82,6 +92,11 @@ additional worker directly:
 ```
 
 ## Delegate a task
+
+The current manual delegation screen lists optional legacy checkouts advertised
+by workers. Add a `[repositories.<key>]` entry when you need that path. Cattle
+workers with no static checkout are currently exercised through centrally
+routed task creation such as the GitHub poller.
 
 In the UI:
 

--- a/docs/local.md
+++ b/docs/local.md
@@ -75,7 +75,9 @@ curl --fail --silent --show-error \
 List the current fleet with `GET /api/v1/repositories`. Set
 `{"enabled":false}` with `PUT /api/v1/repositories/REPOSITORY_ID/enabled` to
 stop new routed work without interrupting an execution whose worker assignment
-is already frozen.
+is already frozen. Posting a repository first discovered from a legacy worker
+promotes it into the enabled central fleet. Reposting a centrally managed
+repository does not override an explicit disable.
 
 To start with a different worker config:
 

--- a/docs/phases/design.md
+++ b/docs/phases/design.md
@@ -303,12 +303,13 @@ environment and never enter Factory storage.
 
 #### Worker router
 
-The router selects one current worker that advertises the provider repository
-through the existing normalized repository identity and advertises live source
-access matching the binding's immutable provider namespace, hostname, and
-scope. It depends on current worker registrations and uses a generic
-least-loaded eligible rule. It does not infer provider access from adapter
-output, inspect the phase name, or create a new worker pool abstraction. The
+The router first resolves an enabled repository in the control-plane managed
+fleet. It then selects one current cattle worker that accepts managed
+repositories and advertises live source access matching the binding's immutable
+provider namespace, hostname, and scope. A legacy worker that already
+advertises the checkout remains eligible during migration. Routing uses the
+generic least-loaded rule. It does not infer provider access from adapter
+output, inspect the phase name, or create a phase-specific worker pool. The
 chosen worker and repository are frozen on the delivery and normal Execution.
 
 #### Browser UI
@@ -456,6 +457,11 @@ installed, authenticated for the hostname, and can read each scope. Old workers
 omit the field and remain valid for manual tasks, but the trigger router does
 not assign them work that requires live source revalidation. The capability
 carries no token and is not phase-specific.
+
+Worker registration also carries a generic managed-repository acquisition
+capability. A selected worker clones or fetches the frozen central repository
+before starting the unchanged agent contract. This capability is runtime
+infrastructure, not phase or repository configuration.
 
 ### Decisions
 
@@ -608,16 +614,17 @@ A later reviewed protocol version may add typed provider-evidence operations
 with explicit idempotency and uncertain-write recovery. Until then, Factory
 claims exactly-once task creation, not exactly-once provider comments or checks.
 
-#### Managed fleet scope uses existing repository advertisements
+#### Managed fleet scope uses the control-plane repository catalog
 
 A repository belongs to a binding’s fleet when its normalized provider identity
-is inside the binding’s organization or group scope and at least one current
-worker advertises that Factory repository. No checked-in file or per-repository
-Factory record opts it in. Optional central include and exclude patterns may
-narrow a binding, but they live on the binding. The router chooses a healthy,
-online advertiser by lowest `(active + queued) / capacity`, breaking ties by
-worker ID, and freezes that assignment. If none is eligible, delivery waits for
-routing rather than creating an unclaimable task.
+is enabled in the central managed-repository catalog and is inside the
+binding’s organization or group scope. No checked-in file or per-repository
+worker configuration opts it in. Optional central include and exclude patterns
+may narrow a binding, but they live on the binding. The router chooses a
+healthy, online worker with matching provider access and managed-repository
+capability by lowest `(active + queued) / capacity`, breaking ties by worker ID,
+and freezes that assignment. If none is eligible, delivery waits for routing
+rather than creating an unclaimable task.
 
 #### Source metadata is provenance, not a work item
 
@@ -788,9 +795,9 @@ require a separate design.
   parsing, arrays, filtering, and pagination.
 - Trigger routing requires a current worker `source_access` capability exactly
   matching the binding's provider namespace, provider, and hostname and
-  containing its organization, group, or site scope, as well as repository
-  advertisement. Workers derive it from central host credentials, not
-  repository configuration, and advertise no secret.
+  containing its organization, group, or site scope, plus generic
+  managed-repository acquisition capability. Workers derive both from host
+  capabilities, not repository configuration, and advertise no secret.
 - Startup reconciliation runs before the trigger manager reports healthy. It
   recovers incomplete deliveries first, then performs one live scan for every
   enabled poll target. Workers may continue existing executions during that
@@ -1002,11 +1009,11 @@ an exact namespace, provider, hostname, and containing scope match. Old
 registrations without the field decode as an empty list. Claims, attempts,
 leases, events, and completions are unchanged.
 
-The worker’s host-level configuration names access probes, not repositories or
-phases. For the MVP, a GitHub probe invokes the existing authenticated `gh`
-profile and advertises only scopes it can read. Failure makes triggered work
-ineligible for that worker but does not make the worker unhealthy for manual
-tasks.
+The worker’s host-level configuration does not name repositories or phases. For
+the MVP, the worker automatically invokes the existing authenticated `gh`
+profile and advertises GitHub access plus managed acquisition while that probe
+succeeds. Failure makes triggered work ineligible for that worker but does not
+make the runtime itself unhealthy for manual tasks.
 
 A Jira probe must exercise the same centrally configured Jira credential path
 that the agent will use. It verifies authenticated identity and performs one
@@ -1326,12 +1333,13 @@ records bounded stderr. It retries with exponential backoff and jitter starting
 at 5 seconds and capped at 15 minutes. A successful complete poll resets the
 backoff. Provider-specific rate-limit behavior remains inside the adapter.
 
-When no healthy online worker advertises a matching managed repository, the
-delivery remains `pending_route`. Registration changes wake routing, and the
-periodic reconciler also retries it. A route is attempted within 10 seconds of
-an eligible registration while the server is running. Once assigned, worker
-loss follows the existing lease and explicit retry model; triggers do not
-reschedule the task to a different worker.
+When no healthy online worker can acquire an enabled matching managed
+repository with the required source access, the delivery remains
+`pending_route`. Registration changes wake routing, and the periodic reconciler
+also retries it. A route is attempted within 10 seconds of an eligible
+registration while the server is running. Once assigned, worker loss follows
+the existing lease and explicit retry model; triggers do not reschedule the task
+to a different worker.
 
 Before any pending delivery creates its task, a new complete poll for its target
 must contain the same source identity and revision. Adapter failure leaves the
@@ -1503,9 +1511,10 @@ relay, repository CI job, worker-side poller, or phase-specific runtime.
 - One central GitHub issue binding expands across currently managed repositories
   in its organization without repository files or a configured repository
   array.
-- Trigger routing selects only a worker that advertises both the repository and
-  fresh provider, hostname, and organization source access. An old worker with
-  no additive capability still runs manual tasks.
+- Trigger routing selects only an enabled central repository and a worker with
+  managed-repository acquisition plus fresh provider, hostname, and
+  organization source access. A legacy worker that advertises the exact
+  checkout remains compatible during migration.
 - A trusted GitHub adapter may use existing `gh` authentication, owns provider
   parsing and pagination, and emits no issue body, description, or raw payload.
 - Factory passes versioned bounded JSON on stdin, executes the absolute adapter
@@ -1597,8 +1606,8 @@ normalization, required-label set inclusion, a candidate that fails
 revalidation, and rejection of an opaque condition not represented by protocol
 version 1.
 
-Polling tests will expand changing bindings and worker repository
-advertisements into independent targets, enforce the concurrency bound, process
+Polling tests will expand changing bindings and the central managed-repository
+fleet into independent targets, enforce the concurrency bound, process
 observations one at a time, and prove that a failed target cannot end
 eligibility or block another target. Fake clocks will prove the 60-second
 default cadence, jitter range, capped adapter backoff, startup

--- a/docs/poller.md
+++ b/docs/poller.md
@@ -13,8 +13,9 @@ task coordination, and workers stay focused on agent execution.
 Requirements:
 
 - a running Factory control plane;
-- a healthy online worker that advertises the target repository and opts into
-  GitHub source access;
+- the target repository enabled in the control-plane managed repository
+  catalog;
+- a healthy online worker whose automatic GitHub probe succeeds;
 - the authenticated `gh` CLI on the poller host;
 - the authenticated `gh` CLI on the worker host when the agent workflow reads
   or updates GitHub.
@@ -56,14 +57,19 @@ Implement and verify the change, update the issue, and open a pull request.
 timeout_seconds = 7200
 ```
 
-Opt each eligible worker into GitHub routing once in `worker.toml`:
+Add the queue repository to the central fleet once:
 
-```toml
-source_access = ["github"]
+```sh
+curl --fail --silent --show-error \
+  -H 'Content-Type: application/json' \
+  -d '{"remote_identity":"github.com/owner/repository"}' \
+  http://127.0.0.1:7337/api/v1/repositories
 ```
 
-The worker advertises GitHub access only while its local
-`gh auth status --hostname github.com` probe succeeds.
+No queue, ticket, or worker configuration names a worker ID or repository path.
+Every worker automatically advertises GitHub access and managed-repository
+acquisition only while its local `gh auth status --hostname github.com` probe
+succeeds.
 
 Safely test GitHub matching before creating a task:
 
@@ -184,10 +190,19 @@ stderr to 64 KiB, execution to 30 seconds, and each result to 100 issues.
 For GitHub tasks, the poller sends the repository remote and required GitHub
 source access to the control plane instead of a worker ID. In the task-creation
 transaction, the control plane considers healthy online workers that advertise
-both and whose repository has retained-worktree headroom under the same rule
-used when claiming work. It chooses the lowest `(active + queued) / capacity`
-load and breaks an exact tie by worker ID. The selected worker and repository
-are then frozen on the task and execution.
+the required source access and accept managed repositories. It also accepts a
+legacy worker that already advertises that checkout. Workers without repository
+retention headroom are excluded. The control plane chooses the lowest
+`(active + queued) / capacity` load and breaks an exact tie by worker ID. The
+selected worker and repository are then frozen on the task and execution.
+
+For a cattle worker, the scheduler reserves cache headroom for dynamic
+repository assignments. A full cache remains eligible for repositories already
+present in it.
+
+A cattle worker clones a missing repository through `gh` or fetches its cached
+copy before starting the agent. The provider identity comes only from the
+enabled central catalog. A ticket cannot supply an arbitrary clone URL.
 
 The poller stores its ledger in
 `~/.factory/poller/poller.sqlite3` by default. It writes the exact task request
@@ -212,9 +227,11 @@ live queue to avoid redispatching old issues.
 - A failed or malformed source result creates no new observations.
 - A failed task submission remains pending and is recovered before the next
   source poll.
-- When no worker currently advertises both the repository and GitHub access,
-  the pass fails without retaining a stale pending request. The next pass
-  refetches and revalidates the issue before trying to route it again.
+- When no worker currently has GitHub access and capacity, the pass fails
+  without retaining a stale pending request. The next pass refetches and
+  revalidates the issue before trying to route it again.
+- An unmanaged or disabled repository fails closed. Enable it centrally before
+  polling that queue.
 - Oversized prompts and source results fail instead of being truncated.
 - A full 10,000-row dispatch ledger rejects new observations.
 - Configuration is read at startup. Restart the poller after changing it.

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -1,8 +1,9 @@
 # Worker contract
 
-A Factory worker is one stable identity, one runtime, a capacity limit, and a
-repository allowlist. It can run on a developer machine, VM, or Unix container.
-Windows is not supported.
+A Factory worker is one stable identity, one runtime, and a capacity limit. It
+can run on a developer machine, VM, or Unix container. Workers are cattle: the
+control plane owns repository scope, and an eligible worker acquires an assigned
+repository into its bounded local cache. Windows is not supported.
 
 ## Configuration
 
@@ -12,22 +13,21 @@ name = "local-codex"
 runtime = "codex"
 max_concurrent = 1
 data_directory = "workers/local-codex"
-source_access = ["github"]
-
-[repositories.factory]
-path = "/absolute/path/to/factory"
 ```
 
 `runtime` is `codex` or `claude-code`. A worker never switches runtime per task.
 Run two workers when you want to send the same task to both agents.
 
-Relative data directories and repository paths resolve from the directory
-containing the worker TOML file. Repository paths must resolve to real, non-bare
-Git repositories with an `origin`.
+Relative data directories resolve from the directory containing the worker
+TOML file. The worker probes `gh auth status --hostname github.com`
+automatically. A successful probe advertises GitHub source access and the
+ability to acquire centrally managed GitHub repositories. It contains no token.
 
-`source_access = ["github"]` opts the worker into centrally routed GitHub issue
-work. The capability is advertised only while the worker's local
-`gh auth status --hostname github.com` probe succeeds. It contains no token.
+The legacy `[repositories.<key>]` map remains optional for manual delegation to
+an existing non-bare checkout. Its paths resolve relative to the worker TOML.
+Newly discovered legacy checkouts enter the catalog disabled and support only
+explicit assignment until an operator enables them centrally. Repositories
+already known before this migration remain enabled for routing compatibility.
 
 ## Identity and registration
 
@@ -40,8 +40,12 @@ Registration advertises:
 - display name and runtime;
 - maximum concurrent attempts;
 - worker version;
-- repository keys, normalized remote identities, and retained counts.
-- successfully probed source access such as GitHub.
+- optional legacy repository keys, normalized remote identities, and retained
+  counts;
+- successfully probed source access such as GitHub;
+- whether the worker can acquire managed repositories;
+- the bounded set of cached control-plane repository IDs, used for exact cache
+  headroom accounting. The public Worker view exposes only the count.
 
 The server returns repository IDs used for task assignment. Heartbeats refresh
 health and current capacity. A worker is offline when its heartbeat expires.
@@ -58,7 +62,7 @@ Print the configured identity without starting the worker:
 Workers poll the loopback API for compatible work. A claim succeeds only when:
 
 - the task targets that worker;
-- the repository is in its current advertisement;
+- the repository assignment is frozen to that worker;
 - worker capacity is available;
 - the repository has fewer than ten retained worktrees, active attempts, and
   terminal attempts awaiting a local disposition on that worker.
@@ -71,8 +75,10 @@ lease expires.
 
 The worker prepares a task as follows:
 
-1. validate the repository and remote identity;
-2. read the base commit from the configured checkout;
+1. validate the repository ID and canonical `github.com/owner/repository`
+   identity;
+2. clone a missing repository with `gh repo clone` or fetch its existing cache,
+   then resolve the current remote default-branch commit;
 3. create an owned worktree below its data directory;
 4. create a `factory/<task-prefix>-<attempt-prefix>` branch;
 5. write a protected, durable attempt manifest;
@@ -87,6 +93,13 @@ the same control-plane result contract.
 
 Runtime output and API event payloads are bounded. Oversized output is truncated
 or summarized so one agent cannot grow a request without limit.
+
+Managed caches live at `DATA_DIRECTORY/repositories/REPOSITORY_ID`. Clone and
+fetch operations are serialized per worker, have a five-minute bound, and
+complete before the agent starts. A worker keeps at most 100 repository cache
+entries. This version does not evict caches automatically.
+Interrupted `.clone-*` directories are removed during startup after the worker
+has locked its data directory, so hard crashes cannot bypass the cache bound.
 
 ## Cancellation and shutdown
 
@@ -132,7 +145,8 @@ factory-worker cleanup ATTEMPT_ID \
 
 Confirmed operator cleanup preserves the local branch but removes the worktree
 with force, so uncommitted changes shown in the preview are lost. Cleanup never
-deletes the configured checkout or another worker's path.
+deletes the repository cache, a legacy configured checkout, or another worker's
+path.
 
 ## Deployment model
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -100,6 +100,8 @@ complete before the agent starts. A worker keeps at most 100 repository cache
 entries. This version does not evict caches automatically.
 Interrupted `.clone-*` directories are removed during startup after the worker
 has locked its data directory, so hard crashes cannot bypass the cache bound.
+On the next registration, the control plane releases an uncached dynamic
+reservation once no queued or active execution and no retained worktree uses it.
 
 ## Cancellation and shutdown
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -26,8 +26,10 @@ ability to acquire centrally managed GitHub repositories. It contains no token.
 The legacy `[repositories.<key>]` map remains optional for manual delegation to
 an existing non-bare checkout. Its paths resolve relative to the worker TOML.
 Newly discovered legacy checkouts enter the catalog disabled and support only
-explicit assignment until an operator enables them centrally. Repositories
-already known before this migration remain enabled for routing compatibility.
+explicit assignment until an operator adds or enables them centrally. Reposting
+a centrally managed repository does not override an explicit disable.
+Repositories already known before this migration remain enabled for routing
+compatibility.
 
 ## Identity and registration
 

--- a/examples/worker.toml
+++ b/examples/worker.toml
@@ -1,17 +1,14 @@
-# Copy this file to ~/.factory/worker.toml, then replace both paths with
-# absolute paths to local non-bare Git repositories that have an origin.
+# Copy this file to ~/.factory/worker.toml.
 server = "http://127.0.0.1:7337"
 name = "local"
 # One worker identity runs exactly one runtime: "codex" or "claude-code".
 runtime = "codex"
 max_concurrent = 1
 data_directory = "workers/local"
-# Opt this worker into centrally routed GitHub issue work. Factory advertises
-# the capability only while `gh auth status --hostname github.com` succeeds.
-source_access = ["github"]
+# No repository or GitHub opt-in is required. Factory advertises GitHub access
+# while `gh auth status --hostname github.com` succeeds and clones centrally
+# managed repositories into this worker's data directory on demand.
 
-[repositories.factory]
-path = "/absolute/path/to/factory"
-
-[repositories.second-repository]
-path = "/absolute/path/to/another-repository"
+# Legacy manual delegation may still point a worker at an existing checkout:
+# [repositories.factory]
+# path = "/absolute/path/to/factory"

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -71,6 +71,10 @@ func NewHandler(store *Store, logger *slog.Logger) http.Handler {
 	mux.HandleFunc("POST /api/v1/workers/{worker_id}/claims", api.claim)
 	mux.HandleFunc("GET /api/v1/workers", api.listWorkers)
 	mux.HandleFunc("GET /api/v1/workers/{worker_id}", api.getWorker)
+	mux.HandleFunc("GET /api/v1/repositories", api.listManagedRepositories)
+	mux.HandleFunc("POST /api/v1/repositories", api.createManagedRepository)
+	mux.HandleFunc("GET /api/v1/repositories/{repository_id}", api.getManagedRepository)
+	mux.HandleFunc("PUT /api/v1/repositories/{repository_id}/enabled", api.setManagedRepositoryEnabled)
 	mux.HandleFunc("GET /api/v1/metrics/summary", api.getMetrics)
 	mux.HandleFunc("GET /api/v1/tasks", api.listTasks)
 	mux.HandleFunc("POST /api/v1/tasks", api.createTask)
@@ -236,6 +240,70 @@ func (a *API) getWorker(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, worker)
+}
+
+func (a *API) listManagedRepositories(w http.ResponseWriter, r *http.Request) {
+	repositories, err := a.store.ManagedRepositories(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"repositories": repositories})
+}
+
+func (a *API) createManagedRepository(w http.ResponseWriter, r *http.Request) {
+	if !prepareMutation(w, r, protocol.MaxBodyBytes) {
+		return
+	}
+	var input protocol.CreateManagedRepositoryRequest
+	if !decodeJSON(w, r, &input) {
+		return
+	}
+	repository, created, err := a.store.CreateManagedRepository(r.Context(), input)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	writeJSON(w, status, repository)
+}
+
+func (a *API) getManagedRepository(w http.ResponseWriter, r *http.Request) {
+	repository, err := a.store.ManagedRepository(r.Context(), r.PathValue("repository_id"))
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, repository)
+}
+
+func (a *API) setManagedRepositoryEnabled(w http.ResponseWriter, r *http.Request) {
+	if !prepareMutation(w, r, protocol.MaxBodyBytes) {
+		return
+	}
+	var input struct {
+		Enabled *bool `json:"enabled"`
+	}
+	if !decodeJSON(w, r, &input) {
+		return
+	}
+	if input.Enabled == nil {
+		writeError(w, invalid("invalid_repository", "enabled is required"))
+		return
+	}
+	repository, err := a.store.SetManagedRepositoryEnabled(
+		r.Context(),
+		r.PathValue("repository_id"),
+		*input.Enabled,
+	)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, repository)
 }
 
 func (a *API) listTasks(w http.ResponseWriter, r *http.Request) {

--- a/internal/controlplane/http_test.go
+++ b/internal/controlplane/http_test.go
@@ -98,6 +98,67 @@ func registerHTTPWorker(t *testing.T, fixture *httpFixture, id, key, remote stri
 	return decodeResponse[protocol.Worker](t, response)
 }
 
+func TestHTTPManagedRepositoryCatalog(t *testing.T) {
+	fixture := newHTTPFixture(t)
+	response := fixture.request(http.MethodPost, "/api/v1/repositories", "application/json", "", map[string]string{
+		"remote_identity": "github.com/OwainLewis/Factory.git",
+	})
+	requireStatus(t, response, http.StatusCreated)
+	repository := decodeResponse[protocol.ManagedRepository](t, response)
+	if repository.RemoteIdentity != "github.com/owainlewis/factory" || !repository.Enabled {
+		t.Fatalf("created repository = %#v", repository)
+	}
+
+	response = fixture.request(http.MethodPost, "/api/v1/repositories", "application/json", "", map[string]string{
+		"remote_identity": "github.com/owainlewis/factory",
+	})
+	requireStatus(t, response, http.StatusOK)
+	replayed := decodeResponse[protocol.ManagedRepository](t, response)
+	if replayed.ID != repository.ID {
+		t.Fatalf("replayed repository = %#v", replayed)
+	}
+
+	response = fixture.request(http.MethodGet, "/api/v1/repositories", "", "", nil)
+	requireStatus(t, response, http.StatusOK)
+	listed := decodeResponse[struct {
+		Repositories []protocol.ManagedRepository `json:"repositories"`
+	}](t, response)
+	if len(listed.Repositories) != 1 || listed.Repositories[0].ID != repository.ID {
+		t.Fatalf("listed repositories = %#v", listed.Repositories)
+	}
+
+	response = fixture.request(
+		http.MethodPut,
+		"/api/v1/repositories/"+repository.ID+"/enabled",
+		"application/json",
+		"",
+		protocol.SetManagedRepositoryEnabledRequest{Enabled: false},
+	)
+	requireStatus(t, response, http.StatusOK)
+	disabled := decodeResponse[protocol.ManagedRepository](t, response)
+	if disabled.Enabled {
+		t.Fatalf("disabled repository = %#v", disabled)
+	}
+
+	response = fixture.request(http.MethodGet, "/api/v1/repositories/"+repository.ID, "", "", nil)
+	requireStatus(t, response, http.StatusOK)
+	if fetched := decodeResponse[protocol.ManagedRepository](t, response); fetched.Enabled {
+		t.Fatalf("fetched repository = %#v", fetched)
+	}
+
+	response = fixture.request(
+		http.MethodPut,
+		"/api/v1/repositories/"+repository.ID+"/enabled",
+		"application/json",
+		"",
+		map[string]any{},
+	)
+	requireStatus(t, response, http.StatusBadRequest)
+	if body := decodeResponse[protocol.ErrorBody](t, response); body.Error.Code != "invalid_repository" {
+		t.Fatalf("missing enabled error = %#v", body)
+	}
+}
+
 func TestHTTPMetricsUseABoundedWindowContract(t *testing.T) {
 	fixture := newHTTPFixture(t)
 	response := fixture.request(http.MethodGet, "/api/v1/metrics/summary", "", "", nil)

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -601,8 +601,13 @@ func (s *Store) RetryExecution(ctx context.Context, executionID string) (protoco
 		return protocol.TaskDetail{}, unavailable(err)
 	}
 	defer tx.Rollback()
-	var taskID, state string
-	err = tx.QueryRowContext(ctx, `SELECT task_id, state FROM executions WHERE id = ?`, executionID).Scan(&taskID, &state)
+	var taskID, state, workerID, repositoryID string
+	err = tx.QueryRowContext(ctx, `
+		SELECT execution.task_id, execution.state, execution.assigned_worker_id, task.repository_id
+		FROM executions execution
+		JOIN tasks task ON task.id = execution.task_id
+		WHERE execution.id = ?
+	`, executionID).Scan(&taskID, &state, &workerID, &repositoryID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return protocol.TaskDetail{}, ErrNotFound
 	}
@@ -611,6 +616,61 @@ func (s *Store) RetryExecution(ctx context.Context, executionID string) (protoco
 	}
 	if state != "failed" && state != "cancelled" {
 		return protocol.TaskDetail{}, conflict("retry_not_allowed", "only a failed or cancelled execution can be retried")
+	}
+	var dynamic, advertised int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT dynamic, advertised
+		FROM worker_repositories
+		WHERE worker_id = ? AND repository_id = ?
+	`, workerID, repositoryID).Scan(&dynamic, &advertised); errors.Is(err, sql.ErrNoRows) {
+		return protocol.TaskDetail{}, conflict(
+			"retry_repository_unavailable", "the frozen worker repository assignment is unavailable")
+	} else if err != nil {
+		return protocol.TaskDetail{}, unavailable(err)
+	}
+	if dynamic != 0 && advertised == 0 {
+		var acceptsManagedRepositories, repositoryCached, cacheUse int
+		err := tx.QueryRowContext(ctx, `
+			SELECT worker.accepts_managed_repositories,
+			       EXISTS (
+			           SELECT 1
+			           FROM json_each(worker.managed_repository_ids_json) cached_repository
+			           WHERE cached_repository.value = ?
+			       ),
+			       json_array_length(worker.managed_repository_ids_json) + (
+			           SELECT COUNT(*)
+			           FROM worker_repositories reservation
+			           WHERE reservation.worker_id = worker.id
+			             AND reservation.dynamic = 1
+			             AND reservation.advertised = 1
+			             AND NOT EXISTS (
+			                 SELECT 1
+			                 FROM json_each(worker.managed_repository_ids_json) cached_repository
+			                 WHERE cached_repository.value = reservation.repository_id
+			             )
+			       )
+			FROM workers worker
+			WHERE worker.id = ?
+		`, repositoryID, workerID).Scan(
+			&acceptsManagedRepositories, &repositoryCached, &cacheUse,
+		)
+		if err != nil {
+			return protocol.TaskDetail{}, unavailable(err)
+		}
+		if acceptsManagedRepositories == 0 ||
+			(repositoryCached == 0 && cacheUse >= protocol.MaxRepositoryCacheEntries) {
+			return protocol.TaskDetail{}, conflict(
+				"retry_repository_unavailable",
+				"the frozen worker cannot currently reserve this managed repository",
+			)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE worker_repositories
+			SET advertised = 1, updated_at = ?
+			WHERE worker_id = ? AND repository_id = ? AND dynamic = 1
+		`, now, workerID, repositoryID); err != nil {
+			return protocol.TaskDetail{}, unavailable(err)
+		}
 	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE executions

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -233,7 +233,9 @@ func (s *Store) claimDetail(ctx context.Context, attemptID string) (protocol.Cla
 		return claim, unavailable(err)
 	}
 	err = s.db.QueryRowContext(ctx, `
-		SELECT r.id, wr.display_key, r.remote_identity, wr.retained_count
+		SELECT r.id, wr.display_key,
+		       COALESCE(NULLIF(wr.worker_remote_identity, ''), r.remote_identity),
+		       wr.retained_count
 		FROM repositories r JOIN worker_repositories wr ON wr.repository_id = r.id
 		WHERE r.id = ? AND wr.worker_id = ?
 	`, claim.Task.RepositoryID, claim.Attempt.WorkerID).Scan(

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -447,6 +447,24 @@ func (s *Store) CreateManagedRepository(
 		WHERE lower(remote_identity) = lower(?)
 	`, remoteIdentity))
 	if err == nil {
+		var centrallyManaged int
+		if err := tx.QueryRowContext(ctx, `
+			SELECT centrally_managed FROM repositories WHERE id = ?
+		`, repository.ID).Scan(&centrallyManaged); err != nil {
+			return protocol.ManagedRepository{}, false, unavailable(err)
+		}
+		if centrallyManaged == 0 {
+			now := s.now().UnixMilli()
+			if _, err := tx.ExecContext(ctx, `
+				UPDATE repositories
+				SET enabled = 1, centrally_managed = 1, updated_at = ?
+				WHERE id = ? AND centrally_managed = 0
+			`, now, repository.ID); err != nil {
+				return protocol.ManagedRepository{}, false, unavailable(err)
+			}
+			repository.Enabled = true
+			repository.UpdatedAt = fromMillis(now)
+		}
 		if err := tx.Commit(); err != nil {
 			return protocol.ManagedRepository{}, false, unavailable(err)
 		}
@@ -471,8 +489,10 @@ func (s *Store) CreateManagedRepository(
 	}
 	now := s.now().UnixMilli()
 	if _, err := tx.ExecContext(ctx, `
-		INSERT INTO repositories(id, remote_identity, enabled, created_at, updated_at)
-		VALUES (?, ?, 1, ?, ?)
+		INSERT INTO repositories(
+			id, remote_identity, enabled, centrally_managed, created_at, updated_at
+		)
+		VALUES (?, ?, 1, 1, ?, ?)
 	`, repositoryID, remoteIdentity, now, now); err != nil {
 		return protocol.ManagedRepository{}, false, unavailable(err)
 	}
@@ -535,7 +555,9 @@ func (s *Store) SetManagedRepositoryEnabled(
 	repositoryID = strings.TrimSpace(repositoryID)
 	now := s.now().UnixMilli()
 	result, err := s.db.ExecContext(ctx, `
-		UPDATE repositories SET enabled = ?, updated_at = ? WHERE id = ?
+		UPDATE repositories
+		SET enabled = ?, centrally_managed = 1, updated_at = ?
+		WHERE id = ?
 	`, enabled, now, repositoryID)
 	if err != nil {
 		return protocol.ManagedRepository{}, unavailable(err)
@@ -690,25 +712,42 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		return protocol.Worker{}, err
 	}
 	input.SourceAccess = sourceAccess
-	seenKeys := map[string]bool{}
-	seenRemotes := map[string]bool{}
-	workerRemoteIdentities := make([]string, len(input.Repositories))
-	for i := range input.Repositories {
-		repo := &input.Repositories[i]
+	seenKeys := make(map[string]bool, len(input.Repositories))
+	seenRemotes := make(map[string]int, len(input.Repositories))
+	normalizedRepositories := make([]protocol.RepositoryRegistration, 0, len(input.Repositories))
+	workerRemoteIdentities := make([]string, 0, len(input.Repositories))
+	for _, value := range input.Repositories {
+		repo := value
 		repo.Key = strings.TrimSpace(repo.Key)
-		workerRemoteIdentities[i] = normalizeRemote(repo.RemoteIdentity)
-		repo.RemoteIdentity = normalizeRegisteredRemote(workerRemoteIdentities[i])
+		workerRemoteIdentity := normalizeRemote(repo.RemoteIdentity)
+		repo.RemoteIdentity = normalizeRegisteredRemote(workerRemoteIdentity)
 		if repo.Key == "" || repo.RemoteIdentity == "" || len(repo.Key) > 200 || len(repo.RemoteIdentity) > 2048 {
 			return protocol.Worker{}, invalid("invalid_repository", "repository key and remote_identity are required")
 		}
 		if repo.RetainedCount < 0 {
 			return protocol.Worker{}, invalid("invalid_repository", "retained_count cannot be negative")
 		}
-		if seenKeys[repo.Key] || seenRemotes[repo.RemoteIdentity] {
+		if seenKeys[repo.Key] {
 			return protocol.Worker{}, invalid("duplicate_repository", "repository keys and identities must be unique per worker")
 		}
-		seenKeys[repo.Key], seenRemotes[repo.RemoteIdentity] = true, true
+		seenKeys[repo.Key] = true
+		if previousIndex, exists := seenRemotes[repo.RemoteIdentity]; exists {
+			previousWorkerRemote := workerRemoteIdentities[previousIndex]
+			if workerRemoteIdentity == previousWorkerRemote ||
+				!strings.EqualFold(workerRemoteIdentity, previousWorkerRemote) {
+				return protocol.Worker{}, invalid(
+					"duplicate_repository", "repository identities must be unique per worker")
+			}
+			if repo.RetainedCount > normalizedRepositories[previousIndex].RetainedCount {
+				normalizedRepositories[previousIndex].RetainedCount = repo.RetainedCount
+			}
+			continue
+		}
+		seenRemotes[repo.RemoteIdentity] = len(normalizedRepositories)
+		normalizedRepositories = append(normalizedRepositories, repo)
+		workerRemoteIdentities = append(workerRemoteIdentities, workerRemoteIdentity)
 	}
+	input.Repositories = normalizedRepositories
 	retainedCounts := make(map[string]int)
 	retainedAttemptIDs := make(map[string][]string)
 	seenRetainedAttempts := make(map[string]string)
@@ -842,11 +881,23 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		if errors.Is(err, sql.ErrNoRows) {
 			repositoryID, err = newID()
 			if err == nil {
+				var repositoryCount int
+				err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM repositories`).Scan(&repositoryCount)
+				if err == nil && repositoryCount >= protocol.MaxManagedRepositories {
+					return protocol.Worker{}, conflict(
+						"repository_limit_reached",
+						"the managed repository limit has been reached",
+					)
+				}
+			}
+			if err == nil {
 				// A legacy static checkout supports explicit manual assignment, but
 				// worker registration must not expand the centrally managed fleet.
 				_, err = tx.ExecContext(ctx, `
-					INSERT INTO repositories(id, remote_identity, enabled, created_at, updated_at)
-					VALUES (?, ?, 0, ?, ?)
+					INSERT INTO repositories(
+						id, remote_identity, enabled, centrally_managed, created_at, updated_at
+					)
+					VALUES (?, ?, 0, 0, ?, ?)
 				`, repositoryID, repo.RemoteIdentity, now, now)
 			}
 		}

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -692,10 +692,12 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 	input.SourceAccess = sourceAccess
 	seenKeys := map[string]bool{}
 	seenRemotes := map[string]bool{}
+	workerRemoteIdentities := make([]string, len(input.Repositories))
 	for i := range input.Repositories {
 		repo := &input.Repositories[i]
 		repo.Key = strings.TrimSpace(repo.Key)
-		repo.RemoteIdentity = normalizeRegisteredRemote(repo.RemoteIdentity)
+		workerRemoteIdentities[i] = normalizeRemote(repo.RemoteIdentity)
+		repo.RemoteIdentity = normalizeRegisteredRemote(workerRemoteIdentities[i])
 		if repo.Key == "" || repo.RemoteIdentity == "" || len(repo.Key) > 200 || len(repo.RemoteIdentity) > 2048 {
 			return protocol.Worker{}, invalid("invalid_repository", "repository key and remote_identity are required")
 		}
@@ -833,7 +835,8 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 	`, input.AcceptsManagedRepositories, now, workerID); err != nil {
 		return protocol.Worker{}, unavailable(err)
 	}
-	for _, repo := range input.Repositories {
+	for index, repo := range input.Repositories {
+		workerRemoteIdentity := workerRemoteIdentities[index]
 		var repositoryID string
 		err := tx.QueryRowContext(ctx, `SELECT id FROM repositories WHERE remote_identity = ?`, repo.RemoteIdentity).Scan(&repositoryID)
 		if errors.Is(err, sql.ErrNoRows) {
@@ -864,22 +867,25 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		case mappingErr == nil && existingKey != repo.Key:
 			_, err = tx.ExecContext(ctx, `
 				UPDATE worker_repositories
-				SET display_key = ?, retained_count = ?, advertised = 1, dynamic = 0, updated_at = ?
+				SET display_key = ?, worker_remote_identity = ?, retained_count = ?,
+				    advertised = 1, dynamic = 0, updated_at = ?
 				WHERE worker_id = ? AND repository_id = ?
-			`, repo.Key, effectiveRetainedCount, now, workerID, repositoryID)
+			`, repo.Key, workerRemoteIdentity, effectiveRetainedCount, now, workerID, repositoryID)
 		case mappingErr == nil:
 			_, err = tx.ExecContext(ctx, `
 				UPDATE worker_repositories
-				SET retained_count = ?, advertised = 1, dynamic = 0, updated_at = ?
+				SET worker_remote_identity = ?, retained_count = ?,
+				    advertised = 1, dynamic = 0, updated_at = ?
 				WHERE worker_id = ? AND repository_id = ?
-			`, effectiveRetainedCount, now, workerID, repositoryID)
+			`, workerRemoteIdentity, effectiveRetainedCount, now, workerID, repositoryID)
 		case errors.Is(mappingErr, sql.ErrNoRows):
 			_, err = tx.ExecContext(ctx, `
 				INSERT INTO worker_repositories(
-					worker_id, display_key, repository_id, retained_count, advertised, dynamic, updated_at
+					worker_id, display_key, repository_id, worker_remote_identity,
+					retained_count, advertised, dynamic, updated_at
 				)
-				VALUES (?, ?, ?, ?, 1, 0, ?)
-			`, workerID, repo.Key, repositoryID, effectiveRetainedCount, now)
+				VALUES (?, ?, ?, ?, ?, 1, 0, ?)
+			`, workerID, repo.Key, repositoryID, workerRemoteIdentity, effectiveRetainedCount, now)
 		default:
 			err = mappingErr
 		}
@@ -1129,7 +1135,9 @@ func scanWorker(row scanner, now time.Time) (protocol.Worker, error) {
 
 func (s *Store) workerRepositories(ctx context.Context, workerID string) ([]protocol.Repository, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT r.id, wr.display_key, r.remote_identity, wr.retained_count
+		SELECT r.id, wr.display_key,
+		       COALESCE(NULLIF(wr.worker_remote_identity, ''), r.remote_identity),
+		       wr.retained_count
 		FROM worker_repositories wr JOIN repositories r ON r.id = wr.repository_id
 		WHERE wr.worker_id = ? AND wr.advertised = 1 ORDER BY wr.display_key
 	`, workerID)
@@ -1239,6 +1247,16 @@ func (s *Store) selectTaskRoute(
 		  AND w.last_heartbeat >= ?
 		  AND (
 		      COALESCE(wr.advertised, 0) = 1
+		      OR NOT EXISTS (
+		          SELECT 1
+		          FROM worker_repositories display_key_conflict
+		          WHERE display_key_conflict.worker_id = w.id
+		            AND display_key_conflict.display_key = ?
+		            AND display_key_conflict.repository_id != ?
+		      )
+		  )
+		  AND (
+		      COALESCE(wr.advertised, 0) = 1
 		      OR (
 		          w.accepts_managed_repositories = 1
 		          AND (
@@ -1281,7 +1299,8 @@ func (s *Store) selectTaskRoute(
 		        AND terminal_attempt.capacity_acknowledged = 0
 		  ) < ?
 		ORDER BY w.id
-	`, repositoryID, now-protocol.WorkerOnlineWindow.Milliseconds(), repositoryID, protocol.MaxRepositoryCacheEntries,
+	`, repositoryID, now-protocol.WorkerOnlineWindow.Milliseconds(), repositoryIdentity, repositoryID,
+		repositoryID, protocol.MaxRepositoryCacheEntries,
 		repositoryID, repositoryID, protocol.MaxRetainedPerRepo)
 	if err != nil {
 		return taskRouteCandidate{}, unavailable(err)
@@ -1335,15 +1354,17 @@ func (s *Store) selectTaskRoute(
 		}
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO worker_repositories(
-				worker_id, display_key, repository_id, retained_count, advertised, dynamic, updated_at
+				worker_id, display_key, repository_id, worker_remote_identity,
+				retained_count, advertised, dynamic, updated_at
 			)
-			VALUES (?, ?, ?, 0, 1, 1, ?)
+			VALUES (?, ?, ?, ?, 0, 1, 1, ?)
 			ON CONFLICT(worker_id, repository_id) DO UPDATE SET
 				display_key=excluded.display_key,
+				worker_remote_identity=excluded.worker_remote_identity,
 				advertised=1,
 				dynamic=1,
 				updated_at=excluded.updated_at
-		`, best.workerID, repositoryIdentity, repositoryID, now); err != nil {
+		`, best.workerID, repositoryIdentity, repositoryID, repositoryIdentity, now); err != nil {
 			return taskRouteCandidate{}, unavailable(err)
 		}
 	}

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -921,6 +921,33 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		`, retainedCounts[repositoryID], input.AcceptsManagedRepositories, now, workerID, repositoryID); err != nil {
 			return protocol.Worker{}, unavailable(err)
 		}
+		if seenManagedRepositoryIDs[repositoryID] || retainedCounts[repositoryID] > 0 {
+			continue
+		}
+		result, err := tx.ExecContext(ctx, `
+			UPDATE worker_repositories
+			SET advertised = 0, updated_at = ?
+			WHERE worker_id = ?
+			  AND repository_id = ?
+			  AND dynamic = 1
+			  AND retained_count = 0
+			  AND NOT EXISTS (
+			      SELECT 1
+			      FROM executions execution
+			      JOIN tasks task ON task.id = execution.task_id
+			      WHERE execution.assigned_worker_id = ?
+			        AND task.repository_id = ?
+			        AND execution.state IN ('queued', 'preparing', 'running')
+			  )
+		`, now, workerID, repositoryID, workerID, repositoryID)
+		if err != nil {
+			return protocol.Worker{}, unavailable(err)
+		}
+		if released, err := result.RowsAffected(); err != nil {
+			return protocol.Worker{}, unavailable(err)
+		} else if released > 0 {
+			delete(advertisedRepositoryIDs, repositoryID)
+		}
 	}
 	canBulkAcknowledge := input.CapacityHandoffVersion == 0 && !hasUnattributedRetainedSummary
 	for repositoryID := range retainedCounts {
@@ -1225,6 +1252,7 @@ func (s *Store) selectTaskRoute(
 		                  FROM worker_repositories reserved_repository
 		                  WHERE reserved_repository.worker_id = w.id
 		                    AND reserved_repository.dynamic = 1
+		                    AND reserved_repository.advertised = 1
 		                    AND NOT EXISTS (
 		                        SELECT 1
 		                        FROM json_each(w.managed_repository_ids_json) cached_repository

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -354,6 +354,202 @@ func normalizeRemote(value string) string {
 	return strings.TrimSpace(value)
 }
 
+func normalizeRegisteredRemote(value string) string {
+	value = normalizeRemote(value)
+	parts := strings.Split(value, "/")
+	if len(parts) == 3 && strings.EqualFold(parts[0], "github.com") {
+		if canonical, err := normalizeManagedGitHubRemote(value); err == nil {
+			return canonical
+		}
+	}
+	return value
+}
+
+func normalizeManagedGitHubRemote(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	value = strings.TrimSuffix(value, ".git")
+	parts := strings.Split(value, "/")
+	if len(parts) != 3 || !strings.EqualFold(parts[0], "github.com") ||
+		!validGitHubOwner(parts[1]) || !validGitHubRepository(parts[2]) {
+		return "", invalid(
+			"invalid_repository",
+			"remote_identity must use the canonical github.com/owner/repository form",
+		)
+	}
+	return strings.ToLower(strings.Join(parts, "/")), nil
+}
+
+func validGitHubOwner(value string) bool {
+	if len(value) < 1 || len(value) > 39 || value[0] == '-' || value[len(value)-1] == '-' || strings.Contains(value, "--") {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') &&
+			(character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func validGitHubRepository(value string) bool {
+	if len(value) < 1 || len(value) > 100 || value == "." || value == ".." {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') &&
+			(character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') &&
+			character != '-' && character != '_' && character != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func scanManagedRepository(row scanner) (protocol.ManagedRepository, error) {
+	var repository protocol.ManagedRepository
+	var enabled int
+	var createdAt, updatedAt int64
+	if err := row.Scan(
+		&repository.ID,
+		&repository.RemoteIdentity,
+		&enabled,
+		&createdAt,
+		&updatedAt,
+	); err != nil {
+		return repository, err
+	}
+	repository.Enabled = enabled != 0
+	repository.CreatedAt = fromMillis(createdAt)
+	repository.UpdatedAt = fromMillis(updatedAt)
+	return repository, nil
+}
+
+func (s *Store) CreateManagedRepository(
+	ctx context.Context,
+	input protocol.CreateManagedRepositoryRequest,
+) (protocol.ManagedRepository, bool, error) {
+	remoteIdentity, err := normalizeManagedGitHubRemote(input.RemoteIdentity)
+	if err != nil {
+		return protocol.ManagedRepository{}, false, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return protocol.ManagedRepository{}, false, unavailable(err)
+	}
+	defer tx.Rollback()
+
+	repository, err := scanManagedRepository(tx.QueryRowContext(ctx, `
+		SELECT id, remote_identity, enabled, created_at, updated_at
+		FROM repositories
+		WHERE lower(remote_identity) = lower(?)
+	`, remoteIdentity))
+	if err == nil {
+		if err := tx.Commit(); err != nil {
+			return protocol.ManagedRepository{}, false, unavailable(err)
+		}
+		return repository, false, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return protocol.ManagedRepository{}, false, unavailable(err)
+	}
+	var count int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM repositories`).Scan(&count); err != nil {
+		return protocol.ManagedRepository{}, false, unavailable(err)
+	}
+	if count >= protocol.MaxManagedRepositories {
+		return protocol.ManagedRepository{}, false, conflict(
+			"repository_limit_reached",
+			"the managed repository limit has been reached",
+		)
+	}
+	repositoryID, err := newID()
+	if err != nil {
+		return protocol.ManagedRepository{}, false, unavailable(err)
+	}
+	now := s.now().UnixMilli()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO repositories(id, remote_identity, enabled, created_at, updated_at)
+		VALUES (?, ?, 1, ?, ?)
+	`, repositoryID, remoteIdentity, now, now); err != nil {
+		return protocol.ManagedRepository{}, false, unavailable(err)
+	}
+	if err := tx.Commit(); err != nil {
+		return protocol.ManagedRepository{}, false, unavailable(err)
+	}
+	return protocol.ManagedRepository{
+		ID:             repositoryID,
+		RemoteIdentity: remoteIdentity,
+		Enabled:        true,
+		CreatedAt:      fromMillis(now),
+		UpdatedAt:      fromMillis(now),
+	}, true, nil
+}
+
+func (s *Store) ManagedRepositories(ctx context.Context) ([]protocol.ManagedRepository, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, remote_identity, enabled, created_at, updated_at
+		FROM repositories
+		ORDER BY remote_identity
+	`)
+	if err != nil {
+		return nil, unavailable(err)
+	}
+	defer rows.Close()
+	repositories := make([]protocol.ManagedRepository, 0)
+	for rows.Next() {
+		repository, err := scanManagedRepository(rows)
+		if err != nil {
+			return nil, unavailable(err)
+		}
+		repositories = append(repositories, repository)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, unavailable(err)
+	}
+	return repositories, nil
+}
+
+func (s *Store) ManagedRepository(ctx context.Context, repositoryID string) (protocol.ManagedRepository, error) {
+	repository, err := scanManagedRepository(s.db.QueryRowContext(ctx, `
+		SELECT id, remote_identity, enabled, created_at, updated_at
+		FROM repositories
+		WHERE id = ?
+	`, strings.TrimSpace(repositoryID)))
+	if errors.Is(err, sql.ErrNoRows) {
+		return protocol.ManagedRepository{}, ErrNotFound
+	}
+	if err != nil {
+		return protocol.ManagedRepository{}, unavailable(err)
+	}
+	return repository, nil
+}
+
+func (s *Store) SetManagedRepositoryEnabled(
+	ctx context.Context,
+	repositoryID string,
+	enabled bool,
+) (protocol.ManagedRepository, error) {
+	repositoryID = strings.TrimSpace(repositoryID)
+	now := s.now().UnixMilli()
+	result, err := s.db.ExecContext(ctx, `
+		UPDATE repositories SET enabled = ?, updated_at = ? WHERE id = ?
+	`, enabled, now, repositoryID)
+	if err != nil {
+		return protocol.ManagedRepository{}, unavailable(err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return protocol.ManagedRepository{}, unavailable(err)
+	}
+	if affected == 0 {
+		return protocol.ManagedRepository{}, ErrNotFound
+	}
+	return s.ManagedRepository(ctx, repositoryID)
+}
+
 func normalizeSourceAccess(values []protocol.SourceAccess) ([]protocol.SourceAccess, error) {
 	if len(values) > 10 {
 		return nil, invalid("invalid_source_access", "a worker may advertise at most 10 source access entries")
@@ -405,6 +601,38 @@ func validHostname(value string) bool {
 	return true
 }
 
+func validUUID(value string) bool {
+	if len(value) != 36 {
+		return false
+	}
+	for index, character := range value {
+		if index == 8 || index == 13 || index == 18 || index == 23 {
+			if character != '-' {
+				return false
+			}
+			continue
+		}
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Store) resolveRepositoryAlias(ctx context.Context, repositoryID string) (string, error) {
+	var canonicalID string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT repository_id FROM repository_aliases WHERE alias_id = ?
+	`, repositoryID).Scan(&canonicalID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return repositoryID, nil
+	}
+	if err != nil {
+		return "", unavailable(err)
+	}
+	return canonicalID, nil
+}
+
 func (s *Store) RegisterWorker(ctx context.Context, workerID string, input protocol.WorkerRegistration) (protocol.Worker, error) {
 	workerID = strings.TrimSpace(workerID)
 	if workerID == "" || len(workerID) > 200 {
@@ -435,8 +663,27 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		return protocol.Worker{}, invalid(
 			"invalid_capacity_handoff", "capacity_handoff_version must be 0 or 1")
 	}
-	if len(input.Repositories) == 0 {
-		return protocol.Worker{}, invalid("invalid_repositories", "at least one repository is required")
+	if len(input.ManagedRepositoryIDs) > protocol.MaxRepositoryCacheEntries {
+		return protocol.Worker{}, invalid(
+			"invalid_managed_repository_ids",
+			"a worker may advertise at most 100 cached managed repository IDs",
+		)
+	}
+	seenManagedRepositoryIDs := make(map[string]bool, len(input.ManagedRepositoryIDs))
+	for index, repositoryID := range input.ManagedRepositoryIDs {
+		canonicalID, err := s.resolveRepositoryAlias(ctx, repositoryID)
+		if err != nil {
+			return protocol.Worker{}, err
+		}
+		input.ManagedRepositoryIDs[index] = canonicalID
+		repositoryID = canonicalID
+		if !validUUID(repositoryID) || seenManagedRepositoryIDs[repositoryID] {
+			return protocol.Worker{}, invalid(
+				"invalid_managed_repository_ids",
+				"cached managed repository IDs must be unique UUIDs",
+			)
+		}
+		seenManagedRepositoryIDs[repositoryID] = true
 	}
 	sourceAccess, err := normalizeSourceAccess(input.SourceAccess)
 	if err != nil {
@@ -448,7 +695,7 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 	for i := range input.Repositories {
 		repo := &input.Repositories[i]
 		repo.Key = strings.TrimSpace(repo.Key)
-		repo.RemoteIdentity = normalizeRemote(repo.RemoteIdentity)
+		repo.RemoteIdentity = normalizeRegisteredRemote(repo.RemoteIdentity)
 		if repo.Key == "" || repo.RemoteIdentity == "" || len(repo.Key) > 200 || len(repo.RemoteIdentity) > 2048 {
 			return protocol.Worker{}, invalid("invalid_repository", "repository key and remote_identity are required")
 		}
@@ -468,6 +715,13 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		worktree := &input.RetainedWorktrees[index]
 		worktree.AttemptID = strings.TrimSpace(worktree.AttemptID)
 		worktree.RepositoryID = strings.TrimSpace(worktree.RepositoryID)
+		if worktree.RepositoryID != "" {
+			canonicalID, err := s.resolveRepositoryAlias(ctx, worktree.RepositoryID)
+			if err != nil {
+				return protocol.Worker{}, err
+			}
+			worktree.RepositoryID = canonicalID
+		}
 		// Older API clients may send display-only summaries before they know the
 		// control-plane repository ID. Preserve those summaries, but do not use
 		// incomplete or duplicate entries as capacity-handoff evidence.
@@ -506,6 +760,13 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 	sourceAccessJSON, err := json.Marshal(input.SourceAccess)
 	if err != nil {
 		return protocol.Worker{}, invalid("invalid_source_access", "source access could not be encoded")
+	}
+	managedRepositoryIDsJSON, err := json.Marshal(input.ManagedRepositoryIDs)
+	if err != nil {
+		return protocol.Worker{}, invalid(
+			"invalid_managed_repository_ids",
+			"cached managed repository IDs could not be encoded",
+		)
 	}
 	now := s.now().UnixMilli()
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -547,20 +808,29 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO workers(
 			id, name, worker_version, runtime, runtime_version, capacity, active_count,
-			health, source_access_json, retained_worktrees_json, registered_at, last_heartbeat
+			health, source_access_json, accepts_managed_repositories,
+			managed_repository_ids_json, retained_worktrees_json, registered_at, last_heartbeat
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			name=excluded.name, worker_version=excluded.worker_version, runtime_version=excluded.runtime_version,
 			capacity=excluded.capacity, active_count=excluded.active_count, health=excluded.health,
 			source_access_json=excluded.source_access_json,
+			accepts_managed_repositories=excluded.accepts_managed_repositories,
+			managed_repository_ids_json=excluded.managed_repository_ids_json,
 			retained_worktrees_json=excluded.retained_worktrees_json, last_heartbeat=excluded.last_heartbeat
 	`, workerID, input.Name, input.WorkerVersion, input.Runtime, input.RuntimeVersion,
-		input.Capacity, input.ActiveCount, input.Health, sourceAccessJSON, retained, now, now)
+		input.Capacity, input.ActiveCount, input.Health, sourceAccessJSON,
+		input.AcceptsManagedRepositories, managedRepositoryIDsJSON, retained, now, now)
 	if err != nil {
 		return protocol.Worker{}, unavailable(err)
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE worker_repositories SET advertised = 0, updated_at = ? WHERE worker_id = ?`, now, workerID); err != nil {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE worker_repositories
+		SET advertised = CASE WHEN dynamic = 1 AND ? THEN 1 ELSE 0 END,
+		    updated_at = ?
+		WHERE worker_id = ?
+	`, input.AcceptsManagedRepositories, now, workerID); err != nil {
 		return protocol.Worker{}, unavailable(err)
 	}
 	for _, repo := range input.Repositories {
@@ -569,7 +839,12 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		if errors.Is(err, sql.ErrNoRows) {
 			repositoryID, err = newID()
 			if err == nil {
-				_, err = tx.ExecContext(ctx, `INSERT INTO repositories(id, remote_identity, created_at) VALUES (?, ?, ?)`, repositoryID, repo.RemoteIdentity, now)
+				// A legacy static checkout supports explicit manual assignment, but
+				// worker registration must not expand the centrally managed fleet.
+				_, err = tx.ExecContext(ctx, `
+					INSERT INTO repositories(id, remote_identity, enabled, created_at, updated_at)
+					VALUES (?, ?, 0, ?, ?)
+				`, repositoryID, repo.RemoteIdentity, now, now)
 			}
 		}
 		if err != nil {
@@ -589,24 +864,61 @@ func (s *Store) RegisterWorker(ctx context.Context, workerID string, input proto
 		case mappingErr == nil && existingKey != repo.Key:
 			_, err = tx.ExecContext(ctx, `
 				UPDATE worker_repositories
-				SET display_key = ?, retained_count = ?, advertised = 1, updated_at = ?
+				SET display_key = ?, retained_count = ?, advertised = 1, dynamic = 0, updated_at = ?
 				WHERE worker_id = ? AND repository_id = ?
 			`, repo.Key, effectiveRetainedCount, now, workerID, repositoryID)
 		case mappingErr == nil:
 			_, err = tx.ExecContext(ctx, `
 				UPDATE worker_repositories
-				SET retained_count = ?, advertised = 1, updated_at = ?
+				SET retained_count = ?, advertised = 1, dynamic = 0, updated_at = ?
 				WHERE worker_id = ? AND repository_id = ?
 			`, effectiveRetainedCount, now, workerID, repositoryID)
 		case errors.Is(mappingErr, sql.ErrNoRows):
 			_, err = tx.ExecContext(ctx, `
-				INSERT INTO worker_repositories(worker_id, display_key, repository_id, retained_count, advertised, updated_at)
-				VALUES (?, ?, ?, ?, 1, ?)
+				INSERT INTO worker_repositories(
+					worker_id, display_key, repository_id, retained_count, advertised, dynamic, updated_at
+				)
+				VALUES (?, ?, ?, ?, 1, 0, ?)
 			`, workerID, repo.Key, repositoryID, effectiveRetainedCount, now)
 		default:
 			err = mappingErr
 		}
 		if err != nil {
+			return protocol.Worker{}, unavailable(err)
+		}
+	}
+	dynamicRows, err := tx.QueryContext(ctx, `
+		SELECT repository_id
+		FROM worker_repositories
+		WHERE worker_id = ? AND dynamic = 1
+	`, workerID)
+	if err != nil {
+		return protocol.Worker{}, unavailable(err)
+	}
+	var dynamicRepositoryIDs []string
+	for dynamicRows.Next() {
+		var repositoryID string
+		if err := dynamicRows.Scan(&repositoryID); err != nil {
+			dynamicRows.Close()
+			return protocol.Worker{}, unavailable(err)
+		}
+		dynamicRepositoryIDs = append(dynamicRepositoryIDs, repositoryID)
+	}
+	if err := dynamicRows.Close(); err != nil {
+		return protocol.Worker{}, unavailable(err)
+	}
+	if err := dynamicRows.Err(); err != nil {
+		return protocol.Worker{}, unavailable(err)
+	}
+	for _, repositoryID := range dynamicRepositoryIDs {
+		if input.AcceptsManagedRepositories {
+			advertisedRepositoryIDs[repositoryID] = true
+		}
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE worker_repositories
+			SET retained_count = ?, advertised = ?, updated_at = ?
+			WHERE worker_id = ? AND repository_id = ? AND dynamic = 1
+		`, retainedCounts[repositoryID], input.AcceptsManagedRepositories, now, workerID, repositoryID); err != nil {
 			return protocol.Worker{}, unavailable(err)
 		}
 	}
@@ -687,7 +999,9 @@ func (s *Store) Workers(ctx context.Context) ([]protocol.Worker, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT w.id, w.name, w.worker_version, w.runtime, w.runtime_version,
 		       w.capacity, w.active_count, w.health, w.source_access_json,
-		       w.retained_worktrees_json, w.registered_at, w.last_heartbeat,
+		       w.accepts_managed_repositories, w.managed_repository_ids_json,
+		       w.retained_worktrees_json,
+		       w.registered_at, w.last_heartbeat,
 		       COALESCE((
 		           SELECT t.title
 		           FROM executions e JOIN tasks t ON t.id = e.task_id
@@ -729,7 +1043,9 @@ func (s *Store) Worker(ctx context.Context, id string) (protocol.Worker, error) 
 	row := s.db.QueryRowContext(ctx, `
 		SELECT w.id, w.name, w.worker_version, w.runtime, w.runtime_version,
 		       w.capacity, w.active_count, w.health, w.source_access_json,
-		       w.retained_worktrees_json, w.registered_at, w.last_heartbeat,
+		       w.accepts_managed_repositories, w.managed_repository_ids_json,
+		       w.retained_worktrees_json,
+		       w.registered_at, w.last_heartbeat,
 		       COALESCE((
 		           SELECT t.title
 		           FROM executions e JOIN tasks t ON t.id = e.task_id
@@ -756,10 +1072,12 @@ type scanner interface {
 
 func scanWorker(row scanner, now time.Time) (protocol.Worker, error) {
 	var worker protocol.Worker
-	var sourceAccess, retained []byte
+	var sourceAccess, managedRepositoryIDs, retained []byte
+	var acceptsManagedRepositories int
 	var registered, heartbeat int64
 	if err := row.Scan(&worker.ID, &worker.Name, &worker.WorkerVersion, &worker.Runtime, &worker.RuntimeVersion,
 		&worker.Capacity, &worker.ActiveCount, &worker.Health, &sourceAccess,
+		&acceptsManagedRepositories, &managedRepositoryIDs,
 		&retained, &registered, &heartbeat,
 		&worker.CurrentTaskTitle); err != nil {
 		return worker, err
@@ -767,6 +1085,12 @@ func scanWorker(row scanner, now time.Time) (protocol.Worker, error) {
 	if err := json.Unmarshal(sourceAccess, &worker.SourceAccess); err != nil {
 		return worker, err
 	}
+	worker.AcceptsManagedRepositories = acceptsManagedRepositories != 0
+	var repositoryIDs []string
+	if err := json.Unmarshal(managedRepositoryIDs, &repositoryIDs); err != nil {
+		return worker, err
+	}
+	worker.RepositoryCacheCount = len(repositoryIDs)
 	if err := json.Unmarshal(retained, &worker.RetainedWorktrees); err != nil {
 		return worker, err
 	}
@@ -798,11 +1122,13 @@ func (s *Store) workerRepositories(ctx context.Context, workerID string) ([]prot
 }
 
 type taskRouteCandidate struct {
-	workerID     string
-	repositoryID string
-	runtime      string
-	capacity     int
-	load         int
+	workerID                   string
+	repositoryID               string
+	runtime                    string
+	capacity                   int
+	load                       int
+	repositoryAdvertised       bool
+	acceptsManagedRepositories bool
 }
 
 func normalizeTaskRoute(route *protocol.TaskRoute) error {
@@ -818,6 +1144,16 @@ func normalizeTaskRoute(route *protocol.TaskRoute) error {
 		)
 	}
 	route.SourceAccess = values[0]
+	if route.SourceAccess.Provider == "github" && route.SourceAccess.Hostname == "github.com" {
+		canonical, err := normalizeManagedGitHubRemote(route.RepositoryRemoteIdentity)
+		if err != nil {
+			return invalid(
+				"invalid_route",
+				"GitHub route repository_remote_identity must use github.com/owner/repository",
+			)
+		}
+		route.RepositoryRemoteIdentity = canonical
+	}
 	return nil
 }
 
@@ -846,26 +1182,65 @@ func (s *Store) selectTaskRoute(
 	if route.SourceAccess.Provider == "github" && route.SourceAccess.Hostname == "github.com" {
 		repositoryPredicate = "lower(r.remote_identity) = lower(?)"
 	}
+	var repositoryID, repositoryIdentity string
+	err := tx.QueryRowContext(ctx, `
+		SELECT r.id, r.remote_identity
+		FROM repositories r
+		WHERE `+repositoryPredicate+` AND r.enabled = 1
+	`, route.RepositoryRemoteIdentity).Scan(&repositoryID, &repositoryIdentity)
+	if errors.Is(err, sql.ErrNoRows) {
+		return taskRouteCandidate{}, conflict(
+			"repository_not_managed",
+			"repository is not enabled in the control-plane managed repository catalog",
+		)
+	}
+	if err != nil {
+		return taskRouteCandidate{}, unavailable(err)
+	}
 	rows, err := tx.QueryContext(ctx, `
-		SELECT w.id, r.id, w.runtime, w.capacity, w.active_count,
-		       w.source_access_json,
+		SELECT w.id, w.runtime, w.capacity, w.active_count,
+		       w.source_access_json, COALESCE(wr.advertised, 0),
+		       w.accepts_managed_repositories,
 		       COALESCE((
 		           SELECT COUNT(*) FROM executions e
 		           WHERE e.assigned_worker_id = w.id AND e.state = 'queued'
 		       ), 0)
 		FROM workers w
-		JOIN worker_repositories wr ON wr.worker_id = w.id AND wr.advertised = 1
-		JOIN repositories r ON r.id = wr.repository_id
-		WHERE `+repositoryPredicate+`
-		  AND w.health = 'healthy'
+		LEFT JOIN worker_repositories wr
+		  ON wr.worker_id = w.id AND wr.repository_id = ?
+		WHERE w.health = 'healthy'
 		  AND w.last_heartbeat >= ?
-		  AND wr.retained_count + (
+		  AND (
+		      COALESCE(wr.advertised, 0) = 1
+		      OR (
+		          w.accepts_managed_repositories = 1
+		          AND (
+		              EXISTS (
+		                  SELECT 1
+		                  FROM json_each(w.managed_repository_ids_json) cached_repository
+		                  WHERE cached_repository.value = ?
+		              )
+		              OR json_array_length(w.managed_repository_ids_json) + (
+		                  SELECT COUNT(*)
+		                  FROM worker_repositories reserved_repository
+		                  WHERE reserved_repository.worker_id = w.id
+		                    AND reserved_repository.dynamic = 1
+		                    AND NOT EXISTS (
+		                        SELECT 1
+		                        FROM json_each(w.managed_repository_ids_json) cached_repository
+		                        WHERE cached_repository.value = reserved_repository.repository_id
+		                    )
+		              ) < ?
+		          )
+		      )
+		  )
+		  AND COALESCE(wr.retained_count, 0) + (
 		      SELECT COUNT(*)
 		      FROM attempts active_attempt
 		      JOIN executions active_execution ON active_execution.id = active_attempt.execution_id
 		      JOIN tasks active_task ON active_task.id = active_execution.task_id
 		      WHERE active_attempt.worker_id = w.id
-		        AND active_task.repository_id = r.id
+		        AND active_task.repository_id = ?
 		        AND active_attempt.state IN ('preparing', 'running')
 		  ) + (
 		      SELECT COUNT(*)
@@ -873,12 +1248,13 @@ func (s *Store) selectTaskRoute(
 		      JOIN executions terminal_execution ON terminal_execution.id = terminal_attempt.execution_id
 		      JOIN tasks terminal_task ON terminal_task.id = terminal_execution.task_id
 		      WHERE terminal_attempt.worker_id = w.id
-		        AND terminal_task.repository_id = r.id
+		        AND terminal_task.repository_id = ?
 		        AND terminal_attempt.state IN ('succeeded', 'failed', 'cancelled', 'lost')
 		        AND terminal_attempt.capacity_acknowledged = 0
 		  ) < ?
 		ORDER BY w.id
-	`, route.RepositoryRemoteIdentity, now-protocol.WorkerOnlineWindow.Milliseconds(), protocol.MaxRetainedPerRepo)
+	`, repositoryID, now-protocol.WorkerOnlineWindow.Milliseconds(), repositoryID, protocol.MaxRepositoryCacheEntries,
+		repositoryID, repositoryID, protocol.MaxRetainedPerRepo)
 	if err != nil {
 		return taskRouteCandidate{}, unavailable(err)
 	}
@@ -887,14 +1263,18 @@ func (s *Store) selectTaskRoute(
 	found := false
 	for rows.Next() {
 		var candidate taskRouteCandidate
-		var active, queued int
+		var active, queued, repositoryAdvertised, acceptsManagedRepositories int
 		var encoded []byte
 		if err := rows.Scan(
-			&candidate.workerID, &candidate.repositoryID, &candidate.runtime,
-			&candidate.capacity, &active, &encoded, &queued,
+			&candidate.workerID, &candidate.runtime, &candidate.capacity,
+			&active, &encoded, &repositoryAdvertised, &acceptsManagedRepositories, &queued,
 		); err != nil {
+			rows.Close()
 			return taskRouteCandidate{}, unavailable(err)
 		}
+		candidate.repositoryID = repositoryID
+		candidate.repositoryAdvertised = repositoryAdvertised != 0
+		candidate.acceptsManagedRepositories = acceptsManagedRepositories != 0
 		var access []protocol.SourceAccess
 		if err := json.Unmarshal(encoded, &access); err != nil {
 			return taskRouteCandidate{}, unavailable(err)
@@ -909,13 +1289,35 @@ func (s *Store) selectTaskRoute(
 		}
 	}
 	if err := rows.Err(); err != nil {
+		rows.Close()
+		return taskRouteCandidate{}, unavailable(err)
+	}
+	if err := rows.Close(); err != nil {
 		return taskRouteCandidate{}, unavailable(err)
 	}
 	if !found {
 		return taskRouteCandidate{}, conflict(
 			"no_eligible_worker",
-			"no healthy online worker advertises the repository and required source access",
+			"no healthy online worker can acquire the repository and access its source provider",
 		)
+	}
+	if !best.repositoryAdvertised {
+		if !best.acceptsManagedRepositories {
+			return taskRouteCandidate{}, unavailable(errors.New("selected worker cannot acquire managed repositories"))
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO worker_repositories(
+				worker_id, display_key, repository_id, retained_count, advertised, dynamic, updated_at
+			)
+			VALUES (?, ?, ?, 0, 1, 1, ?)
+			ON CONFLICT(worker_id, repository_id) DO UPDATE SET
+				display_key=excluded.display_key,
+				advertised=1,
+				dynamic=1,
+				updated_at=excluded.updated_at
+		`, best.workerID, repositoryIdentity, repositoryID, now); err != nil {
+			return taskRouteCandidate{}, unavailable(err)
+		}
 	}
 	return best, nil
 }

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -394,6 +394,71 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 	}
 }
 
+func TestManagedRepositoryMigrationPreservesLegacyClaimRemoteSpelling(t *testing.T) {
+	database, err := sql.Open("sqlite", t.TempDir()+"/legacy-remote.sqlite3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	database.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := database.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	schema, err := migrations.Files.ReadFile("001_controlplane.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.Exec(string(schema)); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	if _, err := database.Exec(`
+		INSERT INTO schema_migrations(version, applied_at) VALUES (1, 1);
+		INSERT INTO workers(
+			id, name, worker_version, codex_version, capacity, active_count, health,
+			retained_worktrees_json, registered_at, last_heartbeat
+		) VALUES ('legacy-case-worker', 'legacy', 'legacy', 'legacy', 1, 0, 'healthy', '[]', ?, ?);
+		INSERT INTO repositories(id, remote_identity, created_at)
+		VALUES ('legacy-case-repository', 'github.com/Owner/Repository', 1);
+		INSERT INTO worker_repositories(
+			worker_id, display_key, repository_id, retained_count, advertised, updated_at
+		) VALUES ('legacy-case-worker', 'legacy', 'legacy-case-repository', 0, 1, 1);
+		INSERT INTO tasks(
+			id, request_key, title, description, repository_id, timeout_seconds, created_at
+		) VALUES ('legacy-case-task', 'legacy-case-task', 'legacy case', '', 'legacy-case-repository', 60, 1);
+		INSERT INTO executions(
+			id, task_id, assigned_worker_id, required_runtime, state,
+			cancellation_requested, created_at, updated_at
+		) VALUES (
+			'legacy-case-execution', 'legacy-case-task', 'legacy-case-worker',
+			'codex', 'queued', 0, 1, 1
+		);
+	`, now.UnixMilli(), now.UnixMilli()); err != nil {
+		t.Fatal(err)
+	}
+	store := &Store{db: database, now: func() time.Time { return now }, sweepEvery: 5 * time.Second}
+	if err := store.migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(context.Background(), "legacy-case-worker", protocol.ClaimRequest{
+		RequestID: "legacy-case-claim", LeaseToken: tokenA,
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("legacy claim = %#v, err %v", claim, err)
+	}
+	if claim.Repository.RemoteIdentity != "github.com/Owner/Repository" {
+		t.Fatalf("legacy claim remote = %q", claim.Repository.RemoteIdentity)
+	}
+	detail, err := store.Task(context.Background(), "legacy-case-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Repository.RemoteIdentity != "github.com/owner/repository" {
+		t.Fatalf("canonical control-plane remote = %q", detail.Repository.RemoteIdentity)
+	}
+}
+
 func TestCapacityMigrationRequiresDrainedLegacyWorkers(t *testing.T) {
 	database, err := sql.Open("sqlite", t.TempDir()+"/active-migration.sqlite3")
 	if err != nil {
@@ -966,6 +1031,44 @@ func TestRoutedTaskCanFreezeAZeroRepositoryCattleWorker(t *testing.T) {
 		TimeoutSeconds: 60,
 	})
 	assertErrorCode(t, err, "repository_not_managed")
+}
+
+func TestRoutedTaskSkipsWorkerWithConflictingDynamicDisplayKey(t *testing.T) {
+	store := newTestStore(t)
+	target := createManagedTestRepository(t, store, "github.com/example/target")
+	common := protocol.WorkerRegistration{
+		WorkerVersion: "test", RuntimeVersion: "test", Capacity: 1, Health: "healthy",
+		SourceAccess:               []protocol.SourceAccess{{Provider: "github", Hostname: "github.com"}},
+		AcceptsManagedRepositories: true,
+	}
+	workerARegistration := common
+	workerARegistration.Name = workerA
+	workerARegistration.Repositories = []protocol.RepositoryRegistration{{
+		Key: target.RemoteIdentity, RemoteIdentity: "github.com/example/different",
+	}}
+	if _, err := store.RegisterWorker(context.Background(), workerA, workerARegistration); err != nil {
+		t.Fatal(err)
+	}
+	workerBRegistration := common
+	workerBRegistration.Name = workerB
+	if _, err := store.RegisterWorker(context.Background(), workerB, workerBRegistration); err != nil {
+		t.Fatal(err)
+	}
+	detail, created, err := store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+		RequestKey: "display-key-collision", Title: "Display key collision",
+		Description: "Route around the collision.",
+		Route: &protocol.TaskRoute{
+			RepositoryRemoteIdentity: target.RemoteIdentity,
+			SourceAccess:             protocol.SourceAccess{Provider: "github", Hostname: "github.com"},
+		},
+		TimeoutSeconds: 60,
+	})
+	if err != nil || !created {
+		t.Fatalf("route around display key collision: created %t, err %v", created, err)
+	}
+	if detail.Execution.AssignedWorkerID != workerB {
+		t.Fatalf("collision route assigned worker %q; want %q", detail.Execution.AssignedWorkerID, workerB)
+	}
 }
 
 func TestRoutedTaskReservesManagedRepositoryCacheHeadroom(t *testing.T) {

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -366,16 +366,21 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 	retainedAliasWorker := protocol.WorkerRegistration{
 		Name: "legacy", WorkerVersion: "upgraded", RuntimeVersion: "upgraded",
 		Capacity: 2, Health: "healthy",
-		Repositories: []protocol.RepositoryRegistration{{
-			Key: "factory", RemoteIdentity: "github.com/Example/Migration",
-		}},
+		Repositories: []protocol.RepositoryRegistration{
+			{Key: "factory", RemoteIdentity: "github.com/Example/Migration"},
+			{Key: "factory-case-alias", RemoteIdentity: "github.com/example/migration"},
+		},
 		RetainedWorktrees: []protocol.RetainedWorktree{{
 			AttemptID: "historical-attempt", RepositoryID: "case-alias-repository",
 		}},
 		CapacityHandoffVersion: 1,
 	}
-	if _, err := store.RegisterWorker(context.Background(), workerA, retainedAliasWorker); err != nil {
+	registeredAliasWorker, err := store.RegisterWorker(context.Background(), workerA, retainedAliasWorker)
+	if err != nil {
 		t.Fatalf("register worker with historical repository alias: %v", err)
+	}
+	if len(registeredAliasWorker.Repositories) != 1 || registeredAliasWorker.Repositories[0].Key != "factory" {
+		t.Fatalf("coalesced historical repository aliases = %#v", registeredAliasWorker.Repositories)
 	}
 	foreignKeys, err := database.Query(`PRAGMA foreign_key_check`)
 	if err != nil {
@@ -958,6 +963,37 @@ func TestManagedRepositoryCatalogIsCanonicalIdempotentAndDisableable(t *testing.
 	}
 }
 
+func TestManagedRepositoryCatalogPromotesOnlyWorkerDiscoveredRows(t *testing.T) {
+	store := newTestStore(t)
+	remoteIdentity := "github.com/example/discovered"
+	worker := registerTestWorker(t, store, workerA, 1, protocol.RepositoryRegistration{
+		Key: "discovered", RemoteIdentity: remoteIdentity,
+	})
+	if len(worker.Repositories) != 1 {
+		t.Fatalf("worker repositories = %#v", worker.Repositories)
+	}
+	discovered, err := store.ManagedRepository(context.Background(), worker.Repositories[0].ID)
+	if err != nil || discovered.Enabled {
+		t.Fatalf("worker-discovered repository = %#v, err %v", discovered, err)
+	}
+	promoted, created, err := store.CreateManagedRepository(
+		context.Background(), protocol.CreateManagedRepositoryRequest{RemoteIdentity: remoteIdentity},
+	)
+	if err != nil || created || !promoted.Enabled || promoted.ID != discovered.ID {
+		t.Fatalf("promoted repository = %#v, created %t, err %v", promoted, created, err)
+	}
+	disabled, err := store.SetManagedRepositoryEnabled(context.Background(), promoted.ID, false)
+	if err != nil || disabled.Enabled {
+		t.Fatalf("disable promoted repository = %#v, err %v", disabled, err)
+	}
+	replayed, created, err := store.CreateManagedRepository(
+		context.Background(), protocol.CreateManagedRepositoryRequest{RemoteIdentity: remoteIdentity},
+	)
+	if err != nil || created || replayed.Enabled {
+		t.Fatalf("replayed explicitly disabled repository = %#v, created %t, err %v", replayed, created, err)
+	}
+}
+
 func TestManagedRepositoryCatalogEnforcesItsHardLimit(t *testing.T) {
 	store := newTestStore(t)
 	for index := 0; index < protocol.MaxManagedRepositories; index++ {
@@ -973,6 +1009,24 @@ func TestManagedRepositoryCatalogEnforcesItsHardLimit(t *testing.T) {
 		protocol.CreateManagedRepositoryRequest{RemoteIdentity: "github.com/example/over-limit"},
 	)
 	assertErrorCode(t, err, "repository_limit_reached")
+	_, err = store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+		Name: workerA, WorkerVersion: "test", RuntimeVersion: "test",
+		Capacity: 1, Health: "healthy",
+		Repositories: []protocol.RepositoryRegistration{{
+			Key: "over-limit", RemoteIdentity: "github.com/example/worker-over-limit",
+		}},
+	})
+	assertErrorCode(t, err, "repository_limit_reached")
+	var repositoryCount, workerCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM repositories`).Scan(&repositoryCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM workers WHERE id = ?`, workerA).Scan(&workerCount); err != nil {
+		t.Fatal(err)
+	}
+	if repositoryCount != protocol.MaxManagedRepositories || workerCount != 0 {
+		t.Fatalf("limit rollback repositories=%d workers=%d", repositoryCount, workerCount)
+	}
 }
 
 func TestRoutedTaskCanFreezeAZeroRepositoryCattleWorker(t *testing.T) {

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -172,7 +172,7 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 	for index := range retained {
 		retained[index] = protocol.RetainedWorktree{
 			AttemptID:    fmt.Sprintf("00000000-0000-4000-8000-%012d", index),
-			RepositoryID: "legacy-repository",
+			RepositoryID: "case-alias-repository",
 			Path:         fmt.Sprintf("/tmp/legacy-%d", index),
 			Reason:       "legacy retained worktree",
 		}
@@ -224,7 +224,7 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 		VALUES ('malformed-repository', 'github.com/example/malformed-migration', 1);
 		INSERT INTO worker_repositories(
 			worker_id, display_key, repository_id, retained_count, advertised, updated_at
-		) VALUES ('worker-a', 'factory', 'legacy-repository', 0, 1, 1);
+		) VALUES ('worker-a', 'factory', 'legacy-repository', 0, 0, 1);
 		INSERT INTO worker_repositories(
 			worker_id, display_key, repository_id, retained_count, advertised, updated_at
 		) VALUES ('worker-a', 'factory-case-alias', 'case-alias-repository', 3, 1, 2);
@@ -254,6 +254,10 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 			id, task_id, assigned_worker_id, required_runtime, state,
 			cancellation_requested, created_at, updated_at
 		) VALUES ('historical-execution', 'historical-task', 'worker-a', 'codex', 'failed', 0, 1, 1);
+		INSERT INTO executions(
+			id, task_id, assigned_worker_id, required_runtime, state,
+			cancellation_requested, created_at, updated_at
+		) VALUES ('case-alias-execution', 'case-alias-task', 'worker-a', 'codex', 'queued', 0, 2, 2);
 		INSERT INTO executions(
 			id, task_id, assigned_worker_id, required_runtime, state,
 			cancellation_requested, created_at, updated_at
@@ -363,6 +367,19 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 			canonicalCount, aliasMappings, canonicalTasks,
 		)
 	}
+	claim := claimTestTask(t, store, workerA, "case-alias-claim", tokenB)
+	if claim.Task.ID != "case-alias-task" {
+		t.Fatalf("claim selected %q; want case-alias-task", claim.Task.ID)
+	}
+	if claim.Repository.Key != "factory-case-alias" ||
+		claim.Repository.RemoteIdentity != "github.com/Example/Migration" {
+		t.Fatalf("claim repository = %#v; want the currently advertised alias", claim.Repository)
+	}
+	if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenB, State: "failed", Error: "migration alias verified",
+	}); err != nil {
+		t.Fatal(err)
+	}
 	retainedAliasWorker := protocol.WorkerRegistration{
 		Name: "legacy", WorkerVersion: "upgraded", RuntimeVersion: "upgraded",
 		Capacity: 2, Health: "healthy",
@@ -393,9 +410,9 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 		t.Fatal(err)
 	}
 	createTestTask(t, store, "post-migration-task", workerA, "legacy-repository")
-	claim := claimTestTask(t, store, workerA, "post-migration-claim", tokenA)
-	if claim.Task.RequestKey != "post-migration-task" {
-		t.Fatalf("post-migration claim selected %q", claim.Task.RequestKey)
+	postMigrationClaim := claimTestTask(t, store, workerA, "post-migration-claim", tokenA)
+	if postMigrationClaim.Task.RequestKey != "post-migration-task" {
+		t.Fatalf("post-migration claim selected %q", postMigrationClaim.Task.RequestKey)
 	}
 }
 

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -217,12 +217,17 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 		INSERT INTO repositories(id, remote_identity, created_at)
 		VALUES ('legacy-repository', 'github.com/example/migration', 1);
 		INSERT INTO repositories(id, remote_identity, created_at)
+		VALUES ('case-alias-repository', 'github.com/Example/Migration', 2);
+		INSERT INTO repositories(id, remote_identity, created_at)
 		VALUES ('invalid-repository', 'github.com/example/invalid-migration', 1);
 		INSERT INTO repositories(id, remote_identity, created_at)
 		VALUES ('malformed-repository', 'github.com/example/malformed-migration', 1);
 		INSERT INTO worker_repositories(
 			worker_id, display_key, repository_id, retained_count, advertised, updated_at
 		) VALUES ('worker-a', 'factory', 'legacy-repository', 0, 1, 1);
+		INSERT INTO worker_repositories(
+			worker_id, display_key, repository_id, retained_count, advertised, updated_at
+		) VALUES ('worker-a', 'factory-case-alias', 'case-alias-repository', 3, 1, 2);
 		INSERT INTO worker_repositories(
 			worker_id, display_key, repository_id, retained_count, advertised, updated_at
 		) VALUES ('worker-b', 'invalid', 'invalid-repository', 0, 1, 1);
@@ -232,6 +237,9 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 		INSERT INTO tasks(
 			id, request_key, title, description, repository_id, timeout_seconds, created_at
 		) VALUES ('historical-task', 'historical-task', 'historical', '', 'legacy-repository', 60, 1);
+		INSERT INTO tasks(
+			id, request_key, title, description, repository_id, timeout_seconds, created_at
+		) VALUES ('case-alias-task', 'case-alias-task', 'case alias', '', 'case-alias-repository', 60, 2);
 		INSERT INTO tasks(
 			id, request_key, title, description, repository_id, timeout_seconds, created_at
 		) VALUES (
@@ -313,6 +321,61 @@ func TestCapacityMigrationDerivesOnlyAttributableLegacyRetainedCounts(t *testing
 	}
 	if runtime != protocol.RuntimeCodex || runtimeVersion != "legacy" {
 		t.Fatalf("migrated worker runtime = %q %q", runtime, runtimeVersion)
+	}
+	var enabled, updatedAt, acceptsManagedRepositories, dynamic int
+	if err := database.QueryRow(`
+		SELECT r.enabled, r.updated_at, w.accepts_managed_repositories, wr.dynamic
+		FROM repositories r
+		JOIN worker_repositories wr ON wr.repository_id = r.id
+		JOIN workers w ON w.id = wr.worker_id
+		WHERE r.id = 'legacy-repository' AND w.id = 'worker-a'
+	`).Scan(&enabled, &updatedAt, &acceptsManagedRepositories, &dynamic); err != nil {
+		t.Fatal(err)
+	}
+	if enabled != 1 || updatedAt != 1 || acceptsManagedRepositories != 0 || dynamic != 0 {
+		t.Fatalf(
+			"managed repository migration = enabled %d, updated %d, accepts %d, dynamic %d",
+			enabled, updatedAt, acceptsManagedRepositories, dynamic,
+		)
+	}
+	var canonicalCount, aliasMappings, canonicalTasks int
+	if err := database.QueryRow(`
+		SELECT COUNT(*) FROM repositories
+		WHERE lower(remote_identity) = 'github.com/example/migration'
+	`).Scan(&canonicalCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRow(`
+		SELECT COUNT(*) FROM repository_aliases
+		WHERE alias_id = 'case-alias-repository' AND repository_id = 'legacy-repository'
+	`).Scan(&aliasMappings); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.QueryRow(`
+		SELECT COUNT(*) FROM tasks
+		WHERE id = 'case-alias-task' AND repository_id = 'legacy-repository'
+	`).Scan(&canonicalTasks); err != nil {
+		t.Fatal(err)
+	}
+	if canonicalCount != 1 || aliasMappings != 1 || canonicalTasks != 1 {
+		t.Fatalf(
+			"GitHub alias migration = repositories %d, aliases %d, tasks %d",
+			canonicalCount, aliasMappings, canonicalTasks,
+		)
+	}
+	retainedAliasWorker := protocol.WorkerRegistration{
+		Name: "legacy", WorkerVersion: "upgraded", RuntimeVersion: "upgraded",
+		Capacity: 2, Health: "healthy",
+		Repositories: []protocol.RepositoryRegistration{{
+			Key: "factory", RemoteIdentity: "github.com/Example/Migration",
+		}},
+		RetainedWorktrees: []protocol.RetainedWorktree{{
+			AttemptID: "historical-attempt", RepositoryID: "case-alias-repository",
+		}},
+		CapacityHandoffVersion: 1,
+	}
+	if _, err := store.RegisterWorker(context.Background(), workerA, retainedAliasWorker); err != nil {
+		t.Fatalf("register worker with historical repository alias: %v", err)
 	}
 	foreignKeys, err := database.Query(`PRAGMA foreign_key_check`)
 	if err != nil {
@@ -447,6 +510,24 @@ func registerTestWorker(t *testing.T, store *Store, id string, capacity int, rep
 		t.Fatal(err)
 	}
 	return worker
+}
+
+func createManagedTestRepository(t *testing.T, store *Store, remoteIdentity string) protocol.ManagedRepository {
+	t.Helper()
+	repository, _, err := store.CreateManagedRepository(
+		context.Background(),
+		protocol.CreateManagedRepositoryRequest{RemoteIdentity: remoteIdentity},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !repository.Enabled {
+		repository, err = store.SetManagedRepositoryEnabled(context.Background(), repository.ID, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return repository
 }
 
 func TestWorkerRuntimeDeterminesExecutionAndCannotChange(t *testing.T) {
@@ -671,6 +752,7 @@ func TestRoutedTaskChoosesLeastLoadedEligibleWorkerAndFreezesAssignment(t *testi
 	repository := protocol.RepositoryRegistration{
 		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
 	}
+	createManagedTestRepository(t, store, repository.RemoteIdentity)
 	access := []protocol.SourceAccess{{Provider: "github", Hostname: "github.com"}}
 	for _, workerID := range []string{workerA, workerB} {
 		if _, err := store.RegisterWorker(context.Background(), workerID, protocol.WorkerRegistration{
@@ -751,6 +833,9 @@ func TestRoutedTaskRequiresRepositoryAndSourceAccessOnHealthyOnlineWorker(t *tes
 		TimeoutSeconds: 60,
 	}
 	_, _, err := store.CreateTask(context.Background(), request)
+	assertErrorCode(t, err, "repository_not_managed")
+	createManagedTestRepository(t, store, repository.RemoteIdentity)
+	_, _, err = store.CreateTask(context.Background(), request)
 	assertErrorCode(t, err, "no_eligible_worker")
 
 	if _, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
@@ -763,6 +848,172 @@ func TestRoutedTaskRequiresRepositoryAndSourceAccessOnHealthyOnlineWorker(t *tes
 	request.RequestKey = "route-wrong-repository"
 	request.Route.RepositoryRemoteIdentity = "github.com/owainlewis/other"
 	_, _, err = store.CreateTask(context.Background(), request)
+	assertErrorCode(t, err, "repository_not_managed")
+
+	request.RequestKey = "route-unsafe-repository"
+	request.Route.RepositoryRemoteIdentity = "https://github.com/owainlewis/factory"
+	_, _, err = store.CreateTask(context.Background(), request)
+	assertErrorCode(t, err, "invalid_route")
+}
+
+func TestManagedRepositoryCatalogIsCanonicalIdempotentAndDisableable(t *testing.T) {
+	store := newTestStore(t)
+	createdRepository, created, err := store.CreateManagedRepository(
+		context.Background(),
+		protocol.CreateManagedRepositoryRequest{RemoteIdentity: " GitHub.com/OwainLewis/Factory.git "},
+	)
+	if err != nil || !created {
+		t.Fatalf("create managed repository: created %t, err %v", created, err)
+	}
+	if createdRepository.RemoteIdentity != "github.com/owainlewis/factory" || !createdRepository.Enabled {
+		t.Fatalf("created managed repository = %#v", createdRepository)
+	}
+	replayed, created, err := store.CreateManagedRepository(
+		context.Background(),
+		protocol.CreateManagedRepositoryRequest{RemoteIdentity: "github.com/owainlewis/factory"},
+	)
+	if err != nil || created || replayed.ID != createdRepository.ID {
+		t.Fatalf("replayed managed repository = %#v, created %t, err %v", replayed, created, err)
+	}
+	repositories, err := store.ManagedRepositories(context.Background())
+	if err != nil || len(repositories) != 1 || repositories[0].ID != createdRepository.ID {
+		t.Fatalf("managed repositories = %#v, err %v", repositories, err)
+	}
+	disabled, err := store.SetManagedRepositoryEnabled(context.Background(), createdRepository.ID, false)
+	if err != nil || disabled.Enabled || disabled.UpdatedAt.Before(disabled.CreatedAt) {
+		t.Fatalf("disabled managed repository = %#v, err %v", disabled, err)
+	}
+	if _, _, err := store.CreateManagedRepository(
+		context.Background(),
+		protocol.CreateManagedRepositoryRequest{RemoteIdentity: "https://github.com/owainlewis/factory"},
+	); err == nil {
+		t.Fatal("URL-shaped managed repository identity was accepted")
+	} else {
+		assertErrorCode(t, err, "invalid_repository")
+	}
+}
+
+func TestManagedRepositoryCatalogEnforcesItsHardLimit(t *testing.T) {
+	store := newTestStore(t)
+	for index := 0; index < protocol.MaxManagedRepositories; index++ {
+		if _, err := store.db.Exec(`
+			INSERT INTO repositories(id, remote_identity, enabled, created_at, updated_at)
+			VALUES (?, ?, 1, 1, 1)
+		`, fmt.Sprintf("repository-%04d", index), fmt.Sprintf("github.com/example/repository-%04d", index)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, _, err := store.CreateManagedRepository(
+		context.Background(),
+		protocol.CreateManagedRepositoryRequest{RemoteIdentity: "github.com/example/over-limit"},
+	)
+	assertErrorCode(t, err, "repository_limit_reached")
+}
+
+func TestRoutedTaskCanFreezeAZeroRepositoryCattleWorker(t *testing.T) {
+	store := newTestStore(t)
+	repository, _, err := store.CreateManagedRepository(
+		context.Background(),
+		protocol.CreateManagedRepositoryRequest{RemoteIdentity: "github.com/owainlewis/factory"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
+		Name: workerA, WorkerVersion: "test", RuntimeVersion: "codex-test",
+		Capacity: 1, Health: "healthy",
+		SourceAccess:               []protocol.SourceAccess{{Provider: "github", Hostname: "github.com"}},
+		AcceptsManagedRepositories: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(worker.Repositories) != 0 || !worker.AcceptsManagedRepositories {
+		t.Fatalf("initial cattle worker = %#v", worker)
+	}
+	detail, created, err := store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+		RequestKey: "cattle-route", Title: "Cattle route", Description: "Fetch the live issue.",
+		Route: &protocol.TaskRoute{
+			RepositoryRemoteIdentity: repository.RemoteIdentity,
+			SourceAccess:             protocol.SourceAccess{Provider: "github", Hostname: "github.com"},
+		},
+		TimeoutSeconds: 60,
+	})
+	if err != nil || !created {
+		t.Fatalf("create cattle task: created %t, err %v", created, err)
+	}
+	if detail.Execution.AssignedWorkerID != workerA || detail.Repository.ID != repository.ID {
+		t.Fatalf("cattle route detail = %#v", detail)
+	}
+	worker, err = store.Worker(context.Background(), workerA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(worker.Repositories) != 1 || worker.Repositories[0].ID != repository.ID ||
+		worker.Repositories[0].Key != repository.RemoteIdentity {
+		t.Fatalf("frozen dynamic repository = %#v", worker.Repositories)
+	}
+
+	if _, err := store.SetManagedRepositoryEnabled(context.Background(), repository.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+		RequestKey: "disabled-cattle-route", Title: "Disabled route", Description: "Do not run.",
+		Route: &protocol.TaskRoute{
+			RepositoryRemoteIdentity: repository.RemoteIdentity,
+			SourceAccess:             protocol.SourceAccess{Provider: "github", Hostname: "github.com"},
+		},
+		TimeoutSeconds: 60,
+	})
+	assertErrorCode(t, err, "repository_not_managed")
+}
+
+func TestRoutedTaskReservesManagedRepositoryCacheHeadroom(t *testing.T) {
+	store := newTestStore(t)
+	firstRepository := createManagedTestRepository(t, store, "github.com/example/first")
+	secondRepository := createManagedTestRepository(t, store, "github.com/example/second")
+	cachedRepositoryIDs := make([]string, 0, protocol.MaxRepositoryCacheEntries-1)
+	for index := 0; index < protocol.MaxRepositoryCacheEntries-1; index++ {
+		cachedRepositoryIDs = append(cachedRepositoryIDs, fmt.Sprintf(
+			"%08x-0000-4000-8000-%012x", index+1, index+1,
+		))
+	}
+	registration := protocol.WorkerRegistration{
+		Name: workerA, WorkerVersion: "test", RuntimeVersion: "test",
+		Capacity: 1, Health: "healthy",
+		SourceAccess:               []protocol.SourceAccess{{Provider: "github", Hostname: "github.com"}},
+		AcceptsManagedRepositories: true,
+		ManagedRepositoryIDs:       cachedRepositoryIDs,
+	}
+	if _, err := store.RegisterWorker(context.Background(), workerA, registration); err != nil {
+		t.Fatal(err)
+	}
+	createRouted := func(requestKey string, repository protocol.ManagedRepository) (protocol.TaskDetail, error) {
+		detail, _, err := store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+			RequestKey: requestKey, Title: requestKey, Description: "Exercise cache routing.",
+			Route: &protocol.TaskRoute{
+				RepositoryRemoteIdentity: repository.RemoteIdentity,
+				SourceAccess:             protocol.SourceAccess{Provider: "github", Hostname: "github.com"},
+			},
+			TimeoutSeconds: 60,
+		})
+		return detail, err
+	}
+	first, err := createRouted("cache-reservation-first", firstRepository)
+	if err != nil || first.Execution.AssignedWorkerID != workerA {
+		t.Fatalf("first cache reservation = %#v, err %v", first, err)
+	}
+	_, err = createRouted("cache-reservation-blocked", secondRepository)
+	assertErrorCode(t, err, "no_eligible_worker")
+
+	registration.ManagedRepositoryIDs = append(registration.ManagedRepositoryIDs, firstRepository.ID)
+	if _, err := store.RegisterWorker(context.Background(), workerA, registration); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := createRouted("cache-reservation-reuse", firstRepository); err != nil {
+		t.Fatalf("route to cached repository: %v", err)
+	}
+	_, err = createRouted("cache-reservation-full", secondRepository)
 	assertErrorCode(t, err, "no_eligible_worker")
 }
 
@@ -771,6 +1022,7 @@ func TestRoutedTaskMatchesGitHubRepositoryIdentityWithoutCaseSensitivity(t *test
 	repository := protocol.RepositoryRegistration{
 		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
 	}
+	createManagedTestRepository(t, store, repository.RemoteIdentity)
 	if _, err := store.RegisterWorker(context.Background(), workerA, protocol.WorkerRegistration{
 		Name: workerA, WorkerVersion: "test", RuntimeVersion: "test",
 		Capacity: 1, Health: "healthy", Repositories: []protocol.RepositoryRegistration{repository},
@@ -801,6 +1053,7 @@ func TestRoutedTaskExcludesWorkersWithoutRepositoryCapacity(t *testing.T) {
 				Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
 				RetainedCount: protocol.MaxRetainedPerRepo - 1,
 			}
+			createManagedTestRepository(t, store, repository.RemoteIdentity)
 			if capacityTerm == "retained" {
 				repository.RetainedCount = protocol.MaxRetainedPerRepo
 			}

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -1017,6 +1017,105 @@ func TestRoutedTaskReservesManagedRepositoryCacheHeadroom(t *testing.T) {
 	assertErrorCode(t, err, "no_eligible_worker")
 }
 
+func TestRegistrationReleasesFailedUncachedRepositoryReservation(t *testing.T) {
+	store := newTestStore(t)
+	failedRepository := createManagedTestRepository(t, store, "github.com/example/failed-clone")
+	nextRepository := createManagedTestRepository(t, store, "github.com/example/next-clone")
+	cachedRepositoryIDs := make([]string, 0, protocol.MaxRepositoryCacheEntries-1)
+	for index := 0; index < protocol.MaxRepositoryCacheEntries-1; index++ {
+		cachedRepositoryIDs = append(cachedRepositoryIDs, fmt.Sprintf(
+			"%08x-0000-4000-8000-%012x", index+1, index+1,
+		))
+	}
+	registration := protocol.WorkerRegistration{
+		Name: workerA, WorkerVersion: "test", RuntimeVersion: "test",
+		Capacity: 1, Health: "healthy",
+		SourceAccess:               []protocol.SourceAccess{{Provider: "github", Hostname: "github.com"}},
+		AcceptsManagedRepositories: true,
+		ManagedRepositoryIDs:       cachedRepositoryIDs,
+	}
+	if _, err := store.RegisterWorker(context.Background(), workerA, registration); err != nil {
+		t.Fatal(err)
+	}
+	createRouted := func(requestKey string, repository protocol.ManagedRepository) (protocol.TaskDetail, error) {
+		detail, _, err := store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+			RequestKey: requestKey, Title: requestKey, Description: "Exercise failed acquisition recovery.",
+			Route: &protocol.TaskRoute{
+				RepositoryRemoteIdentity: repository.RemoteIdentity,
+				SourceAccess:             protocol.SourceAccess{Provider: "github", Hostname: "github.com"},
+			},
+			TimeoutSeconds: 60,
+		})
+		return detail, err
+	}
+	failed, err := createRouted("failed-cache-reservation", failedRepository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := createRouted("blocked-by-failed-reservation", nextRepository); err == nil {
+		t.Fatal("cache headroom ignored the outstanding acquisition reservation")
+	} else {
+		assertErrorCode(t, err, "no_eligible_worker")
+	}
+	claim := claimTestTask(t, store, workerA, "failed-cache-claim", tokenA)
+	if claim.Task.ID != failed.Task.ID {
+		t.Fatalf("claimed task = %s; want %s", claim.Task.ID, failed.Task.ID)
+	}
+	if _, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "failed", Error: "clone failed",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RegisterWorker(context.Background(), workerA, registration); err != nil {
+		t.Fatal(err)
+	}
+	detail, err := store.Task(context.Background(), failed.Task.ID)
+	if err != nil || detail.Repository.ID != failedRepository.ID || detail.RepositoryAvailable {
+		t.Fatalf("failed task after reservation release = %#v, err %v", detail, err)
+	}
+	next, err := createRouted("route-after-failed-reservation", nextRepository)
+	if err != nil {
+		t.Fatalf("failed reservation still consumes cache headroom: %v", err)
+	}
+	var remaining, advertised int
+	if err := store.db.QueryRow(`
+		SELECT COUNT(*), COALESCE(MAX(advertised), 0)
+		FROM worker_repositories
+		WHERE worker_id = ? AND repository_id = ? AND dynamic = 1
+	`, workerA, failedRepository.ID).Scan(&remaining, &advertised); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 1 || advertised != 0 {
+		t.Fatalf("released historical association count = %d, advertised = %d", remaining, advertised)
+	}
+	if _, err := store.RetryExecution(context.Background(), failed.Execution.ID); err == nil {
+		t.Fatal("retry ignored managed repository cache headroom")
+	} else {
+		assertErrorCode(t, err, "retry_repository_unavailable")
+	}
+	failedAfterBlockedRetry, err := store.Task(context.Background(), failed.Task.ID)
+	if err != nil || failedAfterBlockedRetry.Execution.State != "failed" || failedAfterBlockedRetry.RepositoryAvailable {
+		t.Fatalf("blocked retry changed failed execution = %#v, err %v", failedAfterBlockedRetry, err)
+	}
+	if _, err := store.CancelTask(context.Background(), next.Task.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RegisterWorker(context.Background(), workerA, registration); err != nil {
+		t.Fatal(err)
+	}
+	retried, err := store.RetryExecution(context.Background(), failed.Execution.ID)
+	if err != nil {
+		t.Fatalf("retry released failed acquisition: %v", err)
+	}
+	if retried.Execution.State != "queued" || !retried.RepositoryAvailable {
+		t.Fatalf("retried failed acquisition = %#v", retried)
+	}
+	retryClaim := claimTestTask(t, store, workerA, "failed-cache-retry-claim", tokenB)
+	if retryClaim.Task.ID != failed.Task.ID || retryClaim.Attempt.AttemptNumber != 2 {
+		t.Fatalf("retry claim = %#v", retryClaim)
+	}
+}
+
 func TestRoutedTaskMatchesGitHubRepositoryIdentityWithoutCaseSensitivity(t *testing.T) {
 	store := newTestStore(t)
 	repository := protocol.RepositoryRegistration{

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -541,6 +541,12 @@ func pollerFixture(t *testing.T) (*controlplane.Store, *httptest.Server, Config)
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = store.Close() })
+	if _, _, err := store.CreateManagedRepository(
+		context.Background(),
+		protocol.CreateManagedRepositoryRequest{RemoteIdentity: "github.com/example/project"},
+	); err != nil {
+		t.Fatal(err)
+	}
 	worker, err := store.RegisterWorker(context.Background(), pollerWorkerID, protocol.WorkerRegistration{
 		Name: "poller-worker", WorkerVersion: "test", Runtime: protocol.RuntimeCodex,
 		RuntimeVersion: "test", Capacity: 1, Health: "healthy",

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -6,26 +6,28 @@ import (
 )
 
 const (
-	RuntimeCodex         = "codex"
-	RuntimeClaudeCode    = "claude-code"
-	MaxBodyBytes         = 1 << 20
-	MaxDescriptionBytes  = 64 << 10
-	MaxEventBatchBytes   = 256 << 10
-	MaxEventBytes        = 64 << 10
-	MaxEventsPerBatch    = 100
-	MaxAttemptEventBytes = 10 << 20
-	MaxResultBytes       = 256 << 10
-	MaxErrorBytes        = 64 << 10
-	DefaultTimeout       = 2 * time.Hour
-	MaxTimeout           = 8 * time.Hour
-	LeaseDuration        = 30 * time.Second
-	EmptyClaimTTL        = 5 * time.Minute
-	WorkerOnlineWindow   = 30 * time.Second
-	MaxRetainedPerRepo   = 10
-	DefaultTaskPageSize  = 50
-	MaxTaskPageSize      = 200
-	DefaultEventPageSize = 100
-	MaxEventPageSize     = 500
+	RuntimeCodex              = "codex"
+	RuntimeClaudeCode         = "claude-code"
+	MaxBodyBytes              = 1 << 20
+	MaxDescriptionBytes       = 64 << 10
+	MaxEventBatchBytes        = 256 << 10
+	MaxEventBytes             = 64 << 10
+	MaxEventsPerBatch         = 100
+	MaxAttemptEventBytes      = 10 << 20
+	MaxResultBytes            = 256 << 10
+	MaxErrorBytes             = 64 << 10
+	DefaultTimeout            = 2 * time.Hour
+	MaxTimeout                = 8 * time.Hour
+	LeaseDuration             = 30 * time.Second
+	EmptyClaimTTL             = 5 * time.Minute
+	WorkerOnlineWindow        = 30 * time.Second
+	MaxRetainedPerRepo        = 10
+	MaxManagedRepositories    = 1000
+	MaxRepositoryCacheEntries = 100
+	DefaultTaskPageSize       = 50
+	MaxTaskPageSize           = 200
+	DefaultEventPageSize      = 100
+	MaxEventPageSize          = 500
 )
 
 func SupportedRuntime(value string) bool {
@@ -52,18 +54,20 @@ type SourceAccess struct {
 }
 
 type WorkerRegistration struct {
-	Name                   string                   `json:"name"`
-	WorkerVersion          string                   `json:"worker_version"`
-	Runtime                string                   `json:"runtime"`
-	RuntimeVersion         string                   `json:"runtime_version"`
-	Capacity               int                      `json:"capacity"`
-	ActiveCount            int                      `json:"active_count"`
-	Health                 string                   `json:"health"`
-	Repositories           []RepositoryRegistration `json:"repositories"`
-	SourceAccess           []SourceAccess           `json:"source_access,omitempty"`
-	RetainedWorktrees      []RetainedWorktree       `json:"retained_worktrees"`
-	CapacityHandoffVersion int                      `json:"capacity_handoff_version,omitempty"`
-	DisposedAttemptIDs     []string                 `json:"disposed_attempt_ids,omitempty"`
+	Name                       string                   `json:"name"`
+	WorkerVersion              string                   `json:"worker_version"`
+	Runtime                    string                   `json:"runtime"`
+	RuntimeVersion             string                   `json:"runtime_version"`
+	Capacity                   int                      `json:"capacity"`
+	ActiveCount                int                      `json:"active_count"`
+	Health                     string                   `json:"health"`
+	Repositories               []RepositoryRegistration `json:"repositories"`
+	SourceAccess               []SourceAccess           `json:"source_access,omitempty"`
+	AcceptsManagedRepositories bool                     `json:"accepts_managed_repositories,omitempty"`
+	ManagedRepositoryIDs       []string                 `json:"managed_repository_ids,omitempty"`
+	RetainedWorktrees          []RetainedWorktree       `json:"retained_worktrees"`
+	CapacityHandoffVersion     int                      `json:"capacity_handoff_version,omitempty"`
+	DisposedAttemptIDs         []string                 `json:"disposed_attempt_ids,omitempty"`
 }
 
 type Repository struct {
@@ -73,22 +77,40 @@ type Repository struct {
 	RetainedCount  int    `json:"retained_count"`
 }
 
+type ManagedRepository struct {
+	ID             string    `json:"id"`
+	RemoteIdentity string    `json:"remote_identity"`
+	Enabled        bool      `json:"enabled"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type CreateManagedRepositoryRequest struct {
+	RemoteIdentity string `json:"remote_identity"`
+}
+
+type SetManagedRepositoryEnabledRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
 type Worker struct {
-	ID                string             `json:"id"`
-	Name              string             `json:"name"`
-	WorkerVersion     string             `json:"worker_version"`
-	Runtime           string             `json:"runtime"`
-	RuntimeVersion    string             `json:"runtime_version"`
-	Capacity          int                `json:"capacity"`
-	ActiveCount       int                `json:"active_count"`
-	Health            string             `json:"health"`
-	Online            bool               `json:"online"`
-	Repositories      []Repository       `json:"repositories"`
-	SourceAccess      []SourceAccess     `json:"source_access,omitempty"`
-	RetainedWorktrees []RetainedWorktree `json:"retained_worktrees"`
-	CurrentTaskTitle  string             `json:"current_task_title,omitempty"`
-	RegisteredAt      time.Time          `json:"registered_at"`
-	LastHeartbeat     time.Time          `json:"last_heartbeat"`
+	ID                         string             `json:"id"`
+	Name                       string             `json:"name"`
+	WorkerVersion              string             `json:"worker_version"`
+	Runtime                    string             `json:"runtime"`
+	RuntimeVersion             string             `json:"runtime_version"`
+	Capacity                   int                `json:"capacity"`
+	ActiveCount                int                `json:"active_count"`
+	Health                     string             `json:"health"`
+	Online                     bool               `json:"online"`
+	Repositories               []Repository       `json:"repositories"`
+	SourceAccess               []SourceAccess     `json:"source_access,omitempty"`
+	AcceptsManagedRepositories bool               `json:"accepts_managed_repositories,omitempty"`
+	RepositoryCacheCount       int                `json:"repository_cache_count,omitempty"`
+	RetainedWorktrees          []RetainedWorktree `json:"retained_worktrees"`
+	CurrentTaskTitle           string             `json:"current_task_title,omitempty"`
+	RegisteredAt               time.Time          `json:"registered_at"`
+	LastHeartbeat              time.Time          `json:"last_heartbeat"`
 }
 
 type CreateTaskRequest struct {

--- a/internal/worker/attempt_lifecycle.go
+++ b/internal/worker/attempt_lifecycle.go
@@ -50,16 +50,20 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 	}()
 	go manager.heartbeatAttempt(handle, claim.Attempt.ID, token)
 
-	repository, err := manager.validateClaim(claim)
-	if err != nil {
-		manager.finishWithoutWorktree(claim, token, handle, "failed", err)
-		return
-	}
 	taskDeadline := claim.Attempt.CreatedAt.Add(time.Duration(claim.Task.TimeoutSeconds) * time.Second)
 	taskTimer := time.AfterFunc(time.Until(taskDeadline), func() {
 		handle.stop("timeout")
 	})
 	defer taskTimer.Stop()
+	if err := manager.validateClaim(claim); err != nil {
+		manager.finishWithoutWorktree(claim, token, handle, "failed", err)
+		return
+	}
+	repository, err := manager.repositoryForClaim(handle.context, claim)
+	if err != nil {
+		manager.finishWithoutWorktree(claim, token, handle, terminalForStop(handle), stoppedAttemptError(handle, err))
+		return
+	}
 	worktreeRoot := filepath.Join(manager.dataDirectory, "worktrees")
 	value, err := prepareWorktree(handle.context, manager.options.GitExecutable, worktreeRoot,
 		repository, claim.Task.ID, claim.Attempt.ID)
@@ -209,27 +213,23 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 		terminalState(message), message.Result, message.Error)
 }
 
-func (manager *Manager) validateClaim(claim protocol.Claim) (Repository, error) {
+func (manager *Manager) validateClaim(claim protocol.Claim) error {
 	if !uuidPattern.MatchString(claim.Attempt.ID) || !uuidPattern.MatchString(claim.Task.ID) {
-		return Repository{}, errors.New("claim contains invalid IDs")
+		return errors.New("claim contains invalid IDs")
 	}
 	if claim.Attempt.WorkerID != manager.id || claim.Execution.AssignedWorkerID != manager.id {
-		return Repository{}, errors.New("claim is assigned to a different worker")
+		return errors.New("claim is assigned to a different worker")
 	}
 	if claim.Execution.RequiredRuntime != manager.config.Runtime {
-		return Repository{}, errors.New("claim requires a different worker runtime")
+		return errors.New("claim requires a different worker runtime")
 	}
 	if claim.Task.RepositoryID != claim.Repository.ID {
-		return Repository{}, errors.New("claim repository IDs do not match")
+		return errors.New("claim repository IDs do not match")
 	}
 	if claim.Task.TimeoutSeconds < 1 || claim.Task.TimeoutSeconds > int(protocol.MaxTimeout/time.Second) {
-		return Repository{}, errors.New("claim timeout is outside the supported range")
+		return errors.New("claim timeout is outside the supported range")
 	}
-	repository, exists := manager.repositoriesByKey[claim.Repository.Key]
-	if !exists || repository.RemoteIdentity != claim.Repository.RemoteIdentity {
-		return Repository{}, errors.New("claim repository is not advertised by this worker")
-	}
-	return repository, nil
+	return nil
 }
 
 func (manager *Manager) heartbeatAttempt(handle *attemptHandle, attemptID, token string) {

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -40,6 +40,7 @@ type Repository struct {
 	Key            string
 	Path           string
 	RemoteIdentity string
+	BaseCommit     string
 }
 
 func LoadConfig(path string) (Config, error) {
@@ -102,9 +103,6 @@ func validateConfig(config Config) error {
 	}
 	if strings.TrimSpace(config.DataDirectory) == "" {
 		return errors.New("data_directory is required")
-	}
-	if len(config.Repositories) == 0 {
-		return errors.New("at least one repository is required")
 	}
 	seenSourceAccess := make(map[string]bool, len(config.SourceAccess))
 	for _, source := range config.SourceAccess {

--- a/internal/worker/git.go
+++ b/internal/worker/git.go
@@ -43,11 +43,12 @@ func resolveRepositories(config Config, gitExecutable string) ([]Repository, err
 		if previous := paths[repository.Path]; previous != "" {
 			return nil, fmt.Errorf("repositories %q and %q resolve to the same path", previous, key)
 		}
-		if previous := identities[repository.RemoteIdentity]; previous != "" {
+		identityKey := remoteIdentityComparisonKey(repository.RemoteIdentity)
+		if previous := identities[identityKey]; previous != "" {
 			return nil, fmt.Errorf("repositories %q and %q resolve to the same remote", previous, key)
 		}
 		paths[repository.Path] = key
-		identities[repository.RemoteIdentity] = key
+		identities[identityKey] = key
 		repositories = append(repositories, repository)
 	}
 	return repositories, nil
@@ -216,6 +217,17 @@ func normalizeHostPath(host, path string) string {
 	return strings.ToLower(host) + "/" + path
 }
 
+func remoteIdentityComparisonKey(value string) string {
+	if strings.HasPrefix(strings.ToLower(value), "github.com/") {
+		return strings.ToLower(value)
+	}
+	return value
+}
+
+func sameRemoteIdentity(left, right string) bool {
+	return remoteIdentityComparisonKey(left) == remoteIdentityComparisonKey(right)
+}
+
 func createWorktree(ctx context.Context, gitExecutable, root string, repository Repository, taskID, attemptID string) (worktree, error) {
 	value, err := prepareWorktree(ctx, gitExecutable, root, repository, taskID, attemptID)
 	if err != nil {
@@ -249,11 +261,14 @@ func prepareWorktree(ctx context.Context, gitExecutable, root string, repository
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return worktree{}, fmt.Errorf("inspect attempt worktree path: %w", err)
 	}
-	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10, "rev-parse", "HEAD")
-	if err != nil {
-		return worktree{}, commandFailure("resolve repository HEAD", stdout, stderr, err)
+	base := repository.BaseCommit
+	if base == "" {
+		stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10, "rev-parse", "HEAD")
+		if err != nil {
+			return worktree{}, commandFailure("resolve repository HEAD", stdout, stderr, err)
+		}
+		base = strings.TrimSpace(string(stdout))
 	}
-	base := strings.TrimSpace(string(stdout))
 	if !commitPattern.MatchString(base) {
 		return worktree{}, errors.New("repository HEAD is not a full commit ID")
 	}

--- a/internal/worker/health.go
+++ b/internal/worker/health.go
@@ -27,7 +27,7 @@ func checkHealth(
 	runtime string,
 	runtimeExecutable string,
 	githubExecutable string,
-	configuredSourceAccess []string,
+	_ []string,
 ) health {
 	result := health{State: "unhealthy"}
 	gitContext, cancel := context.WithTimeout(ctx, healthCheckTimeout)
@@ -81,21 +81,16 @@ func checkHealth(
 		result.Error = errors.New("Codex authentication check returned no status")
 		return result
 	}
-	for _, source := range configuredSourceAccess {
-		if source != "github" {
-			continue
-		}
-		githubContext, githubCancel := context.WithTimeout(ctx, healthCheckTimeout)
-		_, _, githubErr := runCommand(
-			githubContext, githubExecutable, "", 64<<10,
-			"auth", "status", "--hostname", "github.com",
-		)
-		githubCancel()
-		if githubErr == nil {
-			result.SourceAccess = append(result.SourceAccess, protocol.SourceAccess{
-				Provider: "github", Hostname: "github.com",
-			})
-		}
+	githubContext, githubCancel := context.WithTimeout(ctx, healthCheckTimeout)
+	_, _, githubErr := runCommand(
+		githubContext, githubExecutable, "", 64<<10,
+		"auth", "status", "--hostname", "github.com",
+	)
+	githubCancel()
+	if githubErr == nil {
+		result.SourceAccess = append(result.SourceAccess, protocol.SourceAccess{
+			Provider: "github", Hostname: "github.com",
+		})
 	}
 	result.State = "healthy"
 	return result

--- a/internal/worker/manager.go
+++ b/internal/worker/manager.go
@@ -58,19 +58,23 @@ type Manager struct {
 	manifests         *manifestStore
 	slots             chan struct{}
 
-	stateMutex     sync.Mutex
-	health         health
-	active         map[string]*attemptHandle
-	seen           map[string]bool
-	retained       map[string]protocol.RetainedWorktree
-	retainedCounts map[string]int
-	disposed       map[string]bool
-	pending        map[string]context.CancelFunc
-	fatalHealth    error
-	registered     bool
-	closed         bool
+	stateMutex           sync.Mutex
+	health               health
+	active               map[string]*attemptHandle
+	seen                 map[string]bool
+	retained             map[string]protocol.RetainedWorktree
+	retainedCounts       map[string]int
+	managedRepositoryIDs map[string]bool
+	disposed             map[string]bool
+	pending              map[string]context.CancelFunc
+	fatalHealth          error
+	registered           bool
+	closed               bool
 
 	randomMutex sync.Mutex
+	// repositoryCacheMutex bounds clone/fetch activity to one repository at a
+	// time per worker and protects cache creation from concurrent claims.
+	repositoryCacheMutex sync.Mutex
 	// registrationMutex keeps a periodic registration from overtaking the
 	// terminal-attempt to retained-worktree capacity handoff.
 	registrationMutex sync.Mutex
@@ -113,6 +117,10 @@ func New(config Config, options Options, logger *slog.Logger) (*Manager, error) 
 	if err != nil {
 		return nil, err
 	}
+	managedRepositoryIDs, err := managedRepositoryCacheIDs(dataDirectory)
+	if err != nil {
+		return nil, err
+	}
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -122,24 +130,25 @@ func New(config Config, options Options, logger *slog.Logger) (*Manager, error) 
 	}
 	cleanupLock = false
 	return &Manager{
-		config:            config,
-		options:           options,
-		logger:            logger,
-		id:                id,
-		dataDirectory:     dataDirectory,
-		lock:              lock,
-		repositories:      repositories,
-		repositoriesByKey: byKey,
-		client:            newClient(config.Server, options.HTTPClient),
-		manifests:         newManifestStore(dataDirectory, id),
-		slots:             make(chan struct{}, config.MaxConcurrent),
-		health:            health{State: "unhealthy"},
-		active:            make(map[string]*attemptHandle),
-		seen:              make(map[string]bool),
-		retained:          make(map[string]protocol.RetainedWorktree),
-		retainedCounts:    make(map[string]int),
-		disposed:          make(map[string]bool),
-		pending:           make(map[string]context.CancelFunc),
+		config:               config,
+		options:              options,
+		logger:               logger,
+		id:                   id,
+		dataDirectory:        dataDirectory,
+		lock:                 lock,
+		repositories:         repositories,
+		repositoriesByKey:    byKey,
+		client:               newClient(config.Server, options.HTTPClient),
+		manifests:            newManifestStore(dataDirectory, id),
+		slots:                make(chan struct{}, config.MaxConcurrent),
+		health:               health{State: "unhealthy"},
+		active:               make(map[string]*attemptHandle),
+		seen:                 make(map[string]bool),
+		retained:             make(map[string]protocol.RetainedWorktree),
+		retainedCounts:       make(map[string]int),
+		managedRepositoryIDs: managedRepositoryIDs,
+		disposed:             make(map[string]bool),
+		pending:              make(map[string]context.CancelFunc),
 	}, nil
 }
 

--- a/internal/worker/manifest_integration_test.go
+++ b/internal/worker/manifest_integration_test.go
@@ -1024,6 +1024,39 @@ func TestAcknowledgedDisposedManifestIsPrunedBeforeSecondRestart(t *testing.T) {
 	}
 }
 
+func TestRestartInspectionAcceptsHistoricalGitHubIdentityCase(t *testing.T) {
+	repository := createRepository(t, "historical-github-case")
+	dataDirectory, err := resolveDataDirectory(filepath.Join(t.TempDir(), "worker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := resolveRepository("factory", repository.path, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskID := fixtureUUID(790)
+	attemptID := fixtureUUID(791)
+	value, err := createWorktree(
+		context.Background(), "git", filepath.Join(dataDirectory, "worktrees"), resolved, taskID, attemptID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a repository that now advertises the canonical lower-case
+	// identity while its pre-upgrade manifest retains historical GitHub case.
+	runGitTest(t, repository.path, "remote", "set-url", "origin", "git@github.com:example/migration.git")
+	manifest := attemptManifest{
+		TaskID: taskID, ExecutionID: fixtureUUID(792), AttemptID: attemptID,
+		RepositoryID: fixtureUUID(793), RepositoryKey: "factory", RepositoryPath: resolved.Path,
+		RemoteIdentity: "github.com/Example/Migration", BaseCommit: value.BaseCommit,
+		WorktreePath: value.Path, Branch: value.Branch, Lifecycle: manifestRetained,
+	}
+
+	if _, err := inspectManifestWorktree(context.Background(), "git", dataDirectory, manifest); err != nil {
+		t.Fatalf("inspect historical mixed-case manifest after restart: %v", err)
+	}
+}
+
 func TestDeletedDisposedAttemptDoesNotPoisonStartupReconciliation(t *testing.T) {
 	fixture := newServerFixture(t, nil)
 	repository := createRepository(t, "deleted-disposed-attempt")

--- a/internal/worker/reconcile.go
+++ b/internal/worker/reconcile.go
@@ -320,7 +320,7 @@ func inspectManifestWorktree(
 	if err != nil {
 		return worktreeInspection{}, fmt.Errorf("verify manifest repository: %w", err)
 	}
-	if repository.Path != manifest.RepositoryPath || repository.RemoteIdentity != manifest.RemoteIdentity {
+	if repository.Path != manifest.RepositoryPath || !sameRemoteIdentity(repository.RemoteIdentity, manifest.RemoteIdentity) {
 		return worktreeInspection{}, worktreeMismatch("manifest repository identity no longer matches")
 	}
 	inspection := worktreeInspection{Repository: repository}

--- a/internal/worker/registration.go
+++ b/internal/worker/registration.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/owainlewis/factory/internal/protocol"
@@ -56,32 +57,49 @@ func (manager *Manager) registration() protocol.WorkerRegistration {
 	repositories := make([]protocol.RepositoryRegistration, 0, len(manager.repositories))
 	retained := make([]protocol.RetainedWorktree, 0, len(manager.retained))
 	disposedAttemptIDs := make([]string, 0, len(manager.disposed))
+	managedRepositoryIDs := make([]string, 0, len(manager.managedRepositoryIDs))
 	for _, value := range manager.retained {
 		retained = append(retained, value)
 	}
 	for attemptID := range manager.disposed {
 		disposedAttemptIDs = append(disposedAttemptIDs, attemptID)
 	}
+	for repositoryID := range manager.managedRepositoryIDs {
+		managedRepositoryIDs = append(managedRepositoryIDs, repositoryID)
+	}
+	sort.Strings(managedRepositoryIDs)
 	for _, repository := range manager.repositories {
 		repositories = append(repositories, protocol.RepositoryRegistration{
 			Key: repository.Key, RemoteIdentity: repository.RemoteIdentity,
 			RetainedCount: manager.retainedCounts[repository.RemoteIdentity],
 		})
 	}
+	acceptsManagedRepositories := hasGitHubSourceAccess(manager.health.SourceAccess)
 	return protocol.WorkerRegistration{
-		Name:                   strings.TrimSpace(manager.config.Name),
-		WorkerVersion:          manager.options.WorkerVersion,
-		Runtime:                manager.config.Runtime,
-		RuntimeVersion:         manager.health.RuntimeVersion,
-		Capacity:               manager.config.MaxConcurrent,
-		ActiveCount:            len(manager.slots),
-		Health:                 manager.health.State,
-		Repositories:           repositories,
-		SourceAccess:           append([]protocol.SourceAccess(nil), manager.health.SourceAccess...),
-		RetainedWorktrees:      retained,
-		CapacityHandoffVersion: 1,
-		DisposedAttemptIDs:     disposedAttemptIDs,
+		Name:                       strings.TrimSpace(manager.config.Name),
+		WorkerVersion:              manager.options.WorkerVersion,
+		Runtime:                    manager.config.Runtime,
+		RuntimeVersion:             manager.health.RuntimeVersion,
+		Capacity:                   manager.config.MaxConcurrent,
+		ActiveCount:                len(manager.slots),
+		Health:                     manager.health.State,
+		Repositories:               repositories,
+		SourceAccess:               append([]protocol.SourceAccess(nil), manager.health.SourceAccess...),
+		AcceptsManagedRepositories: acceptsManagedRepositories,
+		ManagedRepositoryIDs:       managedRepositoryIDs,
+		RetainedWorktrees:          retained,
+		CapacityHandoffVersion:     1,
+		DisposedAttemptIDs:         disposedAttemptIDs,
 	}
+}
+
+func hasGitHubSourceAccess(values []protocol.SourceAccess) bool {
+	for _, value := range values {
+		if value.Provider == "github" && value.Hostname == "github.com" {
+			return true
+		}
+	}
+	return false
 }
 
 func (manager *Manager) register(ctx context.Context) {

--- a/internal/worker/repository_cache.go
+++ b/internal/worker/repository_cache.go
@@ -1,0 +1,260 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const repositoryAcquisitionTimeout = 5 * time.Minute
+
+func normalizeManagedGitHubIdentity(value string) (identity, slug string, err error) {
+	parts := strings.Split(strings.TrimSpace(value), "/")
+	if len(parts) != 3 || !strings.EqualFold(parts[0], "github.com") ||
+		!validGitHubOwner(parts[1]) || !validGitHubRepository(parts[2]) {
+		return "", "", errors.New("managed repository identity must use github.com/owner/repository")
+	}
+	owner := strings.ToLower(parts[1])
+	repository := strings.ToLower(parts[2])
+	return "github.com/" + owner + "/" + repository, owner + "/" + repository, nil
+}
+
+func validGitHubOwner(value string) bool {
+	if len(value) < 1 || len(value) > 39 || value[0] == '-' || value[len(value)-1] == '-' || strings.Contains(value, "--") {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') &&
+			(character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func validGitHubRepository(value string) bool {
+	if len(value) < 1 || len(value) > 100 || value == "." || value == ".." {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') &&
+			(character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') &&
+			character != '-' && character != '_' && character != '.' {
+			return false
+		}
+	}
+	return true
+}
+
+func (manager *Manager) repositoryForClaim(ctx context.Context, claim protocol.Claim) (Repository, error) {
+	if repository, exists := manager.repositoriesByKey[claim.Repository.Key]; exists {
+		if !sameRemoteIdentity(repository.RemoteIdentity, claim.Repository.RemoteIdentity) {
+			return Repository{}, errors.New("claim repository identity does not match the configured repository")
+		}
+		return repository, nil
+	}
+	return manager.acquireManagedRepository(ctx, claim.Repository)
+}
+
+func (manager *Manager) acquireManagedRepository(
+	ctx context.Context,
+	claimRepository protocol.Repository,
+) (Repository, error) {
+	if !uuidPattern.MatchString(claimRepository.ID) {
+		return Repository{}, errors.New("claim contains an invalid repository ID")
+	}
+	identity, slug, err := normalizeManagedGitHubIdentity(claimRepository.RemoteIdentity)
+	if err != nil {
+		return Repository{}, err
+	}
+	if !strings.EqualFold(identity, claimRepository.RemoteIdentity) {
+		return Repository{}, errors.New("claim contains a non-canonical managed repository identity")
+	}
+
+	manager.repositoryCacheMutex.Lock()
+	defer manager.repositoryCacheMutex.Unlock()
+
+	acquisitionContext, cancel := context.WithTimeout(ctx, repositoryAcquisitionTimeout)
+	defer cancel()
+	cacheRoot, err := manager.prepareRepositoryCacheRoot()
+	if err != nil {
+		return Repository{}, err
+	}
+	target := filepath.Join(cacheRoot, claimRepository.ID)
+	if info, inspectErr := os.Lstat(target); errors.Is(inspectErr, os.ErrNotExist) {
+		if err := enforceRepositoryCacheLimit(cacheRoot); err != nil {
+			return Repository{}, err
+		}
+		if err := manager.cloneManagedRepository(acquisitionContext, cacheRoot, target, slug); err != nil {
+			return Repository{}, err
+		}
+		manager.stateMutex.Lock()
+		manager.managedRepositoryIDs[claimRepository.ID] = true
+		manager.stateMutex.Unlock()
+	} else if inspectErr != nil {
+		return Repository{}, fmt.Errorf("inspect managed repository cache: %w", inspectErr)
+	} else if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return Repository{}, errors.New("managed repository cache entry must be a real directory")
+	}
+
+	repository, err := resolveRepository(claimRepository.Key, target, manager.options.GitExecutable)
+	if err != nil {
+		return Repository{}, fmt.Errorf("validate managed repository cache: %w", err)
+	}
+	if repository.Path != target {
+		return Repository{}, errors.New("managed repository cache path escaped its assigned entry")
+	}
+	if !strings.EqualFold(repository.RemoteIdentity, identity) {
+		return Repository{}, errors.New("managed repository cache origin does not match the assigned repository")
+	}
+	stdout, stderr, err := runCommand(
+		acquisitionContext,
+		manager.options.GitExecutable,
+		repository.Path,
+		256<<10,
+		"fetch", "--prune", "origin",
+	)
+	if err != nil {
+		return Repository{}, commandFailure("fetch managed repository", stdout, stderr, err)
+	}
+	stdout, stderr, err = runCommand(
+		acquisitionContext,
+		manager.options.GitExecutable,
+		repository.Path,
+		64<<10,
+		"remote", "set-head", "origin", "--auto",
+	)
+	if err != nil {
+		return Repository{}, commandFailure("refresh managed repository default branch", stdout, stderr, err)
+	}
+	stdout, stderr, err = runCommand(
+		acquisitionContext,
+		manager.options.GitExecutable,
+		repository.Path,
+		64<<10,
+		"rev-parse", "refs/remotes/origin/HEAD^{commit}",
+	)
+	if err != nil {
+		return Repository{}, commandFailure("resolve managed repository default branch", stdout, stderr, err)
+	}
+	repository.BaseCommit = strings.TrimSpace(string(stdout))
+	if !commitPattern.MatchString(repository.BaseCommit) {
+		return Repository{}, errors.New("managed repository default branch is not a full commit ID")
+	}
+	return repository, nil
+}
+
+func (manager *Manager) prepareRepositoryCacheRoot() (string, error) {
+	root := filepath.Join(manager.dataDirectory, "repositories")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return "", fmt.Errorf("create managed repository cache: %w", err)
+	}
+	info, err := os.Lstat(root)
+	if err != nil {
+		return "", fmt.Errorf("inspect managed repository cache: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return "", errors.New("managed repository cache root must be a real directory")
+	}
+	canonical, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize managed repository cache: %w", err)
+	}
+	return canonical, nil
+}
+
+func enforceRepositoryCacheLimit(root string) error {
+	ids, err := managedRepositoryCacheIDsFromRoot(root)
+	if err != nil {
+		return err
+	}
+	if len(ids) >= protocol.MaxRepositoryCacheEntries {
+		return fmt.Errorf("managed repository cache limit of %d entries reached", protocol.MaxRepositoryCacheEntries)
+	}
+	return nil
+}
+
+func managedRepositoryCacheIDs(dataDirectory string) (map[string]bool, error) {
+	root := filepath.Join(dataDirectory, "repositories")
+	info, err := os.Lstat(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return make(map[string]bool), nil
+	} else if err != nil {
+		return nil, fmt.Errorf("inspect managed repository cache: %w", err)
+	} else if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("managed repository cache root must be a real directory")
+	}
+	// New calls this only after taking the worker data-directory lock, so no
+	// clone can still own one of these temporary directories. Removing them on
+	// startup bounds disk use after a hard crash during gh repo clone.
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("list managed repository cache: %w", err)
+	}
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".clone-") {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(root, entry.Name())); err != nil {
+			return nil, fmt.Errorf("remove interrupted managed repository clone: %w", err)
+		}
+	}
+	return managedRepositoryCacheIDsFromRoot(root)
+}
+
+func managedRepositoryCacheIDsFromRoot(root string) (map[string]bool, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("list managed repository cache: %w", err)
+	}
+	ids := make(map[string]bool)
+	for _, entry := range entries {
+		if uuidPattern.MatchString(entry.Name()) {
+			ids[entry.Name()] = true
+		}
+	}
+	return ids, nil
+}
+
+func (manager *Manager) cloneManagedRepository(ctx context.Context, root, target, slug string) (resultErr error) {
+	temporaryRoot, err := os.MkdirTemp(root, ".clone-")
+	if err != nil {
+		return fmt.Errorf("create managed repository clone directory: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(temporaryRoot); err != nil && resultErr == nil {
+			resultErr = fmt.Errorf("remove managed repository clone directory: %w", err)
+		}
+	}()
+	clonePath := filepath.Join(temporaryRoot, "repository")
+	stdout, stderr, err := runCommand(
+		ctx,
+		manager.options.GitHubExecutable,
+		"",
+		256<<10,
+		"repo", "clone", slug, clonePath, "--", "--no-checkout",
+	)
+	if err != nil {
+		return commandFailure("clone managed GitHub repository", stdout, stderr, err)
+	}
+	repository, err := resolveRepository(slug, clonePath, manager.options.GitExecutable)
+	if err != nil {
+		return fmt.Errorf("validate cloned managed repository: %w", err)
+	}
+	expectedIdentity := "github.com/" + slug
+	if !strings.EqualFold(repository.RemoteIdentity, expectedIdentity) {
+		return errors.New("cloned managed repository origin does not match the assigned repository")
+	}
+	if err := os.Rename(clonePath, target); err != nil {
+		return fmt.Errorf("install managed repository cache entry: %w", err)
+	}
+	return nil
+}

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -314,7 +314,7 @@ func TestGitHubSourceAccessIsAdvertisedOnlyAfterSuccessfulProbe(t *testing.T) {
 	writeProbe("0")
 	value := checkHealth(
 		context.Background(), "git", protocol.RuntimeCodex, codexPath,
-		githubPath, []string{"github"},
+		githubPath, nil,
 	)
 	want := []protocol.SourceAccess{{Provider: "github", Hostname: "github.com"}}
 	if value.State != "healthy" || !reflect.DeepEqual(value.SourceAccess, want) {
@@ -328,6 +328,241 @@ func TestGitHubSourceAccessIsAdvertisedOnlyAfterSuccessfulProbe(t *testing.T) {
 	)
 	if value.State != "healthy" || len(value.SourceAccess) != 0 {
 		t.Fatalf("failed GitHub probe health = %#v", value)
+	}
+}
+
+func TestZeroRepositoryWorkerAcquiresCentrallyManagedGitHubRepository(t *testing.T) {
+	upstream := createRepository(t, "cattle")
+	fixture := newServerFixture(t, nil)
+	managed, created, err := fixture.store.CreateManagedRepository(
+		context.Background(),
+		protocol.CreateManagedRepositoryRequest{RemoteIdentity: "github.com/example/cattle"},
+	)
+	if err != nil || !created {
+		t.Fatalf("create managed repository: created %t, err %v", created, err)
+	}
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	toolDirectory := t.TempDir()
+	githubPath := filepath.Join(toolDirectory, "gh")
+	gitPath := filepath.Join(toolDirectory, "git")
+	t.Setenv("FACTORY_TEST_REAL_GIT", realGit)
+	t.Setenv("FACTORY_TEST_GH_ORIGIN", upstream.origin)
+	githubScript := `#!/bin/sh
+set -eu
+if [ "${1:-}" = "auth" ] && [ "${2:-}" = "status" ]; then
+  exit 0
+fi
+if [ "${1:-}" != "repo" ] || [ "${2:-}" != "clone" ] || [ "${3:-}" != "example/cattle" ]; then
+  exit 91
+fi
+"$FACTORY_TEST_REAL_GIT" clone --no-checkout "$FACTORY_TEST_GH_ORIGIN" "$4"
+"$FACTORY_TEST_REAL_GIT" -C "$4" remote set-url origin https://github.com/example/cattle.git
+`
+	if err := os.WriteFile(githubPath, []byte(githubScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	gitScript := `#!/bin/sh
+set -eu
+if [ "${1:-}" = "remote" ] && [ "${2:-}" = "get-url" ] && [ "${3:-}" = "origin" ]; then
+  case "$PWD" in
+    */repositories/*)
+      echo https://github.com/example/cattle.git
+      exit 0
+      ;;
+  esac
+fi
+if [ "${1:-}" = "fetch" ]; then
+  exec "$FACTORY_TEST_REAL_GIT" -c "url.$FACTORY_TEST_GH_ORIGIN.insteadOf=https://github.com/example/cattle.git" "$@"
+fi
+if [ "${1:-}" = "remote" ] && [ "${2:-}" = "set-head" ]; then
+  exec "$FACTORY_TEST_REAL_GIT" -c "url.$FACTORY_TEST_GH_ORIGIN.insteadOf=https://github.com/example/cattle.git" "$@"
+fi
+exec "$FACTORY_TEST_REAL_GIT" "$@"
+`
+	if err := os.WriteFile(gitPath, []byte(gitScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	codexPath := filepath.Join(toolDirectory, "codex")
+	writeFakeCodex(t, codexPath)
+	t.Setenv("FACTORY_TEST_SUPERVISOR", "1")
+	logDirectory := filepath.Join(t.TempDir(), "codex-log")
+	t.Setenv("FACTORY_TEST_CODEX_LOG", logDirectory)
+	dataDirectory := filepath.Join(t.TempDir(), "worker")
+	options := testOptions(codexPath)
+	options.GitExecutable = gitPath
+	options.GitHubExecutable = githubPath
+	manager, err := New(Config{
+		Server: fixture.server.URL, Name: "cattle-worker", MaxConcurrent: 1,
+		DataDirectory: dataDirectory,
+	}, options, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelFirst, firstDone := startManager(t, manager)
+	worker := waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" && worker.AcceptsManagedRepositories &&
+			len(worker.Repositories) == 0 && hasGitHubSourceAccess(worker.SourceAccess)
+	})
+
+	task, taskCreated, err := fixture.store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+		RequestKey: "cattle-e2e", Title: "Cattle worker task",
+		Description: "Exercise managed repository acquisition.\nFAKE_MODE=success",
+		Route: &protocol.TaskRoute{
+			RepositoryRemoteIdentity: managed.RemoteIdentity,
+			SourceAccess:             protocol.SourceAccess{Provider: "github", Hostname: "github.com"},
+		},
+		TimeoutSeconds: 60,
+	})
+	if err != nil || !taskCreated {
+		t.Fatalf("create routed task: created %t, err %v", taskCreated, err)
+	}
+	if task.Execution.AssignedWorkerID != worker.ID {
+		t.Fatalf("assigned worker = %q, want %q", task.Execution.AssignedWorkerID, worker.ID)
+	}
+	task = waitForTaskState(t, fixture.store, task.Task.ID, "succeeded")
+	if len(task.Attempts) != 1 || task.Attempts[0].Result != "completed by fake Codex" {
+		t.Fatalf("cattle task attempts = %#v", task.Attempts)
+	}
+	cachePath := filepath.Join(dataDirectory, "repositories", managed.ID)
+	if info, err := os.Stat(cachePath); err != nil || !info.IsDir() {
+		t.Fatalf("managed repository cache = %v, err %v", info, err)
+	}
+	if err := os.WriteFile(filepath.Join(upstream.path, "SECOND.md"), []byte("second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, upstream.path, "add", "SECOND.md")
+	runGitTest(t, upstream.path, "commit", "-m", "second")
+	runGitTest(t, upstream.path, "push", "origin", "main")
+	refreshed, err := manager.acquireManagedRepository(context.Background(), protocol.Repository{
+		ID: managed.ID, Key: managed.RemoteIdentity, RemoteIdentity: managed.RemoteIdentity,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := runGitTest(t, upstream.path, "rev-parse", "HEAD"); refreshed.BaseCommit != want {
+		t.Fatalf("refreshed base commit = %q, want %q", refreshed.BaseCommit, want)
+	}
+	worker = waitForWorker(t, fixture.store, manager.ID(), func(worker protocol.Worker) bool {
+		return len(worker.Repositories) == 1 && worker.Repositories[0].ID == managed.ID
+	})
+	if worker.Repositories[0].Key != managed.RemoteIdentity {
+		t.Fatalf("dynamic repository = %#v", worker.Repositories[0])
+	}
+	prompt, err := os.ReadFile(filepath.Join(logDirectory, task.Attempts[0].ID+".prompt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(prompt), "Repository: "+managed.RemoteIdentity) {
+		t.Fatalf("prompt did not identify managed repository:\n%s", prompt)
+	}
+
+	cancelFirst()
+	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	restarted, err := New(Config{
+		Server: fixture.server.URL, Name: "cattle-worker", MaxConcurrent: 1,
+		DataDirectory: dataDirectory,
+	}, options, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restarted.ID() != manager.ID() {
+		t.Fatalf("worker ID changed across restart: %q != %q", restarted.ID(), manager.ID())
+	}
+	startManager(t, restarted)
+	waitForWorker(t, fixture.store, restarted.ID(), func(worker protocol.Worker) bool {
+		return worker.Health == "healthy" && worker.AcceptsManagedRepositories &&
+			len(worker.Repositories) == 1 && worker.Repositories[0].ID == managed.ID
+	})
+	restartedTask, restartedCreated, err := fixture.store.CreateTask(context.Background(), protocol.CreateTaskRequest{
+		RequestKey: "cattle-e2e-restart", Title: "Restarted cattle worker task",
+		Description: "Reuse the managed repository cache.\nFAKE_MODE=success",
+		Route: &protocol.TaskRoute{
+			RepositoryRemoteIdentity: managed.RemoteIdentity,
+			SourceAccess:             protocol.SourceAccess{Provider: "github", Hostname: "github.com"},
+		},
+		TimeoutSeconds: 60,
+	})
+	if err != nil || !restartedCreated {
+		t.Fatalf("create restarted routed task: created %t, err %v", restartedCreated, err)
+	}
+	restartedTask = waitForTaskState(t, fixture.store, restartedTask.Task.ID, "succeeded")
+	if len(restartedTask.Attempts) != 1 || restartedTask.Attempts[0].Result != "completed by fake Codex" {
+		t.Fatalf("restarted cattle task attempts = %#v", restartedTask.Attempts)
+	}
+}
+
+func TestManagedRepositoryCacheEnforcesItsHardLimit(t *testing.T) {
+	root := t.TempDir()
+	for index := 0; index < protocol.MaxRepositoryCacheEntries; index++ {
+		if err := os.Mkdir(filepath.Join(root, fixtureUUID(index+1)), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := enforceRepositoryCacheLimit(root); err == nil || !strings.Contains(err.Error(), "cache limit") {
+		t.Fatalf("cache limit error = %v", err)
+	}
+}
+
+func TestManagedRepositoryCacheStartupRemovesInterruptedClones(t *testing.T) {
+	dataDirectory := t.TempDir()
+	root := filepath.Join(dataDirectory, "repositories")
+	staleClone := filepath.Join(root, ".clone-interrupted", "repository")
+	if err := os.MkdirAll(staleClone, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleClone, "partial.pack"), []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	installedID := fixtureUUID(780)
+	if err := os.Mkdir(filepath.Join(root, installedID), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	unrelated := filepath.Join(root, "operator-note")
+	if err := os.Mkdir(unrelated, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := managedRepositoryCacheIDs(dataDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || !ids[installedID] {
+		t.Fatalf("managed repository cache IDs = %#v", ids)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".clone-interrupted")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("interrupted clone remains after startup scan: %v", err)
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Fatalf("startup scan removed an unrelated entry: %v", err)
+	}
+}
+
+func TestFailedManagedRepositoryCloneLeavesNoCacheEntry(t *testing.T) {
+	dataDirectory := t.TempDir()
+	githubPath := filepath.Join(t.TempDir(), "gh")
+	if err := os.WriteFile(githubPath, []byte("#!/bin/sh\nexit 42\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manager := &Manager{
+		dataDirectory: dataDirectory,
+		options:       Options{GitExecutable: "git", GitHubExecutable: githubPath},
+	}
+	repositoryID := fixtureUUID(500)
+	_, err := manager.acquireManagedRepository(context.Background(), protocol.Repository{
+		ID: repositoryID, Key: "github.com/example/failure",
+		RemoteIdentity: "github.com/example/failure",
+	})
+	if err == nil || !strings.Contains(err.Error(), "clone managed GitHub repository") {
+		t.Fatalf("clone failure = %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dataDirectory, "repositories", repositoryID)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("failed clone left cache entry: %v", err)
 	}
 }
 
@@ -390,6 +625,7 @@ func TestClaudeCodeSupervisorAcceptsOversizedResult(t *testing.T) {
 func testOptions(codexPath string) Options {
 	return Options{
 		GitExecutable:        "git",
+		GitHubExecutable:     filepath.Join(filepath.Dir(codexPath), "unavailable-gh"),
 		RuntimeExecutable:    codexPath,
 		SupervisorCommand:    []string{os.Args[0], "-test.run=TestWorkerSupervisorHelperProcess", "--"},
 		WorkerVersion:        "test",

--- a/migrations/008_managed_repositories.sql
+++ b/migrations/008_managed_repositories.sql
@@ -1,0 +1,182 @@
+-- factory: foreign-keys-off
+
+ALTER TABLE workers
+ADD COLUMN accepts_managed_repositories INTEGER NOT NULL DEFAULT 0
+CHECK (accepts_managed_repositories IN (0, 1));
+
+ALTER TABLE workers
+ADD COLUMN managed_repository_ids_json TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE repositories
+ADD COLUMN enabled INTEGER NOT NULL DEFAULT 1
+CHECK (enabled IN (0, 1));
+
+ALTER TABLE repositories
+ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0;
+
+UPDATE repositories
+SET updated_at = created_at
+WHERE updated_at = 0;
+
+ALTER TABLE worker_repositories
+ADD COLUMN dynamic INTEGER NOT NULL DEFAULT 0
+CHECK (dynamic IN (0, 1));
+
+-- Historical worker registrations preserved GitHub owner/repository casing.
+-- Collapse those aliases before making the surviving identity canonical. The
+-- temporary tables also merge the unlikely case where one worker advertised
+-- multiple differently cased aliases for the same repository.
+CREATE TEMP TABLE repository_canonical AS
+SELECT
+    repository.id AS repository_id,
+    lower(repository.remote_identity) AS canonical_identity,
+    (
+        SELECT candidate.id
+        FROM repositories candidate
+        WHERE lower(candidate.remote_identity) = lower(repository.remote_identity)
+        ORDER BY
+            CASE WHEN candidate.remote_identity = lower(candidate.remote_identity) THEN 0 ELSE 1 END,
+            candidate.created_at,
+            candidate.id
+        LIMIT 1
+    ) AS survivor_id
+FROM repositories repository
+WHERE lower(repository.remote_identity) LIKE 'github.com/%/%'
+  AND length(repository.remote_identity) - length(replace(repository.remote_identity, '/', '')) = 2;
+
+CREATE TABLE repository_aliases (
+    alias_id TEXT PRIMARY KEY,
+    repository_id TEXT NOT NULL REFERENCES repositories(id)
+);
+
+INSERT INTO repository_aliases(alias_id, repository_id)
+SELECT repository_id, survivor_id
+FROM repository_canonical
+WHERE repository_id != survivor_id;
+
+CREATE TEMP TABLE worker_repository_rank AS
+SELECT
+    worker_repository.worker_id,
+    worker_repository.display_key,
+    canonical.survivor_id,
+    row_number() OVER (
+        PARTITION BY worker_repository.worker_id, canonical.survivor_id
+        ORDER BY
+            CASE WHEN worker_repository.repository_id = canonical.survivor_id THEN 0 ELSE 1 END,
+            worker_repository.display_key
+    ) AS rank
+FROM worker_repositories worker_repository
+JOIN repository_canonical canonical
+  ON canonical.repository_id = worker_repository.repository_id;
+
+UPDATE worker_repositories AS keeper
+SET retained_count = (
+        SELECT max(candidate.retained_count)
+        FROM worker_repositories candidate
+        JOIN repository_canonical canonical
+          ON canonical.repository_id = candidate.repository_id
+        WHERE candidate.worker_id = keeper.worker_id
+          AND canonical.survivor_id = (
+              SELECT rank.survivor_id
+              FROM worker_repository_rank rank
+              WHERE rank.worker_id = keeper.worker_id
+                AND rank.display_key = keeper.display_key
+          )
+    ),
+    advertised = (
+        SELECT max(candidate.advertised)
+        FROM worker_repositories candidate
+        JOIN repository_canonical canonical
+          ON canonical.repository_id = candidate.repository_id
+        WHERE candidate.worker_id = keeper.worker_id
+          AND canonical.survivor_id = (
+              SELECT rank.survivor_id
+              FROM worker_repository_rank rank
+              WHERE rank.worker_id = keeper.worker_id
+                AND rank.display_key = keeper.display_key
+          )
+    ),
+    dynamic = (
+        SELECT min(candidate.dynamic)
+        FROM worker_repositories candidate
+        JOIN repository_canonical canonical
+          ON canonical.repository_id = candidate.repository_id
+        WHERE candidate.worker_id = keeper.worker_id
+          AND canonical.survivor_id = (
+              SELECT rank.survivor_id
+              FROM worker_repository_rank rank
+              WHERE rank.worker_id = keeper.worker_id
+                AND rank.display_key = keeper.display_key
+          )
+    ),
+    updated_at = (
+        SELECT max(candidate.updated_at)
+        FROM worker_repositories candidate
+        JOIN repository_canonical canonical
+          ON canonical.repository_id = candidate.repository_id
+        WHERE candidate.worker_id = keeper.worker_id
+          AND canonical.survivor_id = (
+              SELECT rank.survivor_id
+              FROM worker_repository_rank rank
+              WHERE rank.worker_id = keeper.worker_id
+                AND rank.display_key = keeper.display_key
+          )
+    )
+WHERE EXISTS (
+    SELECT 1
+    FROM worker_repository_rank rank
+    WHERE rank.worker_id = keeper.worker_id
+      AND rank.display_key = keeper.display_key
+      AND rank.rank = 1
+);
+
+DELETE FROM worker_repositories
+WHERE EXISTS (
+    SELECT 1
+    FROM worker_repository_rank rank
+    WHERE rank.worker_id = worker_repositories.worker_id
+      AND rank.display_key = worker_repositories.display_key
+      AND rank.rank > 1
+);
+
+UPDATE worker_repositories
+SET repository_id = (
+    SELECT rank.survivor_id
+    FROM worker_repository_rank rank
+    WHERE rank.worker_id = worker_repositories.worker_id
+      AND rank.display_key = worker_repositories.display_key
+      AND rank.rank = 1
+)
+WHERE EXISTS (
+    SELECT 1
+    FROM worker_repository_rank rank
+    WHERE rank.worker_id = worker_repositories.worker_id
+      AND rank.display_key = worker_repositories.display_key
+      AND rank.rank = 1
+);
+
+UPDATE tasks
+SET repository_id = (
+    SELECT canonical.survivor_id
+    FROM repository_canonical canonical
+    WHERE canonical.repository_id = tasks.repository_id
+)
+WHERE repository_id IN (
+    SELECT repository_id FROM repository_canonical
+);
+
+DELETE FROM repositories
+WHERE id IN (
+    SELECT repository_id
+    FROM repository_canonical
+    WHERE repository_id != survivor_id
+);
+
+UPDATE repositories
+SET remote_identity = lower(remote_identity)
+WHERE id IN (
+    SELECT survivor_id FROM repository_canonical
+);
+
+DROP TABLE worker_repository_rank;
+DROP TABLE repository_canonical;

--- a/migrations/008_managed_repositories.sql
+++ b/migrations/008_managed_repositories.sql
@@ -22,6 +22,18 @@ ALTER TABLE worker_repositories
 ADD COLUMN dynamic INTEGER NOT NULL DEFAULT 0
 CHECK (dynamic IN (0, 1));
 
+ALTER TABLE worker_repositories
+ADD COLUMN worker_remote_identity TEXT NOT NULL DEFAULT '';
+
+-- Claims sent to a pre-upgrade worker must retain the exact remote spelling
+-- that worker advertised because its compatibility check is byte-for-byte.
+UPDATE worker_repositories
+SET worker_remote_identity = (
+    SELECT repository.remote_identity
+    FROM repositories repository
+    WHERE repository.id = worker_repositories.repository_id
+);
+
 -- Historical worker registrations preserved GitHub owner/repository casing.
 -- Collapse those aliases before making the surviving identity canonical. The
 -- temporary tables also merge the unlikely case where one worker advertised

--- a/migrations/008_managed_repositories.sql
+++ b/migrations/008_managed_repositories.sql
@@ -78,6 +78,7 @@ SELECT
     row_number() OVER (
         PARTITION BY worker_repository.worker_id, canonical.survivor_id
         ORDER BY
+            worker_repository.advertised DESC,
             CASE WHEN worker_repository.repository_id = canonical.survivor_id THEN 0 ELSE 1 END,
             worker_repository.display_key
     ) AS rank

--- a/migrations/008_managed_repositories.sql
+++ b/migrations/008_managed_repositories.sql
@@ -14,6 +14,10 @@ CHECK (enabled IN (0, 1));
 ALTER TABLE repositories
 ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0;
 
+ALTER TABLE repositories
+ADD COLUMN centrally_managed INTEGER NOT NULL DEFAULT 1
+CHECK (centrally_managed IN (0, 1));
+
 UPDATE repositories
 SET updated_at = created_at
 WHERE updated_at = 0;


### PR DESCRIPTION
## Summary

- add a central managed-repository catalog and cattle-worker routing
- let zero-repository workers acquire GitHub repositories into a bounded cache
- preserve explicit static assignments and upgrade compatibility
- document the operator flow, limits, security boundary, and phase-trigger integration

## Verification

- `just check`
- independent final review: approved with no findings

Closes #169