### PR TITLE
fix: classify schedule catch-up by minute

### DIFF
--- a/internal/controlplane/schedule_automations_test.go
+++ b/internal/controlplane/schedule_automations_test.go
@@ -248,26 +248,39 @@ func TestScheduleStartupCatchUpAdvancesToFirstFutureInstant(t *testing.T) {
 	}
 }
 
-func TestScheduleCatchUpDoesNotClaimUnmatchedInstantsWereSkipped(t *testing.T) {
-	now := time.Date(2026, 8, 1, 7, 0, 0, 0, time.UTC)
-	store, detail := createScheduleAutomationFixture(t, &now, false)
-	enabled := enableAutomation(t, store, detail.Automation.ID)
-	now = enabled.Automation.NextDueAt.Add(time.Minute)
-	if err := store.recoverAutomationRuntime(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if err := store.processDueSchedules(context.Background(), 100); err != nil {
-		t.Fatal(err)
-	}
-	current, err := store.Automation(context.Background(), detail.Automation.ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(current.Occurrences) != 1 || current.Occurrences[0].Diagnostic != "catch_up" {
-		t.Fatalf("catch-up occurrence = %#v", current.Occurrences)
-	}
-	if current.Automation.SkippedCount != 0 {
-		t.Fatalf("catch-up skipped count = %d, want 0", current.Automation.SkippedCount)
+func TestScheduleCatchUpClassificationStartsAfterDueMinute(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		offset         time.Duration
+		wantDiagnostic string
+	}{
+		{name: "exact due instant"},
+		{name: "milliseconds after due", offset: 100 * time.Millisecond},
+		{name: "end of due minute", offset: 59*time.Second + 999*time.Millisecond},
+		{name: "start of next minute", offset: time.Minute, wantDiagnostic: "catch_up"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Date(2026, 8, 1, 7, 0, 0, 0, time.UTC)
+			store, detail := createScheduleAutomationFixture(t, &now, false)
+			enabled := enableAutomation(t, store, detail.Automation.ID)
+			now = enabled.Automation.NextDueAt.Add(test.offset)
+			if err := store.recoverAutomationRuntime(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.processDueSchedules(context.Background(), 100); err != nil {
+				t.Fatal(err)
+			}
+			current, err := store.Automation(context.Background(), detail.Automation.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(current.Occurrences) != 1 || current.Occurrences[0].Diagnostic != test.wantDiagnostic {
+				t.Fatalf("occurrences = %#v, want diagnostic %q", current.Occurrences, test.wantDiagnostic)
+			}
+			if current.Automation.SkippedCount != 0 {
+				t.Fatalf("skipped count = %d, want 0", current.Automation.SkippedCount)
+			}
+		})
 	}
 }
 

--- a/internal/controlplane/schedule_runtime.go
+++ b/internal/controlplane/schedule_runtime.go
@@ -196,7 +196,7 @@ func (s *Store) admitDueSchedule(ctx context.Context, automationID string) error
 			state, diagnostic, skipped = "failed", "repository_disabled", 1
 			healthStatus, healthCode, healthMessage = "blocked", "repository_disabled", "Scheduled occurrence recorded without a task because the repository is disabled."
 		}
-		if now.After(due) {
+		if !now.Before(due.Truncate(time.Minute).Add(time.Minute)) {
 			missed, err := countScheduledInstants(schedule, due, now)
 			if err != nil {
 				return unavailable(err)


### PR DESCRIPTION
## Problem

Follow-up to merged PR #192 and [its unresolved P2 review thread](https://github.com/owainlewis/factory/pull/192#discussion_r3695790863). Schedule ticks normally arrive milliseconds or seconds after a minute-aligned due instant, but those ordinary ticks were incorrectly labeled `catch_up`.

## Changes

Treat the due minute as the ordinary admission window `[due, due + 1 minute)`, and begin catch-up classification at the next minute. Actual skipped-instant enumeration for genuinely overdue schedules is unchanged. Deterministic fake-clock tests cover exact due, +100 ms, +59.999 s, exactly +1 minute, multi-day missed matches, and disabled dependencies.

## Verification

- focused schedule tests, 50 repetitions
- focused race tests, 10 repetitions
- `just ui-check` (58 tests)
- `just test-browser` (16 tests)
- `just check`
- fresh independent exact-diff review: approved with no findings
- [exact-head CI](https://github.com/owainlewis/factory/actions/runs/30704092544/job/91380081470): passed

## Risks

Low. The production change is one time-boundary condition and keeps durable occurrence identity, cursor advancement, and skipped-instant enumeration unchanged.

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests and documentation cover changed behavior.
- [x] Logs, fixtures, and screenshots contain no secrets or private repository data.
