### PR TITLE
feat(worker): default data directory from config

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -387,9 +387,12 @@ preview storage format. They do not represent a second application.
 names remain migration aliases in code and the local launcher, but are not
 operator-facing configuration.
 
-Relative worker data and optional legacy repository paths are resolved from the
-directory that contains the worker TOML. Managed repositories are configured by
-the control-plane API and cached below the worker data directory.
+When `data_directory` is omitted, a worker derives the absolute
+`<config-directory>/workers/<config-basename-without-.toml>` path. Explicit
+relative worker data paths and optional legacy repository paths are resolved
+from the directory that contains the worker TOML; explicit absolute worker data
+paths are unchanged. Managed repositories are configured by the control-plane
+API and cached below the worker data directory.
 
 ## 7. Security and trust boundaries
 

--- a/cmd/factory-worker/main_test.go
+++ b/cmd/factory-worker/main_test.go
@@ -2,11 +2,61 @@ package main
 
 import (
 	"flag"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestIdentityCommandUsesDerivedDataDirectory(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "cli-worker.toml")
+	if err := os.WriteFile(configPath, []byte(`name = "cli-worker"`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	runIdentity := func() string {
+		t.Helper()
+		reader, writer, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldArgs, oldStdout := os.Args, os.Stdout
+		os.Args = []string{"factory-worker", "identity", "--config", configPath}
+		os.Stdout = writer
+		err = run()
+		os.Args, os.Stdout = oldArgs, oldStdout
+		if closeErr := writer.Close(); err == nil {
+			err = closeErr
+		}
+		if err != nil {
+			reader.Close()
+			t.Fatal(err)
+		}
+		output, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := reader.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return strings.TrimSpace(string(output))
+	}
+
+	first := runIdentity()
+	second := runIdentity()
+	if first == "" || first != second {
+		t.Fatalf("identity output changed: %q != %q", first, second)
+	}
+	body, err := os.ReadFile(filepath.Join(root, "workers", "cli-worker", "worker-id"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(body)) != first {
+		t.Fatalf("worker-id does not match identity output %q", first)
+	}
+}
 
 func TestExplicitConfigSelectionBypassesLegacyDefault(t *testing.T) {
 	home := t.TempDir()

--- a/docs/local.md
+++ b/docs/local.md
@@ -30,8 +30,11 @@ server = "http://127.0.0.1:7337"
 name = "local-codex"
 runtime = "codex"
 max_concurrent = 1
-data_directory = "workers/local-codex"
 ```
+
+With this `~/.factory/worker.toml` filename, Factory defaults durable worker
+state to `~/.factory/workers/worker`. The config filename, rather than `name`,
+selects the state directory.
 
 No worker repository list is required. Factory detects local GitHub access with
 `gh auth status` and clones centrally managed repositories on demand. Optional
@@ -45,10 +48,13 @@ server = "http://127.0.0.1:7337"
 name = "local-claude"
 runtime = "claude-code"
 max_concurrent = 1
-data_directory = "workers/local-claude"
 ```
 
-Do not share a `data_directory` between worker identities.
+Saved as `~/.factory/claude-worker.toml`, this worker uses
+`~/.factory/workers/claude-worker`. Different config filenames keep multiple
+worker identities separate on one host. Set `data_directory` only when an
+explicit relative or absolute override is needed; never share one data
+directory between worker identities.
 
 ## Start
 

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -12,14 +12,21 @@ server = "http://127.0.0.1:7337"
 name = "local-codex"
 runtime = "codex"
 max_concurrent = 1
-data_directory = "workers/local-codex"
 ```
 
 `runtime` is `codex` or `claude-code`. A worker never switches runtime per task.
 Run two workers when you want to send the same task to both agents.
 
-Relative data directories resolve from the directory containing the worker
-TOML file. The worker probes `gh auth status --hostname github.com`
+When `data_directory` is omitted, Factory derives an absolute path beside the
+configuration as `workers/<config filename without .toml>`. For example,
+`~/.factory/worker.toml` uses `~/.factory/workers/worker`, while
+`~/.factory/claude-worker.toml` uses `~/.factory/workers/claude-worker`. The
+config filename, not the mutable worker display name, selects durable local
+state, so use a different config filename for each worker on one host.
+
+Set `data_directory` to override the default. Explicit relative paths resolve
+from the directory containing the worker TOML file; explicit absolute paths are
+used as written. The worker probes `gh auth status --hostname github.com`
 automatically. A successful probe advertises GitHub source access and the
 ability to acquire centrally managed GitHub repositories. It contains no token.
 

--- a/examples/worker.toml
+++ b/examples/worker.toml
@@ -4,7 +4,9 @@ name = "local"
 # One worker identity runs exactly one runtime: "codex" or "claude-code".
 runtime = "codex"
 max_concurrent = 1
-data_directory = "workers/local"
+# With no data_directory, this worker stores durable state in
+# ~/.factory/workers/worker, derived from this file's name (worker.toml).
+# Set data_directory only to override that location.
 # No repository or GitHub opt-in is required. Factory advertises GitHub access
 # while `gh auth status --hostname github.com` succeeds and clones centrally
 # managed repositories into this worker's data directory on demand.

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -66,13 +66,21 @@ func LoadConfig(path string) (Config, error) {
 	if config.MaxConcurrent == 0 {
 		config.MaxConcurrent = defaultMaxConcurrent
 	}
-	if config.DataDirectory == "" {
-		return Config{}, errors.New("data_directory is required")
+	config.path, err = filepath.Abs(path)
+	if err != nil {
+		return Config{}, fmt.Errorf("resolve worker configuration path: %w", err)
+	}
+	dataDirectoryDefaulted := config.DataDirectory == ""
+	if dataDirectoryDefaulted {
+		config.DataDirectory, err = defaultDataDirectory(config.path)
+		if err != nil {
+			return Config{}, err
+		}
 	}
 	for index := range config.SourceAccess {
 		config.SourceAccess[index] = strings.ToLower(strings.TrimSpace(config.SourceAccess[index]))
 	}
-	if !filepath.IsAbs(config.DataDirectory) {
+	if !dataDirectoryDefaulted && !filepath.IsAbs(config.DataDirectory) {
 		config.DataDirectory = filepath.Join(filepath.Dir(path), config.DataDirectory)
 	}
 	for key, repository := range config.Repositories {
@@ -81,11 +89,15 @@ func LoadConfig(path string) (Config, error) {
 			config.Repositories[key] = repository
 		}
 	}
-	config.path, err = filepath.Abs(path)
-	if err != nil {
-		return Config{}, fmt.Errorf("resolve worker configuration path: %w", err)
-	}
 	return config, validateConfig(config)
+}
+
+func defaultDataDirectory(configPath string) (string, error) {
+	base := strings.TrimSuffix(filepath.Base(configPath), ".toml")
+	if strings.TrimSpace(base) == "" || base == "." || base == ".." {
+		return "", errors.New("derive data_directory: worker configuration filename has no usable basename after removing .toml")
+	}
+	return filepath.Join(filepath.Dir(configPath), "workers", base), nil
 }
 
 func validateConfig(config Config) error {

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -70,7 +70,7 @@ func LoadConfig(path string) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("resolve worker configuration path: %w", err)
 	}
-	dataDirectoryDefaulted := config.DataDirectory == ""
+	dataDirectoryDefaulted := !metadata.IsDefined("data_directory")
 	if dataDirectoryDefaulted {
 		config.DataDirectory, err = defaultDataDirectory(config.path)
 		if err != nil {
@@ -80,7 +80,7 @@ func LoadConfig(path string) (Config, error) {
 	for index := range config.SourceAccess {
 		config.SourceAccess[index] = strings.ToLower(strings.TrimSpace(config.SourceAccess[index]))
 	}
-	if !dataDirectoryDefaulted && !filepath.IsAbs(config.DataDirectory) {
+	if !dataDirectoryDefaulted && strings.TrimSpace(config.DataDirectory) != "" && !filepath.IsAbs(config.DataDirectory) {
 		config.DataDirectory = filepath.Join(filepath.Dir(path), config.DataDirectory)
 	}
 	for key, repository := range config.Repositories {

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -1634,6 +1634,112 @@ path = %q
 	}
 }
 
+func TestLoadConfigDefaultsDataDirectoryFromConfigFilename(t *testing.T) {
+	root := t.TempDir()
+	body := []byte(`name = "local"
+runtime = "codex"
+`)
+
+	for _, filename := range []string{"worker.toml", "claude-worker.toml"} {
+		configPath := filepath.Join(root, filename)
+		if err := os.WriteFile(configPath, body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		config, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(root, "workers", strings.TrimSuffix(filename, ".toml"))
+		if config.DataDirectory != want {
+			t.Fatalf("%s data directory = %q, want %q", filename, config.DataDirectory, want)
+		}
+	}
+}
+
+func TestLoadConfigPreservesExplicitDataDirectories(t *testing.T) {
+	root := t.TempDir()
+	absolute := filepath.Join(t.TempDir(), "worker-data")
+	for name, dataDirectory := range map[string]string{
+		"relative": "custom-data",
+		"absolute": absolute,
+	} {
+		t.Run(name, func(t *testing.T) {
+			configPath := filepath.Join(root, name+".toml")
+			body := fmt.Sprintf("name = %q\ndata_directory = %q\n", name, dataDirectory)
+			if err := os.WriteFile(configPath, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			config, err := LoadConfig(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := dataDirectory
+			if !filepath.IsAbs(want) {
+				want = filepath.Join(root, want)
+			}
+			if config.DataDirectory != want {
+				t.Fatalf("data directory = %q, want %q", config.DataDirectory, want)
+			}
+		})
+	}
+}
+
+func TestLoadConfigRejectsDefaultWithoutUsableBasename(t *testing.T) {
+	for _, filename := range []string{".toml", "..toml", "...toml"} {
+		t.Run(filename, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), filename)
+			if err := os.WriteFile(configPath, []byte(`name = "local"`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadConfig(configPath); err == nil || !strings.Contains(err.Error(), "no usable basename") {
+				t.Fatalf("invalid default basename error = %v", err)
+			}
+		})
+	}
+}
+
+func TestDerivedDataDirectoryReusesIdentityAndRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	configPath := filepath.Join(root, "worker.toml")
+	if err := os.WriteFile(configPath, []byte(`name = "local"`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := ResolveWorkerID(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ResolveWorkerID(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("worker ID changed: %q != %q", first, second)
+	}
+
+	unsafeRoot := t.TempDir()
+	unsafeConfigPath := filepath.Join(unsafeRoot, "unsafe.toml")
+	if err := os.WriteFile(unsafeConfigPath, []byte(`name = "unsafe"`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(unsafeRoot, "workers"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), filepath.Join(unsafeRoot, "workers", "unsafe")); err != nil {
+		t.Fatal(err)
+	}
+	unsafeConfig, err := LoadConfig(unsafeConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveWorkerID(unsafeConfig); err == nil || !strings.Contains(err.Error(), "not a symlink") {
+		t.Fatalf("derived symlink error = %v", err)
+	}
+}
+
 func TestDefaultConfigPathUsesFactoryHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/worker/worker_integration_test.go
+++ b/internal/worker/worker_integration_test.go
@@ -1656,6 +1656,36 @@ runtime = "codex"
 	}
 }
 
+func TestLoadConfigDistinguishesOmittedAndEmptyDataDirectory(t *testing.T) {
+	root := t.TempDir()
+
+	t.Run("omitted", func(t *testing.T) {
+		configPath := filepath.Join(root, "omitted.toml")
+		if err := os.WriteFile(configPath, []byte(`name = "local"`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		config, err := LoadConfig(configPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(root, "workers", "omitted")
+		if config.DataDirectory != want {
+			t.Fatalf("data directory = %q, want %q", config.DataDirectory, want)
+		}
+	})
+
+	t.Run("explicitly empty", func(t *testing.T) {
+		configPath := filepath.Join(root, "empty.toml")
+		body := []byte("name = \"local\"\ndata_directory = \"\"\n")
+		if err := os.WriteFile(configPath, body, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadConfig(configPath); err == nil || !strings.Contains(err.Error(), "data_directory is required") {
+			t.Fatalf("explicitly empty data directory error = %v", err)
+		}
+	})
+}
+
 func TestLoadConfigPreservesExplicitDataDirectories(t *testing.T) {
 	root := t.TempDir()
 	absolute := filepath.Join(t.TempDir(), "worker-data")


### PR DESCRIPTION
## Summary

- derive an omitted worker `data_directory` from the absolute config directory and TOML filename
- preserve explicit relative and absolute overrides while keeping existing identity and directory safety paths
- document the default in the example, worker contract, local guide, and architecture
- cover distinct config names, unusable basenames, identity reuse, CLI identity, overrides, and symlink rejection

Closes #180

## Tests

- `go test ./internal/worker ./cmd/factory-worker` (completed as exhaustive worker test batches because the full worker package exceeds the local command window)
- all remaining `go test ./...` packages
- `just vet`
- `just boundary`
- `just test-tooling`
- `just test-launcher`
- `just format-check`
- `git diff --check`

No browser check was needed because this change does not affect browser-rendered behavior.

## Review

A fresh independent review found a dot-component basename path-collapse edge case. The implementation now rejects `.`, `..`, and empty derived basenames with regression coverage. A second fresh independent review reported no findings.
