### PR TITLE
feat: add durable Cloud Run agent experiment

### DIFF
--- a/experiments/cloud-run-agent/Dockerfile
+++ b/experiments/cloud-run-agent/Dockerfile
@@ -5,6 +5,7 @@ ARG PI_VERSION=0.80.10
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
+        curl \
         git \
         jq \
     && rm -rf /var/lib/apt/lists/*

--- a/experiments/cloud-run-agent/Dockerfile
+++ b/experiments/cloud-run-agent/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22.19.0-bookworm-slim
+
+ARG PI_VERSION=0.80.10
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        jq \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install --global "@earendil-works/pi-coding-agent@${PI_VERSION}"
+
+RUN mkdir -p /workspace \
+    && chown node:node /workspace
+
+COPY --chown=node:node run-agent.sh /usr/local/bin/run-agent
+RUN chmod 0755 /usr/local/bin/run-agent
+
+ENV PI_SKIP_VERSION_CHECK=1 \
+    PI_TELEMETRY=0
+
+USER node
+WORKDIR /workspace
+
+ENTRYPOINT ["/usr/local/bin/run-agent"]

--- a/experiments/cloud-run-agent/README.md
+++ b/experiments/cloud-run-agent/README.md
@@ -1,62 +1,73 @@
-# Cloud Run agent experiment
+# Cloud Run agent proof of concept
 
-This experiment proves that one Cloud Run Job can check out a Git repository,
-run Pi with DeepSeek V4 Flash through OpenRouter from that checkout, report JSON
-events and cost, and exit. It is intentionally separate from Factory's durable
+This proof of concept runs Pi as a disposable Cloud Run Job while keeping its
+result after the container exits. It is intentionally separate from Factory's
 Worker protocol.
 
-The experiment trusts the selected repository and prompt. Pi can execute code
-with the same environment and credentials as the container. Use `read-only`
-mode unless a write-capable run is required.
+One reusable Job handles every execution. A run freezes a public GitHub
+repository to one full commit, uploads an input document to a private GCS
+bucket, starts the Job, and verifies the returned result archive. Completed
+Cloud Run execution records are deleted by default. The reusable Job remains.
 
-Cloud Logging receives sanitized assistant events and the final summary. Pi's
-raw JSON stream, including reasoning events, exists only on the Job's ephemeral
-filesystem and disappears with the container. The base64 prompt is not secret:
-it is visible in Cloud Run execution metadata to users who can inspect the Job.
+The proof trusts the selected repository and prompt. Repository code can read
+the OpenRouter credential mounted in its container and can make outbound
+network requests. This is managed disposable compute, not a sandbox for hostile
+code.
+
+## What the operator provisions
+
+`deploy.sh` performs the manual project setup:
+
+- one Artifact Registry repository;
+- one Cloud Run Job service account;
+- one private artifact bucket with seven-day object cleanup;
+- read and write access from that service account to the artifact bucket;
+- access to one existing OpenRouter secret;
+- one reusable Cloud Run Job with a digest-pinned image, one task, and zero
+  native retries.
+
+The OpenRouter secret must exist before deployment. Its latest enabled numeric
+version is pinned on the Job. Factory does not receive or store the secret.
 
 ## Files
 
 - `Dockerfile` builds a pinned Node and Pi image.
-- `run-agent.sh` checks out the requested Git ref and runs Pi.
-- `deploy.sh` creates or updates the Artifact Registry repository, runtime
-  service account, image, and Cloud Run Job.
-- `execute.sh` starts one Job execution from a prompt file.
-- `test-run-agent.sh` verifies checkout, invocation, patch capture, cost capture,
-  failure propagation, and mode validation without using an API key.
+- `run-agent.sh` reads frozen input, checks out the exact commit, runs Pi, and
+  uploads one immutable result archive.
+- `deploy.sh` creates or updates the manually managed Google Cloud resources.
+- `validate.sh` checks the deployed profile and prints actionable failures.
+- `execute.sh` resolves a commit, starts one execution, verifies its archive,
+  and requests execution cleanup.
+- `inspect.sh` resumes polling and artifact recovery from a durable launch
+  record.
+- `resolve-git-ref.sh` freezes branches, lightweight tags, and annotated tags.
+- `cleanup.sh` lists or deletes old completed execution records.
+- `test-run-agent.sh` tests checkout, invocation, redaction, failure artifacts,
+  and input identity without a real model call.
 
 ## Local checks
-
-Run the shell and behavior checks:
 
 ```sh
 bash -n experiments/cloud-run-agent/*.sh
 experiments/cloud-run-agent/test-run-agent.sh
+experiments/cloud-run-agent/test-control.sh
+experiments/cloud-run-agent/test-validate.sh
 ```
 
-With a Docker daemon running, build and run the real image:
+With a Docker daemon running:
 
 ```sh
 docker build --platform linux/amd64 \
   --tag factory-agent-experiment \
   experiments/cloud-run-agent
-
-PROMPT_B64="$(base64 < experiments/cloud-run-agent/smoke-prompt.txt | tr -d '\n')"
-
-docker run --rm \
-  --env OPENROUTER_API_KEY \
-  --env REPOSITORY_URL=https://github.com/owainlewis/factory.git \
-  --env GIT_REF=main \
-  --env PROMPT_B64="$PROMPT_B64" \
-  --env AGENT_MODE=read-only \
-  factory-agent-experiment
 ```
 
-## Google Cloud setup
+## Deploy to the Factory Google Cloud project
 
-The deploy script enables the required APIs, grants the default Cloud Build
-service account the standard Cloud Build builder role, and creates the
-non-secret resources. Create the OpenRouter secret once without placing the
-value in shell history:
+The project name is `Factory` and its project ID is `factory-505220`. Commands
+use the project ID explicitly and do not depend on the global `gcloud` project.
+
+Create the secret without placing the value in shell history:
 
 ```sh
 export PROJECT_ID=factory-505220
@@ -67,7 +78,7 @@ printf '%s' "$OPENROUTER_API_KEY" | \
     --project "$PROJECT_ID"
 ```
 
-If the secret already exists, add a new version instead:
+If it already exists, add a version instead:
 
 ```sh
 printf '%s' "$OPENROUTER_API_KEY" | \
@@ -76,7 +87,7 @@ printf '%s' "$OPENROUTER_API_KEY" | \
     --project "$PROJECT_ID"
 ```
 
-Build the image and create or update the Job:
+Build the image and deploy the reusable Job:
 
 ```sh
 PROJECT_ID=factory-505220 \
@@ -84,11 +95,21 @@ REGION=europe-west1 \
   experiments/cloud-run-agent/deploy.sh
 ```
 
-By default, deploys require a clean experiment directory and tag the image with
-the containing Git commit. For an intentional development build, set a unique
-`IMAGE_TAG`. The Job itself is updated with the resolved image digest.
+By default, a clean experiment directory is required and the image is tagged
+with the Git commit. Set a unique `IMAGE_TAG` only for an intentional
+development deployment. The Job always uses the resolved image digest.
 
-Execute the read-only smoke test:
+Validate the profile:
+
+```sh
+PROJECT_ID=factory-505220 \
+REGION=europe-west1 \
+  experiments/cloud-run-agent/validate.sh
+```
+
+## Run an agent
+
+The safe smoke prompt uses read-only Pi tools:
 
 ```sh
 PROJECT_ID=factory-505220 \
@@ -97,36 +118,96 @@ REGION=europe-west1 \
   experiments/cloud-run-agent/smoke-prompt.txt
 ```
 
-`execute.sh` calls the Cloud Run v2 API directly and uses `gcloud` only for the
-current access token. This avoids client-version-specific execution overrides.
-It waits for the execution and prints its final state and Cloud Logging URL.
+To produce a patch:
 
-The first live read-only run against Factory completed in 1 minute 40 seconds
-with zero retries. OpenRouter reported a model cost of `$0.013663` for that run.
+```sh
+PROJECT_ID=factory-505220 \
+REGION=europe-west1 \
+AGENT_MODE=write \
+  experiments/cloud-run-agent/execute.sh \
+  experiments/cloud-run-agent/write-smoke-prompt.txt
+```
 
-Use `AGENT_MODE=write` to enable Pi's Bash and file mutation tools. The runner
-prints a binary Git patch after Pi exits. The patch is diagnostic output only;
-the experiment does not upload it or push a branch.
+The run stores verified files under
+`./factory-agent-results/<attempt-id>/`. The same archive remains in GCS until
+the bucket's lifecycle rule deletes it.
 
-## Inputs
+`execute.sh` writes `launch.json` immediately after Cloud Run accepts the run.
+If the terminal closes or polling fails, use the printed resume command. You
+can also resume directly:
 
-| Name | Default | Meaning |
-| --- | --- | --- |
-| `REPOSITORY_URL` | none | Git remote fetched by the Job. |
-| `GIT_REF` | none | Branch, tag, or reachable commit to fetch. |
-| `PROMPT_B64` | none | Base64-encoded task prompt. |
-| `AGENT_MODE` | `read-only` | `read-only` or `write`. |
-| `MODEL` | `deepseek/deepseek-v4-flash` | OpenRouter model ID. |
-| `THINKING` | `low` | Pi thinking level. |
-| `OPENROUTER_API_KEY` | none | Secret used by Pi's OpenRouter provider. |
-| `WORKSPACE_ROOT` | `/workspace` | Checkout and result root. |
+```sh
+PROJECT_ID=factory-505220 \
+  experiments/cloud-run-agent/inspect.sh <attempt-id>
+```
+
+Set `DELETE_EXECUTION_ON_TERMINAL=false` to retain one execution for console
+inspection. The default requests deletion after terminal state and artifact
+verification.
+
+## Input contract
+
+The only per-execution environment overrides are `ATTEMPT_ID`, `INPUT_URI`, and
+`OUTPUT_URI`. The private input object contains:
+
+```json
+{
+  "version": 1,
+  "attempt_id": "attempt-...",
+  "repository_url": "https://github.com/owainlewis/factory.git",
+  "git_commit": "full 40 character commit",
+  "prompt": "the agent task",
+  "agent_mode": "read-only",
+  "model": "deepseek/deepseek-v4-flash",
+  "thinking": "low"
+}
+```
+
+The first proof supports public GitHub HTTPS repositories only. `execute.sh`
+resolves a branch or tag before uploading the input. Set `GIT_COMMIT` to supply
+an already resolved full commit.
+
+## Result contract
+
+`attempt-result.tar.gz` contains exactly:
+
+```text
+manifest.json
+result.json
+changes.patch
+status.txt
+events.jsonl
+```
+
+The manifest binds the archive to the Attempt and frozen commit and includes a
+SHA-256 digest for every result file. `execute.sh` checks the paths, identity,
+and every digest before accepting the result. Raw Pi reasoning and the prompt
+are not included in the result archive or mirrored to container logs.
+
+## Clean old execution records
+
+List completed execution records without deleting them:
+
+```sh
+PROJECT_ID=factory-505220 \
+  experiments/cloud-run-agent/cleanup.sh
+```
+
+Delete every completed execution record for the reusable Job:
+
+```sh
+PROJECT_ID=factory-505220 APPLY=true \
+  experiments/cloud-run-agent/cleanup.sh
+```
+
+This does not delete the reusable Job or the GCS artifacts.
 
 ## Deliberate limits
 
-- One repository and one agent process per Job execution.
-- Public HTTPS repositories are the supported deployment path.
-- No Factory task, lease, event, or cancellation integration.
-- No automatic retries.
-- No branch push, pull request, or durable patch storage.
-- No Codex or Claude Code installation.
-- No private-repository authentication or secret-prompt transport.
+- Manual executions only.
+- One public repository and one Pi process per execution.
+- No Factory Work, Attempt, lease, or cancellation integration yet.
+- No private repository authentication.
+- No branch push or pull request publishing.
+- No untrusted repository isolation.
+- No automatic infrastructure provisioning from the Factory UI.

--- a/experiments/cloud-run-agent/README.md
+++ b/experiments/cloud-run-agent/README.md
@@ -1,0 +1,132 @@
+# Cloud Run agent experiment
+
+This experiment proves that one Cloud Run Job can check out a Git repository,
+run Pi with DeepSeek V4 Flash through OpenRouter from that checkout, report JSON
+events and cost, and exit. It is intentionally separate from Factory's durable
+Worker protocol.
+
+The experiment trusts the selected repository and prompt. Pi can execute code
+with the same environment and credentials as the container. Use `read-only`
+mode unless a write-capable run is required.
+
+Cloud Logging receives sanitized assistant events and the final summary. Pi's
+raw JSON stream, including reasoning events, exists only on the Job's ephemeral
+filesystem and disappears with the container. The base64 prompt is not secret:
+it is visible in Cloud Run execution metadata to users who can inspect the Job.
+
+## Files
+
+- `Dockerfile` builds a pinned Node and Pi image.
+- `run-agent.sh` checks out the requested Git ref and runs Pi.
+- `deploy.sh` creates or updates the Artifact Registry repository, runtime
+  service account, image, and Cloud Run Job.
+- `execute.sh` starts one Job execution from a prompt file.
+- `test-run-agent.sh` verifies checkout, invocation, patch capture, cost capture,
+  failure propagation, and mode validation without using an API key.
+
+## Local checks
+
+Run the shell and behavior checks:
+
+```sh
+bash -n experiments/cloud-run-agent/*.sh
+experiments/cloud-run-agent/test-run-agent.sh
+```
+
+With a Docker daemon running, build and run the real image:
+
+```sh
+docker build --platform linux/amd64 \
+  --tag factory-agent-experiment \
+  experiments/cloud-run-agent
+
+PROMPT_B64="$(base64 < experiments/cloud-run-agent/smoke-prompt.txt | tr -d '\n')"
+
+docker run --rm \
+  --env OPENROUTER_API_KEY \
+  --env REPOSITORY_URL=https://github.com/owainlewis/factory.git \
+  --env GIT_REF=main \
+  --env PROMPT_B64="$PROMPT_B64" \
+  --env AGENT_MODE=read-only \
+  factory-agent-experiment
+```
+
+## Google Cloud setup
+
+The deploy script enables the required APIs, grants the default Cloud Build
+service account the standard Cloud Build builder role, and creates the
+non-secret resources. Create the OpenRouter secret once without placing the
+value in shell history:
+
+```sh
+export PROJECT_ID=factory-505220
+printf '%s' "$OPENROUTER_API_KEY" | \
+  gcloud secrets create openrouter-api-key \
+    --data-file=- \
+    --replication-policy=automatic \
+    --project "$PROJECT_ID"
+```
+
+If the secret already exists, add a new version instead:
+
+```sh
+printf '%s' "$OPENROUTER_API_KEY" | \
+  gcloud secrets versions add openrouter-api-key \
+    --data-file=- \
+    --project "$PROJECT_ID"
+```
+
+Build the image and create or update the Job:
+
+```sh
+PROJECT_ID=factory-505220 \
+REGION=europe-west1 \
+  experiments/cloud-run-agent/deploy.sh
+```
+
+By default, deploys require a clean experiment directory and tag the image with
+the containing Git commit. For an intentional development build, set a unique
+`IMAGE_TAG`. The Job itself is updated with the resolved image digest.
+
+Execute the read-only smoke test:
+
+```sh
+PROJECT_ID=factory-505220 \
+REGION=europe-west1 \
+  experiments/cloud-run-agent/execute.sh \
+  experiments/cloud-run-agent/smoke-prompt.txt
+```
+
+`execute.sh` calls the Cloud Run v2 API directly and uses `gcloud` only for the
+current access token. This avoids client-version-specific execution overrides.
+It waits for the execution and prints its final state and Cloud Logging URL.
+
+The first live read-only run against Factory completed in 1 minute 40 seconds
+with zero retries. OpenRouter reported a model cost of `$0.013663` for that run.
+
+Use `AGENT_MODE=write` to enable Pi's Bash and file mutation tools. The runner
+prints a binary Git patch after Pi exits. The patch is diagnostic output only;
+the experiment does not upload it or push a branch.
+
+## Inputs
+
+| Name | Default | Meaning |
+| --- | --- | --- |
+| `REPOSITORY_URL` | none | Git remote fetched by the Job. |
+| `GIT_REF` | none | Branch, tag, or reachable commit to fetch. |
+| `PROMPT_B64` | none | Base64-encoded task prompt. |
+| `AGENT_MODE` | `read-only` | `read-only` or `write`. |
+| `MODEL` | `deepseek/deepseek-v4-flash` | OpenRouter model ID. |
+| `THINKING` | `low` | Pi thinking level. |
+| `OPENROUTER_API_KEY` | none | Secret used by Pi's OpenRouter provider. |
+| `WORKSPACE_ROOT` | `/workspace` | Checkout and result root. |
+
+## Deliberate limits
+
+- One repository and one agent process per Job execution.
+- Public HTTPS repositories are the supported deployment path.
+- No Factory task, lease, event, or cancellation integration.
+- No automatic retries.
+- No branch push, pull request, or durable patch storage.
+- No Codex or Claude Code installation.
+- No private-repository authentication or secret-prompt transport.

--- a/experiments/cloud-run-agent/README.md
+++ b/experiments/cloud-run-agent/README.md
@@ -152,8 +152,9 @@ The only per-execution environment overrides are `ATTEMPT_ID`, `INPUT_URI`, and
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "attempt_id": "attempt-...",
+  "dispatch_nonce": "32 lowercase hexadecimal characters",
   "repository_url": "https://github.com/owainlewis/factory.git",
   "git_commit": "full 40 character commit",
   "prompt": "the agent task",

--- a/experiments/cloud-run-agent/bucket-lifecycle.json
+++ b/experiments/cloud-run-agent/bucket-lifecycle.json
@@ -1,0 +1,12 @@
+{
+  "rule": [
+    {
+      "action": {
+        "type": "Delete"
+      },
+      "condition": {
+        "age": 7
+      }
+    }
+  ]
+}

--- a/experiments/cloud-run-agent/cleanup.sh
+++ b/experiments/cloud-run-agent/cleanup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly project_id="${PROJECT_ID:?PROJECT_ID is required}"
+readonly region="${REGION:-europe-west1}"
+readonly job_name="${JOB_NAME:-factory-agent-experiment}"
+readonly apply="${APPLY:-false}"
+
+case "$apply" in
+    true | false) ;;
+    *)
+        printf 'APPLY must be true or false\n' >&2
+        exit 2
+        ;;
+esac
+
+access_token="$(gcloud auth print-access-token)"
+parent="projects/${project_id}/locations/${region}/jobs/${job_name}"
+page_token=""
+execution_names=()
+
+while :; do
+    url="https://run.googleapis.com/v2/${parent}/executions?pageSize=100"
+    if [[ -n "$page_token" ]]; then
+        encoded_token="$(jq -rn --arg value "$page_token" '$value | @uri')"
+        url="${url}&pageToken=${encoded_token}"
+    fi
+    response="$(
+        curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer ${access_token}" \
+            "$url"
+    )"
+    while IFS= read -r execution_name; do
+        [[ -n "$execution_name" ]] && execution_names+=("$execution_name")
+    done < <(jq -r '.executions[]? | select(.completionTime != null) | .name' <<< "$response")
+    page_token="$(jq -r '.nextPageToken // ""' <<< "$response")"
+    [[ -n "$page_token" ]] || break
+done
+
+if (( ${#execution_names[@]} == 0 )); then
+    printf 'No completed executions to clean up.\n'
+    exit 0
+fi
+
+printf 'Completed executions:\n'
+printf '  %s\n' "${execution_names[@]##*/}"
+if [[ "$apply" != true ]]; then
+    printf '\nDry run. Set APPLY=true to delete these execution records.\n'
+    exit 0
+fi
+
+for execution_name in "${execution_names[@]}"; do
+    curl --fail-with-body --silent --show-error \
+        --request DELETE \
+        --header "Authorization: Bearer ${access_token}" \
+        "https://run.googleapis.com/v2/${execution_name}" >/dev/null
+    printf 'Cleanup requested: %s\n' "${execution_name##*/}"
+done

