### PR TITLE
fix(ui): limit overview to three recent jobs

### DIFF
--- a/internal/controlplane/run_metrics.go
+++ b/internal/controlplane/run_metrics.go
@@ -10,6 +10,8 @@ import (
 	"github.com/owainlewis/factory/internal/protocol"
 )
 
+const runHealthRecentJobsLimit = 3
+
 func runMetricsFilter(
 	start *time.Time,
 	end time.Time,
@@ -121,8 +123,8 @@ func (s *Store) loadRunHealthMetrics(
 		FROM facts
 		`+jobViewWhere+`
 		ORDER BY admitted_at DESC, job_id DESC
-		LIMIT 100
-	`), args...)
+		LIMIT ?
+	`), append(args, runHealthRecentJobsLimit)...)
 	if err != nil {
 		return err
 	}

--- a/internal/controlplane/run_metrics_test.go
+++ b/internal/controlplane/run_metrics_test.go
@@ -85,9 +85,19 @@ func TestRunHealthMetricsUseOneFilteredJobCohort(t *testing.T) {
 	requireRunMetric(t, "success rate", metrics.SuccessRate, 0.5)
 	requireRunMetric(t, "average queue", metrics.AverageQueueTimeSeconds, 20*time.Minute.Seconds())
 	requireRunMetric(t, "average cycle", metrics.AverageCycleTimeSeconds, 75*time.Minute.Seconds())
-	if len(metrics.Jobs) != 5 || len(metrics.Definitions) != 2 || len(metrics.Repositories) != 3 ||
+	if len(metrics.Jobs) != 3 || len(metrics.Definitions) != 2 || len(metrics.Repositories) != 3 ||
 		len(metrics.Workers) != 1 || metrics.Workers[0].Name != "Metrics Worker" {
 		t.Fatalf("Run health drill-down/options = %#v", metrics)
+	}
+	wantRecentAdmissions := []time.Time{
+		now.Add(-30 * time.Minute),
+		now.Add(-45 * time.Minute),
+		now.Add(-time.Hour),
+	}
+	for index, want := range wantRecentAdmissions {
+		if !metrics.Jobs[index].AdmittedAt.Equal(want) {
+			t.Fatalf("recent Job %d admitted at %s, want %s", index, metrics.Jobs[index].AdmittedAt, want)
+		}
 	}
 
 	definitionFiltered, err := store.MetricsFiltered(context.Background(), metricsWindow24Hours, MetricsFilter{


### PR DESCRIPTION
## Summary

- return only the three newest jobs in the overview metrics drill-down
- keep aggregate metrics calculated across the full filtered cohort
- verify newest-first ordering with a regression test

## Verification

- `go test ./...`
- `npm test -- App.test.tsx` (87 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- independent subagent review: approved with no findings