### PR TITLE
Fix malformed sentence in worker prompt

### DIFF
--- a/internal/worker/attempt_lifecycle.go
+++ b/internal/worker/attempt_lifecycle.go
@@ -619,7 +619,7 @@ func terminalState(message supervisorMessage) string {
 
 func buildPrompt(claim protocol.Claim) string {
 	return "You are running in a Factory managed Git worktree.\n" +
-		"Work only on the assigned task and repository. Preserve unrelated changes and do not touch Factory state or unrelated worktrees. " +
+		"Work only on the assigned task and repository. Preserve unrelated changes and do not touch Factory state or unrelated worktrees, " +
 		"and do not delete worktrees or branches. Complete and verify the task before returning a concise result.\n\n" +
 		"Task title: " + claim.Task.Title + "\n" +
 		"Repository: " + claim.Repository.RemoteIdentity + "\n\n" +

--- a/internal/worker/attempt_lifecycle_test.go
+++ b/internal/worker/attempt_lifecycle_test.go
@@ -1,0 +1,28 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestBuildPromptIncludesGrammaticalSafetyInstruction(t *testing.T) {
+	claim := protocol.Claim{
+		Task: protocol.Task{
+			Title:       "Fix the prompt",
+			Description: "Keep the change focused.",
+		},
+		Repository: protocol.Repository{RemoteIdentity: "github.com/owainlewis/factory"},
+	}
+
+	want := "You are running in a Factory managed Git worktree.\n" +
+		"Work only on the assigned task and repository. Preserve unrelated changes and do not touch Factory state or unrelated worktrees, " +
+		"and do not delete worktrees or branches. Complete and verify the task before returning a concise result.\n\n" +
+		"Task title: Fix the prompt\n" +
+		"Repository: github.com/owainlewis/factory\n\n" +
+		"Keep the change focused."
+
+	if got := buildPrompt(claim); got != want {
+		t.Fatalf("buildPrompt() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

The worker safety preamble contains a malformed sentence. Closes #166.

## Changes

Replace the incorrect sentence break with a comma while preserving both safety requirements. Add an exact-output regression test for the generated prompt.

## Verification

- `GOCACHE=/tmp/factory-166-go-cache go test ./internal/worker -run "^TestBuildPromptIncludesGrammaticalSafetyInstruction$" -count=1` passes.
- `go test ./...` passes all non-worker packages. Worker integration tests are blocked in the managed sandbox because `/bin/ps` returns `operation not permitted`; this is unrelated to the prompt-only change.
- `git diff --check` passes.
- Independent review approved with no findings.

## Risks

None.

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests and documentation cover changed behavior.
- [x] Logs, fixtures, and screenshots contain no secrets or private repository data.