### PR TITLE
docs: define optional Temporal orchestration direction

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,14 @@
 > the intended product model. This document remains the source of truth for
 > behavior that exists today.
 
+The current implementation uses one embedded SQLite orchestration path. The
+longer-term direction is to keep that path as the first-class local default and
+allow production installations to select a durable backend such as Temporal
+without changing Definitions or the Runner-facing product model. No such
+backend abstraction exists today. Its decision record, ownership boundary,
+migration plan, and prototype are tracked in
+[#259](https://github.com/owainlewis/factory/issues/259).
+
 ## 1. Executive summary
 
 Factory is the current local implementation of a control plane for running

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -19,6 +19,14 @@ Code are initial runtime examples. Remote VM Runners are the next scaling step.
 GitHub webhook Triggers follow later. Kubernetes is a possible future Runner
 target, but it is not on the active roadmap.
 
+The built-in SQLite orchestration path remains the first-class V1 backend. A
+later production deployment may select Temporal or a similar durable workflow
+engine behind the same product model. Definitions and Runner behavior must not
+depend on that choice. The architecture decision, history migration, and
+same-Definition prototype remain tracked in
+[#259](https://github.com/owainlewis/factory/issues/259); they are not part of
+this V1 implementation.
+
 The main tradeoff is trust. The agent uses the tools and credentials available
 on its Runner, including authenticated `gh`. Factory does not intermediate
 comments, branches, issues, or pull requests and cannot promise exactly-once
@@ -164,6 +172,14 @@ contract later. They are not active roadmap milestones.
 These paths must create the same Run and Job records. They are not different
 automation products.
 
+After the local and VM Runner experience is stable, a production-scale
+orchestration backend may move durable timers, retries, cancellation, fan-out,
+and recovery to Temporal. Factory remains the product and API boundary. The
+selected backend is an operational choice, not a Definition authoring choice.
+The detailed design must decide whether Runners continue to use Factory's
+lifecycle API or consume backend task queues directly while preserving
+outbound-only connections and the existing trust model.
+
 ### Agent-owned GitHub work
 
 The agent reads and changes GitHub through `gh`, just as it does when run
@@ -224,6 +240,22 @@ records. A Trigger decides when to admit work. It does not execute an agent.
 The Runner gives the agent a prepared repository and its configured tools.
 Factory does not become a GitHub client on behalf of the agent. This preserves
 the capability of the underlying agent and avoids a second action language.
+
+#### Backend-neutral orchestration
+
+SQLite-backed orchestration is the default and supported local product, not a
+temporary demo. A future durable backend must preserve Definition snapshots,
+Run and Job identities, idempotent admission, per-Job history, cancellation,
+and the retry warning for agent-owned external effects. Factory must keep the
+same operator API and product vocabulary across backends. Temporal workflow,
+activity, task-queue, and retry-policy concepts stay out of normal Definition
+authoring.
+
+This direction does not assert that the current store already implements a
+backend interface. [Issue #259](https://github.com/owainlewis/factory/issues/259)
+owns the architecture decision, state-ownership boundary, mixed-version
+migration and rollback plan, operational requirements, and a prototype that
+runs one unchanged Definition on both backends.
 
 ## 5. Invariants and requirements
 
@@ -426,6 +458,10 @@ and an Occurrence-linked Task through their preserved URLs and Legacy history.
 No question blocks V1. Remote credentials and public webhook deployment require
 focused designs before those later milestones start. Any future Runner target,
 including Kubernetes, requires its own accepted design before implementation.
+The optional production orchestration backend is deliberately unresolved until
+[#259](https://github.com/owainlewis/factory/issues/259) defines ownership,
+deployment, migration, rollback, and failure behavior and proves the boundary
+with a small prototype.
 
 ## 13. Out of scope
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -21,9 +21,9 @@ target, but it is not on the active roadmap.
 
 The built-in SQLite orchestration path remains the first-class V1 backend. A
 later production deployment may select Temporal or a similar durable workflow
-engine behind the same product model. Definitions and Runner behavior must not
-depend on that choice. The architecture decision, history migration, and
-same-Definition prototype remain tracked in
+engine behind the same product model. Definitions and the Runner-facing product
+contract must not depend on that choice. The architecture decision, history
+migration, and same-Definition prototype remain tracked in
 [#259](https://github.com/owainlewis/factory/issues/259); they are not part of
 this V1 implementation.
 
@@ -178,7 +178,9 @@ and recovery to Temporal. Factory remains the product and API boundary. The
 selected backend is an operational choice, not a Definition authoring choice.
 The detailed design must decide whether Runners continue to use Factory's
 lifecycle API or consume backend task queues directly while preserving
-outbound-only connections and the existing trust model.
+outbound-only connections and the existing trust model. Internal Runner
+transport and configuration may vary, but identity, capability, capacity,
+lifecycle, and trust semantics remain stable.
 
 ### Agent-owned GitHub work
 

--- a/docs/software-factory/vision.md
+++ b/docs/software-factory/vision.md
@@ -131,6 +131,15 @@ scheduled path works end to end. GitHub webhook Triggers follow later.
 Kubernetes and other execution targets remain possible future Runner types,
 but they are not on the active roadmap.
 
+The built-in SQLite control plane remains a first-class deployment for local
+use and small teams. For larger production installations, the intended
+direction is an optional durable orchestration backend such as Temporal. That
+backend may own timers, retries, cancellation, fan-out, and recovery, but it
+must not change the Definition, Trigger, Run, Job, or Runner experience. The
+full boundary and migration design is tracked in
+[#259](https://github.com/owainlewis/factory/issues/259) and follows the stable
+local and VM Runner experience.
+
 ## Measures of progress
 
 The product is moving toward this vision when a team can:


### PR DESCRIPTION
Relates to #259

## Summary

- keep SQLite as the first-class local V1 orchestration backend
- define Temporal or a similar durable engine as an optional production direction
- preserve the Definition, Trigger, Run, Job, Runner model and outbound-only trust boundary
- leave backend ownership, migration, rollback, and the same-Definition prototype to #259

## Verification

- `git diff --check`
- `just format-check`
- `just boundary`
- `GOTOOLCHAIN=go1.25.12 just check`
- independent design review approved