### PR TITLE
fix: harden legacy migration recovery

### DIFF
--- a/internal/controlplane/legacy_poller_archive.go
+++ b/internal/controlplane/legacy_poller_archive.go
@@ -25,6 +25,7 @@ type legacyPollerArchiveManifest struct {
 }
 
 var legacyArchiveRename = os.Rename
+var legacyArchiveSyncDirectory = syncDirectory
 
 func (s *Store) FinalizeLegacyPoller(
 	ctx context.Context,
@@ -117,6 +118,9 @@ func createLegacyPollerArchive(source *legacyLockedSource, migrationID string) (
 		if err := verifyLegacyArchive(finalPath, manifest); err != nil {
 			return "", fmt.Errorf("archive collision at %s: %w", finalPath, err)
 		}
+		if err := legacyArchiveSyncDirectory(snapshot.ArchiveRoot); err != nil {
+			return "", fmt.Errorf("sync recovered archive parent: %w", err)
+		}
 		return finalPath, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("inspect final archive: %w", err)
@@ -150,7 +154,7 @@ func createLegacyPollerArchive(source *legacyLockedSource, migrationID string) (
 	if err := ensureArchiveBytes(filepath.Join(stagingPath, "manifest.json"), manifestBody, hex.EncodeToString(manifestDigest[:])); err != nil {
 		return "", err
 	}
-	if err := syncDirectory(stagingPath); err != nil {
+	if err := legacyArchiveSyncDirectory(stagingPath); err != nil {
 		return "", fmt.Errorf("sync archive staging directory: %w", err)
 	}
 	if err := source.verifyLedgerPath(); err != nil {
@@ -158,11 +162,14 @@ func createLegacyPollerArchive(source *legacyLockedSource, migrationID string) (
 	}
 	if err := legacyArchiveRename(stagingPath, finalPath); err != nil {
 		if verifyErr := verifyLegacyArchive(finalPath, manifest); verifyErr == nil {
+			if syncErr := legacyArchiveSyncDirectory(snapshot.ArchiveRoot); syncErr != nil {
+				return "", fmt.Errorf("sync recovered archive parent: %w", syncErr)
+			}
 			return finalPath, nil
 		}
 		return "", fmt.Errorf("publish archive: %w", err)
 	}
-	if err := syncDirectory(snapshot.ArchiveRoot); err != nil {
+	if err := legacyArchiveSyncDirectory(snapshot.ArchiveRoot); err != nil {
 		return "", fmt.Errorf("sync archive parent: %w", err)
 	}
 	return finalPath, nil
@@ -174,10 +181,12 @@ func ensureArchiveBytes(path string, body []byte, expectedDigest string) error {
 			return errors.New("archive staging file must be a regular non-symlink file: " + path)
 		}
 		digest, digestErr := digestFile(path)
-		if digestErr != nil || digest != expectedDigest {
-			return errors.New("archive staging file conflicts with the locked snapshot: " + path)
+		if digestErr == nil && digest == expectedDigest {
+			return nil
 		}
-		return nil
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("replace invalid archive staging file: %w", err)
+		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("inspect archive staging file: %w", err)
 	}
@@ -205,10 +214,12 @@ func ensureArchiveCopy(path string, source *os.File, expectedDigest string) erro
 			return errors.New("archive staging ledger must be a regular non-symlink file")
 		}
 		digest, digestErr := digestFile(path)
-		if digestErr != nil || digest != expectedDigest {
-			return errors.New("archive staging ledger conflicts with the locked snapshot")
+		if digestErr == nil && digest == expectedDigest {
+			return nil
 		}
-		return nil
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("replace invalid archive staging ledger: %w", err)
+		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("inspect archive staging ledger: %w", err)
 	}

--- a/internal/controlplane/legacy_poller_migration_test.go
+++ b/internal/controlplane/legacy_poller_migration_test.go
@@ -320,6 +320,86 @@ func TestLegacyPollerResumeRecoversAfterTaskCommitAndRestart(t *testing.T) {
 	}
 }
 
+func TestLegacyPollerResumeResetsAfterCanceledLinkBeginAndRestart(t *testing.T) {
+	queueID := legacyQueueID(legacyPollerQueue{Name: "github-ready", Source: "github", Project: "example/project"})
+	observation := legacyPendingRequest(t, queueID, 20)
+	fixture := newLegacyMigrationFixture(t, []legacyPollerObservation{observation})
+	databasePath := filepath.Join(t.TempDir(), "controlplane.sqlite3")
+	store, err := Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := createManagedTestRepository(t, store, "github.com/example/project")
+	_, err = store.RegisterWorker(context.Background(), "link-failure-worker", protocol.WorkerRegistration{
+		Name: "link-failure-worker", WorkerVersion: "test", Runtime: protocol.RuntimeCodex,
+		RuntimeVersion: "test", Capacity: 1, Health: "healthy",
+		AcceptsManagedRepositories: true, ManagedRepositoryIDs: []string{repository.ID},
+		SourceAccess: []protocol.SourceAccess{{Provider: "github", Hostname: "github.com"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selection := migrationSelection(fixture)
+	preview, err := store.PreviewLegacyPoller(context.Background(), protocol.PreviewLegacyPollerRequest{LegacyPollerSelection: selection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	imported, err := store.ImportLegacyPoller(context.Background(), protocol.ImportLegacyPollerRequest{
+		LegacyPollerSelection: selection, MigrationID: preview.ID, SnapshotDigest: preview.SnapshotDigest,
+		Mappings: []protocol.LegacyPollerQueueMapping{{QueueID: queueID, WorkflowName: "Link failure workflow", AutomationName: "Link failure issues"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resumeContext, cancelResume := context.WithCancel(context.Background())
+	store.beginLegacyResumeLink = func(context.Context) (*sql.Tx, error) {
+		cancelResume()
+		return nil, context.Canceled
+	}
+	_, err = store.ResumeLegacyPollerOccurrence(resumeContext, imported.Occurrences[0].ID)
+	if !errors.Is(err, context.Canceled) || resumeContext.Err() != context.Canceled {
+		t.Fatalf("injected link failure = %v, context = %v", err, resumeContext.Err())
+	}
+	var state, diagnostic string
+	var retainedRequest []byte
+	if err := store.db.QueryRowContext(context.Background(), `
+		SELECT state, diagnostic, legacy_task_request_json
+		FROM automation_occurrences
+		WHERE id = ?
+	`, imported.Occurrences[0].ID).Scan(&state, &diagnostic, &retainedRequest); err != nil {
+		t.Fatal(err)
+	}
+	if state != "pending" || !strings.Contains(diagnostic, "context canceled") || len(retainedRequest) == 0 {
+		t.Fatalf("occurrence after link failure: state=%q diagnostic=%q request=%q", state, diagnostic, retainedRequest)
+	}
+	page, err := store.Tasks(context.Background(), protocol.TaskPageRequest{Limit: 50})
+	if err != nil || len(page.Tasks) != 1 || page.Tasks[0].RequestKey != observation.RequestKey {
+		t.Fatalf("created Task after link failure = %#v, error %v", page.Tasks, err)
+	}
+	createdTaskID := page.Tasks[0].ID
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	resumed, err := reopened.ResumeLegacyPollerOccurrence(context.Background(), imported.Occurrences[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumed.State != "dispatched" || resumed.Task == nil || resumed.Task.ID != createdTaskID {
+		t.Fatalf("Resume after restart = %#v", resumed)
+	}
+	page, err = reopened.Tasks(context.Background(), protocol.TaskPageRequest{Limit: 50})
+	if err != nil || len(page.Tasks) != 1 {
+		t.Fatalf("Tasks after recovered Resume = %#v, error %v", page.Tasks, err)
+	}
+}
+
 func TestLegacyPollerImportPreservesSubmittedDeletedAndBlankTaskIDIdentity(t *testing.T) {
 	store := newTestStore(t)
 	repository := createManagedTestRepository(t, store, "github.com/example/project")
@@ -476,6 +556,150 @@ func TestLegacyPollerSkipArchiveFailureRetryAndFinalizeSnapshotGuard(t *testing.
 	}
 	if _, err := os.Stat(filepath.Join(changedFixture.dataHome, "archive", "poller", changedPreview.ID)); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("archive exists after source-change abort: %v", err)
+	}
+}
+
+func TestLegacyPollerFinalizeRebuildsInvalidStagingFilesAfterRestart(t *testing.T) {
+	queueID := legacyQueueID(legacyPollerQueue{Name: "github-ready", Source: "github", Project: "example/project"})
+	fixture := newLegacyMigrationFixture(t, []legacyPollerObservation{legacyPendingRequest(t, queueID, 23)})
+	databasePath := filepath.Join(t.TempDir(), "controlplane.sqlite3")
+	store, err := Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createManagedTestRepository(t, store, "github.com/example/project")
+	selection := migrationSelection(fixture)
+	preview, err := store.PreviewLegacyPoller(context.Background(), protocol.PreviewLegacyPollerRequest{LegacyPollerSelection: selection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	imported, err := store.ImportLegacyPoller(context.Background(), protocol.ImportLegacyPollerRequest{
+		LegacyPollerSelection: selection, MigrationID: preview.ID, SnapshotDigest: preview.SnapshotDigest,
+		Mappings: []protocol.LegacyPollerQueueMapping{{QueueID: queueID, WorkflowName: "Staging workflow", AutomationName: "Staging issues"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SkipLegacyPollerOccurrence(context.Background(), imported.Occurrences[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	stagingPath := filepath.Join(fixture.dataHome, "archive", "poller", "."+preview.ID+".staging")
+	if err := os.MkdirAll(stagingPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"poller.toml", "poller.sqlite3", "manifest.json"} {
+		if err := os.WriteFile(filepath.Join(stagingPath, name), []byte("incomplete write"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	finalized, err := reopened.FinalizeLegacyPoller(context.Background(), protocol.FinalizeLegacyPollerRequest{
+		LegacyPollerSelection: selection, MigrationID: preview.ID, SnapshotDigest: preview.SnapshotDigest,
+	})
+	if err != nil || finalized.Status != "finalized" {
+		t.Fatalf("Finalize after partial staging restart = %#v, error %v", finalized, err)
+	}
+	if _, err := os.Stat(stagingPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staging path remains after Finalize: %v", err)
+	}
+	configBody, err := os.ReadFile(fixture.configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archivedConfig, err := os.ReadFile(filepath.Join(finalized.ArchivePath, "poller.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(archivedConfig) != string(configBody) {
+		t.Fatal("Finalize did not rebuild the partial staged configuration")
+	}
+	sourceLedgerDigest, err := digestFile(fixture.ledgerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archivedLedgerDigest, err := digestFile(filepath.Join(finalized.ArchivePath, "poller.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archivedLedgerDigest != sourceLedgerDigest {
+		t.Fatalf("archived ledger digest = %s, want %s", archivedLedgerDigest, sourceLedgerDigest)
+	}
+}
+
+func TestLegacyPollerFinalizeResyncsArchiveParentAfterRestart(t *testing.T) {
+	queueID := legacyQueueID(legacyPollerQueue{Name: "github-ready", Source: "github", Project: "example/project"})
+	fixture := newLegacyMigrationFixture(t, []legacyPollerObservation{legacyPendingRequest(t, queueID, 24)})
+	databasePath := filepath.Join(t.TempDir(), "controlplane.sqlite3")
+	store, err := Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createManagedTestRepository(t, store, "github.com/example/project")
+	selection := migrationSelection(fixture)
+	preview, err := store.PreviewLegacyPoller(context.Background(), protocol.PreviewLegacyPollerRequest{LegacyPollerSelection: selection})
+	if err != nil {
+		t.Fatal(err)
+	}
+	imported, err := store.ImportLegacyPoller(context.Background(), protocol.ImportLegacyPollerRequest{
+		LegacyPollerSelection: selection, MigrationID: preview.ID, SnapshotDigest: preview.SnapshotDigest,
+		Mappings: []protocol.LegacyPollerQueueMapping{{QueueID: queueID, WorkflowName: "Parent sync workflow", AutomationName: "Parent sync issues"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SkipLegacyPollerOccurrence(context.Background(), imported.Occurrences[0].ID); err != nil {
+		t.Fatal(err)
+	}
+
+	archiveRoot := filepath.Join(fixture.dataHome, "archive", "poller")
+	parentSyncs := 0
+	originalSyncDirectory := legacyArchiveSyncDirectory
+	legacyArchiveSyncDirectory = func(path string) error {
+		if path == archiveRoot {
+			parentSyncs++
+			if parentSyncs == 1 {
+				return errors.New("injected archive parent sync failure")
+			}
+		}
+		return syncDirectory(path)
+	}
+	t.Cleanup(func() { legacyArchiveSyncDirectory = originalSyncDirectory })
+	_, err = store.FinalizeLegacyPoller(context.Background(), protocol.FinalizeLegacyPollerRequest{
+		LegacyPollerSelection: selection, MigrationID: preview.ID, SnapshotDigest: preview.SnapshotDigest,
+	})
+	var serviceErr *ServiceError
+	if !errors.As(err, &serviceErr) || serviceErr.Code != "migration_archive_failed" {
+		t.Fatalf("injected parent sync failure = %v", err)
+	}
+	finalPath := filepath.Join(archiveRoot, preview.ID)
+	if _, err := os.Stat(finalPath); err != nil {
+		t.Fatalf("published archive after parent sync failure: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := Open(context.Background(), databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	finalized, err := reopened.FinalizeLegacyPoller(context.Background(), protocol.FinalizeLegacyPollerRequest{
+		LegacyPollerSelection: selection, MigrationID: preview.ID, SnapshotDigest: preview.SnapshotDigest,
+	})
+	if err != nil || finalized.Status != "finalized" || finalized.ArchivePath != finalPath {
+		t.Fatalf("Finalize after parent sync restart = %#v, error %v", finalized, err)
+	}
+	if parentSyncs != 2 {
+		t.Fatalf("archive parent syncs = %d, want 2", parentSyncs)
 	}
 }
 

--- a/internal/controlplane/legacy_poller_occurrences.go
+++ b/internal/controlplane/legacy_poller_occurrences.go
@@ -5,9 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/owainlewis/factory/internal/protocol"
 )
+
+const legacyResumeCleanupTimeout = 5 * time.Second
 
 func (s *Store) ResumeLegacyPollerOccurrence(
 	ctx context.Context,
@@ -71,16 +74,28 @@ func (s *Store) ResumeLegacyPollerOccurrence(
 		s.resetLegacyResume(ctx, occurrenceID, truncateAutomationDiagnostic(createErr.Error()))
 		return protocol.AutomationOccurrence{}, createErr
 	}
+	linked := false
+	cleanupDiagnostic := "legacy_resume_link_failed"
+	defer func() {
+		if !linked {
+			s.resetLegacyResume(ctx, occurrenceID, cleanupDiagnostic)
+		}
+	}()
 	if !equalLegacyTask(detail, request, repositoryID) {
-		s.resetLegacyResume(ctx, occurrenceID, "legacy_task_conflict")
+		cleanupDiagnostic = "legacy_task_conflict"
 		return protocol.AutomationOccurrence{}, conflict(
 			"legacy_task_conflict",
 			"the legacy request key belongs to a Task with a different repository, title, description, or timeout; Skip the observation or repair the conflicting Task",
 		)
 	}
 
-	link, err := s.db.BeginTx(ctx, nil)
+	beginLink := s.beginLegacyResumeLink
+	if beginLink == nil {
+		beginLink = func(ctx context.Context) (*sql.Tx, error) { return s.db.BeginTx(ctx, nil) }
+	}
+	link, err := beginLink(ctx)
 	if err != nil {
+		cleanupDiagnostic = truncateAutomationDiagnostic(err.Error())
 		return protocol.AutomationOccurrence{}, unavailable(err)
 	}
 	defer link.Rollback()
@@ -110,13 +125,17 @@ func (s *Store) ResumeLegacyPollerOccurrence(
 		return protocol.AutomationOccurrence{}, unavailable(err)
 	}
 	if err := link.Commit(); err != nil {
+		cleanupDiagnostic = truncateAutomationDiagnostic(err.Error())
 		return protocol.AutomationOccurrence{}, unavailable(err)
 	}
+	linked = true
 	return s.legacyOccurrence(ctx, occurrenceID)
 }
 
 func (s *Store) resetLegacyResume(ctx context.Context, occurrenceID, diagnostic string) {
-	_, _ = s.db.ExecContext(ctx, `
+	cleanupContext, cancel := context.WithTimeout(context.WithoutCancel(ctx), legacyResumeCleanupTimeout)
+	defer cancel()
+	_, _ = s.db.ExecContext(cleanupContext, `
 		UPDATE automation_occurrences
 		SET state = 'pending', diagnostic = ?, updated_at = ?
 		WHERE id = ? AND state = 'dispatching' AND legacy_task_request_json IS NOT NULL

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -49,9 +49,10 @@ func invalid(code, message string) error {
 }
 
 type Store struct {
-	db         *sql.DB
-	now        func() time.Time
-	sweepEvery time.Duration
+	db                    *sql.DB
+	now                   func() time.Time
+	sweepEvery            time.Duration
+	beginLegacyResumeLink func(context.Context) (*sql.Tx, error)
 }
 
 func Open(ctx context.Context, path string) (*Store, error) {
@@ -81,6 +82,9 @@ func Open(ctx context.Context, path string) (*Store, error) {
 	}
 	db.SetMaxOpenConns(8)
 	store := &Store{db: db, now: time.Now, sweepEvery: 5 * time.Second}
+	store.beginLegacyResumeLink = func(ctx context.Context) (*sql.Tx, error) {
+		return db.BeginTx(ctx, nil)
+	}
 	if err := db.PingContext(ctx); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("ping sqlite: %w", err)


### PR DESCRIPTION
## Summary

- rebuild invalid regular files left in the private archive staging directory before a Finalize retry, while retaining symlink and nonregular collision checks
- re-sync the archive parent when Finalize recovers an already-published verified archive after restart
- reset a legacy occurrence from dispatching with bounded cleanup detached from request cancellation when post-Task linking fails, preserving and reusing the Task

## Verification

- focused recovery regressions: passed
- focused race detector: passed
- all legacy poller tests: passed
- just check: passed
- just test-browser: 17 passed
- independent exact-diff review: approved with no findings; focused tests rerun three times

Follow-up to merged #194.

Addresses:
- https://github.com/owainlewis/factory/pull/194#discussion_r3696087585
- https://github.com/owainlewis/factory/pull/194#discussion_r3696087587
- https://github.com/owainlewis/factory/pull/194#discussion_r3696087591