--- a/experiments/cloud-run-agent/deploy.sh
+++ b/experiments/cloud-run-agent/deploy.sh
@@ -8,6 +8,7 @@ readonly repository="${ARTIFACT_REPOSITORY:-experiments}"
 readonly job_name="${JOB_NAME:-factory-agent-experiment}"
 readonly service_account_name="${SERVICE_ACCOUNT_NAME:-factory-agent-experiment}"
 readonly secret_name="${OPENROUTER_SECRET_NAME:-openrouter-api-key}"
+readonly artifact_bucket="${ARTIFACT_BUCKET:-${project_id}-factory-agent-artifacts}"
 readonly service_account="${service_account_name}@${project_id}.iam.gserviceaccount.com"
 readonly source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -34,6 +35,7 @@ gcloud services enable \
     cloudbuild.googleapis.com \
     run.googleapis.com \
     secretmanager.googleapis.com \
+    storage.googleapis.com \
     --project "$project_id" \
     --quiet
 
@@ -60,6 +62,29 @@ if ! gcloud iam service-accounts describe "$service_account" \
         --quiet
 fi
 
+if ! gcloud storage buckets describe "gs://${artifact_bucket}" \
+    --project "$project_id" >/dev/null 2>&1; then
+    gcloud storage buckets create "gs://${artifact_bucket}" \
+        --location "$region" \
+        --uniform-bucket-level-access \
+        --public-access-prevention \
+        --project "$project_id" \
+        --quiet
+fi
+
+gcloud storage buckets update "gs://${artifact_bucket}" \
+    --lifecycle-file "${source_dir}/bucket-lifecycle.json" \
+    --uniform-bucket-level-access \
+    --public-access-prevention \
+    --project "$project_id" \
+    --quiet >/dev/null
+
+gcloud storage buckets add-iam-policy-binding "gs://${artifact_bucket}" \
+    --member "serviceAccount:${service_account}" \
+    --role roles/storage.objectUser \
+    --project "$project_id" \
+    --quiet >/dev/null
+
 readonly build_service_account="$(
     gcloud builds get-default-service-account \
         --project "$project_id"
@@ -74,6 +99,20 @@ if ! gcloud secrets describe "$secret_name" \
     --project "$project_id" >/dev/null 2>&1; then
     printf 'Secret %s does not exist in project %s.\n' "$secret_name" "$project_id" >&2
     printf 'Create it before deploying; see README.md.\n' >&2
+    exit 1
+fi
+
+secret_version="$(
+    gcloud secrets versions list "$secret_name" \
+        --filter 'state=ENABLED' \
+        --sort-by='~createTime' \
+        --limit 1 \
+        --format 'value(name)' \
+        --project "$project_id"
+)"
+readonly secret_version
+if [[ ! "$secret_version" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'Secret %s has no enabled numeric version.\n' "$secret_name" >&2
     exit 1
 fi
 
@@ -109,7 +148,7 @@ job_flags=(
     --memory 2Gi
     --task-timeout 10m
     --max-retries 0
-    --set-secrets "OPENROUTER_API_KEY=${secret_name}:latest"
+    --set-secrets "OPENROUTER_API_KEY=${secret_name}:${secret_version}"
     --quiet
 )
 
@@ -164,3 +203,15 @@ gcloud run jobs update "$job_name" "${job_flags[@]}"
 printf 'IMAGE=%s\n' "$image"
 printf 'IMAGE_TAG=%s\n' "$tagged_image"
 printf 'JOB=%s\n' "$job_name"
+printf 'ARTIFACT_BUCKET=%s\n' "$artifact_bucket"
+printf 'OPENROUTER_SECRET_VERSION=%s\n' "$secret_version"
+printf '\nFactory profile:\n'
+printf '[[cloud_profiles]]\n'
+printf 'id = "%s"\n' "$job_name"
+printf 'kind = "cloud_run"\n'
+printf 'project = "%s"\n' "$project_id"
+printf 'region = "%s"\n' "$region"
+printf 'job = "%s"\n' "$job_name"
+printf 'artifact_bucket = "%s"\n' "$artifact_bucket"
+printf 'image = "%s"\n' "$image"
+printf 'job_service_account = "%s"\n' "$service_account"

--- a/experiments/cloud-run-agent/deploy.sh
+++ b/experiments/cloud-run-agent/deploy.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly project_id="${PROJECT_ID:?PROJECT_ID is required}"
+readonly region="${REGION:-europe-west1}"
+readonly repository="${ARTIFACT_REPOSITORY:-experiments}"
+readonly job_name="${JOB_NAME:-factory-agent-experiment}"
+readonly service_account_name="${SERVICE_ACCOUNT_NAME:-factory-agent-experiment}"
+readonly secret_name="${OPENROUTER_SECRET_NAME:-openrouter-api-key}"
+readonly service_account="${service_account_name}@${project_id}.iam.gserviceaccount.com"
+readonly source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+image_tag=""
+if [[ -n "${IMAGE_TAG:-}" ]]; then
+    image_tag="$IMAGE_TAG"
+else
+    source_status="$(
+        git -C "$source_dir" status --short --untracked-files=all -- .
+    )"
+    readonly source_status
+    if [[ -n "$source_status" ]]; then
+        printf 'Build context has uncommitted changes. Commit them or set a unique IMAGE_TAG.\n' >&2
+        exit 2
+    fi
+    image_tag="$(git -C "$source_dir" rev-parse --short=12 HEAD)"
+fi
+readonly image_tag
+
+readonly tagged_image="${region}-docker.pkg.dev/${project_id}/${repository}/factory-agent:${image_tag}"
+
+gcloud services enable \
+    artifactregistry.googleapis.com \
+    cloudbuild.googleapis.com \
+    run.googleapis.com \
+    secretmanager.googleapis.com \
+    --project "$project_id" \
+    --quiet
+
+gcloud beta services identity create \
+    --service run.googleapis.com \
+    --project "$project_id" \
+    --quiet >/dev/null
+
+if ! gcloud artifacts repositories describe "$repository" \
+    --location "$region" --project "$project_id" >/dev/null 2>&1; then
+    gcloud artifacts repositories create "$repository" \
+        --repository-format docker \
+        --location "$region" \
+        --description "Factory agent experiments" \
+        --project "$project_id" \
+        --quiet
+fi
+
+if ! gcloud iam service-accounts describe "$service_account" \
+    --project "$project_id" >/dev/null 2>&1; then
+    gcloud iam service-accounts create "$service_account_name" \
+        --display-name "Factory agent experiment" \
+        --project "$project_id" \
+        --quiet
+fi
+
+readonly build_service_account="$(
+    gcloud builds get-default-service-account \
+        --project "$project_id"
+)"
+gcloud projects add-iam-policy-binding "$project_id" \
+    --member "serviceAccount:${build_service_account}" \
+    --role roles/cloudbuild.builds.builder \
+    --condition None \
+    --quiet >/dev/null
+
+if ! gcloud secrets describe "$secret_name" \
+    --project "$project_id" >/dev/null 2>&1; then
+    printf 'Secret %s does not exist in project %s.\n' "$secret_name" "$project_id" >&2
+    printf 'Create it before deploying; see README.md.\n' >&2
+    exit 1
+fi
+
+gcloud secrets add-iam-policy-binding "$secret_name" \
+    --member "serviceAccount:${service_account}" \
+    --role roles/secretmanager.secretAccessor \
+    --project "$project_id" \
+    --quiet >/dev/null
+
+gcloud builds submit "$source_dir" \
+    --tag "$tagged_image" \
+    --project "$project_id" \
+    --quiet
+
+image="$(
+    gcloud artifacts docker images describe "$tagged_image" \
+        --project "$project_id" \
+        --format 'value(image_summary.fully_qualified_digest)'
+)"
+readonly image
+if [[ -z "$image" ]]; then
+    printf 'Could not resolve image digest for %s\n' "$tagged_image" >&2
+    exit 1
+fi
+
+job_flags=(
+    --image "$image"
+    --region "$region"
+    --project "$project_id"
+    --service-account "$service_account"
+    --tasks 1
+    --cpu 1
+    --memory 2Gi
+    --task-timeout 10m
+    --max-retries 0
+    --set-secrets "OPENROUTER_API_KEY=${secret_name}:latest"
+    --quiet
+)
+
+job_exists() {
+    gcloud run jobs describe "$job_name" \
+        --region "$region" --project "$project_id" >/dev/null 2>&1
+}
+
+wait_for_job_ready() {
+    local attempt_index
+    local ready_state
+    local ready_message
+    for attempt_index in $(seq 1 60); do
+        ready_state="$(
+            gcloud run jobs describe "$job_name" \
+                --region "$region" \
+                --project "$project_id" \
+                --format 'value(status.conditions[0].status)' \
+                2>/dev/null || true
+        )"
+        ready_message="$(
+            gcloud run jobs describe "$job_name" \
+                --region "$region" \
+                --project "$project_id" \
+                --format 'value(status.conditions[0].message)' \
+                2>/dev/null || true
+        )"
+        case "$ready_state" in
+            True)
+                return 0
+                ;;
+            False)
+                printf 'Cloud Run Job became unready: %s\n' "$ready_message" >&2
+                return 1
+                ;;
+        esac
+        sleep 5
+    done
+    printf 'Cloud Run Job was not ready after five minutes\n' >&2
+    return 1
+}
+
+if ! job_exists; then
+    if ! gcloud run jobs create "$job_name" "${job_flags[@]}"; then
+        job_exists || exit 1
+    fi
+    wait_for_job_ready
+fi
+
+gcloud run jobs update "$job_name" "${job_flags[@]}"
+
+printf 'IMAGE=%s\n' "$image"
+printf 'IMAGE_TAG=%s\n' "$tagged_image"
+printf 'JOB=%s\n' "$job_name"

--- a/experiments/cloud-run-agent/execute.sh
+++ b/experiments/cloud-run-agent/execute.sh
@@ -65,6 +65,9 @@ fi
 readonly input_uri="gs://${artifact_bucket}/attempts/${attempt_id}/input.json"
 readonly output_uri="gs://${artifact_bucket}/attempts/${attempt_id}/attempt-result.tar.gz"
 readonly input_path="${temp_root}/input.json"
+readonly attempt_output="${output_root}/${attempt_id}"
+readonly launch_path="${attempt_output}/launch.json"
+mkdir -p "$attempt_output"
 
 jq -nc \
     --arg attempt_id "$attempt_id" \
@@ -81,6 +84,17 @@ gcloud storage cp "$input_path" "$input_uri" \
     --if-generation-match 0 \
     --project "$project_id" --quiet
 
+jq -n \
+    --arg project "$project_id" \
+    --arg region "$region" \
+    --arg job "$job_name" \
+    --arg attempt "$attempt_id" \
+    --arg commit "$git_commit" \
+    --arg input_uri "$input_uri" \
+    --arg output_uri "$output_uri" \
+    '{version: 1, project: $project, region: $region, job: $job, attempt: $attempt, execution_name: null, execution: null, commit: $commit, input_uri: $input_uri, output_uri: $output_uri, dispatch_state: "dispatching"}' \
+    > "$launch_path"
+
 readonly request_body="$(
     jq -nc \
         --arg attempt_id "$attempt_id" \
@@ -90,37 +104,35 @@ readonly request_body="$(
 )"
 readonly access_token="$(gcloud auth print-access-token)"
 readonly run_url="https://run.googleapis.com/v2/projects/${project_id}/locations/${region}/jobs/${job_name}:run"
-readonly run_response="$(
+run_response=''
+run_response_received=false
+if run_response="$(
     curl --fail-with-body --silent --show-error \
         --request POST \
         --header "Authorization: Bearer ${access_token}" \
         --header 'Content-Type: application/json' \
         --data "$request_body" \
         "$run_url"
-)"
-readonly execution_name="$(jq -er '.metadata.name' <<< "$run_response")"
-readonly execution_id="${execution_name##*/}"
-readonly attempt_output="${output_root}/${attempt_id}"
-mkdir -p "$attempt_output"
-
-jq -n \
-    --arg project "$project_id" \
-    --arg region "$region" \
-    --arg job "$job_name" \
-    --arg attempt "$attempt_id" \
-    --arg execution_name "$execution_name" \
-    --arg execution "$execution_id" \
-    --arg commit "$git_commit" \
-    --arg input_uri "$input_uri" \
-    --arg output_uri "$output_uri" \
-    '{version: 1, project: $project, region: $region, job: $job, attempt: $attempt, execution_name: $execution_name, execution: $execution, commit: $commit, input_uri: $input_uri, output_uri: $output_uri}' \
-    > "${attempt_output}/launch.json"
+)"; then
+    run_response_received=true
+    execution_name="$(jq -er '.metadata.name' <<< "$run_response")"
+    execution_id="${execution_name##*/}"
+    launch_update="$(mktemp "${attempt_output}/launch.XXXXXX")"
+    jq --arg execution_name "$execution_name" --arg execution "$execution_id" \
+        '.execution_name = $execution_name | .execution = $execution | .dispatch_state = "accepted"' \
+        "$launch_path" > "$launch_update"
+    mv "$launch_update" "$launch_path"
+fi
 
 printf 'Attempt: %s\n' "$attempt_id"
 printf 'Commit: %s\n' "$git_commit"
-printf 'Execution started: %s\n' "$execution_id"
+if [[ "$run_response_received" == true ]]; then
+    printf 'Execution started: %s\n' "$execution_id"
+else
+    printf 'RunJob response was lost; reconciling by Attempt ID.\n' >&2
+fi
 printf 'Input: %s\n' "$input_uri"
-printf 'Launch record: %s\n' "${attempt_output}/launch.json"
+printf 'Launch record: %s\n' "$launch_path"
 printf 'Resume: PROJECT_ID=%s OUTPUT_ROOT=%q %q %q\n' \
     "$project_id" "$output_root" "${script_dir}/inspect.sh" "$attempt_id"
 

--- a/experiments/cloud-run-agent/execute.sh
+++ b/experiments/cloud-run-agent/execute.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly project_id="${PROJECT_ID:?PROJECT_ID is required}"
+readonly prompt_path="${1:?usage: execute.sh PROMPT_FILE}"
+readonly region="${REGION:-europe-west1}"
+readonly job_name="${JOB_NAME:-factory-agent-experiment}"
+readonly repository_url="${REPOSITORY_URL:-https://github.com/owainlewis/factory.git}"
+readonly git_ref="${GIT_REF:-main}"
+readonly agent_mode="${AGENT_MODE:-read-only}"
+readonly wait_seconds="${WAIT_SECONDS:-600}"
+
+if [[ ! -f "$prompt_path" ]]; then
+    printf 'prompt file does not exist: %s\n' "$prompt_path" >&2
+    exit 2
+fi
+
+readonly prompt_base64="$(base64 < "$prompt_path" | tr -d '\n')"
+if [[ -z "$prompt_base64" ]]; then
+    printf 'prompt file must not be empty\n' >&2
+    exit 2
+fi
+
+case "$agent_mode" in
+    read-only | write) ;;
+    *)
+        printf 'AGENT_MODE must be read-only or write\n' >&2
+        exit 2
+        ;;
+esac
+
+if [[ ! "$wait_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'WAIT_SECONDS must be a positive integer\n' >&2
+    exit 2
+fi
+
+readonly request_body="$(
+    jq -nc \
+        --arg repository_url "$repository_url" \
+        --arg git_ref "$git_ref" \
+        --arg prompt_base64 "$prompt_base64" \
+        --arg agent_mode "$agent_mode" \
+        '{
+            overrides: {
+                containerOverrides: [{
+                    env: [
+                        {name: "REPOSITORY_URL", value: $repository_url},
+                        {name: "GIT_REF", value: $git_ref},
+                        {name: "PROMPT_B64", value: $prompt_base64},
+                        {name: "AGENT_MODE", value: $agent_mode}
+                    ]
+                }],
+                taskCount: 1,
+                timeout: "600s"
+            }
+        }'
+)"
+readonly access_token="$(gcloud auth print-access-token)"
+readonly run_url="https://run.googleapis.com/v2/projects/${project_id}/locations/${region}/jobs/${job_name}:run"
+readonly run_response="$(
+    curl --fail-with-body --silent --show-error \
+        --request POST \
+        --header "Authorization: Bearer ${access_token}" \
+        --header 'Content-Type: application/json' \
+        --data "$request_body" \
+        "$run_url"
+)"
+readonly execution_name="$(jq -er '.metadata.name' <<< "$run_response")"
+readonly execution_id="${execution_name##*/}"
+readonly execution_url="https://run.googleapis.com/v2/${execution_name}"
+
+printf 'Execution started: %s\n' "$execution_id"
+
+readonly poll_count="$((wait_seconds / 5 + 1))"
+for _poll_index in $(seq 1 "$poll_count"); do
+    execution_response="$(
+        curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer ${access_token}" \
+            "$execution_url"
+    )"
+    completion_state="$(
+        jq -r '
+            first(.conditions[]? | select(.type == "Completed") | .state)
+            // "CONDITION_PENDING"
+        ' <<< "$execution_response"
+    )"
+    case "$completion_state" in
+        CONDITION_SUCCEEDED)
+            jq -nc \
+                --arg execution "$execution_id" \
+                --arg log_uri "$(jq -r '.logUri // ""' <<< "$execution_response")" \
+                '{execution: $execution, state: "succeeded", log_uri: $log_uri}'
+            exit 0
+            ;;
+        CONDITION_FAILED)
+            jq -c '{execution: .name, conditions: .conditions}' <<< "$execution_response" >&2
+            exit 1
+            ;;
+    esac
+    sleep 5
+done
+
+printf 'Execution did not finish within %s seconds: %s\n' "$wait_seconds" "$execution_id" >&2
+exit 1

--- a/experiments/cloud-run-agent/execute.sh
+++ b/experiments/cloud-run-agent/execute.sh
@@ -62,38 +62,61 @@ if [[ ! "$attempt_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
     printf 'ATTEMPT_ID contains unsupported characters\n' >&2
     exit 2
 fi
+readonly dispatch_nonce="${DISPATCH_NONCE:-$(openssl rand -hex 16)}"
+if [[ ! "$dispatch_nonce" =~ ^[0-9a-f]{32}$ ]]; then
+    printf 'DISPATCH_NONCE must be 32 lowercase hexadecimal characters\n' >&2
+    exit 2
+fi
 readonly input_uri="gs://${artifact_bucket}/attempts/${attempt_id}/input.json"
 readonly output_uri="gs://${artifact_bucket}/attempts/${attempt_id}/attempt-result.tar.gz"
 readonly input_path="${temp_root}/input.json"
+readonly existing_input_path="${temp_root}/existing-input.json"
 readonly attempt_output="${output_root}/${attempt_id}"
 readonly launch_path="${attempt_output}/launch.json"
-mkdir -p "$attempt_output"
+mkdir -p "$output_root"
+if ! mkdir "$attempt_output" 2>/dev/null; then
+    printf 'Attempt already exists locally: %s\n' "$attempt_id" >&2
+    printf 'Resume it with: PROJECT_ID=%s OUTPUT_ROOT=%q %q %q\n' \
+        "$project_id" "$output_root" "${script_dir}/inspect.sh" "$attempt_id" >&2
+    printf 'Use a new ATTEMPT_ID for a genuine retry.\n' >&2
+    exit 2
+fi
 
 jq -nc \
     --arg attempt_id "$attempt_id" \
+    --arg dispatch_nonce "$dispatch_nonce" \
     --arg repository_url "$repository_url" \
     --arg git_commit "$git_commit" \
     --rawfile prompt "$prompt_path" \
     --arg agent_mode "$agent_mode" \
     --arg model "$model" \
     --arg thinking "$thinking" \
-    '{version: 1, attempt_id: $attempt_id, repository_url: $repository_url, git_commit: $git_commit, prompt: $prompt, agent_mode: $agent_mode, model: $model, thinking: $thinking}' \
+    '{version: 2, attempt_id: $attempt_id, dispatch_nonce: $dispatch_nonce, repository_url: $repository_url, git_commit: $git_commit, prompt: $prompt, agent_mode: $agent_mode, model: $model, thinking: $thinking}' \
     > "$input_path"
-
-gcloud storage cp "$input_path" "$input_uri" \
-    --if-generation-match 0 \
-    --project "$project_id" --quiet
 
 jq -n \
     --arg project "$project_id" \
     --arg region "$region" \
     --arg job "$job_name" \
     --arg attempt "$attempt_id" \
+    --arg dispatch_nonce "$dispatch_nonce" \
     --arg commit "$git_commit" \
     --arg input_uri "$input_uri" \
     --arg output_uri "$output_uri" \
-    '{version: 1, project: $project, region: $region, job: $job, attempt: $attempt, execution_name: null, execution: null, commit: $commit, input_uri: $input_uri, output_uri: $output_uri, dispatch_state: "dispatching"}' \
+    '{version: 2, project: $project, region: $region, job: $job, attempt: $attempt, dispatch_nonce: $dispatch_nonce, execution_name: null, execution: null, commit: $commit, input_uri: $input_uri, output_uri: $output_uri, dispatch_state: "dispatching"}' \
     > "$launch_path"
+
+if ! gcloud storage cp "$input_path" "$input_uri" \
+    --if-generation-match 0 \
+    --project "$project_id" --quiet; then
+    if ! gcloud storage cp "$input_uri" "$existing_input_path" \
+        --project "$project_id" --quiet \
+        || ! cmp -s "$input_path" "$existing_input_path"; then
+        printf 'input upload failed and no byte-identical object could be recovered: %s\n' "$input_uri" >&2
+        exit 1
+    fi
+    printf 'Recovered byte-identical input after an ambiguous upload response.\n' >&2
+fi
 
 readonly request_body="$(
     jq -nc \

--- a/experiments/cloud-run-agent/execute.sh
+++ b/experiments/cloud-run-agent/execute.sh
@@ -6,22 +6,31 @@ readonly project_id="${PROJECT_ID:?PROJECT_ID is required}"
 readonly prompt_path="${1:?usage: execute.sh PROMPT_FILE}"
 readonly region="${REGION:-europe-west1}"
 readonly job_name="${JOB_NAME:-factory-agent-experiment}"
+readonly artifact_bucket="${ARTIFACT_BUCKET:-${project_id}-factory-agent-artifacts}"
 readonly repository_url="${REPOSITORY_URL:-https://github.com/owainlewis/factory.git}"
 readonly git_ref="${GIT_REF:-main}"
 readonly agent_mode="${AGENT_MODE:-read-only}"
+readonly model="${MODEL:-deepseek/deepseek-v4-flash}"
+readonly thinking="${THINKING:-low}"
 readonly wait_seconds="${WAIT_SECONDS:-600}"
+readonly delete_on_terminal="${DELETE_EXECUTION_ON_TERMINAL:-true}"
+readonly output_root="${OUTPUT_ROOT:-./factory-agent-results}"
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly temp_root="$(mktemp -d)"
+trap 'rm -rf "$temp_root"' EXIT
 
 if [[ ! -f "$prompt_path" ]]; then
     printf 'prompt file does not exist: %s\n' "$prompt_path" >&2
     exit 2
 fi
-
-readonly prompt_base64="$(base64 < "$prompt_path" | tr -d '\n')"
-if [[ -z "$prompt_base64" ]]; then
-    printf 'prompt file must not be empty\n' >&2
+if [[ ! "$repository_url" =~ ^https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\.git$ ]]; then
+    printf 'REPOSITORY_URL must be a public GitHub HTTPS clone URL\n' >&2
     exit 2
 fi
-
+if [[ ! "$wait_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'WAIT_SECONDS must be a positive integer\n' >&2
+    exit 2
+fi
 case "$agent_mode" in
     read-only | write) ;;
     *)
@@ -29,32 +38,55 @@ case "$agent_mode" in
         exit 2
         ;;
 esac
+case "$delete_on_terminal" in
+    true | false) ;;
+    *)
+        printf 'DELETE_EXECUTION_ON_TERMINAL must be true or false\n' >&2
+        exit 2
+        ;;
+esac
 
-if [[ ! "$wait_seconds" =~ ^[1-9][0-9]*$ ]]; then
-    printf 'WAIT_SECONDS must be a positive integer\n' >&2
+if [[ -n "${GIT_COMMIT:-}" ]]; then
+    git_commit="$GIT_COMMIT"
+else
+    git_commit="$("${script_dir}/resolve-git-ref.sh" "$repository_url" "$git_ref")"
+fi
+readonly git_commit
+if [[ ! "$git_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'Could not resolve GIT_REF to a full commit: %s\n' "$git_ref" >&2
     exit 2
 fi
 
+readonly attempt_id="${ATTEMPT_ID:-attempt-$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 6)}"
+if [[ ! "$attempt_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+    printf 'ATTEMPT_ID contains unsupported characters\n' >&2
+    exit 2
+fi
+readonly input_uri="gs://${artifact_bucket}/attempts/${attempt_id}/input.json"
+readonly output_uri="gs://${artifact_bucket}/attempts/${attempt_id}/attempt-result.tar.gz"
+readonly input_path="${temp_root}/input.json"
+
+jq -nc \
+    --arg attempt_id "$attempt_id" \
+    --arg repository_url "$repository_url" \
+    --arg git_commit "$git_commit" \
+    --rawfile prompt "$prompt_path" \
+    --arg agent_mode "$agent_mode" \
+    --arg model "$model" \
+    --arg thinking "$thinking" \
+    '{version: 1, attempt_id: $attempt_id, repository_url: $repository_url, git_commit: $git_commit, prompt: $prompt, agent_mode: $agent_mode, model: $model, thinking: $thinking}' \
+    > "$input_path"
+
+gcloud storage cp "$input_path" "$input_uri" \
+    --if-generation-match 0 \
+    --project "$project_id" --quiet
+
 readonly request_body="$(
     jq -nc \
-        --arg repository_url "$repository_url" \
-        --arg git_ref "$git_ref" \
-        --arg prompt_base64 "$prompt_base64" \
-        --arg agent_mode "$agent_mode" \
-        '{
-            overrides: {
-                containerOverrides: [{
-                    env: [
-                        {name: "REPOSITORY_URL", value: $repository_url},
-                        {name: "GIT_REF", value: $git_ref},
-                        {name: "PROMPT_B64", value: $prompt_base64},
-                        {name: "AGENT_MODE", value: $agent_mode}
-                    ]
-                }],
-                taskCount: 1,
-                timeout: "600s"
-            }
-        }'
+        --arg attempt_id "$attempt_id" \
+        --arg input_uri "$input_uri" \
+        --arg output_uri "$output_uri" \
+        '{overrides: {containerOverrides: [{env: [{name: "ATTEMPT_ID", value: $attempt_id}, {name: "INPUT_URI", value: $input_uri}, {name: "OUTPUT_URI", value: $output_uri}]}], taskCount: 1, timeout: "600s"}}'
 )"
 readonly access_token="$(gcloud auth print-access-token)"
 readonly run_url="https://run.googleapis.com/v2/projects/${project_id}/locations/${region}/jobs/${job_name}:run"
@@ -68,38 +100,32 @@ readonly run_response="$(
 )"
 readonly execution_name="$(jq -er '.metadata.name' <<< "$run_response")"
 readonly execution_id="${execution_name##*/}"
-readonly execution_url="https://run.googleapis.com/v2/${execution_name}"
+readonly attempt_output="${output_root}/${attempt_id}"
+mkdir -p "$attempt_output"
 
+jq -n \
+    --arg project "$project_id" \
+    --arg region "$region" \
+    --arg job "$job_name" \
+    --arg attempt "$attempt_id" \
+    --arg execution_name "$execution_name" \
+    --arg execution "$execution_id" \
+    --arg commit "$git_commit" \
+    --arg input_uri "$input_uri" \
+    --arg output_uri "$output_uri" \
+    '{version: 1, project: $project, region: $region, job: $job, attempt: $attempt, execution_name: $execution_name, execution: $execution, commit: $commit, input_uri: $input_uri, output_uri: $output_uri}' \
+    > "${attempt_output}/launch.json"
+
+printf 'Attempt: %s\n' "$attempt_id"
+printf 'Commit: %s\n' "$git_commit"
 printf 'Execution started: %s\n' "$execution_id"
+printf 'Input: %s\n' "$input_uri"
+printf 'Launch record: %s\n' "${attempt_output}/launch.json"
+printf 'Resume: PROJECT_ID=%s OUTPUT_ROOT=%q %q %q\n' \
+    "$project_id" "$output_root" "${script_dir}/inspect.sh" "$attempt_id"
 
-readonly poll_count="$((wait_seconds / 5 + 1))"
-for _poll_index in $(seq 1 "$poll_count"); do
-    execution_response="$(
-        curl --fail-with-body --silent --show-error \
-            --header "Authorization: Bearer ${access_token}" \
-            "$execution_url"
-    )"
-    completion_state="$(
-        jq -r '
-            first(.conditions[]? | select(.type == "Completed") | .state)
-            // "CONDITION_PENDING"
-        ' <<< "$execution_response"
-    )"
-    case "$completion_state" in
-        CONDITION_SUCCEEDED)
-            jq -nc \
-                --arg execution "$execution_id" \
-                --arg log_uri "$(jq -r '.logUri // ""' <<< "$execution_response")" \
-                '{execution: $execution, state: "succeeded", log_uri: $log_uri}'
-            exit 0
-            ;;
-        CONDITION_FAILED)
-            jq -c '{execution: .name, conditions: .conditions}' <<< "$execution_response" >&2
-            exit 1
-            ;;
-    esac
-    sleep 5
-done
-
-printf 'Execution did not finish within %s seconds: %s\n' "$wait_seconds" "$execution_id" >&2
-exit 1
+PROJECT_ID="$project_id" \
+WAIT_SECONDS="$wait_seconds" \
+DELETE_EXECUTION_ON_TERMINAL="$delete_on_terminal" \
+OUTPUT_ROOT="$output_root" \
+    "${script_dir}/inspect.sh" "$attempt_id"

--- a/experiments/cloud-run-agent/inspect.sh
+++ b/experiments/cloud-run-agent/inspect.sh
@@ -30,6 +30,7 @@ readonly launch_project="$(jq -er '.project' "$launch_path")"
 readonly region="$(jq -er '.region' "$launch_path")"
 readonly job_name="$(jq -er '.job' "$launch_path")"
 readonly recorded_attempt="$(jq -er '.attempt' "$launch_path")"
+readonly dispatch_nonce="$(jq -r '.dispatch_nonce // ""' "$launch_path")"
 readonly git_commit="$(jq -er '.commit' "$launch_path")"
 readonly input_uri="$(jq -er '.input_uri' "$launch_path")"
 readonly output_uri="$(jq -er '.output_uri' "$launch_path")"
@@ -40,6 +41,10 @@ if [[ "$launch_project" != "$project_id" || "$recorded_attempt" != "$attempt_id"
 fi
 if [[ ! "$git_commit" =~ ^[0-9a-f]{40}$ ]]; then
     printf 'launch record contains an invalid commit identity\n' >&2
+    exit 2
+fi
+if [[ -n "$dispatch_nonce" && ! "$dispatch_nonce" =~ ^[0-9a-f]{32}$ ]]; then
+    printf 'launch record contains an invalid dispatch nonce\n' >&2
     exit 2
 fi
 
@@ -128,6 +133,11 @@ verify_archive() {
     if [[ "$(jq -er '.attempt_id' "${attempt_output}/manifest.json")" != "$attempt_id" ]] \
         || [[ "$(jq -er '.commit' "${attempt_output}/manifest.json")" != "$git_commit" ]]; then
         printf 'result archive identity does not match the frozen input\n' >&2
+        return 1
+    fi
+    if [[ -n "$dispatch_nonce" ]] \
+        && [[ "$(jq -er '.dispatch_nonce' "${attempt_output}/manifest.json")" != "$dispatch_nonce" ]]; then
+        printf 'result archive dispatch nonce does not match the immutable input\n' >&2
         return 1
     fi
 }

--- a/experiments/cloud-run-agent/inspect.sh
+++ b/experiments/cloud-run-agent/inspect.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly project_id="${PROJECT_ID:?PROJECT_ID is required}"
+readonly attempt_id="${1:?usage: inspect.sh ATTEMPT_ID}"
+readonly wait_seconds="${WAIT_SECONDS:-600}"
+readonly delete_on_terminal="${DELETE_EXECUTION_ON_TERMINAL:-true}"
+readonly output_root="${OUTPUT_ROOT:-./factory-agent-results}"
+readonly attempt_output="${output_root}/${attempt_id}"
+readonly launch_path="${attempt_output}/launch.json"
+
+if [[ ! "$wait_seconds" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'WAIT_SECONDS must be a positive integer\n' >&2
+    exit 2
+fi
+case "$delete_on_terminal" in
+    true | false) ;;
+    *)
+        printf 'DELETE_EXECUTION_ON_TERMINAL must be true or false\n' >&2
+        exit 2
+        ;;
+esac
+if [[ ! -f "$launch_path" ]]; then
+    printf 'launch record does not exist: %s\n' "$launch_path" >&2
+    exit 2
+fi
+
+readonly launch_project="$(jq -er '.project' "$launch_path")"
+readonly region="$(jq -er '.region' "$launch_path")"
+readonly job_name="$(jq -er '.job' "$launch_path")"
+readonly recorded_attempt="$(jq -er '.attempt' "$launch_path")"
+readonly execution_name="$(jq -er '.execution_name' "$launch_path")"
+readonly execution_id="$(jq -er '.execution' "$launch_path")"
+readonly git_commit="$(jq -er '.commit' "$launch_path")"
+readonly input_uri="$(jq -er '.input_uri' "$launch_path")"
+readonly output_uri="$(jq -er '.output_uri' "$launch_path")"
+
+if [[ "$launch_project" != "$project_id" || "$recorded_attempt" != "$attempt_id" ]]; then
+    printf 'launch record identity does not match this inspection\n' >&2
+    exit 2
+fi
+if [[ ! "$execution_name" =~ ^projects/${project_id}/locations/${region}/jobs/${job_name}/executions/${execution_id}$ ]] \
+    || [[ ! "$git_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'launch record contains an invalid execution or commit identity\n' >&2
+    exit 2
+fi
+
+verify_archive() {
+    local archive_path="$1"
+    local archive_listing expected_listing artifact_name expected_digest actual_digest
+    archive_listing="$(tar -tzf "$archive_path")"
+    expected_listing=$'manifest.json\nresult.json\nchanges.patch\nstatus.txt\nevents.jsonl'
+    if [[ "$archive_listing" != "$expected_listing" ]]; then
+        printf 'result archive contains unexpected paths\n' >&2
+        return 1
+    fi
+    tar -xzf "$archive_path" -C "$attempt_output"
+    for artifact_name in result.json changes.patch status.txt events.jsonl; do
+        expected_digest="$(jq -er --arg name "$artifact_name" '.files[$name]' "${attempt_output}/manifest.json")"
+        if command -v sha256sum >/dev/null 2>&1; then
+            actual_digest="$(sha256sum "${attempt_output}/${artifact_name}" | awk '{print $1}')"
+        else
+            actual_digest="$(shasum -a 256 "${attempt_output}/${artifact_name}" | awk '{print $1}')"
+        fi
+        if [[ "$actual_digest" != "$expected_digest" ]]; then
+            printf 'artifact digest mismatch: %s\n' "$artifact_name" >&2
+            return 1
+        fi
+    done
+    if [[ "$(jq -er '.attempt_id' "${attempt_output}/manifest.json")" != "$attempt_id" ]] \
+        || [[ "$(jq -er '.commit' "${attempt_output}/manifest.json")" != "$git_commit" ]]; then
+        printf 'result archive identity does not match the frozen input\n' >&2
+        return 1
+    fi
+}
+
+readonly access_token="$(gcloud auth print-access-token)"
+readonly execution_url="https://run.googleapis.com/v2/${execution_name}"
+completion_state=CONDITION_PENDING
+execution_response='{}'
+readonly poll_count="$((wait_seconds / 5 + 1))"
+for _poll_index in $(seq 1 "$poll_count"); do
+    execution_response="$(
+        curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer ${access_token}" \
+            "$execution_url"
+    )"
+    completion_state="$(
+        jq -r 'first(.conditions[]? | select(.type == "Completed") | .state) // "CONDITION_PENDING"' \
+            <<< "$execution_response"
+    )"
+    [[ "$completion_state" == CONDITION_PENDING ]] || break
+    sleep 5
+done
+
+readonly archive_path="${attempt_output}/attempt-result.tar.gz"
+artifact_available=false
+if gcloud storage cp "$output_uri" "$archive_path" \
+    --project "$project_id" --quiet 2>/dev/null; then
+    verify_archive "$archive_path"
+    artifact_available=true
+    printf 'Verified result: %s\n' "$attempt_output"
+fi
+
+jq -n \
+    --arg attempt "$attempt_id" \
+    --arg execution "$execution_id" \
+    --arg state "$completion_state" \
+    --arg commit "$git_commit" \
+    --arg input_uri "$input_uri" \
+    --arg output_uri "$output_uri" \
+    --arg log_uri "$(jq -r '.logUri // ""' <<< "$execution_response")" \
+    --argjson artifact_available "$artifact_available" \
+    '{attempt: $attempt, execution: $execution, state: $state, commit: $commit, input_uri: $input_uri, output_uri: $output_uri, artifact_available: $artifact_available, log_uri: $log_uri}' \
+    > "${attempt_output}/execution.json"
+
+if [[ "$delete_on_terminal" == true && "$completion_state" != CONDITION_PENDING ]]; then
+    curl --fail-with-body --silent --show-error \
+        --request DELETE \
+        --header "Authorization: Bearer ${access_token}" \
+        "$execution_url" >/dev/null
+    printf 'Execution cleanup requested: %s\n' "$execution_id"
+else
+    printf 'Execution retained: https://console.cloud.google.com/run/jobs/executions/details/%s/%s?project=%s\n' \
+        "$region" "$execution_id" "$project_id"
+fi
+
+if [[ "$completion_state" != CONDITION_SUCCEEDED ]]; then
+    jq -c '{name, conditions}' <<< "$execution_response" >&2
+    exit 1
+fi
+if [[ "$artifact_available" != true ]]; then
+    printf 'execution succeeded without a result artifact: %s\n' "$output_uri" >&2
+    exit 1
+fi

--- a/experiments/cloud-run-agent/inspect.sh
+++ b/experiments/cloud-run-agent/inspect.sh
@@ -47,15 +47,15 @@ if [[ ! "$execution_name" =~ ^projects/${project_id}/locations/${region}/jobs/${
 fi
 
 verify_archive() {
-    local archive_path="$1"
+    local verified_archive_path="$1"
     local archive_listing expected_listing artifact_name expected_digest actual_digest
-    archive_listing="$(tar -tzf "$archive_path")"
+    archive_listing="$(tar -tzf "$verified_archive_path")"
     expected_listing=$'manifest.json\nresult.json\nchanges.patch\nstatus.txt\nevents.jsonl'
     if [[ "$archive_listing" != "$expected_listing" ]]; then
         printf 'result archive contains unexpected paths\n' >&2
         return 1
     fi
-    tar -xzf "$archive_path" -C "$attempt_output"
+    tar -xzf "$verified_archive_path" -C "$attempt_output"
     for artifact_name in result.json changes.patch status.txt events.jsonl; do
         expected_digest="$(jq -er --arg name "$artifact_name" '.files[$name]' "${attempt_output}/manifest.json")"
         if command -v sha256sum >/dev/null 2>&1; then

--- a/experiments/cloud-run-agent/inspect.sh
+++ b/experiments/cloud-run-agent/inspect.sh
@@ -122,7 +122,9 @@ jq -n \
     '{attempt: $attempt, execution: $execution, state: $state, commit: $commit, input_uri: $input_uri, output_uri: $output_uri, artifact_available: $artifact_available, log_uri: $log_uri}' \
     > "${attempt_output}/execution.json"
 
-if [[ "$delete_on_terminal" == true && "$completion_state" != CONDITION_PENDING ]]; then
+if [[ "$delete_on_terminal" == true \
+    && "$completion_state" != CONDITION_PENDING \
+    && "$artifact_available" == true ]]; then
     curl --fail-with-body --silent --show-error \
         --request DELETE \
         --header "Authorization: Bearer ${access_token}" \

--- a/experiments/cloud-run-agent/inspect.sh
+++ b/experiments/cloud-run-agent/inspect.sh
@@ -90,7 +90,14 @@ for _poll_index in $(seq 1 "$poll_count"); do
         jq -r 'first(.conditions[]? | select(.type == "Completed") | .state) // "CONDITION_PENDING"' \
             <<< "$execution_response"
     )"
-    [[ "$completion_state" == CONDITION_PENDING ]] || break
+    case "$completion_state" in
+        CONDITION_SUCCEEDED | CONDITION_FAILED)
+            break
+            ;;
+        *)
+            completion_state=CONDITION_PENDING
+            ;;
+    esac
     sleep 5
 done
 

--- a/experiments/cloud-run-agent/inspect.sh
+++ b/experiments/cloud-run-agent/inspect.sh
@@ -30,8 +30,6 @@ readonly launch_project="$(jq -er '.project' "$launch_path")"
 readonly region="$(jq -er '.region' "$launch_path")"
 readonly job_name="$(jq -er '.job' "$launch_path")"
 readonly recorded_attempt="$(jq -er '.attempt' "$launch_path")"
-readonly execution_name="$(jq -er '.execution_name' "$launch_path")"
-readonly execution_id="$(jq -er '.execution' "$launch_path")"
 readonly git_commit="$(jq -er '.commit' "$launch_path")"
 readonly input_uri="$(jq -er '.input_uri' "$launch_path")"
 readonly output_uri="$(jq -er '.output_uri' "$launch_path")"
@@ -40,10 +38,69 @@ if [[ "$launch_project" != "$project_id" || "$recorded_attempt" != "$attempt_id"
     printf 'launch record identity does not match this inspection\n' >&2
     exit 2
 fi
-if [[ ! "$execution_name" =~ ^projects/${project_id}/locations/${region}/jobs/${job_name}/executions/${execution_id}$ ]] \
-    || [[ ! "$git_commit" =~ ^[0-9a-f]{40}$ ]]; then
-    printf 'launch record contains an invalid execution or commit identity\n' >&2
+if [[ ! "$git_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'launch record contains an invalid commit identity\n' >&2
     exit 2
+fi
+
+readonly access_token="$(gcloud auth print-access-token)"
+execution_name="$(jq -r '.execution_name // ""' "$launch_path")"
+execution_id="$(jq -r '.execution // ""' "$launch_path")"
+
+find_execution() {
+    local page_token='' list_url list_response match next_page_token
+    while true; do
+        list_url="https://run.googleapis.com/v2/projects/${project_id}/locations/${region}/jobs/${job_name}/executions?pageSize=100"
+        if [[ -n "$page_token" ]]; then
+            list_url="${list_url}&pageToken=$(jq -rn --arg value "$page_token" '$value | @uri')"
+        fi
+        list_response="$(
+            curl --fail-with-body --silent --show-error \
+                --header "Authorization: Bearer ${access_token}" \
+                "$list_url"
+        )"
+        match="$(
+            jq -r \
+                --arg attempt "$attempt_id" \
+                --arg input "$input_uri" \
+                --arg output "$output_uri" '
+                first(.executions[]? | select(
+                    any(.template.containers[].env[]?; .name == "ATTEMPT_ID" and .value == $attempt)
+                    and any(.template.containers[].env[]?; .name == "INPUT_URI" and .value == $input)
+                    and any(.template.containers[].env[]?; .name == "OUTPUT_URI" and .value == $output)
+                ) | .name) // ""
+                ' <<< "$list_response"
+        )"
+        if [[ -n "$match" ]]; then
+            printf '%s\n' "$match"
+            return 0
+        fi
+        next_page_token="$(jq -r '.nextPageToken // ""' <<< "$list_response")"
+        [[ -n "$next_page_token" ]] || return 1
+        page_token="$next_page_token"
+    done
+}
+
+if [[ -z "$execution_name" ]]; then
+    readonly reconcile_count="$((wait_seconds / 5 + 1))"
+    for _reconcile_index in $(seq 1 "$reconcile_count"); do
+        if execution_name="$(find_execution)"; then
+            execution_id="${execution_name##*/}"
+            launch_update="$(mktemp "${attempt_output}/launch.XXXXXX")"
+            jq --arg execution_name "$execution_name" --arg execution "$execution_id" \
+                '.execution_name = $execution_name | .execution = $execution | .dispatch_state = "reconciled"' \
+                "$launch_path" > "$launch_update"
+            mv "$launch_update" "$launch_path"
+            printf 'Reconciled execution: %s\n' "$execution_id"
+            break
+        fi
+        sleep 5
+    done
+fi
+readonly execution_name execution_id
+if [[ ! "$execution_name" =~ ^projects/${project_id}/locations/${region}/jobs/${job_name}/executions/${execution_id}$ ]]; then
+    printf 'No matching Cloud Run execution is visible yet; retry this inspect command.\n' >&2
+    exit 1
 fi
 
 verify_archive() {
@@ -75,7 +132,6 @@ verify_archive() {
     fi
 }
 
-readonly access_token="$(gcloud auth print-access-token)"
 readonly execution_url="https://run.googleapis.com/v2/${execution_name}"
 completion_state=CONDITION_PENDING
 execution_response='{}'

--- a/experiments/cloud-run-agent/resolve-git-ref.sh
+++ b/experiments/cloud-run-agent/resolve-git-ref.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly repository_url="${1:?usage: resolve-git-ref.sh REPOSITORY_URL GIT_REF}"
+readonly git_ref="${2:?usage: resolve-git-ref.sh REPOSITORY_URL GIT_REF}"
+
+git ls-remote "$repository_url" \
+    "refs/heads/${git_ref}" "refs/tags/${git_ref}^{}" "refs/tags/${git_ref}" \
+    | awk -v branch="refs/heads/${git_ref}" \
+        -v peeled="refs/tags/${git_ref}^{}" \
+        -v tag="refs/tags/${git_ref}" '
+        $2 == peeled { peeled_commit = $1 }
+        $2 == branch { branch_commit = $1 }
+        $2 == tag { tag_commit = $1 }
+        END {
+            if (peeled_commit != "") print peeled_commit
+            else if (branch_commit != "") print branch_commit
+            else if (tag_commit != "") print tag_commit
+        }
+    '

--- a/experiments/cloud-run-agent/run-agent.sh
+++ b/experiments/cloud-run-agent/run-agent.sh
@@ -5,22 +5,22 @@ set -Eeuo pipefail
 readonly workspace_root="${WORKSPACE_ROOT:-/workspace}"
 readonly checkout_dir="${workspace_root}/repo"
 readonly result_dir="${workspace_root}/result"
+readonly input_path="${workspace_root}/input.json"
+readonly archive_path="${workspace_root}/attempt-result.tar.gz"
+readonly raw_events_path="${workspace_root}/raw-events.jsonl"
 readonly events_path="${result_dir}/events.jsonl"
 readonly patch_path="${result_dir}/changes.patch"
 readonly status_path="${result_dir}/status.txt"
-readonly decoded_prompt_path="${result_dir}/prompt.txt"
-readonly model="${MODEL:-deepseek/deepseek-v4-flash}"
-readonly thinking="${THINKING:-low}"
-readonly agent_mode="${AGENT_MODE:-read-only}"
 
 emit_error() {
     local exit_code="$?"
     jq -nc \
-        --arg type "factory_agent_error" \
+        --arg type factory_agent_error \
+        --arg attempt "${ATTEMPT_ID:-unknown}" \
         --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
-        --arg message "agent job failed before completion" \
+        --arg message "agent job failed before publishing a complete result" \
         --argjson exit_code "$exit_code" \
-        '{type: $type, execution: $execution, exit_code: $exit_code, message: $message}'
+        '{type: $type, attempt: $attempt, execution: $execution, exit_code: $exit_code, message: $message}'
     exit "$exit_code"
 }
 trap emit_error ERR
@@ -33,21 +33,103 @@ require_value() {
     fi
 }
 
-decode_prompt() {
-    if base64 --help 2>&1 | grep -q -- '--decode'; then
-        printf '%s' "$PROMPT_B64" | base64 --decode
-    else
-        printf '%s' "$PROMPT_B64" | base64 -D
+parse_gs_uri() {
+    local uri="$1"
+    if [[ ! "$uri" =~ ^gs://([^/]+)/(.+)$ ]]; then
+        printf 'invalid GCS object URI: %s\n' "$uri" >&2
+        return 1
     fi
+    storage_bucket="${BASH_REMATCH[1]}"
+    storage_object="${BASH_REMATCH[2]}"
 }
 
-require_value REPOSITORY_URL
-require_value GIT_REF
-require_value PROMPT_B64
+storage_token() {
+    curl --fail-with-body --silent --show-error \
+        --header 'Metadata-Flavor: Google' \
+        'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token' \
+        | jq -er '.access_token'
+}
+
+download_object() {
+    local uri="$1"
+    local destination="$2"
+    local storage_bucket storage_object encoded_object token
+    parse_gs_uri "$uri"
+    encoded_object="$(jq -rn --arg value "$storage_object" '$value | @uri')"
+    token="$(storage_token)"
+    curl --fail-with-body --silent --show-error \
+        --retry 3 --retry-all-errors \
+        --header "Authorization: Bearer ${token}" \
+        --output "$destination" \
+        "https://storage.googleapis.com/storage/v1/b/${storage_bucket}/o/${encoded_object}?alt=media"
+}
+
+upload_object_create_only() {
+    local source="$1"
+    local uri="$2"
+    local storage_bucket storage_object encoded_object token
+    parse_gs_uri "$uri"
+    encoded_object="$(jq -rn --arg value "$storage_object" '$value | @uri')"
+    token="$(storage_token)"
+    curl --fail-with-body --silent --show-error \
+        --retry 3 --retry-all-errors \
+        --request POST \
+        --header "Authorization: Bearer ${token}" \
+        --header 'Content-Type: application/gzip' \
+        --data-binary "@${source}" \
+        "https://storage.googleapis.com/upload/storage/v1/b/${storage_bucket}/o?uploadType=media&ifGenerationMatch=0&name=${encoded_object}" \
+        >/dev/null
+}
+
+file_digest() {
+    sha256sum "$1" | awk '{print $1}'
+}
+
+require_value ATTEMPT_ID
+require_value INPUT_URI
+require_value OUTPUT_URI
 require_value OPENROUTER_API_KEY
 
-if [[ "$REPOSITORY_URL" == -* || "$GIT_REF" == -* ]]; then
-    printf 'REPOSITORY_URL and GIT_REF must not begin with a dash\n' >&2
+if [[ ! "$ATTEMPT_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+    printf 'ATTEMPT_ID contains unsupported characters\n' >&2
+    exit 2
+fi
+if [[ -e "$checkout_dir" || -e "$result_dir" ]]; then
+    printf 'workspace paths already exist under %s\n' "$workspace_root" >&2
+    exit 2
+fi
+mkdir -p "$result_dir"
+
+download_object "$INPUT_URI" "$input_path"
+
+readonly input_version="$(jq -er '.version' "$input_path")"
+readonly input_attempt="$(jq -er '.attempt_id' "$input_path")"
+readonly repository_url="$(jq -er '.repository_url' "$input_path")"
+readonly git_commit="$(jq -er '.git_commit' "$input_path")"
+readonly prompt="$(jq -er '.prompt | select(type == "string" and length > 0)' "$input_path")"
+readonly agent_mode="$(jq -er '.agent_mode' "$input_path")"
+readonly model="$(jq -er '.model' "$input_path")"
+readonly thinking="$(jq -er '.thinking // "low"' "$input_path")"
+
+if [[ "$input_version" != 1 || "$input_attempt" != "$ATTEMPT_ID" ]]; then
+    printf 'input identity does not match this execution\n' >&2
+    exit 2
+fi
+if [[ ! "$git_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'git_commit must be a full lowercase commit SHA\n' >&2
+    exit 2
+fi
+if [[ "$repository_url" != https://github.com/*.git && ( "${FACTORY_AGENT_TEST:-}" != 1 || -n "${CLOUD_RUN_EXECUTION:-}" ) ]]; then
+    printf 'repository_url must be a public GitHub HTTPS clone URL\n' >&2
+    exit 2
+fi
+readonly prompt_bytes="$(printf '%s' "$prompt" | wc -c | tr -d ' ')"
+if (( prompt_bytes > 65536 )); then
+    printf 'prompt exceeds 64 KiB\n' >&2
+    exit 2
+fi
+if [[ -z "$model" || ${#model} -gt 200 || -z "$thinking" || ${#thinking} -gt 32 ]]; then
+    printf 'model or thinking setting is invalid\n' >&2
     exit 2
 fi
 
@@ -59,60 +141,32 @@ case "$agent_mode" in
         readonly agent_tools="read,grep,find,ls,bash,edit,write"
         ;;
     *)
-        printf 'AGENT_MODE must be read-only or write\n' >&2
+        printf 'agent_mode must be read-only or write\n' >&2
         exit 2
         ;;
 esac
 
-if [[ -e "$checkout_dir" ]]; then
-    printf 'checkout path already exists: %s\n' "$checkout_dir" >&2
-    exit 2
-fi
-
-mkdir -p "$checkout_dir" "$result_dir"
-
-if (( ${#PROMPT_B64} % 4 != 0 )) \
-    || [[ ! "$PROMPT_B64" =~ ^[A-Za-z0-9+/]*={0,2}$ ]]; then
-    printf 'PROMPT_B64 must contain valid base64\n' >&2
-    exit 2
-fi
-
-if ! decode_prompt > "$decoded_prompt_path"; then
-    printf 'PROMPT_B64 must contain valid base64\n' >&2
-    exit 2
-fi
-
-canonical_prompt="$(base64 < "$decoded_prompt_path" | tr -d '\n')"
-readonly canonical_prompt
-if [[ "$canonical_prompt" != "$PROMPT_B64" ]]; then
-    printf 'PROMPT_B64 must contain canonical base64\n' >&2
-    exit 2
-fi
-
-prompt="$(< "$decoded_prompt_path")"
-readonly prompt
-rm -f "$decoded_prompt_path"
-if [[ -z "$prompt" ]]; then
-    printf 'decoded prompt must not be empty\n' >&2
-    exit 2
-fi
-
-git -C "$checkout_dir" init --quiet
-git -C "$checkout_dir" remote add origin "$REPOSITORY_URL"
-git -C "$checkout_dir" fetch --quiet --depth=1 origin "$GIT_REF"
+git init --quiet "$checkout_dir"
+git -C "$checkout_dir" remote add origin "$repository_url"
+git -C "$checkout_dir" fetch --quiet --depth=1 origin "$git_commit"
 git -C "$checkout_dir" checkout --quiet --detach FETCH_HEAD
 readonly base_commit="$(git -C "$checkout_dir" rev-parse HEAD)"
+if [[ "$base_commit" != "$git_commit" ]]; then
+    printf 'checked out commit does not match frozen input\n' >&2
+    exit 2
+fi
 
 jq -nc \
-    --arg type "factory_agent_start" \
+    --arg type factory_agent_start \
+    --arg attempt "$ATTEMPT_ID" \
     --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
-    --arg repository "$REPOSITORY_URL" \
-    --arg ref "$GIT_REF" \
+    --arg repository "$repository_url" \
     --arg commit "$base_commit" \
     --arg model "$model" \
     --arg mode "$agent_mode" \
-    '{type: $type, execution: $execution, repository: $repository, ref: $ref, commit: $commit, model: $model, mode: $mode}'
+    '{type: $type, attempt: $attempt, execution: $execution, repository: $repository, commit: $commit, model: $model, mode: $mode}'
 
+trap - ERR
 set +e
 (
     cd "$checkout_dir"
@@ -127,48 +181,68 @@ set +e
         --model "$model" \
         --thinking "$thinking" \
         --tools "$agent_tools" \
+        -- \
         "$prompt"
-) | tee "$events_path" | jq --unbuffered -c '
-    if .type == "message_end" and .message.role == "assistant" then
-        .message.content |= map(select(.type != "thinking"))
-    else
-        empty
-    end
-'
-readonly agent_exit_code="${PIPESTATUS[0]}"
+) | tee "$raw_events_path" | jq --unbuffered -c '
+    select(.type == "message_end" and .message.role == "assistant")
+    | .message.content |= map(select(.type != "thinking"))
+' | tee "$events_path"
+pipeline_status=("${PIPESTATUS[@]}")
+agent_exit_code="${pipeline_status[0]}"
+for pipeline_exit_code in "${pipeline_status[@]:1}"; do
+    if (( agent_exit_code == 0 && pipeline_exit_code != 0 )); then
+        agent_exit_code="$pipeline_exit_code"
+    fi
+done
+readonly agent_exit_code
 set -e
+trap emit_error ERR
 
 git -C "$checkout_dir" add --intent-to-add .
 git -C "$checkout_dir" status --short > "$status_path"
 git -C "$checkout_dir" diff --binary "$base_commit" > "$patch_path"
 
 readonly cost="$(
-    jq -s '
-        [
-            .[]
-            | select(.type == "message_end" and .message.role == "assistant")
-            | (.message.usage.cost.total // 0)
-        ]
-        | add // 0
-    ' "$events_path"
+    jq -s '[.[] | select(.type == "message_end" and .message.role == "assistant") | (.message.usage.cost.total // 0)] | add // 0' \
+        "$raw_events_path"
 )"
 
 jq -nc \
-    --arg type "factory_agent_summary" \
+    --arg attempt_id "$ATTEMPT_ID" \
     --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
     --arg commit "$base_commit" \
     --arg model "$model" \
     --arg mode "$agent_mode" \
     --arg status "$(cat "$status_path")" \
-    --arg patch "$patch_path" \
-    --argjson cost "$cost" \
+    --argjson cost_usd "$cost" \
     --argjson exit_code "$agent_exit_code" \
-    '{type: $type, execution: $execution, commit: $commit, model: $model, mode: $mode, exit_code: $exit_code, cost_usd: $cost, git_status: $status, patch_path: $patch}'
+    '{attempt_id: $attempt_id, execution: $execution, commit: $commit, model: $model, mode: $mode, exit_code: $exit_code, cost_usd: $cost_usd, git_status: $status}' \
+    > "${result_dir}/result.json"
 
-if [[ -s "$patch_path" ]]; then
-    printf '%s\n' '----- BEGIN FACTORY AGENT PATCH -----'
-    cat "$patch_path"
-    printf '%s\n' '----- END FACTORY AGENT PATCH -----'
-fi
+jq -nc \
+    --arg attempt_id "$ATTEMPT_ID" \
+    --arg input_uri "$INPUT_URI" \
+    --arg output_uri "$OUTPUT_URI" \
+    --arg commit "$base_commit" \
+    --arg result_sha256 "$(file_digest "${result_dir}/result.json")" \
+    --arg patch_sha256 "$(file_digest "$patch_path")" \
+    --arg status_sha256 "$(file_digest "$status_path")" \
+    --arg events_sha256 "$(file_digest "$events_path")" \
+    '{version: 1, attempt_id: $attempt_id, input_uri: $input_uri, output_uri: $output_uri, commit: $commit, files: {"result.json": $result_sha256, "changes.patch": $patch_sha256, "status.txt": $status_sha256, "events.jsonl": $events_sha256}}' \
+    > "${result_dir}/manifest.json"
+
+tar -czf "$archive_path" -C "$result_dir" \
+    manifest.json result.json changes.patch status.txt events.jsonl
+upload_object_create_only "$archive_path" "$OUTPUT_URI"
+
+jq -nc \
+    --arg type factory_agent_summary \
+    --arg attempt "$ATTEMPT_ID" \
+    --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
+    --arg commit "$base_commit" \
+    --arg output_uri "$OUTPUT_URI" \
+    --argjson cost_usd "$cost" \
+    --argjson exit_code "$agent_exit_code" \
+    '{type: $type, attempt: $attempt, execution: $execution, commit: $commit, exit_code: $exit_code, cost_usd: $cost_usd, output_uri: $output_uri}'
 
 exit "$agent_exit_code"

--- a/experiments/cloud-run-agent/run-agent.sh
+++ b/experiments/cloud-run-agent/run-agent.sh
@@ -170,7 +170,7 @@ trap - ERR
 set +e
 (
     cd "$checkout_dir"
-    pi \
+    printf '%s' "$prompt" | pi \
         --mode json \
         --no-session \
         --no-approve \
@@ -180,9 +180,7 @@ set +e
         --provider openrouter \
         --model "$model" \
         --thinking "$thinking" \
-        --tools "$agent_tools" \
-        -- \
-        "$prompt"
+        --tools "$agent_tools"
 ) | tee "$raw_events_path" | jq --unbuffered -c '
     select(.type == "message_end" and .message.role == "assistant")
     | .message.content |= map(select(.type != "thinking"))

--- a/experiments/cloud-run-agent/run-agent.sh
+++ b/experiments/cloud-run-agent/run-agent.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly workspace_root="${WORKSPACE_ROOT:-/workspace}"
+readonly checkout_dir="${workspace_root}/repo"
+readonly result_dir="${workspace_root}/result"
+readonly events_path="${result_dir}/events.jsonl"
+readonly patch_path="${result_dir}/changes.patch"
+readonly status_path="${result_dir}/status.txt"
+readonly decoded_prompt_path="${result_dir}/prompt.txt"
+readonly model="${MODEL:-deepseek/deepseek-v4-flash}"
+readonly thinking="${THINKING:-low}"
+readonly agent_mode="${AGENT_MODE:-read-only}"
+
+emit_error() {
+    local exit_code="$?"
+    jq -nc \
+        --arg type "factory_agent_error" \
+        --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
+        --arg message "agent job failed before completion" \
+        --argjson exit_code "$exit_code" \
+        '{type: $type, execution: $execution, exit_code: $exit_code, message: $message}'
+    exit "$exit_code"
+}
+trap emit_error ERR
+
+require_value() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        printf '%s is required\n' "$name" >&2
+        return 1
+    fi
+}
+
+decode_prompt() {
+    if base64 --help 2>&1 | grep -q -- '--decode'; then
+        printf '%s' "$PROMPT_B64" | base64 --decode
+    else
+        printf '%s' "$PROMPT_B64" | base64 -D
+    fi
+}
+
+require_value REPOSITORY_URL
+require_value GIT_REF
+require_value PROMPT_B64
+require_value OPENROUTER_API_KEY
+
+if [[ "$REPOSITORY_URL" == -* || "$GIT_REF" == -* ]]; then
+    printf 'REPOSITORY_URL and GIT_REF must not begin with a dash\n' >&2
+    exit 2
+fi
+
+case "$agent_mode" in
+    read-only)
+        readonly agent_tools="read,grep,find,ls"
+        ;;
+    write)
+        readonly agent_tools="read,grep,find,ls,bash,edit,write"
+        ;;
+    *)
+        printf 'AGENT_MODE must be read-only or write\n' >&2
+        exit 2
+        ;;
+esac
+
+if [[ -e "$checkout_dir" ]]; then
+    printf 'checkout path already exists: %s\n' "$checkout_dir" >&2
+    exit 2
+fi
+
+mkdir -p "$checkout_dir" "$result_dir"
+
+if (( ${#PROMPT_B64} % 4 != 0 )) \
+    || [[ ! "$PROMPT_B64" =~ ^[A-Za-z0-9+/]*={0,2}$ ]]; then
+    printf 'PROMPT_B64 must contain valid base64\n' >&2
+    exit 2
+fi
+
+if ! decode_prompt > "$decoded_prompt_path"; then
+    printf 'PROMPT_B64 must contain valid base64\n' >&2
+    exit 2
+fi
+
+canonical_prompt="$(base64 < "$decoded_prompt_path" | tr -d '\n')"
+readonly canonical_prompt
+if [[ "$canonical_prompt" != "$PROMPT_B64" ]]; then
+    printf 'PROMPT_B64 must contain canonical base64\n' >&2
+    exit 2
+fi
+
+prompt="$(< "$decoded_prompt_path")"
+readonly prompt
+rm -f "$decoded_prompt_path"
+if [[ -z "$prompt" ]]; then
+    printf 'decoded prompt must not be empty\n' >&2
+    exit 2
+fi
+
+git -C "$checkout_dir" init --quiet
+git -C "$checkout_dir" remote add origin "$REPOSITORY_URL"
+git -C "$checkout_dir" fetch --quiet --depth=1 origin "$GIT_REF"
+git -C "$checkout_dir" checkout --quiet --detach FETCH_HEAD
+readonly base_commit="$(git -C "$checkout_dir" rev-parse HEAD)"
+
+jq -nc \
+    --arg type "factory_agent_start" \
+    --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
+    --arg repository "$REPOSITORY_URL" \
+    --arg ref "$GIT_REF" \
+    --arg commit "$base_commit" \
+    --arg model "$model" \
+    --arg mode "$agent_mode" \
+    '{type: $type, execution: $execution, repository: $repository, ref: $ref, commit: $commit, model: $model, mode: $mode}'
+
+set +e
+(
+    cd "$checkout_dir"
+    pi \
+        --mode json \
+        --no-session \
+        --no-approve \
+        --no-extensions \
+        --no-skills \
+        --no-prompt-templates \
+        --provider openrouter \
+        --model "$model" \
+        --thinking "$thinking" \
+        --tools "$agent_tools" \
+        "$prompt"
+) | tee "$events_path" | jq --unbuffered -c '
+    if .type == "message_end" and .message.role == "assistant" then
+        .message.content |= map(select(.type != "thinking"))
+    else
+        empty
+    end
+'
+readonly agent_exit_code="${PIPESTATUS[0]}"
+set -e
+
+git -C "$checkout_dir" add --intent-to-add .
+git -C "$checkout_dir" status --short > "$status_path"
+git -C "$checkout_dir" diff --binary "$base_commit" > "$patch_path"
+
+readonly cost="$(
+    jq -s '
+        [
+            .[]
+            | select(.type == "message_end" and .message.role == "assistant")
+            | (.message.usage.cost.total // 0)
+        ]
+        | add // 0
+    ' "$events_path"
+)"
+
+jq -nc \
+    --arg type "factory_agent_summary" \
+    --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
+    --arg commit "$base_commit" \
+    --arg model "$model" \
+    --arg mode "$agent_mode" \
+    --arg status "$(cat "$status_path")" \
+    --arg patch "$patch_path" \
+    --argjson cost "$cost" \
+    --argjson exit_code "$agent_exit_code" \
+    '{type: $type, execution: $execution, commit: $commit, model: $model, mode: $mode, exit_code: $exit_code, cost_usd: $cost, git_status: $status, patch_path: $patch}'
+
+if [[ -s "$patch_path" ]]; then
+    printf '%s\n' '----- BEGIN FACTORY AGENT PATCH -----'
+    cat "$patch_path"
+    printf '%s\n' '----- END FACTORY AGENT PATCH -----'
+fi
+
+exit "$agent_exit_code"

--- a/experiments/cloud-run-agent/run-agent.sh
+++ b/experiments/cloud-run-agent/run-agent.sh
@@ -140,6 +140,7 @@ download_object "$INPUT_URI" "$input_path"
 
 readonly input_version="$(jq -er '.version' "$input_path")"
 readonly input_attempt="$(jq -er '.attempt_id' "$input_path")"
+readonly dispatch_nonce="$(jq -er '.dispatch_nonce' "$input_path")"
 readonly repository_url="$(jq -er '.repository_url' "$input_path")"
 readonly git_commit="$(jq -er '.git_commit' "$input_path")"
 readonly prompt="$(jq -er '.prompt | select(type == "string" and length > 0)' "$input_path")"
@@ -147,8 +148,12 @@ readonly agent_mode="$(jq -er '.agent_mode' "$input_path")"
 readonly model="$(jq -er '.model' "$input_path")"
 readonly thinking="$(jq -er '.thinking // "low"' "$input_path")"
 
-if [[ "$input_version" != 1 || "$input_attempt" != "$ATTEMPT_ID" ]]; then
+if [[ "$input_version" != 2 || "$input_attempt" != "$ATTEMPT_ID" ]]; then
     printf 'input identity does not match this execution\n' >&2
+    exit 2
+fi
+if [[ ! "$dispatch_nonce" =~ ^[0-9a-f]{32}$ ]]; then
+    printf 'dispatch_nonce must be 32 lowercase hexadecimal characters\n' >&2
     exit 2
 fi
 if [[ ! "$git_commit" =~ ^[0-9a-f]{40}$ ]]; then
@@ -196,6 +201,7 @@ jq -nc \
     --arg type factory_agent_start \
     --arg attempt "$ATTEMPT_ID" \
     --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
+    --arg dispatch_nonce "$dispatch_nonce" \
     --arg repository "$repository_url" \
     --arg commit "$base_commit" \
     --arg model "$model" \
@@ -243,6 +249,7 @@ readonly cost="$(
 
 jq -nc \
     --arg attempt_id "$ATTEMPT_ID" \
+    --arg dispatch_nonce "$dispatch_nonce" \
     --arg execution "${CLOUD_RUN_EXECUTION:-local}" \
     --arg commit "$base_commit" \
     --arg model "$model" \
@@ -250,11 +257,12 @@ jq -nc \
     --arg status "$(cat "$status_path")" \
     --argjson cost_usd "$cost" \
     --argjson exit_code "$agent_exit_code" \
-    '{attempt_id: $attempt_id, execution: $execution, commit: $commit, model: $model, mode: $mode, exit_code: $exit_code, cost_usd: $cost_usd, git_status: $status}' \
+    '{attempt_id: $attempt_id, dispatch_nonce: $dispatch_nonce, execution: $execution, commit: $commit, model: $model, mode: $mode, exit_code: $exit_code, cost_usd: $cost_usd, git_status: $status}' \
     > "${result_dir}/result.json"
 
 jq -nc \
     --arg attempt_id "$ATTEMPT_ID" \
+    --arg dispatch_nonce "$dispatch_nonce" \
     --arg input_uri "$INPUT_URI" \
     --arg output_uri "$OUTPUT_URI" \
     --arg commit "$base_commit" \
@@ -262,7 +270,7 @@ jq -nc \
     --arg patch_sha256 "$(file_digest "$patch_path")" \
     --arg status_sha256 "$(file_digest "$status_path")" \
     --arg events_sha256 "$(file_digest "$events_path")" \
-    '{version: 1, attempt_id: $attempt_id, input_uri: $input_uri, output_uri: $output_uri, commit: $commit, files: {"result.json": $result_sha256, "changes.patch": $patch_sha256, "status.txt": $status_sha256, "events.jsonl": $events_sha256}}' \
+    '{version: 2, attempt_id: $attempt_id, dispatch_nonce: $dispatch_nonce, input_uri: $input_uri, output_uri: $output_uri, commit: $commit, files: {"result.json": $result_sha256, "changes.patch": $patch_sha256, "status.txt": $status_sha256, "events.jsonl": $events_sha256}}' \
     > "${result_dir}/manifest.json"
 
 tar -czf "$archive_path" -C "$result_dir" \

--- a/experiments/cloud-run-agent/run-agent.sh
+++ b/experiments/cloud-run-agent/run-agent.sh
@@ -67,18 +67,54 @@ download_object() {
 upload_object_create_only() {
     local source="$1"
     local uri="$2"
-    local storage_bucket storage_object encoded_object token
+    local storage_bucket storage_object encoded_object token response_path existing_path
+    local http_code curl_exit upload_attempt
     parse_gs_uri "$uri"
     encoded_object="$(jq -rn --arg value "$storage_object" '$value | @uri')"
     token="$(storage_token)"
-    curl --fail-with-body --silent --show-error \
-        --retry 3 --retry-all-errors \
-        --request POST \
-        --header "Authorization: Bearer ${token}" \
-        --header 'Content-Type: application/gzip' \
-        --data-binary "@${source}" \
-        "https://storage.googleapis.com/upload/storage/v1/b/${storage_bucket}/o?uploadType=media&ifGenerationMatch=0&name=${encoded_object}" \
-        >/dev/null
+    response_path="$(mktemp "${workspace_root}/upload-response.XXXXXX")"
+    existing_path="$(mktemp "${workspace_root}/existing-result.XXXXXX")"
+
+    for upload_attempt in 1 2 3 4; do
+        if http_code="$(
+            curl --silent --show-error \
+                --request POST \
+                --header "Authorization: Bearer ${token}" \
+                --header 'Content-Type: application/gzip' \
+                --data-binary "@${source}" \
+                --output "$response_path" \
+                --write-out '%{http_code}' \
+                "https://storage.googleapis.com/upload/storage/v1/b/${storage_bucket}/o?uploadType=media&ifGenerationMatch=0&name=${encoded_object}"
+        )"; then
+            curl_exit=0
+        else
+            curl_exit="$?"
+        fi
+
+        if (( curl_exit == 0 )) && [[ "$http_code" =~ ^2[0-9][0-9]$ ]]; then
+            rm -f "$response_path" "$existing_path"
+            return 0
+        fi
+        if [[ "$http_code" == 412 ]]; then
+            download_object "$uri" "$existing_path"
+            if cmp -s "$source" "$existing_path"; then
+                rm -f "$response_path" "$existing_path"
+                return 0
+            fi
+            printf 'result object already exists with different content: %s\n' "$uri" >&2
+            rm -f "$response_path" "$existing_path"
+            return 1
+        fi
+        if (( upload_attempt < 4 )); then
+            sleep "$upload_attempt"
+        fi
+    done
+
+    printf 'result upload failed with HTTP %s: ' "${http_code:-unknown}" >&2
+    cat "$response_path" >&2
+    printf '\n' >&2
+    rm -f "$response_path" "$existing_path"
+    return 1
 }
 
 file_digest() {

--- a/experiments/cloud-run-agent/smoke-prompt.txt
+++ b/experiments/cloud-run-agent/smoke-prompt.txt
@@ -1,0 +1,8 @@
+Read README.md and ARCHITECTURE.md.
+
+Return:
+1. What Factory does.
+2. Which agent runtimes it supports.
+3. How the Worker launches Pi.
+
+Do not modify files.

--- a/experiments/cloud-run-agent/test-control.sh
+++ b/experiments/cloud-run-agent/test-control.sh
@@ -36,8 +36,17 @@ if [[ "$1 $2 $3" == "auth print-access-token " ]]; then
 fi
 if [[ "$1 $2" == "storage cp" ]]; then
     if [[ "$3" == gs://* ]]; then
+        if [[ "$3" == *'/input.json' && -n "${FAKE_STORED_INPUT:-}" ]]; then
+            cp "$FAKE_STORED_INPUT" "$4"
+            exit 0
+        fi
         [[ "${FAKE_ARTIFACT_MISSING:-}" != 1 ]] || exit 1
         cp "${FAKE_RESULT_ARCHIVE:?}" "$4"
+    elif [[ "${FAKE_INPUT_LOST_RESPONSE:-}" == 1 ]]; then
+        [[ -s "${EXPECTED_LAUNCH_PATH:?}" ]]
+        [[ "$(jq -r '.dispatch_state' "$EXPECTED_LAUNCH_PATH")" == dispatching ]]
+        [[ -e "${FAKE_STORED_INPUT:?}" ]] || cp "$3" "$FAKE_STORED_INPUT"
+        exit 1
     fi
     exit 0
 fi
@@ -79,6 +88,19 @@ readonly launch_path="${output_root}/attempt-launch-record/launch.json"
 [[ "$(jq -r '.commit' "$launch_path")" == "$source_commit" ]]
 grep -F -- 'Resume:' "${temp_root}/execute-output" >/dev/null
 
+set +e
+PATH="${fake_bin}:$PATH" \
+PROJECT_ID=factory-505220 \
+GIT_COMMIT="$source_commit" \
+ATTEMPT_ID=attempt-launch-record \
+OUTPUT_ROOT="$output_root" \
+    "${script_dir}/execute.sh" "${temp_root}/prompt.txt" > "${temp_root}/duplicate-attempt-output" 2>&1
+duplicate_attempt_exit="$?"
+set -e
+[[ "$duplicate_attempt_exit" -eq 2 ]]
+grep -F -- 'Attempt already exists locally: attempt-launch-record' "${temp_root}/duplicate-attempt-output" >/dev/null
+grep -F -- 'Use a new ATTEMPT_ID for a genuine retry.' "${temp_root}/duplicate-attempt-output" >/dev/null
+
 cat > "${fake_bin}/curl" <<'EOF'
 #!/usr/bin/env bash
 set -Eeuo pipefail
@@ -109,11 +131,14 @@ PATH="${fake_bin}:$PATH" \
 PROJECT_ID=factory-505220 \
 GIT_COMMIT="$source_commit" \
 ATTEMPT_ID=attempt-dispatch-recovery \
+DISPATCH_NONCE=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
 OUTPUT_ROOT="$output_root" \
 WAIT_SECONDS=10 \
 DELETE_EXECUTION_ON_TERMINAL=false \
 FAKE_ARTIFACT_MISSING=1 \
 EXPECTED_LAUNCH_PATH="$recovered_launch_path" \
+FAKE_INPUT_LOST_RESPONSE=1 \
+FAKE_STORED_INPUT="${temp_root}/stored-input.json" \
     "${script_dir}/execute.sh" "${temp_root}/prompt.txt" > "${temp_root}/dispatch-recovery-output" 2>&1
 dispatch_recovery_exit="$?"
 set -e
@@ -121,7 +146,28 @@ set -e
 [[ "$(jq -r '.dispatch_state' "$recovered_launch_path")" == reconciled ]]
 [[ "$(jq -r '.execution' "$recovered_launch_path")" == execution-reconciled ]]
 grep -F -- 'RunJob response was lost; reconciling by Attempt ID.' "${temp_root}/dispatch-recovery-output" >/dev/null
+grep -F -- 'Recovered byte-identical input after an ambiguous upload response.' "${temp_root}/dispatch-recovery-output" >/dev/null
 grep -F -- 'Reconciled execution: execution-reconciled' "${temp_root}/dispatch-recovery-output" >/dev/null
+
+readonly second_output_root="${temp_root}/second-results"
+readonly second_launch_path="${second_output_root}/attempt-dispatch-recovery/launch.json"
+set +e
+PATH="${fake_bin}:$PATH" \
+PROJECT_ID=factory-505220 \
+GIT_COMMIT="$source_commit" \
+ATTEMPT_ID=attempt-dispatch-recovery \
+DISPATCH_NONCE=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+OUTPUT_ROOT="$second_output_root" \
+WAIT_SECONDS=10 \
+DELETE_EXECUTION_ON_TERMINAL=false \
+FAKE_INPUT_LOST_RESPONSE=1 \
+FAKE_STORED_INPUT="${temp_root}/stored-input.json" \
+EXPECTED_LAUNCH_PATH="$second_launch_path" \
+    "${script_dir}/execute.sh" "${temp_root}/prompt.txt" > "${temp_root}/cross-root-duplicate-output" 2>&1
+cross_root_duplicate_exit="$?"
+set -e
+[[ "$cross_root_duplicate_exit" -eq 1 ]]
+grep -F -- 'input upload failed and no byte-identical object could be recovered' "${temp_root}/cross-root-duplicate-output" >/dev/null
 
 readonly result_fixture="${temp_root}/result-fixture"
 mkdir -p "$result_fixture"
@@ -132,12 +178,13 @@ printf '%s\n' '{"attempt_id":"attempt-launch-record"}' > "${result_fixture}/resu
 digest_file() { shasum -a 256 "$1" | awk '{print $1}'; }
 jq -nc \
     --arg attempt_id attempt-launch-record \
+    --arg dispatch_nonce "$(jq -r '.dispatch_nonce' "$launch_path")" \
     --arg commit "$source_commit" \
     --arg result "$(digest_file "${result_fixture}/result.json")" \
     --arg patch "$(digest_file "${result_fixture}/changes.patch")" \
     --arg status "$(digest_file "${result_fixture}/status.txt")" \
     --arg events "$(digest_file "${result_fixture}/events.jsonl")" \
-    '{version:1,attempt_id:$attempt_id,commit:$commit,files:{"result.json":$result,"changes.patch":$patch,"status.txt":$status,"events.jsonl":$events}}' \
+    '{version:2,attempt_id:$attempt_id,dispatch_nonce:$dispatch_nonce,commit:$commit,files:{"result.json":$result,"changes.patch":$patch,"status.txt":$status,"events.jsonl":$events}}' \
     > "${result_fixture}/manifest.json"
 tar -czf "$fake_archive" -C "$result_fixture" \
     manifest.json result.json changes.patch status.txt events.jsonl

--- a/experiments/cloud-run-agent/test-control.sh
+++ b/experiments/cloud-run-agent/test-control.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly temp_root="$(mktemp -d)"
+trap 'rm -rf "$temp_root"' EXIT
+
+readonly source_repo="${temp_root}/source"
+mkdir -p "$source_repo"
+git -C "$source_repo" init --quiet --initial-branch main
+printf 'fixture\n' > "${source_repo}/README.md"
+git -C "$source_repo" add README.md
+git -C "$source_repo" -c user.name=Factory -c user.email=factory@example.invalid \
+    commit --quiet -m fixture
+readonly source_commit="$(git -C "$source_repo" rev-parse HEAD)"
+git -C "$source_repo" -c user.name=Factory -c user.email=factory@example.invalid \
+    tag -a annotated -m annotated
+readonly tag_object="$(git -C "$source_repo" rev-parse annotated)"
+
+resolved_commit="$("${script_dir}/resolve-git-ref.sh" "$source_repo" annotated)"
+[[ "$resolved_commit" == "$source_commit" ]]
+[[ "$resolved_commit" != "$tag_object" ]]
+
+readonly fake_bin="${temp_root}/bin"
+readonly output_root="${temp_root}/results"
+mkdir -p "$fake_bin"
+
+cat > "${fake_bin}/gcloud" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "$1 $2 $3" == "auth print-access-token " ]]; then
+    printf 'test-token\n'
+    exit 0
+fi
+if [[ "$1 $2" == "storage cp" ]]; then
+    exit 0
+fi
+printf 'unexpected gcloud call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod 0755 "${fake_bin}/gcloud"
+
+cat > "${fake_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+for argument in "$@"; do
+    if [[ "$argument" == *':run' ]]; then
+        printf '%s\n' '{"metadata":{"name":"projects/factory-505220/locations/europe-west1/jobs/factory-agent-experiment/executions/execution-test"}}'
+        exit 0
+    fi
+done
+printf 'simulated polling interruption\n' >&2
+exit 22
+EOF
+chmod 0755 "${fake_bin}/curl"
+
+printf 'inspect this repository\n' > "${temp_root}/prompt.txt"
+set +e
+PATH="${fake_bin}:$PATH" \
+PROJECT_ID=factory-505220 \
+GIT_COMMIT="$source_commit" \
+ATTEMPT_ID=attempt-launch-record \
+OUTPUT_ROOT="$output_root" \
+    "${script_dir}/execute.sh" "${temp_root}/prompt.txt" > "${temp_root}/execute-output" 2>&1
+execute_exit="$?"
+set -e
+
+[[ "$execute_exit" -ne 0 ]]
+readonly launch_path="${output_root}/attempt-launch-record/launch.json"
+[[ -s "$launch_path" ]]
+[[ "$(jq -r '.attempt' "$launch_path")" == attempt-launch-record ]]
+[[ "$(jq -r '.execution' "$launch_path")" == execution-test ]]
+[[ "$(jq -r '.commit' "$launch_path")" == "$source_commit" ]]
+grep -F -- 'Resume:' "${temp_root}/execute-output" >/dev/null
+
+printf 'cloud-run control tests passed\n'

--- a/experiments/cloud-run-agent/test-control.sh
+++ b/experiments/cloud-run-agent/test-control.sh
@@ -24,6 +24,7 @@ resolved_commit="$("${script_dir}/resolve-git-ref.sh" "$source_repo" annotated)"
 
 readonly fake_bin="${temp_root}/bin"
 readonly output_root="${temp_root}/results"
+readonly fake_archive="${temp_root}/attempt-result.tar.gz"
 mkdir -p "$fake_bin"
 
 cat > "${fake_bin}/gcloud" <<'EOF'
@@ -34,7 +35,9 @@ if [[ "$1 $2 $3" == "auth print-access-token " ]]; then
     exit 0
 fi
 if [[ "$1 $2" == "storage cp" ]]; then
-    [[ "$3" != gs://* ]] || exit 1
+    if [[ "$3" == gs://* ]]; then
+        cp "${FAKE_RESULT_ARCHIVE:?}" "$4"
+    fi
     exit 0
 fi
 printf 'unexpected gcloud call: %s\n' "$*" >&2
@@ -75,6 +78,25 @@ readonly launch_path="${output_root}/attempt-launch-record/launch.json"
 [[ "$(jq -r '.commit' "$launch_path")" == "$source_commit" ]]
 grep -F -- 'Resume:' "${temp_root}/execute-output" >/dev/null
 
+readonly result_fixture="${temp_root}/result-fixture"
+mkdir -p "$result_fixture"
+printf '%s\n' '{"attempt_id":"attempt-launch-record"}' > "${result_fixture}/result.json"
+: > "${result_fixture}/changes.patch"
+: > "${result_fixture}/status.txt"
+: > "${result_fixture}/events.jsonl"
+digest_file() { shasum -a 256 "$1" | awk '{print $1}'; }
+jq -nc \
+    --arg attempt_id attempt-launch-record \
+    --arg commit "$source_commit" \
+    --arg result "$(digest_file "${result_fixture}/result.json")" \
+    --arg patch "$(digest_file "${result_fixture}/changes.patch")" \
+    --arg status "$(digest_file "${result_fixture}/status.txt")" \
+    --arg events "$(digest_file "${result_fixture}/events.jsonl")" \
+    '{version:1,attempt_id:$attempt_id,commit:$commit,files:{"result.json":$result,"changes.patch":$patch,"status.txt":$status,"events.jsonl":$events}}' \
+    > "${result_fixture}/manifest.json"
+tar -czf "$fake_archive" -C "$result_fixture" \
+    manifest.json result.json changes.patch status.txt events.jsonl
+
 cat > "${fake_bin}/curl" <<'EOF'
 #!/usr/bin/env bash
 set -Eeuo pipefail
@@ -86,7 +108,7 @@ printf '%s' "$counter" > "$counter_path"
 if (( counter == 1 )); then
     printf '%s\n' '{"name":"projects/factory-505220/locations/europe-west1/jobs/factory-agent-experiment/executions/execution-test","conditions":[{"type":"Completed","state":"CONDITION_RECONCILING"}]}'
 else
-    printf '%s\n' '{"name":"projects/factory-505220/locations/europe-west1/jobs/factory-agent-experiment/executions/execution-test","conditions":[{"type":"Completed","state":"CONDITION_FAILED"}]}'
+    printf '%s\n' '{"name":"projects/factory-505220/locations/europe-west1/jobs/factory-agent-experiment/executions/execution-test","conditions":[{"type":"Completed","state":"CONDITION_SUCCEEDED"}]}'
 fi
 EOF
 chmod 0755 "${fake_bin}/curl"
@@ -98,11 +120,13 @@ OUTPUT_ROOT="$output_root" \
 WAIT_SECONDS=10 \
 DELETE_EXECUTION_ON_TERMINAL=false \
 FAKE_CURL_COUNTER="${temp_root}/curl-counter" \
+FAKE_RESULT_ARCHIVE="$fake_archive" \
     "${script_dir}/inspect.sh" attempt-launch-record > "${temp_root}/inspect-output" 2>&1
 inspect_exit="$?"
 set -e
-[[ "$inspect_exit" -eq 1 ]]
+[[ "$inspect_exit" -eq 0 ]]
 [[ "$(cat "${temp_root}/curl-counter")" -eq 2 ]]
-grep -F -- 'CONDITION_FAILED' "${temp_root}/inspect-output" >/dev/null
+grep -F -- 'Verified result:' "${temp_root}/inspect-output" >/dev/null
+[[ "$(jq -r '.state' "${output_root}/attempt-launch-record/execution.json")" == CONDITION_SUCCEEDED ]]
 
 printf 'cloud-run control tests passed\n'

--- a/experiments/cloud-run-agent/test-control.sh
+++ b/experiments/cloud-run-agent/test-control.sh
@@ -79,6 +79,50 @@ readonly launch_path="${output_root}/attempt-launch-record/launch.json"
 [[ "$(jq -r '.commit' "$launch_path")" == "$source_commit" ]]
 grep -F -- 'Resume:' "${temp_root}/execute-output" >/dev/null
 
+cat > "${fake_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+url="${!#}"
+case "$url" in
+    *:run)
+        [[ -s "${EXPECTED_LAUNCH_PATH:?}" ]]
+        [[ "$(jq -r '.dispatch_state' "$EXPECTED_LAUNCH_PATH")" == dispatching ]]
+        exit 28
+        ;;
+    *'/executions?pageSize=100')
+        jq -nc '{executions:[{name:"projects/factory-505220/locations/europe-west1/jobs/factory-agent-experiment/executions/execution-reconciled",template:{containers:[{env:[{name:"ATTEMPT_ID",value:"attempt-dispatch-recovery"},{name:"INPUT_URI",value:"gs://factory-505220-factory-agent-artifacts/attempts/attempt-dispatch-recovery/input.json"},{name:"OUTPUT_URI",value:"gs://factory-505220-factory-agent-artifacts/attempts/attempt-dispatch-recovery/attempt-result.tar.gz"}]}]}}]}'
+        ;;
+    *'/executions/execution-reconciled')
+        jq -nc '{name:"projects/factory-505220/locations/europe-west1/jobs/factory-agent-experiment/executions/execution-reconciled",conditions:[{type:"Completed",state:"CONDITION_FAILED"}]}'
+        ;;
+    *)
+        printf 'unexpected curl URL: %s\n' "$url" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod 0755 "${fake_bin}/curl"
+
+readonly recovered_launch_path="${output_root}/attempt-dispatch-recovery/launch.json"
+set +e
+PATH="${fake_bin}:$PATH" \
+PROJECT_ID=factory-505220 \
+GIT_COMMIT="$source_commit" \
+ATTEMPT_ID=attempt-dispatch-recovery \
+OUTPUT_ROOT="$output_root" \
+WAIT_SECONDS=10 \
+DELETE_EXECUTION_ON_TERMINAL=false \
+FAKE_ARTIFACT_MISSING=1 \
+EXPECTED_LAUNCH_PATH="$recovered_launch_path" \
+    "${script_dir}/execute.sh" "${temp_root}/prompt.txt" > "${temp_root}/dispatch-recovery-output" 2>&1
+dispatch_recovery_exit="$?"
+set -e
+[[ "$dispatch_recovery_exit" -eq 1 ]]
+[[ "$(jq -r '.dispatch_state' "$recovered_launch_path")" == reconciled ]]
+[[ "$(jq -r '.execution' "$recovered_launch_path")" == execution-reconciled ]]
+grep -F -- 'RunJob response was lost; reconciling by Attempt ID.' "${temp_root}/dispatch-recovery-output" >/dev/null
+grep -F -- 'Reconciled execution: execution-reconciled' "${temp_root}/dispatch-recovery-output" >/dev/null
+
 readonly result_fixture="${temp_root}/result-fixture"
 mkdir -p "$result_fixture"
 printf '%s\n' '{"attempt_id":"attempt-launch-record"}' > "${result_fixture}/result.json"

--- a/experiments/cloud-run-agent/test-control.sh
+++ b/experiments/cloud-run-agent/test-control.sh
@@ -36,6 +36,7 @@ if [[ "$1 $2 $3" == "auth print-access-token " ]]; then
 fi
 if [[ "$1 $2" == "storage cp" ]]; then
     if [[ "$3" == gs://* ]]; then
+        [[ "${FAKE_ARTIFACT_MISSING:-}" != 1 ]] || exit 1
         cp "${FAKE_RESULT_ARCHIVE:?}" "$4"
     fi
     exit 0
@@ -128,5 +129,28 @@ set -e
 [[ "$(cat "${temp_root}/curl-counter")" -eq 2 ]]
 grep -F -- 'Verified result:' "${temp_root}/inspect-output" >/dev/null
 [[ "$(jq -r '.state' "${output_root}/attempt-launch-record/execution.json")" == CONDITION_SUCCEEDED ]]
+
+rm -f "${output_root}/attempt-launch-record/attempt-result.tar.gz" \
+    "${output_root}/attempt-launch-record/manifest.json" \
+    "${output_root}/attempt-launch-record/result.json" \
+    "${output_root}/attempt-launch-record/changes.patch" \
+    "${output_root}/attempt-launch-record/status.txt" \
+    "${output_root}/attempt-launch-record/events.jsonl"
+: > "${temp_root}/curl-counter"
+set +e
+PATH="${fake_bin}:$PATH" \
+PROJECT_ID=factory-505220 \
+OUTPUT_ROOT="$output_root" \
+WAIT_SECONDS=10 \
+DELETE_EXECUTION_ON_TERMINAL=true \
+FAKE_CURL_COUNTER="${temp_root}/curl-counter" \
+FAKE_RESULT_ARCHIVE="$fake_archive" \
+FAKE_ARTIFACT_MISSING=1 \
+    "${script_dir}/inspect.sh" attempt-launch-record > "${temp_root}/missing-artifact-output" 2>&1
+missing_artifact_exit="$?"
+set -e
+[[ "$missing_artifact_exit" -eq 1 ]]
+grep -F -- 'Execution retained:' "${temp_root}/missing-artifact-output" >/dev/null
+grep -F -- 'execution succeeded without a result artifact' "${temp_root}/missing-artifact-output" >/dev/null
 
 printf 'cloud-run control tests passed\n'

--- a/experiments/cloud-run-agent/test-control.sh
+++ b/experiments/cloud-run-agent/test-control.sh
@@ -34,6 +34,7 @@ if [[ "$1 $2 $3" == "auth print-access-token " ]]; then
     exit 0
 fi
 if [[ "$1 $2" == "storage cp" ]]; then
+    [[ "$3" != gs://* ]] || exit 1
     exit 0
 fi
 printf 'unexpected gcloud call: %s\n' "$*" >&2
@@ -73,5 +74,35 @@ readonly launch_path="${output_root}/attempt-launch-record/launch.json"
 [[ "$(jq -r '.execution' "$launch_path")" == execution-test ]]
 [[ "$(jq -r '.commit' "$launch_path")" == "$source_commit" ]]
 grep -F -- 'Resume:' "${temp_root}/execute-output" >/dev/null
+
+cat > "${fake_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+counter_path="${FAKE_CURL_COUNTER:?}"
+counter=0
+[[ ! -f "$counter_path" ]] || counter="$(cat "$counter_path")"
+counter=$((counter + 1))
+printf '%s' "$counter" > "$counter_path"
+if (( counter == 1 )); then
+    printf '%s\n' '{"name":"projects/factory-505220/locations/europe-west1/jobs/factory-agent-experiment/executions/execution-test","conditions":[{"type":"Completed","state":"CONDITION_RECONCILING"}]}'
+else
+    printf '%s\n' '{"name":"projects/factory-505220/locations/europe-west1/jobs/factory-agent-experiment/executions/execution-test","conditions":[{"type":"Completed","state":"CONDITION_FAILED"}]}'
+fi
+EOF
+chmod 0755 "${fake_bin}/curl"
+
+set +e
+PATH="${fake_bin}:$PATH" \
+PROJECT_ID=factory-505220 \
+OUTPUT_ROOT="$output_root" \
+WAIT_SECONDS=10 \
+DELETE_EXECUTION_ON_TERMINAL=false \
+FAKE_CURL_COUNTER="${temp_root}/curl-counter" \
+    "${script_dir}/inspect.sh" attempt-launch-record > "${temp_root}/inspect-output" 2>&1
+inspect_exit="$?"
+set -e
+[[ "$inspect_exit" -eq 1 ]]
+[[ "$(cat "${temp_root}/curl-counter")" -eq 2 ]]
+grep -F -- 'CONDITION_FAILED' "${temp_root}/inspect-output" >/dev/null
 
 printf 'cloud-run control tests passed\n'

--- a/experiments/cloud-run-agent/test-run-agent.sh
+++ b/experiments/cloud-run-agent/test-run-agent.sh
@@ -42,6 +42,7 @@ set -Eeuo pipefail
 output=""
 source_file=""
 url=""
+write_out=false
 while (( $# > 0 )); do
     case "$1" in
         --output)
@@ -50,6 +51,10 @@ while (( $# > 0 )); do
             ;;
         --data-binary)
             source_file="${2#@}"
+            shift 2
+            ;;
+        --write-out)
+            write_out=true
             shift 2
             ;;
         http://* | https://*)
@@ -66,11 +71,30 @@ case "$url" in
         printf '%s\n' '{"access_token":"test-token"}'
         ;;
     *'?alt=media')
-        cp "$FAKE_INPUT_JSON" "$output"
+        if [[ "$url" == *attempt-result.tar.gz* ]]; then
+            cp "$FAKE_OUTPUT_ARCHIVE" "$output"
+        else
+            cp "$FAKE_INPUT_JSON" "$output"
+        fi
         ;;
     https://storage.googleapis.com/upload/*)
-        cp "$source_file" "$FAKE_OUTPUT_ARCHIVE"
-        printf '%s\n' '{}'
+        if [[ "${FAKE_UPLOAD_LOST_RESPONSE:-}" == 1 ]]; then
+            counter=0
+            [[ ! -f "$FAKE_UPLOAD_COUNTER" ]] || counter="$(cat "$FAKE_UPLOAD_COUNTER")"
+            counter=$((counter + 1))
+            printf '%s' "$counter" > "$FAKE_UPLOAD_COUNTER"
+            if (( counter == 1 )); then
+                cp "$source_file" "$FAKE_OUTPUT_ARCHIVE"
+                printf '000'
+                exit 28
+            fi
+            printf '%s' '{"error":{"code":412}}' > "$output"
+            printf '412'
+        else
+            cp "$source_file" "$FAKE_OUTPUT_ARCHIVE"
+            printf '%s' '{}' > "$output"
+            [[ "$write_out" == false ]] || printf '200'
+        fi
         ;;
     *)
         printf 'unexpected curl URL: %s\n' "$url" >&2
@@ -101,6 +125,7 @@ run_agent() {
     local output="$4"
     local exit_code="${5:-0}"
     local malformed="${6:-0}"
+    local lost_upload_response="${7:-0}"
     mkdir -p "$workspace" "${workspace}/capture"
     PATH="${fake_bin}:$PATH" \
     WORKSPACE_ROOT="$workspace" \
@@ -114,7 +139,24 @@ run_agent() {
     FAKE_PI_CAPTURE="${workspace}/capture" \
     FAKE_PI_EXIT_CODE="$exit_code" \
     FAKE_PI_MALFORMED="$malformed" \
+    FAKE_UPLOAD_LOST_RESPONSE="$lost_upload_response" \
+    FAKE_UPLOAD_COUNTER="${workspace}/upload-counter" \
         "$script_dir/run-agent.sh" > "${workspace}/output"
+}
+
+run_lost_upload_response_test() {
+    local workspace="${temp_root}/lost-upload-response"
+    local input="${temp_root}/lost-upload-response-input.json"
+    local output="${temp_root}/lost-upload-response-result.tar.gz"
+    write_input "$input" attempt-lost-upload-response read-only
+
+    run_agent "$workspace" attempt-lost-upload-response "$input" "$output" 0 0 1
+
+    [[ "$(cat "${workspace}/upload-counter")" -eq 2 ]]
+    [[ -s "$output" ]]
+    mkdir -p "${workspace}/verified"
+    tar -xzf "$output" -C "${workspace}/verified"
+    [[ "$(jq -r '.exit_code' "${workspace}/verified/result.json")" == 0 ]]
 }
 
 run_malformed_event_test() {
@@ -238,6 +280,7 @@ run_cloud_run_test_bypass_rejection_test() {
 
 run_success_test
 run_agent_failure_test
+run_lost_upload_response_test
 run_malformed_event_test
 run_invalid_input_test
 run_cloud_run_test_bypass_rejection_test

--- a/experiments/cloud-run-agent/test-run-agent.sh
+++ b/experiments/cloud-run-agent/test-run-agent.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly temp_root="$(mktemp -d)"
+trap 'rm -rf "$temp_root"' EXIT
+
+readonly source_repo="${temp_root}/source"
+readonly fake_bin="${temp_root}/bin"
+mkdir -p "$source_repo" "$fake_bin"
+
+git -C "$source_repo" init --quiet --initial-branch main
+printf 'fixture\n' > "${source_repo}/README.md"
+git -C "$source_repo" add README.md
+git -C "$source_repo" \
+    -c user.name=Factory \
+    -c user.email=factory@example.invalid \
+    commit --quiet -m fixture
+readonly source_commit="$(git -C "$source_repo" rev-parse HEAD)"
+
+cat > "${fake_bin}/pi" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$PWD" > "${FAKE_PI_CAPTURE}/cwd"
+printf '%s\n' "$@" > "${FAKE_PI_CAPTURE}/arguments"
+printf 'CLOUD_RUN_AGENT_OK\n' > cloud-run-smoke.txt
+printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"PRIVATE_REASONING"}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"PRIVATE_PROMPT"}]}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"thinking","thinking":"PRIVATE_THOUGHT"},{"type":"text","text":"finished"}],"usage":{"cost":{"total":0.0123}}}}'
+exit "${FAKE_PI_EXIT_CODE:-0}"
+EOF
+chmod 0755 "${fake_bin}/pi"
+
+run_success_test() {
+    local workspace="${temp_root}/success"
+    local prompt
+    prompt="$(printf 'make the smoke change' | base64 | tr -d '\n')"
+    mkdir -p "$workspace"
+
+    PATH="${fake_bin}:$PATH" \
+    WORKSPACE_ROOT="$workspace" \
+    REPOSITORY_URL="$source_repo" \
+    GIT_REF=main \
+    PROMPT_B64="$prompt" \
+    OPENROUTER_API_KEY=test-key \
+    AGENT_MODE=write \
+    FAKE_PI_CAPTURE="$workspace" \
+        "$script_dir/run-agent.sh" > "${workspace}/output"
+
+    [[ "$(cat "${workspace}/cwd")" == "${workspace}/repo" ]]
+    [[ "$(git -C "${workspace}/repo" rev-parse HEAD)" == "$source_commit" ]]
+    grep -Fx -- '--provider' "${workspace}/arguments" >/dev/null
+    grep -Fx -- 'openrouter' "${workspace}/arguments" >/dev/null
+    grep -Fx -- 'deepseek/deepseek-v4-flash' "${workspace}/arguments" >/dev/null
+    grep -F -- 'CLOUD_RUN_AGENT_OK' "${workspace}/result/changes.patch" >/dev/null
+    grep -F -- '"cost_usd":0.0123' "${workspace}/output" >/dev/null
+    grep -F -- '"exit_code":0' "${workspace}/output" >/dev/null
+    grep -F -- '"text":"finished"' "${workspace}/output" >/dev/null
+    ! grep -F -- 'PRIVATE_REASONING' "${workspace}/output" >/dev/null
+    ! grep -F -- 'PRIVATE_PROMPT' "${workspace}/output" >/dev/null
+    ! grep -F -- 'PRIVATE_THOUGHT' "${workspace}/output" >/dev/null
+    grep -F -- 'PRIVATE_REASONING' "${workspace}/result/events.jsonl" >/dev/null
+}
+
+run_agent_failure_test() {
+    local workspace="${temp_root}/failure"
+    local prompt
+    prompt="$(printf 'fail after running' | base64 | tr -d '\n')"
+    mkdir -p "$workspace"
+
+    set +e
+    PATH="${fake_bin}:$PATH" \
+    WORKSPACE_ROOT="$workspace" \
+    REPOSITORY_URL="$source_repo" \
+    GIT_REF=main \
+    PROMPT_B64="$prompt" \
+    OPENROUTER_API_KEY=test-key \
+    AGENT_MODE=read-only \
+    FAKE_PI_CAPTURE="$workspace" \
+    FAKE_PI_EXIT_CODE=7 \
+        "$script_dir/run-agent.sh" > "${workspace}/output"
+    local exit_code="$?"
+    set -e
+
+    [[ "$exit_code" -eq 7 ]]
+    grep -F -- '"exit_code":7' "${workspace}/output" >/dev/null
+}
+
+run_invalid_mode_test() {
+    local workspace="${temp_root}/invalid-mode"
+    local prompt
+    prompt="$(printf test | base64 | tr -d '\n')"
+    mkdir -p "$workspace"
+
+    set +e
+    PATH="${fake_bin}:$PATH" \
+    WORKSPACE_ROOT="$workspace" \
+    REPOSITORY_URL="$source_repo" \
+    GIT_REF=main \
+    PROMPT_B64="$prompt" \
+    OPENROUTER_API_KEY=test-key \
+    AGENT_MODE=unsafe \
+    FAKE_PI_CAPTURE="$workspace" \
+        "$script_dir/run-agent.sh" > "${workspace}/output" 2>&1
+    local exit_code="$?"
+    set -e
+
+    [[ "$exit_code" -eq 2 ]]
+    grep -F -- 'AGENT_MODE must be read-only or write' "${workspace}/output" >/dev/null
+}
+
+run_malformed_prompt_test() {
+    local encoded_prompt="$1"
+    local case_name="$2"
+    local workspace="${temp_root}/${case_name}"
+    mkdir -p "$workspace"
+
+    set +e
+    PATH="${fake_bin}:$PATH" \
+    WORKSPACE_ROOT="$workspace" \
+    REPOSITORY_URL="$source_repo" \
+    GIT_REF=main \
+    PROMPT_B64="$encoded_prompt" \
+    OPENROUTER_API_KEY=test-key \
+    AGENT_MODE=write \
+    FAKE_PI_CAPTURE="$workspace" \
+        "$script_dir/run-agent.sh" > "${workspace}/output" 2>&1
+    local exit_code="$?"
+    set -e
+
+    [[ "$exit_code" -eq 2 ]]
+    grep -F -- 'PROMPT_B64 must contain valid base64' "${workspace}/output" >/dev/null
+    [[ ! -e "${workspace}/cwd" ]]
+}
+
+run_success_test
+run_agent_failure_test
+run_invalid_mode_test
+run_malformed_prompt_test 'bWFrZSBhIGNoYW5nZQ==!!!' malformed-characters
+run_malformed_prompt_test 'bWFrZSBhIGNoYW5nZQ' truncated-alphabet
+
+printf 'cloud-run agent tests passed\n'

--- a/experiments/cloud-run-agent/test-run-agent.sh
+++ b/experiments/cloud-run-agent/test-run-agent.sh
@@ -24,6 +24,7 @@ cat > "${fake_bin}/pi" <<'EOF'
 set -Eeuo pipefail
 printf '%s\n' "$PWD" > "${FAKE_PI_CAPTURE}/cwd"
 printf '%s\n' "$@" > "${FAKE_PI_CAPTURE}/arguments"
+cat > "${FAKE_PI_CAPTURE}/prompt"
 printf 'CLOUD_RUN_AGENT_OK\n' > cloud-run-smoke.txt
 printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"PRIVATE_REASONING"}}'
 printf '%s\n' '{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"PRIVATE_PROMPT"}]}}'
@@ -142,9 +143,8 @@ run_success_test() {
     grep -Fx -- '--provider' "${workspace}/capture/arguments" >/dev/null
     grep -Fx -- 'openrouter' "${workspace}/capture/arguments" >/dev/null
     grep -Fx -- 'deepseek/deepseek-v4-flash' "${workspace}/capture/arguments" >/dev/null
-    readonly separator_line="$(grep -nFx -- '--' "${workspace}/capture/arguments" | cut -d: -f1)"
-    readonly prompt_line="$(grep -nFx -- '--help' "${workspace}/capture/arguments" | cut -d: -f1)"
-    [[ "$separator_line" -lt "$prompt_line" ]]
+    ! grep -Fx -- '--help' "${workspace}/capture/arguments" >/dev/null
+    [[ "$(cat "${workspace}/capture/prompt")" == '--help' ]]
     grep -F -- '"cost_usd":0.0123' "${workspace}/output" >/dev/null
     grep -F -- '"exit_code":0' "${workspace}/output" >/dev/null
     ! grep -F -- 'PRIVATE_REASONING' "${workspace}/output" >/dev/null

--- a/experiments/cloud-run-agent/test-run-agent.sh
+++ b/experiments/cloud-run-agent/test-run-agent.sh
@@ -114,7 +114,7 @@ write_input() {
         --arg git_commit "$source_commit" \
         --arg prompt "${TEST_PROMPT:---help}" \
         --arg agent_mode "$mode" \
-        '{version: 1, attempt_id: $attempt_id, repository_url: $repository_url, git_commit: $git_commit, prompt: $prompt, agent_mode: $agent_mode, model: "deepseek/deepseek-v4-flash", thinking: "low"}' \
+        '{version: 2, attempt_id: $attempt_id, dispatch_nonce: "0123456789abcdef0123456789abcdef", repository_url: $repository_url, git_commit: $git_commit, prompt: $prompt, agent_mode: $agent_mode, model: "deepseek/deepseek-v4-flash", thinking: "low"}' \
         > "$path"
 }
 
@@ -200,6 +200,7 @@ run_success_test() {
     ! grep -F -- 'PRIVATE_REASONING' "${workspace}/verified/events.jsonl" >/dev/null
     [[ "$(jq -r '.attempt_id' "${workspace}/verified/manifest.json")" == attempt-success ]]
     [[ "$(jq -r '.commit' "${workspace}/verified/manifest.json")" == "$source_commit" ]]
+    [[ "$(jq -r '.dispatch_nonce' "${workspace}/verified/manifest.json")" == 0123456789abcdef0123456789abcdef ]]
 }
 
 run_agent_failure_test() {

--- a/experiments/cloud-run-agent/test-run-agent.sh
+++ b/experiments/cloud-run-agent/test-run-agent.sh
@@ -28,116 +28,218 @@ printf 'CLOUD_RUN_AGENT_OK\n' > cloud-run-smoke.txt
 printf '%s\n' '{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"PRIVATE_REASONING"}}'
 printf '%s\n' '{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"PRIVATE_PROMPT"}]}}'
 printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"thinking","thinking":"PRIVATE_THOUGHT"},{"type":"text","text":"finished"}],"usage":{"cost":{"total":0.0123}}}}'
+if [[ "${FAKE_PI_MALFORMED:-}" == 1 ]]; then
+    printf '%s\n' '{malformed'
+fi
 exit "${FAKE_PI_EXIT_CODE:-0}"
 EOF
 chmod 0755 "${fake_bin}/pi"
 
-run_success_test() {
-    local workspace="${temp_root}/success"
-    local prompt
-    prompt="$(printf 'make the smoke change' | base64 | tr -d '\n')"
-    mkdir -p "$workspace"
+cat > "${fake_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+output=""
+source_file=""
+url=""
+while (( $# > 0 )); do
+    case "$1" in
+        --output)
+            output="$2"
+            shift 2
+            ;;
+        --data-binary)
+            source_file="${2#@}"
+            shift 2
+            ;;
+        http://* | https://*)
+            url="$1"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+case "$url" in
+    http://metadata.google.internal/*)
+        printf '%s\n' '{"access_token":"test-token"}'
+        ;;
+    *'?alt=media')
+        cp "$FAKE_INPUT_JSON" "$output"
+        ;;
+    https://storage.googleapis.com/upload/*)
+        cp "$source_file" "$FAKE_OUTPUT_ARCHIVE"
+        printf '%s\n' '{}'
+        ;;
+    *)
+        printf 'unexpected curl URL: %s\n' "$url" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod 0755 "${fake_bin}/curl"
 
+write_input() {
+    local path="$1"
+    local attempt="$2"
+    local mode="$3"
+    jq -nc \
+        --arg attempt_id "$attempt" \
+        --arg repository_url "$source_repo" \
+        --arg git_commit "$source_commit" \
+        --arg prompt "${TEST_PROMPT:---help}" \
+        --arg agent_mode "$mode" \
+        '{version: 1, attempt_id: $attempt_id, repository_url: $repository_url, git_commit: $git_commit, prompt: $prompt, agent_mode: $agent_mode, model: "deepseek/deepseek-v4-flash", thinking: "low"}' \
+        > "$path"
+}
+
+run_agent() {
+    local workspace="$1"
+    local attempt="$2"
+    local input="$3"
+    local output="$4"
+    local exit_code="${5:-0}"
+    local malformed="${6:-0}"
+    mkdir -p "$workspace" "${workspace}/capture"
     PATH="${fake_bin}:$PATH" \
     WORKSPACE_ROOT="$workspace" \
-    REPOSITORY_URL="$source_repo" \
-    GIT_REF=main \
-    PROMPT_B64="$prompt" \
+    ATTEMPT_ID="$attempt" \
+    INPUT_URI="gs://test-bucket/attempts/${attempt}/input.json" \
+    OUTPUT_URI="gs://test-bucket/attempts/${attempt}/attempt-result.tar.gz" \
     OPENROUTER_API_KEY=test-key \
-    AGENT_MODE=write \
-    FAKE_PI_CAPTURE="$workspace" \
+    FACTORY_AGENT_TEST=1 \
+    FAKE_INPUT_JSON="$input" \
+    FAKE_OUTPUT_ARCHIVE="$output" \
+    FAKE_PI_CAPTURE="${workspace}/capture" \
+    FAKE_PI_EXIT_CODE="$exit_code" \
+    FAKE_PI_MALFORMED="$malformed" \
         "$script_dir/run-agent.sh" > "${workspace}/output"
+}
 
-    [[ "$(cat "${workspace}/cwd")" == "${workspace}/repo" ]]
+run_malformed_event_test() {
+    local workspace="${temp_root}/malformed"
+    local input="${temp_root}/malformed-input.json"
+    local output="${temp_root}/malformed-result.tar.gz"
+    write_input "$input" attempt-malformed read-only
+
+    set +e
+    run_agent "$workspace" attempt-malformed "$input" "$output" 0 1 2>/dev/null
+    local exit_code="$?"
+    set -e
+
+    [[ "$exit_code" -ne 0 ]]
+}
+
+run_success_test() {
+    local workspace="${temp_root}/success"
+    local input="${temp_root}/success-input.json"
+    local output="${temp_root}/success-result.tar.gz"
+    write_input "$input" attempt-success write
+    run_agent "$workspace" attempt-success "$input" "$output"
+
+    [[ "$(cat "${workspace}/capture/cwd")" == "${workspace}/repo" ]]
     [[ "$(git -C "${workspace}/repo" rev-parse HEAD)" == "$source_commit" ]]
-    grep -Fx -- '--provider' "${workspace}/arguments" >/dev/null
-    grep -Fx -- 'openrouter' "${workspace}/arguments" >/dev/null
-    grep -Fx -- 'deepseek/deepseek-v4-flash' "${workspace}/arguments" >/dev/null
-    grep -F -- 'CLOUD_RUN_AGENT_OK' "${workspace}/result/changes.patch" >/dev/null
+    grep -Fx -- '--provider' "${workspace}/capture/arguments" >/dev/null
+    grep -Fx -- 'openrouter' "${workspace}/capture/arguments" >/dev/null
+    grep -Fx -- 'deepseek/deepseek-v4-flash' "${workspace}/capture/arguments" >/dev/null
+    readonly separator_line="$(grep -nFx -- '--' "${workspace}/capture/arguments" | cut -d: -f1)"
+    readonly prompt_line="$(grep -nFx -- '--help' "${workspace}/capture/arguments" | cut -d: -f1)"
+    [[ "$separator_line" -lt "$prompt_line" ]]
     grep -F -- '"cost_usd":0.0123' "${workspace}/output" >/dev/null
     grep -F -- '"exit_code":0' "${workspace}/output" >/dev/null
-    grep -F -- '"text":"finished"' "${workspace}/output" >/dev/null
     ! grep -F -- 'PRIVATE_REASONING' "${workspace}/output" >/dev/null
     ! grep -F -- 'PRIVATE_PROMPT' "${workspace}/output" >/dev/null
     ! grep -F -- 'PRIVATE_THOUGHT' "${workspace}/output" >/dev/null
-    grep -F -- 'PRIVATE_REASONING' "${workspace}/result/events.jsonl" >/dev/null
+
+    mkdir -p "${workspace}/verified"
+    tar -xzf "$output" -C "${workspace}/verified"
+    grep -F -- 'CLOUD_RUN_AGENT_OK' "${workspace}/verified/changes.patch" >/dev/null
+    grep -F -- '"text":"finished"' "${workspace}/verified/events.jsonl" >/dev/null
+    ! grep -F -- 'PRIVATE_REASONING' "${workspace}/verified/events.jsonl" >/dev/null
+    [[ "$(jq -r '.attempt_id' "${workspace}/verified/manifest.json")" == attempt-success ]]
+    [[ "$(jq -r '.commit' "${workspace}/verified/manifest.json")" == "$source_commit" ]]
 }
 
 run_agent_failure_test() {
     local workspace="${temp_root}/failure"
-    local prompt
-    prompt="$(printf 'fail after running' | base64 | tr -d '\n')"
-    mkdir -p "$workspace"
+    local input="${temp_root}/failure-input.json"
+    local output="${temp_root}/failure-result.tar.gz"
+    write_input "$input" attempt-failure read-only
 
     set +e
-    PATH="${fake_bin}:$PATH" \
-    WORKSPACE_ROOT="$workspace" \
-    REPOSITORY_URL="$source_repo" \
-    GIT_REF=main \
-    PROMPT_B64="$prompt" \
-    OPENROUTER_API_KEY=test-key \
-    AGENT_MODE=read-only \
-    FAKE_PI_CAPTURE="$workspace" \
-    FAKE_PI_EXIT_CODE=7 \
-        "$script_dir/run-agent.sh" > "${workspace}/output"
+    run_agent "$workspace" attempt-failure "$input" "$output" 7
     local exit_code="$?"
     set -e
 
     [[ "$exit_code" -eq 7 ]]
-    grep -F -- '"exit_code":7' "${workspace}/output" >/dev/null
+    if [[ ! -s "$output" ]]; then
+        printf 'failed agent did not publish a result archive\n' >&2
+        return 1
+    fi
+    mkdir -p "${workspace}/verified"
+    tar -xzf "$output" -C "${workspace}/verified"
+    [[ "$(jq -r '.exit_code' "${workspace}/verified/result.json")" == 7 ]]
 }
 
-run_invalid_mode_test() {
-    local workspace="${temp_root}/invalid-mode"
-    local prompt
-    prompt="$(printf test | base64 | tr -d '\n')"
-    mkdir -p "$workspace"
+run_invalid_input_test() {
+    local workspace="${temp_root}/invalid"
+    local input="${temp_root}/invalid-input.json"
+    local output="${temp_root}/invalid-result.tar.gz"
+    write_input "$input" another-attempt unsafe
+    mkdir -p "$workspace" "${workspace}/capture"
 
     set +e
     PATH="${fake_bin}:$PATH" \
     WORKSPACE_ROOT="$workspace" \
-    REPOSITORY_URL="$source_repo" \
-    GIT_REF=main \
-    PROMPT_B64="$prompt" \
+    ATTEMPT_ID=attempt-invalid \
+    INPUT_URI=gs://test-bucket/input.json \
+    OUTPUT_URI=gs://test-bucket/output.tar.gz \
     OPENROUTER_API_KEY=test-key \
-    AGENT_MODE=unsafe \
-    FAKE_PI_CAPTURE="$workspace" \
+    FACTORY_AGENT_TEST=1 \
+    FAKE_INPUT_JSON="$input" \
+    FAKE_OUTPUT_ARCHIVE="$output" \
+    FAKE_PI_CAPTURE="${workspace}/capture" \
         "$script_dir/run-agent.sh" > "${workspace}/output" 2>&1
     local exit_code="$?"
     set -e
 
     [[ "$exit_code" -eq 2 ]]
-    grep -F -- 'AGENT_MODE must be read-only or write' "${workspace}/output" >/dev/null
+    grep -F -- 'input identity does not match this execution' "${workspace}/output" >/dev/null
+    [[ ! -e "$output" ]]
 }
 
-run_malformed_prompt_test() {
-    local encoded_prompt="$1"
-    local case_name="$2"
-    local workspace="${temp_root}/${case_name}"
-    mkdir -p "$workspace"
+run_cloud_run_test_bypass_rejection_test() {
+    local workspace="${temp_root}/cloud-run-bypass"
+    local input="${temp_root}/cloud-run-bypass-input.json"
+    local output="${temp_root}/cloud-run-bypass-result.tar.gz"
+    write_input "$input" attempt-cloud-run-bypass read-only
+    mkdir -p "$workspace" "${workspace}/capture"
 
     set +e
     PATH="${fake_bin}:$PATH" \
     WORKSPACE_ROOT="$workspace" \
-    REPOSITORY_URL="$source_repo" \
-    GIT_REF=main \
-    PROMPT_B64="$encoded_prompt" \
+    ATTEMPT_ID=attempt-cloud-run-bypass \
+    INPUT_URI=gs://test-bucket/input.json \
+    OUTPUT_URI=gs://test-bucket/output.tar.gz \
     OPENROUTER_API_KEY=test-key \
-    AGENT_MODE=write \
-    FAKE_PI_CAPTURE="$workspace" \
+    FACTORY_AGENT_TEST=1 \
+    CLOUD_RUN_EXECUTION=factory-agent-experiment-test \
+    FAKE_INPUT_JSON="$input" \
+    FAKE_OUTPUT_ARCHIVE="$output" \
+    FAKE_PI_CAPTURE="${workspace}/capture" \
         "$script_dir/run-agent.sh" > "${workspace}/output" 2>&1
     local exit_code="$?"
     set -e
 
     [[ "$exit_code" -eq 2 ]]
-    grep -F -- 'PROMPT_B64 must contain valid base64' "${workspace}/output" >/dev/null
-    [[ ! -e "${workspace}/cwd" ]]
+    grep -F -- 'repository_url must be a public GitHub HTTPS clone URL' "${workspace}/output" >/dev/null
+    [[ ! -e "$output" ]]
 }
 
 run_success_test
 run_agent_failure_test
-run_invalid_mode_test
-run_malformed_prompt_test 'bWFrZSBhIGNoYW5nZQ==!!!' malformed-characters
-run_malformed_prompt_test 'bWFrZSBhIGNoYW5nZQ' truncated-alphabet
+run_malformed_event_test
+run_invalid_input_test
+run_cloud_run_test_bypass_rejection_test
 
 printf 'cloud-run agent tests passed\n'

--- a/experiments/cloud-run-agent/test-validate.sh
+++ b/experiments/cloud-run-agent/test-validate.sh
@@ -23,7 +23,7 @@ case "$1 $2 $3" in
         ;;
     secrets\ get-iam-policy\ *)
         if [[ "${FAKE_SECRET_ACCESS:-true}" == true ]]; then
-            jq -nc '{bindings:[{role:"roles/secretmanager.secretAccessor",members:["serviceAccount:factory-agent-experiment@factory-505220.iam.gserviceaccount.com"]}]}'
+            jq -nc '{bindings:[{role:"roles/secretmanager.secretAccessor",members:["serviceAccount:factory-agent-experiment@factory-505220.iam.gserviceaccount.com","serviceAccount:another@example.invalid"]}]}'
         else
             jq -nc '{bindings:[]}'
         fi
@@ -33,7 +33,7 @@ case "$1 $2 $3" in
             '{public_access_prevention:$pap,uniform_bucket_level_access:$uniform}'
         ;;
     'storage buckets get-iam-policy')
-        jq -nc '{bindings:[{role:"roles/storage.objectUser",members:["serviceAccount:factory-agent-experiment@factory-505220.iam.gserviceaccount.com"]}]}'
+        jq -nc '{bindings:[{role:"roles/storage.objectUser",members:["serviceAccount:factory-agent-experiment@factory-505220.iam.gserviceaccount.com","serviceAccount:another@example.invalid"]}]}'
         ;;
     *)
         printf 'unexpected gcloud call: %s\n' "$*" >&2

--- a/experiments/cloud-run-agent/test-validate.sh
+++ b/experiments/cloud-run-agent/test-validate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly temp_root="$(mktemp -d)"
+trap 'rm -rf "$temp_root"' EXIT
+readonly fake_bin="${temp_root}/bin"
+mkdir -p "$fake_bin"
+
+cat > "${fake_bin}/gcloud" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+case "$1 $2 $3" in
+    'projects describe factory-505220')
+        printf 'factory-505220\n'
+        ;;
+    'run jobs describe')
+        jq -nc '{spec:{template:{spec:{taskCount:1,template:{spec:{maxRetries:0,serviceAccountName:"factory-agent-experiment@factory-505220.iam.gserviceaccount.com",containers:[{image:"example.invalid/agent@sha256:abc",env:[{name:"OPENROUTER_API_KEY",valueFrom:{secretKeyRef:{name:"openrouter-api-key",key:"1"}}}]}]}}}}}}'
+        ;;
+    'secrets versions describe')
+        printf 'ENABLED\n'
+        ;;
+    secrets\ get-iam-policy\ *)
+        if [[ "${FAKE_SECRET_ACCESS:-true}" == true ]]; then
+            jq -nc '{bindings:[{role:"roles/secretmanager.secretAccessor",members:["serviceAccount:factory-agent-experiment@factory-505220.iam.gserviceaccount.com"]}]}'
+        else
+            jq -nc '{bindings:[]}'
+        fi
+        ;;
+    'storage buckets describe')
+        jq -nc --arg pap "${FAKE_BUCKET_PAP:-enforced}" --argjson uniform "${FAKE_BUCKET_UNIFORM:-true}" \
+            '{public_access_prevention:$pap,uniform_bucket_level_access:$uniform}'
+        ;;
+    'storage buckets get-iam-policy')
+        jq -nc '{bindings:[{role:"roles/storage.objectUser",members:["serviceAccount:factory-agent-experiment@factory-505220.iam.gserviceaccount.com"]}]}'
+        ;;
+    *)
+        printf 'unexpected gcloud call: %s\n' "$*" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod 0755 "${fake_bin}/gcloud"
+
+PATH="${fake_bin}:$PATH" PROJECT_ID=factory-505220 \
+    "${script_dir}/validate.sh" > "${temp_root}/valid-output"
+grep -F -- 'Profile is ready.' "${temp_root}/valid-output" >/dev/null
+
+set +e
+PATH="${fake_bin}:$PATH" PROJECT_ID=factory-505220 FAKE_SECRET_ACCESS=false \
+    "${script_dir}/validate.sh" > "${temp_root}/invalid-output" 2>&1
+invalid_exit="$?"
+set -e
+[[ "$invalid_exit" -eq 1 ]]
+grep -F -- 'Job is missing roles/secretmanager.secretAccessor' "${temp_root}/invalid-output" >/dev/null
+
+set +e
+PATH="${fake_bin}:$PATH" PROJECT_ID=factory-505220 \
+FAKE_BUCKET_PAP=inherited FAKE_BUCKET_UNIFORM=false \
+    "${script_dir}/validate.sh" > "${temp_root}/public-bucket-output" 2>&1
+public_bucket_exit="$?"
+set -e
+[[ "$public_bucket_exit" -eq 1 ]]
+grep -F -- 'Artifact bucket must enforce public access prevention' "${temp_root}/public-bucket-output" >/dev/null
+grep -F -- 'Artifact bucket must use uniform bucket-level access' "${temp_root}/public-bucket-output" >/dev/null
+
+printf 'cloud-run validation tests passed\n'

--- a/experiments/cloud-run-agent/validate.sh
+++ b/experiments/cloud-run-agent/validate.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly project_id="${PROJECT_ID:?PROJECT_ID is required}"
+readonly region="${REGION:-europe-west1}"
+readonly job_name="${JOB_NAME:-factory-agent-experiment}"
+readonly artifact_bucket="${ARTIFACT_BUCKET:-${project_id}-factory-agent-artifacts}"
+readonly secret_name="${OPENROUTER_SECRET_NAME:-openrouter-api-key}"
+readonly expected_service_account="${SERVICE_ACCOUNT_NAME:-factory-agent-experiment}@${project_id}.iam.gserviceaccount.com"
+readonly job_json="$(mktemp)"
+readonly bucket_json="$(mktemp)"
+trap 'rm -f "$job_json" "$bucket_json"' EXIT
+
+pass() {
+    printf '✓ %s\n' "$1"
+}
+
+fail() {
+    printf '✗ %s\n' "$1" >&2
+    failures=$((failures + 1))
+}
+
+failures=0
+printf 'Cloud Run agent profile\n\n'
+
+if gcloud projects describe "$project_id" \
+    --format='value(projectId)' | grep -Fx "$project_id" >/dev/null; then
+    pass "Project is active: ${project_id}"
+else
+    fail "Project is unavailable: ${project_id}"
+fi
+
+if gcloud run jobs describe "$job_name" \
+    --region "$region" --project "$project_id" --format=json > "$job_json"; then
+    pass "Job exists: ${job_name}"
+else
+    fail "Job is unavailable: ${job_name}"
+fi
+
+if [[ -s "$job_json" ]]; then
+    image="$(jq -r '.spec.template.spec.template.spec.containers[0].image // ""' "$job_json")"
+    retries="$(jq -r '.spec.template.spec.template.spec.maxRetries // ""' "$job_json")"
+    tasks="$(jq -r '.spec.template.spec.taskCount // ""' "$job_json")"
+    service_account="$(jq -r '.spec.template.spec.template.spec.serviceAccountName // ""' "$job_json")"
+    secret_key="$(jq -r '.spec.template.spec.template.spec.containers[0].env[]? | select(.name == "OPENROUTER_API_KEY") | .valueFrom.secretKeyRef.key' "$job_json")"
+    secret_resource="$(jq -r '.spec.template.spec.template.spec.containers[0].env[]? | select(.name == "OPENROUTER_API_KEY") | .valueFrom.secretKeyRef.name' "$job_json")"
+
+    [[ "$image" == *@sha256:* ]] && pass "Image is pinned by digest" || fail "Job image is not pinned by digest"
+    [[ "$retries" == 0 ]] && pass "Native retries are zero" || fail "Native retries must be zero"
+    [[ "$tasks" == 1 ]] && pass "Task count is one" || fail "Task count must be one"
+    [[ "$service_account" == "$expected_service_account" ]] \
+        && pass "Job service account matches" \
+        || fail "Job service account does not match ${expected_service_account}"
+    [[ "$secret_resource" == "$secret_name" && "$secret_key" =~ ^[1-9][0-9]*$ ]] \
+        && pass "Model secret uses pinned version ${secret_key}" \
+        || fail "Model secret must use a numeric pinned version"
+
+    if [[ "$secret_resource" == "$secret_name" && "$secret_key" =~ ^[1-9][0-9]*$ ]] \
+        && gcloud secrets versions describe "$secret_key" --secret "$secret_name" \
+            --project "$project_id" --format='value(state)' | grep -Fx ENABLED >/dev/null; then
+        pass "Pinned model secret version is enabled"
+    else
+        fail "Pinned model secret version is unavailable or disabled"
+    fi
+fi
+
+if gcloud secrets get-iam-policy "$secret_name" \
+    --project "$project_id" --format=json \
+    | jq -e --arg member "serviceAccount:${expected_service_account}" \
+        '.bindings[]? | select(.role == "roles/secretmanager.secretAccessor") | .members[]? == $member' \
+        >/dev/null; then
+    pass "Job can access the model secret"
+else
+    fail "Job is missing roles/secretmanager.secretAccessor on the model secret"
+fi
+
+if gcloud storage buckets describe "gs://${artifact_bucket}" \
+    --project "$project_id" --format=json > "$bucket_json" 2>/dev/null; then
+    pass "Artifact bucket exists: ${artifact_bucket}"
+else
+    fail "Artifact bucket is unavailable: ${artifact_bucket}"
+fi
+
+if [[ -s "$bucket_json" ]]; then
+    bucket_public_access="$(jq -r '.public_access_prevention // ""' "$bucket_json")"
+    bucket_uniform_access="$(jq -r '.uniform_bucket_level_access // false' "$bucket_json")"
+    [[ "$bucket_public_access" == enforced ]] \
+        && pass "Artifact bucket prevents public access" \
+        || fail "Artifact bucket must enforce public access prevention"
+    [[ "$bucket_uniform_access" == true ]] \
+        && pass "Artifact bucket uses uniform access" \
+        || fail "Artifact bucket must use uniform bucket-level access"
+fi
+
+if gcloud storage buckets get-iam-policy "gs://${artifact_bucket}" \
+    --project "$project_id" --format=json \
+    | jq -e --arg member "serviceAccount:${expected_service_account}" \
+        '.bindings[]? | select(.role == "roles/storage.objectUser") | .members[]? == $member' \
+        >/dev/null; then
+    pass "Job can read and write attempt artifacts"
+else
+    fail "Job is missing roles/storage.objectUser on the artifact bucket"
+fi
+
+if [[ "$failures" -ne 0 ]]; then
+    printf '\nProfile is not ready: %d check(s) failed.\n' "$failures" >&2
+    exit 1
+fi
+
+printf '\nProfile is ready.\n'

--- a/experiments/cloud-run-agent/validate.sh
+++ b/experiments/cloud-run-agent/validate.sh
@@ -68,7 +68,7 @@ fi
 if gcloud secrets get-iam-policy "$secret_name" \
     --project "$project_id" --format=json \
     | jq -e --arg member "serviceAccount:${expected_service_account}" \
-        '.bindings[]? | select(.role == "roles/secretmanager.secretAccessor") | .members[]? == $member' \
+        'any(.bindings[]?; .role == "roles/secretmanager.secretAccessor" and any(.members[]?; . == $member))' \
         >/dev/null; then
     pass "Job can access the model secret"
 else
@@ -96,7 +96,7 @@ fi
 if gcloud storage buckets get-iam-policy "gs://${artifact_bucket}" \
     --project "$project_id" --format=json \
     | jq -e --arg member "serviceAccount:${expected_service_account}" \
-        '.bindings[]? | select(.role == "roles/storage.objectUser") | .members[]? == $member' \
+        'any(.bindings[]?; .role == "roles/storage.objectUser" and any(.members[]?; . == $member))' \
         >/dev/null; then
     pass "Job can read and write attempt artifacts"
 else

--- a/experiments/cloud-run-agent/write-smoke-prompt.txt
+++ b/experiments/cloud-run-agent/write-smoke-prompt.txt
@@ -1,0 +1,5 @@
+Create a file named cloud-run-smoke.txt in the repository root containing exactly:
+
+CLOUD_RUN_AGENT_OK
+
+Do not modify any other file. Finish after creating the file.


### PR DESCRIPTION
## Summary

- add a pinned, non-root Pi coding-agent container under `experiments/cloud-run-agent`
- provision one reusable Cloud Run Job, a private seven-day artifact bucket, Secret Manager access, and a digest-pinned image
- freeze public GitHub branches or tags to an exact commit and pass each prompt through immutable GCS input
- preserve and verify result metadata, sanitized assistant events, Git status, and a binary patch after the container exits
- persist launch identity immediately so polling and artifact recovery can resume after interruption
- delete terminal Cloud Run execution records by default, with dry-run cleanup for older records

## Verification

- `bash -n experiments/cloud-run-agent/*.sh`
- `experiments/cloud-run-agent/test-run-agent.sh`
- `experiments/cloud-run-agent/test-control.sh`
- `experiments/cloud-run-agent/test-validate.sh`
- independent review: approved after all findings and live-test fixes
- Cloud Build `43f47634-06fc-4559-b9ff-aa5aa7da6573`: success; deployed image `sha256:6e4cfdcd277841714d4e12f4499fe73892b8fbed75d56b32fba9d1ed8e48e2e8`
- deployed profile validation: all project, Job, digest, retry, service-account, secret, bucket privacy, and bucket IAM checks pass
- retained read-only execution `factory-agent-experiment-gckbn`: success at commit `687eb51c2d2682abe8776ac363ad28d6d7030c73`, verified durable artifact, $0.000893564 model cost
- write execution `factory-agent-experiment-949vz`: success, verified `cloud-run-smoke.txt` patch, $0.0002922948 model cost, execution record deleted after verification

## Limits

This is an isolated experiment, not Factory control-plane integration. It supports public GitHub HTTPS repositories, one Pi process per execution, manual dispatch, no private repository authentication, and no branch push or pull-request publishing.