### PR TITLE
docs: design elastic Cloud Run agents

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,9 +6,9 @@
 >
 > **Future direction:** The proposed
 > [Cloud Run agent backend](docs/cloud-run-agents/design.md) adds elastic
-> execution without changing Factory's product lifecycle. The broader
-> [Software Factory target architecture](docs/software-factory/design.md) is
-> also proposed. This document describes code that exists today.
+> execution without changing Factory's product lifecycle. The Software Factory
+> target architecture is a historical proposal superseded by Routines and Work.
+> This document describes code that exists today.
 
 ## 1. Executive summary
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,755 +2,335 @@
 
 > **Status:** Current implementation
 >
-> **Verification basis:** Working tree based on commit `2ed92c3`
+> **Verification basis:** `origin/main` at commit `003ed8f`
 >
-> **Direction:** The proposed
-> [Software Factory target architecture](docs/software-factory/design.md) defines
-> the intended product model. This document remains the source of truth for
-> behavior that exists today.
-
-The current implementation uses one embedded SQLite orchestration path. The
-longer-term direction is to keep that path as the first-class local default and
-allow production installations to select a durable backend such as Temporal
-without changing Definitions or the Worker-facing product model. No such
-backend abstraction exists today. Its decision record, ownership boundary,
-migration plan, and prototype are tracked in
-[#259](https://github.com/owainlewis/factory/issues/259).
+> **Future direction:** The proposed
+> [Cloud Run agent backend](docs/cloud-run-agents/design.md) adds elastic
+> execution without changing Factory's product lifecycle. The broader
+> [Software Factory target architecture](docs/software-factory/design.md) is
+> also proposed. This document describes code that exists today.
 
 ## 1. Executive summary
 
-Factory is the current local implementation of a control plane for running
-software-engineering agents in Git repositories. It separates durable
-coordination from agent execution:
+Factory is a local-first control plane for repeatable software-engineering
+agents. An operator saves a prompt and execution settings as a Routine. Running
+or scheduling that Routine creates Work with one Target per repository. A
+persistent Worker claims each Target, prepares an isolated Git worktree, runs
+Pi, Codex, or Claude Code, streams events, and reports one terminal result.
 
-- `factory-server` stores work, assigns it, evaluates legacy typed GitHub
-  polling Automations through `gh`, admits Definition-backed schedule and
-  signed webhook Automations, exposes the HTTP API, and serves the embedded UI.
-- `factory-worker` has one stable identity and a configurable pool for several
-  coding-agent runtimes. It advertises runtime capacity and provider access, acquires centrally
-  managed repositories on demand, and runs concurrent attempts in isolated Git
-  worktrees.
-- Codex or Claude Code performs the repository work as a child process of the
-  worker.
+The implementation has three main parts:
 
-The current task contract is a title, either a legacy free-text description or
-a pinned Workflow revision plus free-text context, assigned worker, repository,
-and timeout. The control plane snapshots one resolved prompt in the existing
-task description field before creating the task. Callers may name the
-assignment directly, constrain a routed assignment to one cattle worker, or
-ask the control-plane scheduler to choose from all eligible cattle workers. The
-operator access is limited to a trusted user and loopback HTTP. Workers may use
-that local endpoint or a separate authenticated HTTPS endpoint from remote VMs.
+- `factory-server` owns durable state, scheduling, routing, the HTTP API, and
+  the embedded browser UI.
+- `factory-worker` owns runtime health, repository caches, worktrees, agent
+  processes, and cleanup or retention.
+- SQLite stores Routines, Work, Targets, executions, Attempts, events, Workers,
+  and repositories.
 
-Workflow, Workflow Revision, Automation, Occurrence, Task, Execution, Attempt,
-and worker are the implemented model. They are not all target product concepts.
-New product work should follow the target design while migration work keeps
-this current behavior and history readable.
+The operator API is loopback-only. Workers make outbound polling requests to
+the server. Remote VM Workers use a separate TLS listener and per-Worker bearer
+credential. No server connection into a Worker host is required.
+
+Cloud Run is not implemented. The proposed backend keeps Factory as the source
+of truth and replaces a persistent Worker process with one disposable Job
+execution plus a verified recovery artifact.
 
 ## 2. System context
 
 ```text
-Operator
-   |
-   | browser or JSON over loopback HTTP
-   v
+Operator browser
+      |
+      | loopback HTTP and JSON
+      v
 factory-server
-   |-- embedded React UI
-   |-- control-plane API and scheduler
-   `-- SQLite
-           ^
-           | registration, polling, leases, events, completion
-           |
-factory-worker (one identity, several runtime capabilities, N agent slots)
-   |-- bounded on-demand repository cache
-   |-- optional legacy static checkouts
-   |-- attempt manifests and owned Git worktrees
-   `-- Pi, Codex, or Claude Code CLI
-
+  |-- Routine scheduler and Work admission
+  |-- routing and lease state machine
+  |-- embedded React UI
+  `-- SQLite
+      ^
+      | register, claim, heartbeat, events, complete
+      | local HTTP or separate authenticated TLS
+      |
+factory-worker
+  |-- stable identity and N slots
+  |-- runtime capability probes
+  |-- bounded repository cache
+  |-- isolated worktrees and manifests
+  `-- Pi, Codex, or Claude Code
 ```
 
-Workers initiate every connection. The server does not connect to workers, and
-the system does not use WebSockets. A remote VM uses a narrow HTTPS surface for
-enrollment and the same Worker lifecycle shown above.
+The control plane decides what should run and records what happened. A Worker
+decides how to execute one claim safely on its machine. The agent runtime is a
+child process and does not receive a control-plane operator credential.
 
-## 3. Architectural invariants
+## 3. Current product model
 
-1. One Worker identity advertises its configured `pi`, `codex`, and
-   `claude-code` capabilities and runs independent sessions up to its configured
-   capacity. Each execution freezes one ready runtime.
-2. Every task freezes one Worker, one runtime, and one control-plane repository.
-   Routed work may select a cattle Worker before that repository exists in its
-   local cache.
-3. Only a healthy, recently registered worker with free capacity can claim its
-   queued work.
-4. A lease token owns one active attempt. Active operations require a matching,
-   unexpired lease. A terminal completion request with the original token may be
-   replayed; the stored outcome wins.
-5. Agent processes start with a worker-owned worktree below that worker's data
-   directory as their working directory.
-6. Cleanup fails closed when the manifest, repository, branch, path, process,
-   or Git worktree identity cannot be proved.
-7. Existing worktrees with unpublished, dirty, failed, cancelled, lost, or
-   uncertain work are retained for inspection.
-8. Plain HTTP remains loopback-only. Remote Workers require the separate TLS
-   listener, a one-time enrollment bound to their stable identity, and their
-   stored per-Worker bearer credential.
-9. Operator builds embed the committed `web/dist` assets and do not require
-   Node.js.
-10. Automation evaluation is read-only. An Automation and provider identity
-    creates at most one Occurrence and task, including across server restarts
-    and lost HTTP responses.
-11. A Workflow has stable identity, enabled state, and immutable numbered
-    Markdown revisions. The control plane alone composes Workflow instructions
-    with free-text task context.
-12. Tasks snapshot their Workflow title, revision, context, and resolved prompt.
-    Workers remain generic and receive the resolved prompt through the existing
-    claim task description.
-13. A typed Automation is created disabled. One issue, pull request, scheduled
-    UTC instant, webhook delivery ID, or idempotent Run now key creates at most
-    one durable Occurrence and one Task or Definition Run per Automation.
+### Routine
 
-## 4. Components and dependencies
+A Routine is a reusable definition containing:
+
+- name and prompt;
+- runtime: `pi`, `codex`, or `claude-code`;
+- timeout and per-Work concurrency limit;
+- one or more managed repositories;
+- optional cron schedule and IANA timezone;
+- mutable generation and archived state.
+
+Updates use an expected generation. Admission snapshots the Routine so later
+edits do not change existing Work. A manual run uses an idempotency key.
+Scheduled admission polls every ten seconds and preserves the frozen pending
+snapshot while retrying a failed admission.
+
+### Work and Target
+
+One Routine admission creates one Work and one Target per selected repository.
+Work stores the Routine snapshot, source (`manual` or `schedule`), schedule time,
+and aggregate state. A Target stores its resolved prompt, repository identity,
+required runtime, timeout, assigned Worker, result, and failure state.
+
+Target states are `blocked`, `queued`, `preparing`, `running`, `succeeded`,
+`failed`, and `cancelled`. Work state is derived from all Targets as `blocked`,
+`queued`, `running`, `succeeded`, `failed`, `partial`, or `cancelled`.
+
+A Target starts blocked when no eligible Worker can currently accept it. A
+later claim can route it when a healthy Worker advertises the runtime and
+repository access. Routine concurrency limits how many sibling Targets may be
+queued or active at once.
+
+### Execution and Attempt
+
+An Execution is the durable assignment of one Target to one Worker and runtime.
+An Attempt is one leased try of that Execution. An explicit retry of a failed or
+cancelled Target requeues its Execution, increments retry history, and warns
+that external effects may repeat.
+
+An Attempt begins in `preparing`, moves to `running` after the Worker reports
+its supervisor identity, then ends as `succeeded`, `failed`, `cancelled`, or
+`lost`. It owns ordered bounded events, a bounded result or error, process
+identity, and a 30-second lease.
+
+### Worker and repository
+
+A Worker has one durable ID, display name, labels, capacity, health, runtime
+capabilities, source access, repository advertisements, and retained-worktree
+inventory. One Worker can advertise several runtimes and run 1 to 100 Attempts,
+with ten slots by default.
+
+The control plane owns a catalog of managed GitHub repositories. Eligible
+Workers clone them on demand with `gh`, keep at most 100 cache entries, fetch
+before an Attempt, and resolve the current base branch and commit. Legacy
+static repository paths remain readable through Worker configuration.
+
+## 4. Architectural invariants
+
+1. SQLite and the control plane are the authority for Work and Attempt state.
+2. A claim is assigned only to its selected, healthy, online Worker with a ready
+   runtime, free capacity, and repository availability.
+3. A random lease token owns one active Attempt. The server stores its digest,
+   not the token. Active mutations require the matching unexpired lease.
+4. Claim request IDs and terminal completion are idempotent. Replays cannot
+   create two Attempts or replace a stored terminal outcome.
+5. Every runtime starts in a Worker-owned worktree. The supervisor owns its
+   process group and enforces cancellation, timeout, lease loss, and parent
+   loss.
+6. Cleanup fails closed unless repository, manifest, path, branch, process, and
+   worktree identity can all be proved.
+7. Dirty, failed, cancelled, lost, unpublished, or uncertain worktrees are
+   retained for inspection. Clean unchanged or proved-published work may be
+   removed.
+8. Plain HTTP accepts loopback clients only. Remote Workers require TLS,
+   one-time enrollment bound to a stable Worker ID, and a stored bearer
+   credential.
+9. Routine admission snapshots prompt, runtime, repositories, timeout,
+   concurrency, generation, and schedule context.
+10. Operator builds embed committed `web/dist` assets and do not require Node.js
+    at runtime.
+
+## 5. Components
 
 ### Control plane
 
-`cmd/factory-server` starts the Go HTTP server. It:
+`cmd/factory-server` loads optional bootstrap TOML, opens SQLite, applies
+embedded migrations, sweeps expired leases, starts the Routine scheduler,
+serves the local API and UI, and optionally starts the remote Worker TLS
+listener. Shutdown stops schedulers first and gives HTTP servers ten seconds.
 
-- validates and binds a loopback address, `127.0.0.1:7337` by default;
-- optionally binds a separate TLS listener containing only enrollment and
-  authenticated Worker lifecycle routes;
-- optionally binds another TLS listener containing only health and the signed
-  GitHub webhook delivery route;
-- opens the SQLite store and applies embedded migrations;
-- sweeps expired leases at startup and every five seconds;
-- mounts the API and embedded UI on one origin;
-- writes structured JSON logs;
-- allows ten seconds for HTTP shutdown.
+`internal/controlplane` owns validation, transactions, Work admission, routing,
+claiming, leases, event ingestion, completion, cancellation, retry, pagination,
+overview aggregates, Worker authentication, and backup or restore validation.
 
-`internal/controlplane` owns the API, validation, state transitions, scheduling,
-metrics, pagination, Workflow revisions, typed GitHub, schedule, and webhook
-Automations, provider health, prompt composition, and persistence.
-Claim selection is transactional and FIFO by execution creation time for the
-requesting worker.
-
-SQLite runs with foreign keys, WAL journaling, a five-second busy timeout, and
-at most eight open connections. The default database is
+SQLite uses foreign keys, WAL journaling, a five-second busy timeout, and a
+bounded connection pool. The default database is
 `~/.factory/server/factory.sqlite3`.
 
-`factory-server -backup` opens only an existing source in read-only mode and
-uses SQLite `VACUUM INTO` to create a standalone, mode-`0600` online snapshot
-that includes committed WAL state. `factory-server -restore` opens a marked
-snapshot in immutable mode and rejects sibling WAL or shared-memory files. Both
-paths validate integrity, migration ledgers, and the complete expected schema.
-They build in an owner-only staging directory and publish the database and
-marker without replacement. Restore applies supported migrations before that
-publication, so startup never sees a partial or structurally invalid target.
-
-### Legacy poller migration
-
-The retired standalone poller has no binary, startup path, command, or current
-configuration example. `internal/controlplane/legacy_poller_*` implements its
-offline migration into typed Automations. Preview, Import, and Finalize each
-resolve the selected legacy config and ledger, acquire an exclusive SQLite
-ledger lock, and hash the exact config bytes, selected paths, schema, and
-ordered observation rows together with the ledger inode and full-file SHA-256.
-A lock failure, pathname replacement, pragma change, or snapshot change aborts
-the action without partial control-plane writes.
-
-Preview records stable source paths, queue mappings, counts, proposed titles,
-and validation errors. Ledger-only queue IDs are visible as unsupported and
-block Import until the matching configuration is restored, preventing silent
-loss of pending or submitted identities. Queue totals and the observation
-totals for archive-only unsupported queues are stored with the migration so
-Import responses and restart recovery report the reviewed source set rather
-than only the created Automations. Import atomically creates one
-Workflow and one disabled GitHub issue Automation per supported queue.
-Submitted observations retain their task identity or deleted-task tombstone.
-Pending observations retain the exact stored request and require explicit
-Resume or Skip. Imported Automations
-cannot be enabled before Finalize. The active imported migration is discoverable
-after a browser or server restart, and every imported observation remains
-visible beyond the ordinary paginated Automation history limit. Finalize
-verifies the same locked snapshot, copies the ledger through the retained locked
-file descriptor, writes and fsyncs the config and hash manifest archive, and
-then records completion. It never changes or deletes the source files.
+The backup path validates a live database and uses `VACUUM INTO` to publish a
+mode-`0600` standalone snapshot without replacement. Restore validates a marked
+snapshot, rejects SQLite sidecars, applies supported migrations in a private
+staging directory, and publishes only a complete destination.
 
 ### Worker
 
-`cmd/factory-worker` starts one worker manager, prints a worker identity, runs
-manual cleanup, or starts the internal attempt supervisor. The manager:
+`cmd/factory-worker` loads TOML configuration and starts one manager. The
+manager:
 
-- resolves and locks its data directory;
-- creates or loads a durable worker ID;
-- resolves any optional legacy repository paths and normalizes their `origin`
-  identities;
-- checks Git and runtime health and automatically probes local GitHub access;
-- clones or fetches assigned managed repositories into a bounded cache before
-  agent startup;
-- registers every ten seconds and polls for claims every two seconds with
-  jitter;
+- creates or loads its stable identity and local credential;
+- probes Git, `gh`, and configured runtime readiness;
+- registers every ten seconds and polls for claims about every two seconds;
+- acquires managed repositories into a bounded local cache;
 - renews active leases every ten seconds;
-- runs up to the configured capacity, from one to 100 attempts, defaulting to
-  ten;
-- reconciles manifests, worktrees, and process groups after restart.
+- starts up to the configured number of isolated sessions;
+- reconciles manifests, worktrees, and owned process groups after restart.
 
-The supervisor is a subprocess of `factory-worker`. It owns the runtime process
-group and enforces cancellation, timeout, lease loss, and parent-process loss.
-Unix process-group behavior is required, so Windows workers are unsupported.
+The supervisor is a subprocess of `factory-worker`. It anchors ownership of the
+runtime process group. Unix process-group behavior is required, so Windows
+Workers are unsupported.
 
 ### Agent runtimes
 
-The worker launches the configured runtime non-interactively:
+The Worker launches each runtime non-interactively in the prepared checkout:
 
-- Codex uses `codex exec` with JSON events and a file for the last message.
-- Claude Code uses `claude --print` with streaming JSON and bypassed permission
-  prompts.
+- Pi uses `--print --no-session` and captures the final plain-text result.
+- Codex uses `codex exec` with JSON events and a last-message file.
+- Claude Code uses `claude --print` with streaming JSON.
 
-Both runtimes receive the same generated prompt and produce the same bounded
-event and completion contract.
+Runtime output is normalized into the same Attempt event and completion
+contract. Event batches are at most 100 events and 256 KiB; each event is at
+most 64 KiB; one Attempt stores at most 10 MiB of events. Results are at most
+256 KiB and errors at most 64 KiB.
 
 ### Browser UI
 
-`web/src` is a React and TypeScript application with Overview, Work, Workers,
-managed Repositories, Runbooks, Automations, Task detail, and Delegate task
-views. Runbook is the browser term for the versioned Workflow resource.
-Automation detail projects each durable Occurrence as a Run and, after task
-creation, derives its visible state from the linked Task instead of persisting a
-second run lifecycle.
-Repository detail combines the central catalog with the control plane's current
-routing and acquisition readiness facts. It polls the same-origin API.
+`web/src` is a React and TypeScript single-page application. It exposes
+Overview, Routines, Work, Workers, and Repositories, with detail views for each
+operational resource. It polls the same-origin API.
 
 `web/dist` is generated, committed, and embedded by `web/embed.go`. The server
-uses an SPA fallback for application routes, immutable caching for versioned
-assets, and restrictive browser security headers.
+uses an SPA fallback, immutable caching for versioned assets, and restrictive
+security headers. Node.js is needed only when UI source changes.
 
-Node.js is a contributor dependency only when UI source changes.
+## 6. Critical flows
 
-## 5. Critical flows
+### Routine admission
 
-### Startup and registration
+1. The operator runs a Routine with a request key, or the scheduler claims a
+   due occurrence.
+2. The server freezes the Routine generation and repository list.
+3. One Work and one Target per repository are inserted transactionally.
+4. Routing selects compatible Workers where possible. Unroutable Targets stay
+   blocked with a reason.
+5. The same manual request key or scheduled occurrence cannot admit duplicate
+   Work.
 
-1. The server validates its data root, opens SQLite, applies migrations, and
-   marks already expired attempts as `lost`.
-2. The worker validates its TOML, data directory, runtime, and any optional
-   legacy repositories.
-3. The worker reconciles durable attempt manifests before accepting new work.
-4. A healthy worker registers its identity, runtime, capacity, provider access,
-   managed-repository acquisition capability, optional legacy repositories,
-   bounded cached repository IDs, retained worktrees, and disposed attempt IDs.
-5. A worker is shown as offline when its last registration is more than 30
-   seconds old.
+### Claim and execution
 
-### Task creation and claiming
-
-1. A caller submits a unique `request_key`, title, either a free-text
-   `description` or a pinned Workflow revision with free-text `context`, an
-   optional timeout, and either an explicit worker/repository pair or a
-   repository remote plus source-access route. The two prompt forms are
-   exclusive.
-2. The control plane returns an existing task before rechecking mutable
-   Workflow state when the request key is a replay. For a new task it validates
-   the selected revision and enabled Workflow, then composes and bounds the
-   resolved prompt.
-3. For a route, the control plane requires an enabled managed repository,
-   chooses an eligible worker by fair load, and freezes both IDs. It then
-   snapshots the context, Workflow identity, revision, and resolved prompt while
-   creating one task and one queued execution.
-4. The assigned worker polls its claim endpoint with a unique request ID and
-   lease token.
-5. The control plane verifies worker health, recency, capacity, runtime,
-   repository advertisement, and repository retention capacity.
-6. It selects the oldest eligible queued execution, creates a preparing
-   attempt, stores only a digest of the lease token, and returns the claim.
-7. An empty response is idempotent for five minutes. A successful response is
-   idempotent while its attempt remains active and its lease remains valid.
-
-### Legacy poller migration
-
-1. The operator stops every legacy poller and requests Preview.
-2. The server holds an exclusive legacy-ledger lock while resolving sources,
-   validating queues and pending payloads, counting observations, and storing
-   the full file identity and snapshot digest.
-3. Import reacquires the lock and accepts only that exact snapshot. One
-   transaction creates disabled typed Automations, Workflows, and deduplicating
-   Occurrences without changing tasks, workers, or source files.
-4. Submitted observations link by their stored task ID. A nonblank missing ID
-   becomes a stable deleted-task tombstone even if its request key was reused.
-   Only a blank historical ID may fall back to the request key.
-5. Each pending observation requires Resume of its exact stored request or an
-   explicit Skip. A restart recovers an interrupted Resume and deterministic
-   request keys prevent duplicate tasks.
-6. Closing the browser or restarting the server rediscovers the one active
-   imported migration. A second Preview is blocked until it is finalized.
-7. Finalize reacquires the lock, verifies the same snapshot, atomically archives
-   consistent config and ledger copies plus a manifest, and unlocks imported
-   Automations for operator review and enablement.
-
-### Product model upgrade
-
-1. Preview classifies legacy Tasks, Attempts, Runbooks, Occurrences, compatible
-   schedules, active executions, and GitHub polling Automations without writing.
-2. Starting the upgrade durably freezes legacy mutations, disables legacy
-   admission, and preserves pending Occurrences with an explicit cancellation
-   diagnostic before active executions drain or are explicitly cancelled.
-3. Compatible schedules become Definition-backed schedules in one transaction.
-   Their repository, prompt and context, timeout, cron, time zone, enabled state,
-   and exact next due instant are preserved.
-4. GitHub pollers are retained disabled with guidance to use a scheduled agent
-   with `gh`, a signed webhook, or retirement. Factory does not infer actions.
-5. Tasks, Attempts, Runbooks, revisions, and Occurrences retain their original
-   IDs and links. No historical Run is invented.
-6. The freeze survives restart. A stored validation report proves conversion
-   totals, retained history totals, and a zero synthetic-Run count.
-
-### Control-plane GitHub Automation
-
-1. An operator creates a disabled Automation bound to one Workflow and one
-   managed GitHub repository, then previews its bounded matches.
-2. Enabling schedules an immediate check. A legacy-imported Automation remains
-   blocked until its migration is finalized.
-3. The evaluator runs fixed `gh issue list` or `gh pr list` arguments without a
-   shell, with a 30-second timeout, bounded output, strict JSON, and
-   repository-specific URL validation. Pull-request checks also validate draft
-   inclusion, labels, optional base branches, and head-commit identity.
-4. One transaction validates the evaluation token and enabled dependencies,
-   stores every new typed Occurrence, updates health and counters, and advances
-   the next check. Repeated issues reuse the existing Occurrence identity.
-5. A later transaction routes the pending Occurrence, creates or exactly
-   recovers its deterministic Task, and links the Task to the Occurrence.
-6. The prompt separates trusted configured conditions from bounded untrusted
-   GitHub metadata and requires authenticated `gh` live-state revalidation
-   before mutation.
-
-### Control-plane schedule Automation
-
-1. An operator creates a disabled Automation with a five-field cron expression
-   and separate IANA timezone, then previews the next matching UTC instant.
-2. Enabling stores the first match strictly after the enable transaction. The
-   existing Automation service checks due schedules alongside provider checks
-   and commits one durable Occurrence before task dispatch.
-3. Cron fields are parsed by a small standard-library-only implementation. It
-   iterates UTC minutes and matches local calendar fields, so a daylight-saving
-   overlap yields two UTC identities and a nonexistent local minute yields none.
-   This explicit behavior is why Factory does not add a cron dependency.
-4. Startup admits at most the stored overdue instant, then advances directly to
-   the first future match. Run now uses a separate idempotent request-key domain
-   and never changes the due cursor.
-5. The occurrence dispatcher creates an ordinary Definition Run using the
-   frozen snapshot and repository set. Schedule work does not require provider
-   access, and workers retain the same claim contract.
-
-### GitHub webhook Automation
-
-1. An operator binds one shared Definition and one configured repository to
-   pull-request `opened` and `synchronize` actions, then enables the Automation.
-2. A separate TLS listener accepts only the signed GitHub route. HMAC-SHA256 is
-   verified over bounded raw bytes before JSON parsing.
-3. The first delivery freezes every matching enabled Automation and Definition
-   snapshot. `(Automation ID, delivery ID)` is the occurrence identity, and a
-   reused delivery ID with different bytes is rejected.
-4. Each occurrence creates an ordinary `source_kind: webhook` Run. Its record
-   includes the delivery, event, pull-request number and URL, and observed head
-   commit. Valid redelivery reuses the same occurrence and Run.
-5. Webhook fields are untrusted agent context. The prompt requires the agent to
-   fetch live state and perform review comments or other GitHub work with its
-   authenticated `gh` CLI. Factory does not publish GitHub actions itself.
-
-### Attempt execution
-
-1. The worker validates the claim identity, assignment, runtime, repository ID,
-   and remote identity.
-2. It uses a compatible legacy checkout or serially clones/acquires the managed
-   repository cache.
-3. It revalidates the registered origin identity, discovers the origin default
-   branch or uses a legacy repository's configured `base_branch`, fetches it,
-   freezes its exact commit, and checks the origin identity again.
-4. It creates a branch named
-   `factory/<task-prefix>-<attempt-prefix>` and an owned worktree.
-5. It writes a protected attempt manifest before starting the runtime.
-6. The internal supervisor starts, then the worker transitions the attempt to
+1. A healthy Worker registers capabilities and polls with a fresh claim request
+   ID and lease token.
+2. In one transaction, the server may materialize a blocked route or reroute a
+   queued Target, checks capacity and Routine concurrency, creates an Attempt,
+   and moves Execution and Target to `preparing`.
+3. The Worker acquires or refreshes the repository, resolves its base commit,
+   creates a branch and worktree, writes a manifest, then starts the supervisor.
+4. The Worker reports process identity and the server moves the lifecycle to
    `running`.
-7. Runtime output is sent as ordered, idempotent event batches.
-8. The worker renews the 30-second lease while the supervisor is active.
-9. Completion records a bounded result, error, and outcome, and moves the
-   execution to `succeeded`, `failed`, or `cancelled`.
+5. Heartbeats extend the lease by 30 seconds and return cancellation state.
+6. Ordered events are appended idempotently. Completion verifies the lease and
+   stores the terminal result once.
+7. The Worker removes proved-safe worktrees and reports retained ones back to
+   the control plane.
 
-The legacy checkout or managed cache is repository metadata and a shared Git
-object store; agent work never runs inside it. Worktrees isolate Git state, not
-process, network, credential, or host filesystem access. A future sandbox may
-contain the prepared worktree without changing task or execution identity.
+### Cancellation, lease loss, and retry
 
-### Cancellation and lease expiry
+Queued or blocked Targets cancel immediately. Active cancellation is stored on
+the Target and Execution, returned by the next heartbeat, and enforced by the
+supervisor. If lease renewal fails or the 30-second deadline passes, the
+supervisor stops the process group and the control plane marks the Attempt
+lost. Startup and periodic sweeps recover expired leases after server failure.
 
-- Cancelling queued work moves its execution directly to `cancelled`.
-- Cancelling preparing or running work sets `cancellation_requested`. The worker
-  observes the flag on its next lease renewal, stops the runtime process group,
-  and reports a cancelled attempt.
-- An expired preparing or running lease moves the attempt to `lost` and its
-  execution to `failed`.
-- Retrying is an explicit operator action available only for failed or cancelled
-  executions. It returns the existing execution to `queued`, increments its
-  retry count, and reuses the task's original resolved prompt even if its
-  Workflow was revised or disabled.
+Only failed or cancelled Targets can be retried. Retry preserves the Target and
+Attempt history, selects a currently eligible Worker, and creates the next
+Attempt when claimed.
 
-### Completion and cleanup
+## 7. API and security boundaries
 
-The worker automatically removes a successful worktree only after proving it is
-clean and either unchanged from its base commit or that every new commit is
-published. It may also delete the managed local branch when that branch is safe
-and unused.
+The local listener exposes health plus operator and Worker routes under
+`/api/v1`: Workers, repositories, Routines, Work, overview, Attempts, and event
+history. It rejects non-loopback clients before route handling.
 
-Other outcomes and uncertain publication are retained. Manual cleanup first
-prints the manifest, path, branch, Git status, and reason. A separate
-`--confirm` run removes the worktree but preserves the local branch.
-The Worker view reports retained paths and ready-to-copy cleanup commands.
+The optional remote listener exposes only health, enrollment exchange, Worker
+registration and claims, and the active Attempt lifecycle. Creating an
+enrollment remains a local operator action. Enrollment tokens are one-time and
+short-lived; exchange installs a per-Worker credential. Attempt routes also
+check that the authenticated Worker owns the Attempt.
 
-At startup, the worker stops process groups recorded as active, compares each
-manifest with server state and Git state, resumes only provably safe cleanup,
-and becomes unhealthy when identity cannot be established.
+Factory is a trusted single-operator system. It has no multi-user tenant model.
+Agents may execute repository code using credentials already available on the
+Worker host. Worktrees isolate Git state, not hostile code. The product must not
+describe a Worker as a security sandbox.
 
-## 6. Interfaces and data
+## 8. Persistence and migration
 
-### Operator API
+Migrations are embedded from `migrations/` and applied in order. Migration 27
+introduces the current Routines and Work model. Migration 28 adds the current
+Work-only claim protocol and rejects incompatible old Workers. Supported legacy
+Definitions, schedules, repositories, and execution history are converted;
+unsupported legacy provider admission is blocked and reported rather than
+silently discarded.
 
-```text
-GET    /healthz
-GET    /api/v1/metrics/summary?window=24h|7d|30d|all
-GET    /api/v1/workers
-GET    /api/v1/workers/{worker_id}
-GET    /api/v1/repositories
-POST   /api/v1/repositories
-GET    /api/v1/repositories/{repository_id}
-PUT    /api/v1/repositories/{repository_id}/enabled
-GET    /api/v1/workflows?title={title}&enabled={bool}&limit={1..200}&cursor={cursor}
-POST   /api/v1/workflows
-GET    /api/v1/workflows/{workflow_id}
-POST   /api/v1/workflows/{workflow_id}/revisions
-PUT    /api/v1/workflows/{workflow_id}/enabled
-GET    /api/v1/automations?limit={1..200}&cursor={cursor}
-POST   /api/v1/automations
-GET    /api/v1/automations/{automation_id}
-PUT    /api/v1/automations/{automation_id}
-PUT    /api/v1/automations/{automation_id}/enabled
-POST   /api/v1/automations/{automation_id}/test
-POST   /api/v1/automations/{automation_id}/check
-POST   /api/v1/automations/{automation_id}/run
-GET    /api/v1/automations/{automation_id}/occurrences?limit={1..200}&cursor={cursor}
-POST   /api/v1/migrations/legacy-poller/preview
-POST   /api/v1/migrations/legacy-poller/import
-GET    /api/v1/migrations/legacy-poller/active
-GET    /api/v1/migrations/legacy-poller/{migration_id}
-POST   /api/v1/migrations/legacy-poller/{migration_id}/finalize
-GET    /api/v1/migrations/product-model
-POST   /api/v1/migrations/product-model/apply
-POST   /api/v1/occurrences/{occurrence_id}/resume
-POST   /api/v1/occurrences/{occurrence_id}/skip
-GET    /api/v1/tasks?limit={1..200}&cursor={cursor}
-POST   /api/v1/tasks
-GET    /api/v1/tasks/{task_id}
-DELETE /api/v1/tasks/{task_id}
-POST   /api/v1/tasks/{task_id}/cancel
-POST   /api/v1/executions/{execution_id}/retry
-GET    /api/v1/attempts/{attempt_id}/events?after={sequence}&limit={1..500}
-```
+Current lifecycle tables include `routines`, `routine_repositories`, `work`,
+`work_targets`, `executions`, `attempts`, `attempt_events`, `workers`,
+`repositories`, Worker repository state, claim request deduplication, and
+Worker enrollment or credentials. Older migration tables may remain for
+history and upgrade compatibility but are not part of the current UI or
+admission path.
 
-Task deletion is limited to terminal history whose worktree disposition has
-been acknowledged. It refuses to delete history for a retained worktree.
+## 9. Future execution backend boundary
 
-### Worker API
+The product direction separates three choices:
 
-```text
-PUT    /api/v1/workers/{worker_id}
-POST   /api/v1/workers/{worker_id}/claims
-GET    /api/v1/attempts/{attempt_id}
-POST   /api/v1/attempts/{attempt_id}/start
-PUT    /api/v1/attempts/{attempt_id}/heartbeat
-POST   /api/v1/attempts/{attempt_id}/events
-POST   /api/v1/attempts/{attempt_id}/complete
-```
+| Choice | Current | Proposed |
+| --- | --- | --- |
+| Execution backend | Persistent local or VM Worker | Cloud Run Job |
+| Agent runtime | Pi, Codex, Claude Code | Same runtime contract |
+| Provider and model | Local subscription or API access | API-backed access |
 
-Mutations require JSON and reject cross-origin browser requests. API requests
-are bounded by operation-specific byte limits.
+Persistent Workers remain the best path for subscription sessions, warm
+caches, and inspectable worktrees. Cloud Run is intended for bursty parallel
+Work where a disposable container and API-backed model are acceptable.
 
-### Persistent model
-
-```text
-Workflow 1 --- * WorkflowRevision 1 --- * Task
-Workflow 1 --- * Automation 1 --- * Occurrence 0..1 --- Task
-Repository 1 --- * Automation
-LegacyPollerMigration 1 --- * Automation
-LegacyPollerMigration 1 --- * imported Occurrence
-Worker   1 --- * WorkerRepository * --- 1 Repository
-Task     1 --- 1 Execution       1 --- * Attempt 1 --- * AttemptEvent
-```
-
-- A Workflow stores stable identity, enabled state, and a pointer to its current
-  immutable revision. The control plane stores at most 500 Workflows and each
-  retains at most 100 revisions.
-- A task stores nullable operator context, repository, optional Workflow
-  snapshot, and its exact resolved prompt in the existing description field.
-- A repository is the central fleet record. Its enabled flag gates new routed
-  work but does not rewrite existing assignments.
-- An Automation stores one concrete `github_issue`, `github_pull_request`,
-  `schedule`, or `github_webhook` Trigger, health and polling or due cursor, counters, and
-  disabled-first state. Its
-  Occurrences snapshot the Workflow revision, repository, predicate,
-  observation, prompt, and deterministic Task request key before dispatch.
-- Automation and Occurrence collection APIs use opaque descending cursors, so
-  every supported record remains reachable beyond the first bounded page.
-- A worker-repository row may be a legacy static advertisement or the dynamic
-  association frozen when a cattle worker is selected.
-- An execution stores its assigned worker, required runtime, state,
-  cancellation flag, and explicit retry count.
-- An attempt stores one claim, lease, process identity, result, and outcome.
-- Attempt events store ordered runtime and lifecycle payloads.
-- Claim requests make empty and successful claims idempotent.
-
-Task lists use an opaque cursor ordered by creation time and ID. Event lists use
-the last sequence number. Prompts remain in task detail but are omitted from the
-task list.
-
-### Limits
-
-| Contract | Limit |
-| --- | ---: |
-| Worker concurrency | 1 to 100, default 10 |
-| Task description | 64 KiB |
-| Workflow instructions | 48 KiB |
-| Resolved prompt | 64 KiB |
-| Complete agent prompt | 72 KiB |
-| Workflows | 500 |
-| Workflow revisions per Workflow | 100 |
-| Workflow page | 50 by default, 200 maximum |
-| Automations | 500 |
-| Automation occurrences | 100,000 |
-| Automation context | 8 KiB |
-| Automation page | 50 by default, 200 maximum |
-| Default task timeout | 2 hours |
-| Maximum task timeout | 8 hours |
-| Lease duration | 30 seconds |
-| Event batch | 100 events and 256 KiB |
-| Single event | 64 KiB |
-| Events stored per attempt | 10 MiB |
-| Completion result | 256 KiB |
-| Completion error | 64 KiB |
-| Retained and reserved worktrees per worker repository | 10 |
-| Managed repositories | 1,000 |
-| Cached repositories per worker | 100 |
-| Task page | 50 by default, 200 maximum |
-| Event page | 100 by default, 500 maximum |
-| Provider matches per Automation check | 100 |
-| Provider command output | 4 MiB |
-| Provider command stderr | 64 KiB |
-| Provider command duration | 30 seconds |
-| Legacy config input | 1 MiB |
-
-### Files and configuration
-
-```text
-~/.factory/
-  bin/
-    factory-server
-    factory-worker
-  server/
-    factory.sqlite3
-    factory.sqlite3.v2-control-plane
-  config.toml
-  worker.toml
-  archive/poller/<migration-id>/
-    poller.toml
-    poller.sqlite3
-    manifest.json
-  workers/<worker>/
-    worker-id
-    worker.lock
-    repositories/<repository-id>/
-    attempts/
-    disposed-attempts.json
-    worktrees/
-```
-
-The marker filename and contents retain compatibility with the earlier Go
-preview storage format. They do not represent a second application.
-
-`FACTORY_DATA_HOME` changes the default root. `FACTORY_SERVER_CONFIG` selects
-the optional control-plane bootstrap TOML. `FACTORY_WORKER_CONFIG` selects one
-worker TOML.
-`FACTORY_BUILD_DIR`, `FACTORY_LISTEN`, `FACTORY_SKIP_BUILD`, and
-`FACTORY_WORKER_READY_SECONDS` configure local commands. Earlier `FACTORY_V2_*`
-names remain migration aliases in code and the local launcher, but are not
-operator-facing configuration.
-
-When `data_directory` is omitted, a worker derives the absolute
-`<config-directory>/workers/<config-basename-without-.toml>` path. Explicit
-relative worker data paths and optional legacy repository paths are resolved
-from the directory that contains the worker TOML; explicit absolute worker data
-paths are unchanged. Managed repositories, Workflows, Automations, and
-evaluation state are configured in SQLite through the control-plane API. Only
-the local listen address, database path, optional remote Worker TLS listener,
-and optional GitHub webhook TLS listener and secret path belong in `config.toml`
-because the server needs them before SQLite opens. Managed repositories are
-cached below the worker data directory.
-
-## 7. Security and trust boundaries
-
-The operator trust boundary is one trusted user on the control-plane host:
-
-- the browser and operator API bind only to loopback and validate request host
-  resolution. There is no operator login or tenant boundary;
-- the optional remote Worker API uses TLS, exposes no operator routes, and
-  authorizes worker and attempt paths against a hashed per-Worker credential;
-- the optional webhook API uses TLS, exposes no operator or Worker routes, and
-  authenticates bounded raw deliveries with an owner-only HMAC secret;
-- ten-minute enrollment tokens are bound to one worker ID and consumed once;
-  long-lived Worker credentials are returned only over TLS, stored in an
-  owner-only file bound to the exact server origin, never logged, and stored
-  server-side only as SHA-256 digests;
-- worker IDs identify stable local state but are not secrets;
-- the agent process has the worker OS user's permissions and can access anything
-  available to that user;
-- the enabled central repository catalog controls routed assignment. Workers
-  accept only canonical GitHub identities from that catalog and never clone an
-  arbitrary URL supplied by a ticket. This is not a filesystem sandbox;
-- provider CLIs own their credentials; Factory does not request, store, or pass
-  provider tokens;
-- the control-plane evaluator invokes the local authenticated `gh` executable
-  with fixed arguments and stores no GitHub token;
-- workers advertise GitHub source access and managed acquisition only after a
-  successful local `gh auth status` probe; registrations contain no token;
-- Workflow instructions and Automation predicates are trusted operator policy;
-- provider item fields are stored in an Automation Occurrence and task prompt
-  as untrusted context;
-- legacy migration reads only explicitly resolved regular non-symlink files,
-  binds and retains the locked ledger inode for each action, rejects pathname
-  replacement, and never deletes the sources;
-- lease tokens are random, sent over loopback HTTP or authenticated HTTPS, and
-  stored as SHA-256 digests;
-- browser mutations must be same-origin and use JSON;
-- worker data directories, identity files, and manifests use restrictive
-  permissions and reject unsafe symlinks where identity matters;
-- an existing database must be a regular non-symlink file; its adjacent marker
-  validates the storage format, and a newly created marker uses mode `0600`;
-- cleanup proves ownership and Git identity before deleting a worktree.
-
-Factory must not be exposed directly to a network. Remote workers require
-authenticated and encrypted transport, scoped authorization, audit records,
-and a reviewed tenant model.
-
-## 8. Failure, capacity, and operations
-
-- Loss of the worker or lease fails the execution. Recovery is an explicit
-  retry, not automatic rescheduling.
-- Loss of the server stops agent process groups after the lease renewal
-  deadline.
-- Worker shutdown stops claiming, terminates active process groups, and reports
-  terminal state when the server remains available.
-- Server shutdown drains HTTP requests, stops the lease sweeper, checkpoints
-  the SQLite WAL, and closes the database.
-- Online backups need no downtime. Restore requires a stopped server and
-  workers, a fresh data home, and post-start health and retained-state checks.
-- A worker data directory is locked to one running worker identity.
-- Worktree reconciliation and cleanup prefer retention over destructive action.
-- Repository capacity counts active work, retained work, and completed attempts
-  whose local disposition has not been acknowledged. This prevents unbounded
-  worktree growth.
-- Task list responses are bounded by cursor pagination, but persistent task,
-  prompt, result, and error history grows until an operator deletes terminal
-  tasks. Factory has no age-based automatic retention job.
-- Event storage is bounded per attempt. Results, errors, prompts, and request
-  bodies also have byte limits.
-- A failed Automation check retains actionable health and retry timing. New
-  Occurrences remain durable pending work until the ordinary dispatcher can
-  route them.
-- Legacy migration lock or snapshot failure makes no partial import or archive.
-  Archive failure leaves the migration imported and retryable. A restart
-  recovers interrupted pending Resume and already completed archive states.
-- Submitted legacy observations preserve their durable identity after import;
-  pending rows retain their exact request only until explicit Resume or Skip.
-- One unhealthy Automation does not stop control-plane APIs or other
-  Automations. Missing, unauthenticated, timed-out, malformed, oversized, and
-  over-limit `gh` results, plus corrupt stored schedule data, are stored as
-  actionable per-Automation health.
-- Normal server shutdown closes a shared occurrence-admission gate for both due
-  schedules and HTTP Run now requests, cancels active `gh` processes, waits for
-  evaluator work to finish, and uses a bounded non-cancelled context to dispatch
-  committed ready Occurrences before closing SQLite.
-
-Summary metrics are derived only from retained control-plane facts: execution
-counts and outcomes, queue and running counts, success and retry rates, median
-cycle time, and worker totals. Factory does not infer merged pull requests or
-triaged tickets from agent text.
-
-## 9. Verification
-
-The implementation is covered by:
-
-- control-plane store, HTTP, state-machine, migration, pagination, deletion,
-  metrics, and lease tests in `internal/controlplane`;
-- worker identity, configuration, registration, process supervision, runtime
-  output, cancellation, lease loss, restart reconciliation, and cleanup tests in
-  `internal/worker`;
-- legacy migration lock, snapshot, identity, pending resolution, archive,
-  restart, and duplicate-prevention tests in `internal/controlplane`;
-- server and worker command tests in `cmd`;
-- embedded asset tests in `web`;
-- React unit, polling, and browser tests in `web/src`;
-- Just command-surface and local-launch checks in `scripts/test-build.sh` and
-  `scripts/test-run-local.sh`.
-
-The contributor check set is documented in [CONTRIBUTING.md](CONTRIBUTING.md).
+The proposed adapter does not make Cloud Run the scheduler or database.
+Factory still owns frozen input, Attempt identity, retry, cancellation, events,
+cost history, and the terminal result. Cloud Run owns disposable compute. A
+verified patch or Git recovery artifact replaces the retained-worktree
+guarantee for ephemeral execution. See the
+[Cloud Run design](docs/cloud-run-agents/design.md) for dispatch fencing,
+outbound control, least-privilege identity, failure recovery, and rollout.
 
 ## 10. Known limitations
 
-- Remote VM Workers require operator-provided VMs, TLS certificates, network
-  policy, agent credentials, and GitHub credentials. Factory does not provision
-  or manage those resources.
-- Windows workers are unsupported.
-- There is no operator authentication or tenant isolation.
-- A task has one execution assigned to one worker. Fan-out and cross-worker
-  rescheduling are not implemented.
-- Execution scheduling is pull-based FIFO per worker. There are no priorities
-  or automatic task retries.
-- GitHub is the only provider implemented for typed provider Automations. Jira,
-  Linear, generic provider plugins, and command adapters are not implemented.
-- Legacy poller command queues are reviewed in Preview and preserved in the
-  archive, but are not imported. Provider items do not automatically rearm.
-- A unified `factory` CLI is proposed but not implemented.
-- Metrics do not confirm external outcomes such as merged pull requests or
-  closed tickets.
-- Terminal history requires explicit deletion. There is no time-based retention
-  policy.
-
-The legacy migration and current typed Automation operation are documented in
-the [local guide](docs/local.md). Design history is described separately in the
-[workflow](docs/workflows/design.md),
-[GitHub ingest](docs/github-ingest/design.md), and [CLI](docs/cli/design.md)
-designs.
+- Only the embedded SQLite orchestration path exists.
+- Cloud Run execution profiles and elastic dispatch are designed but not
+  implemented.
+- Managed repository acquisition supports GitHub through `gh`.
+- The current Worker resolves a repository's base commit during Attempt
+  preparation, so a later retry can observe a newer default branch commit.
+- Remote Workers require operator-managed TLS certificates and enrollment.
+- Windows Workers are unsupported.
+- Execution isolates worktrees and process groups but does not sandbox hostile
+  repository code or network egress.
 
 ## 11. Source map
 
-| Area | Source |
+| Area | Primary files |
 | --- | --- |
-| Server process and defaults | `cmd/factory-server` |
-| Worker process and commands | `cmd/factory-worker` |
-| HTTP API and state machine | `internal/controlplane/http.go`, `state.go` |
-| Persistence and metrics | `internal/controlplane/store.go`, `metrics.go` |
-| Workflow identity, revisions, and listing | `internal/controlplane/workflows.go` |
-| Typed Automation store and API | `internal/controlplane/automations.go`, `automations_http.go` |
-| GitHub evaluator and occurrence dispatch | `internal/controlplane/automation_runtime.go` |
-| Schedule parsing and admission | `internal/controlplane/schedule_cron.go`, `schedule_runtime.go` |
-| GitHub webhook verification and admission | `internal/controlplane/github_webhook_http.go`, `github_webhooks.go` |
-| Legacy poller migration and archive | `internal/controlplane/legacy_poller_*` |
-| Product model upgrade | `internal/controlplane/product_upgrade.go` |
-| Prompt composition and complete agent input | `internal/protocol/prompt.go` |
-| Database schema | `migrations` |
-| Shared contracts and limits | `internal/protocol` |
-| Worker orchestration | `internal/worker/manager.go`, `registration.go`, `claiming.go`, `attempt_lifecycle.go` |
-| Runtime supervision | `internal/worker/supervisor.go` |
-| Repository acquisition, Git worktrees, and cleanup | `internal/worker/repository_cache.go`, `git.go`, `reconcile.go`, `cleanup.go` |
-| Durable worker state | `internal/worker/identity.go`, `manifest.go` |
-| State path compatibility | `internal/statepath` |
-| UI source and API client | `web/src` |
-| Embedded UI serving | `web/embed.go`, `web/dist` |
-| Build and checks | `Justfile` |
-| Local process launcher | `scripts/run-local.sh` |
+| Server startup and config | `cmd/factory-server/main.go`, `cmd/factory-server/config.go` |
+| HTTP routes and auth | `internal/controlplane/http.go`, `internal/controlplane/worker_auth.go` |
+| Routine and Work model | `internal/controlplane/routines.go`, `internal/protocol/routines.go` |
+| Schedule admission | `internal/controlplane/routine_scheduler.go`, `internal/controlplane/schedule_cron.go` |
+| Routing and claims | `internal/controlplane/routine_claim.go`, `internal/controlplane/state.go` |
+| Lease sweep and recovery | `internal/controlplane/server.go`, `internal/controlplane/recovery.go` |
+| Worker manager | `internal/worker/manager.go`, `internal/worker/registration.go`, `internal/worker/claiming.go` |
+| Attempt execution | `internal/worker/attempt_lifecycle.go`, `internal/worker/supervisor.go`, `internal/worker/events.go` |
+| Git and worktrees | `internal/worker/git.go`, `internal/worker/repository_cache.go`, `internal/worker/reconcile.go` |
+| Protocol limits and types | `internal/protocol/types.go`, `internal/protocol/prompt.go` |
+| Schema | `migrations/027_routines_work.sql`, `migrations/028_work_claim_protocol.sql` |
+| Browser UI | `web/src/App.tsx`, `web/src/Routines.tsx`, `web/src/RoutineWork.tsx`, `web/src/Workers.tsx`, `web/src/Repositories.tsx` |

--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ VMs.
 
 Factory starts with coding agents on machines you control and is intended to
 scale to elastic cloud execution without rewriting a Routine or splitting its
-Work history. Existing Routines remain persistent by default; a manual run can
-select a compatible elastic profile. Persistent local and VM Workers remain
-the rich path for subscription authentication, warm repository caches, and
-inspectable worktrees. A proposed
+Work history. Existing Routines remain persistent by default. Once the proposed
+cloud backend is implemented, a manual run will be able to select a compatible
+elastic profile. Persistent local and VM Workers remain the rich path for
+subscription authentication, warm repository caches, and inspectable
+worktrees. A proposed
 Cloud Run backend adds disposable, API-backed agent containers for bursty and
 parallel Work. Read the
 [Cloud Run agent backend design](docs/cloud-run-agents/design.md) for the

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Factory is local-first. Its browser and operator API accept loopback connections
 only. An optional, separate TLS-authenticated endpoint accepts Workers on remote
 VMs.
 
+Factory starts with coding agents on machines you control and is intended to
+scale to elastic cloud execution without rewriting a Routine or splitting its
+Work history. Existing Routines remain persistent by default; a manual run can
+select a compatible elastic profile. Persistent local and VM Workers remain
+the rich path for subscription authentication, warm repository caches, and
+inspectable worktrees. A proposed
+Cloud Run backend adds disposable, API-backed agent containers for bursty and
+parallel Work. Read the
+[Cloud Run agent backend design](docs/cloud-run-agents/design.md) for the
+planned boundary, security model, and rollout.
+
 Read the [product vision](docs/software-factory/vision.md), the
 [target architecture](docs/software-factory/design.md), and the
 [current implementation architecture](ARCHITECTURE.md). Planned work follows
@@ -107,6 +118,20 @@ The control plane owns durable coordination. Workers own execution and Git
 worktrees. Workers poll the API, so the system does not require WebSockets or
 inbound connections to worker hosts.
 
+The future execution model keeps three choices independent:
+
+```text
+Execution backend     Agent runtime              Provider and model
+-----------------     -------------              ------------------
+Persistent Worker  +  Pi, Codex, Claude Code  +  subscription or API
+Cloud Run Job      +  Pi, Codex, Claude Code  +  API-backed model
+```
+
+Cloud Run is a proposed execution backend, not a DeepSeek-specific product.
+For example, the completed experiment ran the Pi runtime in Cloud Run with
+DeepSeek V4 Flash through OpenRouter. Cloud execution is managed and elastic,
+but not infrastructure-free, infinitely scalable, or a hostile-code sandbox.
+
 All default state is below `~/.factory`:
 
 ```text
@@ -138,7 +163,8 @@ Implemented:
 - automatic cleanup of clean unchanged or published work and preservation of
   unpublished branches.
 
-Designed but not implemented: a unified `factory` CLI.
+Designed but not implemented: a unified `factory` CLI and an elastic Cloud Run
+agent backend.
 
 See the [documentation index](docs/README.md) for current guides and proposed
 designs.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ parallel Work. Read the
 planned boundary, security model, and rollout.
 
 Read the [product vision](docs/software-factory/vision.md), the
-[target architecture](docs/software-factory/design.md), and the
-[current implementation architecture](ARCHITECTURE.md). Planned work follows
-the [project workflow](WORKFLOW.md). The target design is a direction, not a
-claim about current behavior.
+[current implementation architecture](ARCHITECTURE.md), and the active
+[Cloud Run backend design](docs/cloud-run-agents/design.md). Planned work
+follows the [project workflow](WORKFLOW.md). Superseded proposals remain
+available through the [documentation index](docs/README.md).
 
 ## Quick start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,10 +11,8 @@ Start with the root [README](../README.md) to run Factory.
   and worktree cleanup.
 - [Remote VM Workers](remote-workers.md): TLS listener, one-time enrollment,
   authentication, and reconnect behavior.
-- [Scheduled Automations](scheduled-automations.md): create, preview, enable,
-  replay, and inspect Definition Runs across repositories.
-- [Product model upgrade](product-upgrade.md): freeze legacy writes, convert
-  compatible schedules, and retain existing history without synthetic Runs.
+- [Routines and Work](routines/design.md): implemented authoring, manual and
+  scheduled Work across repositories, lifecycle, and migration decisions.
 - [Release guide](release.md): install, verify, upgrade, roll back, reproduce,
   and publish tagged releases.
 - [Changelog](../CHANGELOG.md): user-visible changes and compatibility notes.
@@ -30,14 +28,17 @@ Start with the root [README](../README.md) to run Factory.
 
 ## Active design work
 
-- [Routines and Work](routines/design.md): proposed single authoring model,
-  manual and scheduled Work across repositories, final database names, and a
-  reduced Overview.
+- [Cloud Run agent backend](cloud-run-agents/design.md): proposed elastic,
+  API-backed execution alongside persistent local and VM Workers.
 - [Software Factory vision](software-factory/vision.md): product thesis, scope,
   principles, and measures of progress.
 
 ## Design records and superseded proposals
 
+- [Scheduled Automations](scheduled-automations.md): superseded operator guide
+  for removed Definitions, Automations, and Definition Runs.
+- [Product model upgrade](product-upgrade.md): completed migration record for
+  converting supported legacy Definitions and Runs into Routines and Work.
 - [External GitHub ingest](github-ingest/design.md): replaced by control-plane
   typed Automations, then superseded by the target architecture.
 - [Retired GitHub webhook settings](github-webhooks.md): upgrade note for the

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -438,11 +438,13 @@ retry instead of silently running different code.
   established before the Run call. The wrapper anchors the remaining duration
   to the monotonic instant recorded before the request, producing a conservative
   deadline shared by Cloud Run startup, checkout, and agent execution. At the
-  deadline it applies the ten-second process-group kill rule, records a timeout
-  outcome, and stops all gateway writes. A wrapper has no more than five minutes
-  from process start to acquire its fence and never beyond `work_deadline_at`.
-  The versioned Cloud Run Job timeout is at least the maximum Work timeout plus
-  ten seconds and is a platform safety limit, not the Work timeout.
+  deadline Factory records timeout intent in SQLite, while the wrapper applies
+  the ten-second process-group kill rule, stops all Job-originated gateway
+  writes, and exits nonzero. Gateway control-plane authority revocation remains
+  permitted. A wrapper has no more than five minutes from process start to
+  acquire its fence and never beyond `work_deadline_at`. The versioned Cloud Run
+  Job timeout is at least the maximum Work timeout plus ten seconds and is a
+  platform safety limit, not the Work timeout.
 - Event and completion sizes reuse the existing Attempt limits. Artifact size
   defaults to 64 MiB and has a 512 MiB maximum. Completion is rejected when the
   configured bound is exceeded.
@@ -671,9 +673,11 @@ the last verified monotonic deadline; there is no grace period after that
 instant. Before checkout, agent start, every external publish action exposed by
 the wrapper, and final manifest upload, it requires current matching authority.
 On expiry or cancellation it sends SIGTERM to the process group immediately,
-waits ten seconds, sends SIGKILL, and exits nonzero. Any bounded failure
-evidence must already have been uploaded while the gateway still authorized
-it; timeout does not grant a post-expiry write window.
+waits ten seconds, sends SIGKILL, stops all Job-originated gateway writes, and
+exits nonzero. Any bounded failure evidence must already have been uploaded
+while the gateway still authorized it; timeout does not grant the Job a
+post-expiry write window. This does not prevent the gateway from performing a
+control-plane authority-revocation compare-and-set requested by Factory.
 
 Factory asks the gateway to refresh authority only while the same Attempt lease
 and dispatch record remain active. Every gateway response includes server time.
@@ -926,7 +930,10 @@ retention and operator warning.
 Wrapper tests will expire the frozen Work timeout during checkout and agent
 execution, expire the five-minute pre-fence window, delay start-fence responses,
 make the process ignore SIGTERM, and delay artifact upload to prove `INV-14`
-and `AC-14` independently from the profile-wide Job timeout.
+and `AC-14` independently from the profile-wide Job timeout. After expiry they
+must observe no attempted or accepted Job-originated timeout event, final
+manifest, artifact, or other gateway write, while still permitting Factory's
+gateway authority-revocation compare-and-set.
 
 A gated real-project integration test will build an immutable image, run one
 read-only and one patch-producing Attempt, cancel one long-running Attempt,

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -706,8 +706,11 @@ The gateway accepts it only while its own clock is before the current object's
 `valid_until`. It computes the new `valid_until` as the earlier of 30 seconds
 after its own server time and `work_deadline_at`, then writes with GCS
 `ifGenerationMatch`. Replaying the same request ID returns the stored result and
-never extends authority again. Factory cannot issue the next request until it
-has received and persisted that result. Thus one lost or delayed refresh can
+never performs another compare-and-set or extends authority again, including
+after a later revocation. The stored response is historical evidence, not the
+current authority state. Factory ignores such a replay after timeout or
+cancellation intent owns the outcome. Factory cannot issue the next request
+until it has received and persisted that result. Thus one lost or delayed refresh can
 extend authority at most one 30-second window beyond the last acknowledged
 deadline; it cannot form an unbounded chain. At or after `work_deadline_at`, the
 gateway refuses refresh and start-fence requests and conditionally revokes any
@@ -751,8 +754,9 @@ gateway to revoke authority even when no start fence exists. Fence and
 revocation requests compete through the same authority generation. On a
 generation conflict, Factory reads the new generation and retries revocation;
 it never refreshes authority. A successful revocation compare-and-set is the
-gateway fence: every delayed refresh carries the older generation or the
-already-consumed request ID and is rejected. When the gateway is unreachable,
+gateway fence: a delayed first delivery carrying the older generation is
+rejected, while replay of an already-consumed request ID may return only its
+immutable historical response and cannot mutate the revoked object. When the gateway is unreachable,
 Factory does not treat the last acknowledged lease alone as proof if a refresh
 is outstanding. Confirmed revocation, a gateway response showing
 that the absolute deadline has arrived, provider-terminal proof, or expiry of a
@@ -1045,7 +1049,10 @@ extend authority again, and Factory cannot issue a second refresh while the
 first is unresolved. A request delayed past the current `valid_until` must be
 rejected without changing the authority generation, last request ID, or
 deadline. When revocation succeeds, its generation and request-ID fence must
-reject the delayed refresh. Duplicate tests must prove that one terminal
+reject a delayed first delivery. A replay of a refresh consumed before
+revocation must return the original response without changing the current
+generation, revocation marker, or deadline, and Factory must ignore it for
+state transitions. Duplicate tests must prove that one terminal
 execution cannot
 satisfy provider-terminal proof while the fence winner remains active, and that
 the no-winner case requires every matching execution to be terminal.

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -97,14 +97,15 @@ repository identity, and execution-profile version on the cloud Target. Every
 cloud Attempt and explicit retry for that Target reuses those inputs.
 
 The embedded Cloud Run dispatcher creates an Attempt and a backend dispatch
-record in one transaction. The record contains a random run nonce and starts in
-`dispatching`. Factory writes an immutable input document and a short-lived
-authority document to cloud storage, then registers the Attempt and run nonce
-with an Attempt gateway. Factory calls one immutable, versioned Cloud Run Job
-resource with the Attempt ID and a random 256-bit run capability as bounded
-overrides. The capability is sensitive, excluded from logs, and visible only to
-identities already allowed to inspect Cloud Run executions. The prompt, model
-credential, and any cloud credential are not override values.
+record in one transaction. The record contains a random non-secret run ID and
+starts in `dispatching`. Factory writes an immutable input document and a
+short-lived authority document to cloud storage, then registers the Attempt and
+run ID with an Attempt gateway. Factory calls one immutable, versioned Cloud
+Run Job resource with the Attempt ID, run ID, and a separate random 256-bit run
+capability as bounded overrides. The capability is sensitive, excluded from
+logs, and visible only to identities already allowed to inspect Cloud Run
+executions. The prompt, model credential, and any cloud credential are not
+override values.
 
 The Job service account has no access to the artifact bucket, Cloud Run
 administration, or sibling Attempts. Its only data permission is access to the
@@ -118,7 +119,7 @@ This prevents one profile's execution from reading or corrupting a sibling
 execution. It does not prevent trusted repository code from tampering with its
 own Attempt, which is part of the initial trusted-repository boundary.
 
-The Job wrapper obtains a start fence for the Attempt and run nonce before it
+The Job wrapper obtains a start fence for the Attempt and run ID before it
 starts the agent. If a lost API response causes Factory to launch a duplicate,
 only one execution can create that fence; every duplicate exits without
 running an agent. The winning wrapper verifies the input, checks out only the
@@ -141,7 +142,7 @@ the event database.
 
 Before exit, the wrapper uploads a bounded result, Git status, checksummed
 patch or Git recovery bundle, untracked-file archive when present, model cost,
-and a final manifest. The manifest binds the Attempt ID, run nonce, exact
+and a final manifest. The manifest binds the Attempt ID, run ID, exact
 commit, canonical input digest, image digest, runtime and model, Cloud
 execution identity, and byte length and SHA-256 digest of every required
 output. It is written last. Factory rejects an object or manifest whose storage
@@ -299,9 +300,10 @@ without changing Attempt identity.
 #### Factory owns retries
 
 Cloud Run task retries are zero. Every operator retry creates a new Factory
-Attempt, run nonce, and cloud execution while reusing the original frozen Work
-input. We reject native task retries because an agent may already have made
-external side effects and Factory must preserve one visible retry history.
+Attempt, run ID, run capability, and cloud execution while reusing the original
+frozen Work input. We reject native task retries because an agent may already
+have made external side effects and Factory must preserve one visible retry
+history.
 
 #### Durable artifact replaces retained worktree
 
@@ -345,11 +347,11 @@ retry instead of silently running different code.
   provider, model, and execution-profile version before its first dispatch;
   every cloud retry reuses them.
 - `INV-3`: At most one agent process can pass the start fence for one Attempt
-  and run nonce.
+  and run ID.
 - `INV-4`: Authority expiry starts process-group shutdown immediately and the
   wrapper sends SIGKILL no later than ten seconds after expiry.
 - `INV-5`: Cloud Run task retries remain zero; Factory creates every retry.
-- `INV-6`: Event ingestion is ordered and idempotent by Attempt, run nonce,
+- `INV-6`: Event ingestion is ordered and idempotent by Attempt, run ID,
   sequence, and event ID.
 - `INV-7`: Factory accepts successful completion only after verifying the final
   manifest and every required artifact.
@@ -362,7 +364,7 @@ retry instead of silently running different code.
 - `INV-11`: Cloud and persistent backends use the same user-facing Routine,
   Work, Target, result, retry, and cancellation concepts.
 - `INV-12`: Cloud execution never weakens the loopback-only operator API.
-- `INV-13`: A Job identity and run nonce can access only its own Attempt
+- `INV-13`: A Job identity and run capability can access only its own Attempt
   protocol and cannot read or mutate a sibling Attempt.
 
 ### Requirements
@@ -377,9 +379,9 @@ retry instead of silently running different code.
   profile version, runtime, provider, model, timeout, resource class, and commit
   resolution policy. Editing a Routine or profile does not change existing
   Work.
-- Dispatch stores the Attempt ID, run nonce, state, immutable profile version,
-  every observed Cloud operation and execution name, timestamps, error, and
-  reconciliation deadline.
+- Dispatch stores the Attempt ID, non-secret run ID, run-capability digest,
+  state, immutable profile version, every observed Cloud operation and
+  execution name, timestamps, error, and reconciliation deadline.
 - The Job input uses the full commit SHA. Branch names and mutable tags are
   rejected.
 - Before every Run call, the dispatcher reads the Job and verifies its resource
@@ -434,11 +436,12 @@ versioned Job configuration.
 The dispatcher creates
 `attempts/<attempt-id>/gateway-registration.json` before launch. The immutable
 registration stores the expected Job service-account principal, SHA-256 digest
-of the run capability, exact Attempt prefix, input digest, protocol version,
-and absolute expiry. The Job sends the raw capability only to the gateway. The
-gateway hashes it, uses its own bucket identity to load the registration and
-authority, and never exposes list or arbitrary object operations. Authority
-revocation closes an otherwise valid registration immediately.
+of the run capability, non-secret run ID, exact Attempt prefix, input digest,
+protocol version, and absolute expiry. The Job sends the raw capability only to
+the gateway. The gateway hashes it, uses its own bucket identity to load the
+registration and authority, and never exposes list or arbitrary object
+operations. Authority revocation closes an otherwise valid registration
+immediately.
 
 ### Naming and identity
 
@@ -450,7 +453,7 @@ at the frozen old profile and synthetic Worker record.
 
 The synthetic Worker cannot authenticate to the Worker HTTP API and cannot be
 claimed by an external process. The dispatcher uses an internal store
-transaction to create its Attempt and lease. Attempt and run nonce identify the
+transaction to create its Attempt and lease. Attempt and run ID identify the
 dispatch protocol; the Google operation name, execution name, and image digest
 are immutable external observations after they become known.
 
@@ -459,7 +462,8 @@ are immutable external observations after they become known.
 ```text
 attempt_id
 backend_profile_id
-run_nonce
+run_id
+run_capability_digest
 state
 cloud_operation_name
 cloud_execution_name
@@ -479,19 +483,20 @@ override digest, state, and duplicate disposition. The winning execution name
 is set only from the create-only start fence. All other matching executions
 are retained as duplicate evidence and cancelled.
 
-`attempt_id` is the Factory identity. `run_nonce` is random and immutable for
-one dispatch. It is also the short-lived run capability described above and is
-stored in raw form only in the dispatcher's protected database and the active
-Cloud Run override; the artifact store keeps only its digest. Cloud operation
-and execution names are observations returned by Google and never replace
-Factory identity. Missing names keep the record in reconciliation; they do not
+`attempt_id` is the Factory identity. `run_id` is random, non-secret, and
+immutable for one dispatch. It is safe for object names, events, manifests,
+logs, and diagnostic URLs. The separate raw run capability is stored only in
+the dispatcher's protected database and the active Cloud Run override; the
+artifact store keeps only `run_capability_digest`. Cloud operation and
+execution names are observations returned by Google and never replace Factory
+identity. Missing names keep the record in reconciliation; they do not
 authorize a second agent to pass the start fence.
 
 ### Object layout
 
 ```text
 attempts/<attempt-id>/gateway-registration.json
-attempts/<attempt-id>/<run-nonce>/
+attempts/<attempt-id>/<run-id>/
   input.json
   authority.json
   started.json
@@ -524,7 +529,7 @@ themselves.
 
 | Factory dispatch state | Required evidence | Allowed next states |
 | --- | --- | --- |
-| `dispatching` | Committed Attempt, run nonce, immutable input | `starting`, `cancel_requested`, `terminal` |
+| `dispatching` | Committed Attempt, run ID, immutable input | `starting`, `cancel_requested`, `terminal` |
 | `starting` | Accepted Run operation or matching start fence | `running`, `reconciling`, `cancel_requested`, `terminal` |
 | `running` | Matching start fence and valid authority generation | `reconciling`, `cancel_requested`, `terminal` |
 | `reconciling` | Incomplete or conflicting cloud observation | `starting`, `running`, `cancel_requested`, `terminal` |
@@ -532,21 +537,21 @@ themselves.
 | `terminal` | One stored Factory outcome | none |
 
 Before every external side effect, the dispatcher commits the intended state
-and immutable run nonce. A crash before the Run call leaves `dispatching` and
-may safely retry the same nonce. A crash after Google accepts the call but
-before its response leaves `dispatching`. Reconciliation pages every execution
-of the frozen Job version created since the recorded dispatch start, inspects
-its effective environment overrides, and persists every execution carrying the
-exact Attempt ID and run nonce before another Run call is allowed. Another call
-may still create a duplicate container. Every
-container must create the exact `started.json` object with
+and immutable run ID. A crash before the Run call leaves `dispatching` and may
+safely retry the same run ID and capability. A crash after Google accepts the
+call but before its response leaves `dispatching`. Reconciliation pages every
+execution of the frozen Job version created since the recorded dispatch start,
+inspects its effective environment overrides, and persists every execution
+carrying the exact Attempt ID and run ID before another Run call is allowed.
+Another call may still create a duplicate container. Every container must
+create the exact `started.json` object with
 `ifGenerationMatch=0` before checkout, model calls, Git writes, or external tool
-use. A fence winner whose Attempt, nonce, input digest, or authority is stale
+use. A fence winner whose Attempt, run ID, input digest, or authority is stale
 exits nonzero. A fence loser exits zero without running the agent.
 
 Cloud Run execution names are provider-assigned and cannot be deterministic.
-The Factory Attempt and run nonce provide deterministic dispatch identity.
-Factory stores every operation or execution name observed for that nonce
+The Factory Attempt and run ID provide deterministic dispatch identity.
+Factory stores every operation or execution name observed for that run ID
 immutably. The `started.json` winner names its `CLOUD_RUN_EXECUTION`; additional
 names are duplicate evidence and are cancelled. They never replace the winning
 identity. The prototype must prove that the v2 execution-list response exposes
@@ -562,9 +567,9 @@ stored outcome always wins.
 ### Authority lease protocol
 
 The dispatcher is the single authority writer. `authority.json` contains the
-Attempt ID, run nonce, monotonically increasing revision, input digest,
-`valid_until`, cancellation flag, and previous object generation. Each refresh
-uses GCS `ifGenerationMatch` against the generation Factory last stored. A
+Attempt ID, run ID, run-capability digest, monotonically increasing revision,
+input digest, `valid_until`, cancellation flag, and previous object generation.
+Each refresh uses GCS `ifGenerationMatch` against the generation Factory last stored. A
 precondition failure moves the dispatch to `reconciling`, stops refresh, and
 revokes the Attempt because another writer or stale state exists.
 
@@ -605,11 +610,12 @@ dispatch deadline. No Cloud Job starts. Reaching the deadline fails the Attempt
 with an actionable storage or permission error.
 
 If the Run API accepts a request but its response is lost, Factory keeps the
-same run nonce and enumerates matching executions as specified in section 6.
-It persists and supervises the complete matching set. A repeated API call may
-create another container, but only the execution that creates `started.json`
-can launch the agent. Other executions exit successfully without agent side
-effects, are recorded as duplicates, and are cancelled if they remain active.
+same run ID and capability and enumerates matching executions as specified in
+section 6. It persists and supervises the complete matching set. A repeated API
+call may create another container, but only the execution that creates
+`started.json` can launch the agent. Other executions exit successfully without
+agent side effects, are recorded as duplicates, and are cancelled if they
+remain active.
 
 If container startup exceeds 30 seconds, the dispatcher continues renewing the
 Factory lease and cloud authority while the execution is starting. The Job
@@ -716,7 +722,7 @@ Cloud Logging retention are diagnostic and are never the only retained record.
 - `AC-2`: A cloud Attempt runs the frozen full commit and rejects a mutable or
   mismatched Git reference.
 - `AC-3`: A lost launch response or duplicate execution starts at most one
-  agent process for the Attempt and run nonce.
+  agent process for the Attempt and run ID.
 - `AC-4`: After Factory commits cancellation, it revokes authority within five
   seconds; a healthy wrapper stops the agent within 15 more seconds, requests
   Cloud Run cancellation, and reaches a stable cancelled outcome. Controller

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -698,21 +698,31 @@ The dispatcher is the sole authority decision-maker, and the gateway is the
 sole physical authority-object writer. `authority.json` contains the Attempt
 ID, run ID, run-capability digest, monotonically increasing revision, input
 digest, `work_deadline_at`, `valid_until`, winning execution identity when
-fenced, the last refresh request ID, revocation reason, and previous object
-generation. An authenticated refresh request contains a durable unique request
-ID and the expected generation, but no caller-supplied time. Factory allows only
-one outstanding refresh per dispatch and commits its request ID before sending.
-The gateway accepts it only while its own clock is before the current object's
+fenced, a complete `last_refresh_receipt`, revocation reason, and previous object
+generation. The receipt contains the request ID, expected and resulting
+generation, gateway processing time, and resulting `valid_until`. It is written
+atomically with the authority extension. Every later non-refresh authority
+mutation, including fencing and revocation, copies it byte-for-byte; the next
+successful refresh atomically replaces it with its own receipt. It remains in
+`authority.json` for the dispatch retention period, so any gateway instance can
+replay the current receipt after restart without process memory.
+
+An authenticated refresh request contains a durable unique request ID and the
+expected generation, but no caller-supplied time. Factory allows only one
+outstanding refresh per dispatch and commits its request ID before sending. The
+gateway accepts it only while its own clock is before the current object's
 `valid_until`. It computes the new `valid_until` as the earlier of 30 seconds
-after its own server time and `work_deadline_at`, then writes with GCS
-`ifGenerationMatch`. Replaying the same request ID returns the stored result and
-never performs another compare-and-set or extends authority again, including
-after a later revocation. The stored response is historical evidence, not the
-current authority state. Factory ignores such a replay after timeout or
-cancellation intent owns the outcome. Factory cannot issue the next request
-until it has received and persisted that result. Thus one lost or delayed refresh can
-extend authority at most one 30-second window beyond the last acknowledged
-deadline; it cannot form an unbounded chain. At or after `work_deadline_at`, the
+after its own server time and `work_deadline_at`, then writes the authority and
+receipt with one GCS `ifGenerationMatch`. Replaying the request ID in the current
+receipt returns that exact receipt and never performs another compare-and-set or
+extends authority again, including after a later revocation. An older resolved
+request ID is rejected without mutation. The stored response is historical
+evidence, not current authority state. Factory ignores such a replay after
+timeout or cancellation intent owns the outcome. Factory cannot issue the next
+request until it has received and persisted that result. Thus one lost or
+delayed refresh can extend authority at most one 30-second window beyond the
+last acknowledged deadline; it cannot form an unbounded chain. At or after
+`work_deadline_at`, the
 gateway refuses refresh and start-fence requests and conditionally revokes any
 remaining authority. A precondition failure moves the dispatch to
 `reconciling` and stops refresh because another writer or stale state exists. A
@@ -756,12 +766,13 @@ generation conflict, Factory reads the new generation and retries revocation;
 it never refreshes authority. A successful revocation compare-and-set is the
 gateway fence: a delayed first delivery carrying the older generation is
 rejected, while replay of an already-consumed request ID may return only its
-immutable historical response and cannot mutate the revoked object. When the gateway is unreachable,
-Factory does not treat the last acknowledged lease alone as proof if a refresh
-is outstanding. Confirmed revocation, a gateway response showing
-that the absolute deadline has arrived, provider-terminal proof, or expiry of a
-conservative authority-uncertainty deadline permits Factory to commit the
-terminal outcome already owned by timeout or cancellation intent. When there is
+immutable durable receipt and cannot mutate the revoked object. When the gateway
+is unreachable, Factory does not treat the last acknowledged lease alone as
+proof if a refresh is outstanding. Confirmed revocation, a gateway response
+showing that the absolute deadline has arrived, provider-terminal proof, or
+expiry of a conservative authority-uncertainty deadline permits Factory to
+commit the terminal outcome already owned by timeout or cancellation intent.
+When there is
 no outstanding refresh, that uncertainty deadline is the last acknowledged
 authority-expiry upper bound, not the earlier client-stop deadline. When one
 refresh may be unacknowledged, Factory adds one full 30-second authority window
@@ -1052,8 +1063,10 @@ deadline. When revocation succeeds, its generation and request-ID fence must
 reject a delayed first delivery. A replay of a refresh consumed before
 revocation must return the original response without changing the current
 generation, revocation marker, or deadline, and Factory must ignore it for
-state transitions. Duplicate tests must prove that one terminal
-execution cannot
+state transitions. The same replay must work after gateway restart and from a
+different gateway instance by reading the receipt retained in `authority.json`;
+an older resolved request ID must be rejected without mutation. Duplicate tests
+must prove that one terminal execution cannot
 satisfy provider-terminal proof while the fence winner remains active, and that
 the no-winner case requires every matching execution to be terminal.
 

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -267,12 +267,20 @@ records, Cloud Run API calls, Attempt lease renewal, authority refresh,
 event ingestion, artifact verification, cancellation, and restart
 reconciliation. It does not run an agent or make Cloud Run state authoritative.
 
-The Attempt gateway is a narrow authenticated Cloud Run service. It maps one
-Job identity plus one random run capability to one active Attempt and exposes only
-input read, authority read, conditional start-fence creation, bounded event
-append, and bounded output publication. Its service account, not the Job
-service account, accesses the artifact bucket. It rejects unknown, expired,
-terminal, mismatched, cross-prefix, conflicting, and oversized operations.
+The Attempt gateway is a narrow authenticated Cloud Run service with separate
+Job and dispatcher surfaces. The Job surface maps one Job identity plus one
+random run capability to one active Attempt and exposes only input read,
+authority read, conditional start-fence creation, bounded event append, and
+bounded output publication. The dispatcher surface authenticates Factory's
+dedicated dispatcher service identity and exposes only initial-authority
+creation, conditional authority refresh, conditional revocation, and trusted
+gateway-time and authority-status reads for the named Attempt and run ID. Job
+identities cannot invoke dispatcher operations, and dispatcher credentials are
+never present in the Job. Every authority mutation requires the expected object
+generation and an active matching dispatch registration. The gateway service
+account, not the Job service account, accesses the artifact bucket. It rejects
+unknown, expired, terminal, mismatched, cross-prefix, conflicting, and oversized
+operations.
 
 The Job wrapper is the trusted container entrypoint. It owns input validation,
 the start fence, exact checkout, runtime supervision, authority checks, event
@@ -817,9 +825,11 @@ granted to the Job service account, and use permitted network egress.
 
 Each trust tier uses dedicated dispatcher, gateway, and Job service accounts
 and preferably a separate Google Cloud project. The dispatcher can run the
-versioned Job and manage its executions. The gateway can access only the
-artifact bucket. The Job can invoke only the gateway and read its dedicated
-model-secret resource, which has one enabled pinned version. It receives no
+versioned Job, manage its executions, and invoke only the gateway's dispatcher
+authority surface. The gateway validates the exact dispatcher principal and can
+access only the artifact bucket. The Job can invoke only the gateway's Job
+surface and read its dedicated model-secret resource, which has one enabled
+pinned version. It receives no
 artifact-store permission, Cloud Run administration, project editor, or
 Factory control-plane credential.
 Repository credentials are short-lived and scoped to one repository when

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -429,8 +429,10 @@ retry instead of silently running different code.
 - Dispatch stores the Attempt ID, non-secret run ID, run-capability digest,
   envelope-encrypted run-capability ciphertext, state, immutable profile
   version, every observed Cloud operation and execution name, timestamps,
-  gateway-derived `work_started_at` and `work_deadline_at`, error, and
-  reconciliation deadline.
+  gateway-derived `work_started_at` and `work_deadline_at`, the last acknowledged
+  authority generation, an early fail-closed client deadline, a conservative
+  authority-expiry upper bound, any single outstanding refresh request ID,
+  error, and reconciliation deadline.
 - The Job input uses the full commit SHA. Branch names and mutable tags are
   rejected.
 - Before every Run call, the dispatcher reads the Job and verifies its resource
@@ -617,8 +619,8 @@ themselves.
 | `starting` | Accepted Run operation or matching start fence, before `work_deadline_at` | `running`, `reconciling`, `timeout_requested`, `cancel_requested`, `terminal` |
 | `running` | Matching start fence and valid authority generation | `reconciling`, `timeout_requested`, `cancel_requested`, `terminal` |
 | `reconciling` | Incomplete or conflicting cloud observation; an unexpired Work deadline before returning to `starting` or `running` | `starting`, `running`, `timeout_requested`, `cancel_requested`, `terminal` |
-| `timeout_requested` | Expired conservative monotonic Work deadline; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed last verified authority deadline, or provider-terminal proof for the matching execution set |
-| `cancel_requested` | Durable cancellation time; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed last verified authority deadline, or provider-terminal proof for the matching execution set |
+| `timeout_requested` | Expired conservative monotonic Work deadline; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed conservative authority-uncertainty deadline, or provider-terminal proof for the matching execution set |
+| `cancel_requested` | Durable cancellation time; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed conservative authority-uncertainty deadline, or provider-terminal proof for the matching execution set |
 | `terminal` | One stored Factory outcome | none |
 
 Before every external side effect, the dispatcher commits the intended state
@@ -696,23 +698,35 @@ The dispatcher is the sole authority decision-maker, and the gateway is the
 sole physical authority-object writer. `authority.json` contains the Attempt
 ID, run ID, run-capability digest, monotonically increasing revision, input
 digest, `work_deadline_at`, `valid_until`, winning execution identity when
-fenced, revocation reason, and previous object generation. An authenticated
-refresh request contains the expected generation and desired revocation state,
-but no caller-supplied time. The
-gateway computes `valid_until` as the earlier of 30 seconds after its own server
-time and `work_deadline_at`, then writes with GCS `ifGenerationMatch`. At or
-after `work_deadline_at`, it refuses refresh and start-fence requests and
-conditionally revokes any remaining authority. A precondition failure moves
-the dispatch to `reconciling` and stops refresh because another writer or stale
-state exists. A timeout or cancellation revocation then reads the new generation
-and retries until revocation is confirmed or the absolute deadline has arrived.
+fenced, the last refresh request ID, revocation reason, and previous object
+generation. An authenticated refresh request contains a durable unique request
+ID and the expected generation, but no caller-supplied time. Factory allows only
+one outstanding refresh per dispatch and commits its request ID before sending.
+The gateway accepts it only while its own clock is before the current object's
+`valid_until`. It computes the new `valid_until` as the earlier of 30 seconds
+after its own server time and `work_deadline_at`, then writes with GCS
+`ifGenerationMatch`. Replaying the same request ID returns the stored result and
+never extends authority again. Factory cannot issue the next request until it
+has received and persisted that result. Thus one lost or delayed refresh can
+extend authority at most one 30-second window beyond the last acknowledged
+deadline; it cannot form an unbounded chain. At or after `work_deadline_at`, the
+gateway refuses refresh and start-fence requests and conditionally revokes any
+remaining authority. A precondition failure moves the dispatch to
+`reconciling` and stops refresh because another writer or stale state exists. A
+timeout or cancellation revocation then reads the new generation and retries
+until revocation is confirmed or the absolute deadline has arrived.
 
 Every refresh and authority-read response returns the gateway server time,
-`valid_until`, revision, and object generation from one operation. The wrapper
-records local monotonic time immediately before every gateway request and sets
-the returned `valid_until - server_time` duration against that earlier instant.
-Network delay can shorten but never extend authority. Neither the Factory clock
-nor the wrapper wall clock can extend validity. It fetches authority at most
+`valid_until`, refresh request ID, revision, and object generation from one
+operation. The wrapper and Factory record suspend-aware monotonic instants both
+immediately before sending and immediately after receiving the response. They
+set an early fail-closed deadline by adding `valid_until - server_time` to the
+pre-request instant. Factory separately persists an authority-expiry upper
+bound by adding the same duration to the response-receipt instant. Network delay
+therefore shortens client permission but lengthens only the conservative proof
+window; neither bound can let Factory terminalize while gateway authority may
+still be valid. Neither the Factory clock nor the wrapper wall clock can extend
+validity. The wrapper fetches authority at most
 five seconds apart and verifies the revision and generation never move
 backwards. A read error is not authority. The wrapper may continue only until
 the last verified monotonic deadline; there is no grace period after that
@@ -736,24 +750,33 @@ refresh and Run calls, atomically records `timeout_requested`, and asks the
 gateway to revoke authority even when no start fence exists. Fence and
 revocation requests compete through the same authority generation. On a
 generation conflict, Factory reads the new generation and retries revocation;
-it never refreshes authority. Confirmed revocation, a gateway response showing
-that the absolute deadline has arrived, provider-terminal proof, or expiry
-of the last verified authority deadline on Factory's suspend-aware monotonic
-clock permits Factory to commit the terminal outcome already owned by timeout or
-cancellation intent. The last case is sufficient because the gateway never
-grants authority beyond that anchored instant; another gateway response is not
-required merely to restate expiry. Factory durably records which proof
-terminalized the outcome, then requests Cloud Run cancellation as platform
-cleanup. Therefore no container can acquire a valid fence after Factory records
-the terminal timeout. After a Factory restart, no refresh or Run retry is
-allowed until a fresh gateway response establishes a new conservative monotonic
-deadline. If the gateway is unreachable, Factory first proves exclusive
-dispatch ownership and waits the full 30-second maximum authority lease from
-its suspend-aware monotonic startup instant. That conservative wait substitutes
-for the lost pre-restart anchor and may terminalize an already owned timeout or
-cancellation without a fresh gateway response; provider terminal state may do
-the same sooner only when it satisfies the set-wide proof below. Gateway failure
-cannot revive the execution.
+it never refreshes authority. A successful revocation compare-and-set is the
+gateway fence: every delayed refresh carries the older generation or the
+already-consumed request ID and is rejected. When the gateway is unreachable,
+Factory does not treat the last acknowledged lease alone as proof if a refresh
+is outstanding. Confirmed revocation, a gateway response showing
+that the absolute deadline has arrived, provider-terminal proof, or expiry of a
+conservative authority-uncertainty deadline permits Factory to commit the
+terminal outcome already owned by timeout or cancellation intent. When there is
+no outstanding refresh, that uncertainty deadline is the last acknowledged
+authority-expiry upper bound, not the earlier client-stop deadline. When one
+refresh may be unacknowledged, Factory adds one full 30-second authority window
+to that receipt-anchored upper bound. The single-flight, idempotent refresh rule
+proves that no delayed request can extend authority beyond that later instant.
+Another gateway
+response is not required merely to restate expiry. Factory durably records which
+proof terminalized the outcome, then requests Cloud Run cancellation as
+platform cleanup. Therefore no container can retain valid authority after
+Factory records the terminal timeout or cancellation. After a Factory restart,
+no refresh or Run retry is allowed until a fresh gateway response establishes a
+new conservative monotonic deadline. If the gateway is unreachable, Factory
+first proves exclusive dispatch ownership and waits a full 60 seconds from its
+suspend-aware monotonic startup instant: one maximum currently valid 30-second
+lease plus one possible unacknowledged refresh extension. That conservative
+wait substitutes for the lost pre-restart anchor and may terminalize an already
+owned timeout or cancellation without a fresh gateway response; provider
+terminal state may do the same sooner only when it satisfies the set-wide proof
+below. Gateway failure cannot revive the execution.
 
 Provider-terminal proof is set-wide, not evidence from any one duplicate. If a
 start-fence winner is known, its Cloud Run execution must be terminal and every
@@ -776,9 +799,11 @@ a further ten seconds.
 The product bound is 15 seconds after successful authority revocation, with a
 five-second allowance for dispatcher scheduling. If the controller disappears
 without revoking authority, the last 30-second authority window plus the
-ten-second kill grace bounds process survival to 40 seconds. Cloud Run may take
-longer to report the execution terminal, so Factory tracks that platform
-reconciliation separately with a two-minute deadline.
+possible single unacknowledged 30-second refresh extension plus the ten-second
+kill grace bounds process survival to 70 seconds. When no refresh is outstanding
+the original 40-second bound applies. Cloud Run may take longer to report the
+execution terminal, so Factory tracks that platform reconciliation separately
+with a two-minute deadline.
 
 ## 7. Failure behavior and lifecycle
 
@@ -852,9 +877,8 @@ reconciles every nonterminal cloud dispatch before admitting new cloud work.
 The two-minute reconciliation deadline never replaces a durable terminal owner
 or bypasses authority-expiry proof. A dispatch with timeout or cancellation
 intent remains nonterminal until the gateway confirms revocation or absolute
-expiry, the last verified suspend-aware authority deadline elapses, set-wide
-provider-terminal proof completes as defined above, or a restarted exclusive
-owner completes the full maximum-lease wait described above. It then commits
+expiry, the conservative authority-uncertainty deadline elapses, or set-wide
+provider-terminal proof completes as defined above. It then commits
 the outcome already owned by that intent. Only a dispatch with neither intent
 that still cannot prove
 ownership within two minutes records a `cloud_reconciliation_timeout` failure
@@ -930,7 +954,9 @@ Cloud Logging retention are diagnostic and are never the only retained record.
 - `AC-4`: After Factory commits cancellation, it revokes authority within five
   seconds; a healthy wrapper stops the agent within 15 more seconds, requests
   Cloud Run cancellation, and reaches a stable cancelled outcome. Controller
-  loss starts shutdown by 30 seconds and kills the process by 40 seconds.
+  loss with no outstanding refresh starts shutdown by 30 seconds and kills the
+  process by 40 seconds. One unacknowledged refresh increases those conservative
+  bounds to 60 and 70 seconds; it cannot chain another extension.
 - `AC-5`: Factory restart reconciles every nonterminal execution before it
   admits new cloud work.
 - `AC-6`: Native Cloud Run retries are zero and only an explicit Factory retry
@@ -1002,13 +1028,25 @@ terminal write. Before the trusted Work deadline, a transient missing or stale
 gateway response must remain `reconciling` and retry rather than record timeout.
 After expiry it must reject success and take the conditional timeout branch.
 Authority tests will make the gateway permanently unreachable after timeout and
-cancellation intent, then prove that expiry of the last verified suspend-aware
-authority deadline terminalizes the owned outcome without another gateway
-response. A separate restart test discards the old monotonic anchor, makes the
-gateway unreachable, and proves terminalization remains blocked until Factory
-acquires exclusive dispatcher ownership and completes the full 30-second
-maximum-lease wait on a fresh suspend-aware clock, including host suspension
-during that wait. Duplicate tests must prove that one terminal execution cannot
+cancellation intent. With no outstanding refresh, expiry of the last
+acknowledged receipt-anchored authority-expiry upper bound terminalizes the
+owned outcome. With one committed unacknowledged refresh, terminalization
+remains blocked for one additional full authority window. Tests delay an
+acknowledged response, then lose a refresh accepted near actual expiry and prove
+Factory waits beyond the real lease plus its possible extension. A separate
+restart test discards the old
+monotonic anchor, makes the gateway unreachable, and proves terminalization
+remains blocked until Factory acquires exclusive dispatcher ownership and
+completes the full 60-second current-plus-unacknowledged-lease wait on a fresh
+suspend-aware clock, including host suspension during that wait. Refresh-race
+tests delay and lose a refresh response, then prove cancellation cannot
+terminalize before the uncertainty deadline, replaying its request ID cannot
+extend authority again, and Factory cannot issue a second refresh while the
+first is unresolved. A request delayed past the current `valid_until` must be
+rejected without changing the authority generation, last request ID, or
+deadline. When revocation succeeds, its generation and request-ID fence must
+reject the delayed refresh. Duplicate tests must prove that one terminal
+execution cannot
 satisfy provider-terminal proof while the fence winner remains active, and that
 the no-winner case requires every matching execution to be terminal.
 

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -1,0 +1,814 @@
+# Elastic Cloud Run agent backend
+
+> **Status:** Proposed for review
+
+## 1. Executive summary
+
+Factory currently runs every coding agent through a persistent Worker on a
+local machine or VM. That path is valuable because it can use authenticated
+subscription CLIs, reuse repository caches, and retain failed worktrees, but an
+operator must provide and maintain enough machines for peak demand.
+
+This design adds Cloud Run Jobs as a second execution backend. Factory will
+start one disposable container for one Work Target, run Pi, Codex, or Claude
+Code with API-backed model access, ingest ordered events, preserve a recovery
+artifact, and stop paying for compute when the Job exits. The existing control
+plane remains the source of truth. Cloud Run provides managed compute, not a
+second scheduler or product model.
+
+The main downside is weaker local recovery. An ephemeral Job cannot retain an
+inspectable worktree after it exits, so it must publish a durable, verified
+artifact before Factory accepts completion. Cloud Run also isolates a process
+from the operator's machine but does not make arbitrary repository code safe.
+
+## 2. Context and scope
+
+The current [architecture](../../ARCHITECTURE.md) separates durable
+coordination from agent execution. A persistent Worker claims work, prepares a
+worktree, owns a 30-second Attempt lease, starts one runtime process, sends
+events, observes cancellation, and retains uncertain Git state. Local and VM
+Workers use the same lifecycle contract.
+
+The [Cloud Run experiment](https://github.com/owainlewis/factory/pull/275)
+proved a narrower path against the Factory repository:
+
+- Cloud Build produced a pinned, non-root Pi container.
+- A Cloud Run Job checked out an exact commit and ran Pi from that directory.
+- Pi used DeepSeek V4 Flash through OpenRouter in read-only and write modes.
+- Structured output omitted model reasoning and reported model cost.
+- Write mode produced an exact patch without pushing a branch.
+- The final read-only execution completed in 55 seconds, including a 33-second
+  start, with $0.00209 of model usage. At the current published default Cloud
+  Run Jobs rates, its one-minute minimum would cost about $0.00132 before the
+  free tier.
+
+That experiment proves container execution, not the Factory lifecycle. It does
+not prove durable dispatch, lease fencing, restart recovery, prompt
+cancellation, private repository access, event ingestion, or artifact
+retention. This design covers those boundaries for one Google Cloud project
+and region. It does not replace persistent Workers or generalize execution to
+every cloud provider.
+
+## 3. System context
+
+```mermaid
+flowchart LR
+    O["Operator"] --> R["Routine and Work"]
+    R --> CP["Factory control plane"]
+    CP --> PW["Persistent Worker backend"]
+    PW --> PA["Subscription or API-backed agent"]
+    CP --> CD["Cloud Run dispatcher"]
+    CD --> CR["One Cloud Run Job execution"]
+    CR --> CA["API-backed agent"]
+    CD <--> CS["Cloud control and artifact storage"]
+    CR --> AG["Attempt gateway"]
+    AG <--> CS
+    PW --> GH["Git repository and external tools"]
+    CR --> GH
+```
+
+Factory owns Routines, Work, Target and Attempt identity, the frozen prompt and
+commit, scheduling, capacity, retries, cancellation, events, results, cost
+history, and terminal outcomes. The persistent Worker owns its cache,
+worktrees, agent processes, and local cleanup. The Cloud Run adapter owns cloud
+dispatch, execution reconciliation, authority publication, cancellation, and
+artifact transport. Cloud Run owns disposable compute only.
+
+Backend, runtime, and model are independent choices:
+
+| Choice | Examples | Owner |
+| --- | --- | --- |
+| Execution backend | Persistent Worker, Cloud Run Job | Factory routing |
+| Agent runtime | Pi, Codex, Claude Code | Backend capability |
+| Provider and model | Subscription session, OpenRouter and DeepSeek | Execution profile |
+
+DeepSeek V4 Flash is one tested model, not a Cloud Run backend type.
+
+## 4. Proposed design
+
+### How it works
+
+An operator runs a Routine against one repository and supplies the configured
+`Cloud Run Europe` profile as a manual run override. Factory creates ordinary
+Work and Target records. A cloud repository input resolver turns the configured
+source ref into a full Git commit SHA before the Target queues. Factory freezes
+that commit, the complete prompt, runtime, provider and model selection,
+repository identity, and execution-profile version on the cloud Target. Every
+cloud Attempt and explicit retry for that Target reuses those inputs.
+
+The embedded Cloud Run dispatcher creates an Attempt and a backend dispatch
+record in one transaction. The record contains a random run nonce and starts in
+`dispatching`. Factory writes an immutable input document and a short-lived
+authority document to cloud storage, then registers the Attempt and run nonce
+with an Attempt gateway. Factory calls one immutable, versioned Cloud Run Job
+resource with the Attempt ID and a random 256-bit run capability as bounded
+overrides. The capability is sensitive, excluded from logs, and visible only to
+identities already allowed to inspect Cloud Run executions. The prompt, model
+credential, and any cloud credential are not override values.
+
+The Job service account has no access to the artifact bucket, Cloud Run
+administration, or sibling Attempts. Its only data permission is access to the
+dedicated, single-version model secret when the selected provider requires one.
+It can mint an identity token whose audience is only the Attempt gateway. The
+gateway requires that token and the random run capability, maps them to one
+active Attempt prefix, and permits only the protocol operations and byte limits
+defined in this document.
+The gateway performs all Job-originated storage reads and conditional writes.
+This prevents one profile's execution from reading or corrupting a sibling
+execution. It does not prevent trusted repository code from tampering with its
+own Attempt, which is part of the initial trusted-repository boundary.
+
+The Job wrapper obtains a start fence for the Attempt and run nonce before it
+starts the agent. If a lost API response causes Factory to launch a duplicate,
+only one execution can create that fence; every duplicate exits without
+running an agent. The winning wrapper verifies the input, checks out only the
+frozen commit, and starts the selected runtime in the checkout.
+
+The dispatcher refreshes the authority document every ten seconds while it
+owns the Attempt. The wrapper checks authority before agent launch and at most
+every five seconds while the process runs. An expired, cancelled, or mismatched
+authority starts shutdown of the runtime process group. This preserves
+fail-closed lease behavior without making the local Factory API reachable from
+the internet.
+Cloud execution therefore depends on one continuously running Factory control
+plane in the first release. Closing a laptop-hosted control plane deliberately
+stops its Cloud Jobs within the authority window.
+
+The wrapper uploads normalized event batches with stable sequence numbers.
+Factory polls and ingests those batches idempotently into the existing Attempt
+event history. Cloud Logging receives a sanitized diagnostic mirror but is not
+the event database.
+
+Before exit, the wrapper uploads a bounded result, Git status, checksummed
+patch or Git recovery bundle, untracked-file archive when present, model cost,
+and a final manifest. The manifest binds the Attempt ID, run nonce, exact
+commit, canonical input digest, image digest, runtime and model, Cloud
+execution identity, and byte length and SHA-256 digest of every required
+output. It is written last. Factory rejects an object or manifest whose storage
+generation, prefix, identity, digest, or immutable input does not match the
+dispatch record. Partial artifacts remain visible on failure.
+
+Cancellation first records Factory's intent and revokes authority. The
+dispatcher then calls the Cloud Run cancellation API and keeps reconciling
+until Google reports a terminal execution. A result published after the
+cancellation decision is retained for inspection but cannot turn the Attempt
+into succeeded.
+
+### Guided setup and operator experience
+
+Persistent Workers remain available with no Google Cloud configuration. An
+operator who adds a Cloud Run profile supplies a project, region, and billing
+account, then asks Factory to validate or provision the managed resources. The
+setup creates or verifies required APIs, Artifact Registry, immutable Job
+versions, artifact storage, the Attempt gateway, separate dispatcher, gateway,
+and Job service accounts, exact secret bindings, budget alerts, and the
+dispatcher identity. It prints every permission before applying it and can run
+in validation-only mode.
+
+The setup screen reports image digest, region, available capacity, supported
+runtimes and models, secret readiness, artifact retention, and the latest
+validation. It never labels the backend as infrastructure-free or unlimited.
+A disabled or unhealthy profile remains visible with an actionable reason and
+cannot receive new Work.
+
+Routine authoring keeps its current runtime field and gains an optional default
+execution profile. A missing profile means the built-in `persistent-auto`
+profile, so every existing Routine keeps its current behavior without a data
+migration. A manual Run request may override the default with any compatible
+profile without creating a new Routine generation. Scheduled Work uses the
+Routine default. Work freezes the effective profile version, runtime, provider,
+and model at admission. A retry cannot change backend, and Factory does not
+automatically fail over between backends in the first release.
+
+Work and Attempt detail show the selected backend, but lists and metrics
+continue to use one product lifecycle across both backends.
+
+### Delivery sequence
+
+The work ships in six independently reviewable slices:
+
+1. **Backend contract.** Add immutable execution-profile versions, a manual Run
+   override, cloud repository input resolution, and a fake cloud backend behind
+   the current Work and Attempt state machine. Existing Persistent Worker
+   configuration and commit-resolution behavior remain compatible.
+2. **Artifact protocol.** Define canonical input, authority, start fence,
+   ordered event batches, recovery artifacts, checksums, size limits, retention,
+   and the Attempt gateway against local test doubles.
+3. **Durable dispatcher.** Add dispatch persistence, zero-retry launch,
+   authority renewal, cancellation, bounded polling, restart reconciliation,
+   quota backoff, and duplicate-start tests against a fake Cloud Run API.
+4. **Managed runner.** Turn the experimental image into the trusted Job wrapper,
+   pin its dependencies and image digest, and prove read-only, patch-producing,
+   cancellation, lease-expiry, and corrupt-artifact cases in a real test project.
+5. **Product setup.** Add profile configuration, validation, guided resource
+   provisioning, health, cost evidence, Attempt diagnostics, and operator
+   documentation.
+6. **Repository publishing.** After the lifecycle is stable, add short-lived,
+   repository-scoped credentials for private checkout and branch or pull-request
+   publication. The first five slices require only durable patch recovery.
+
+Each slice must preserve the invariants and pass independent review before the
+next slice depends on it. The Cloud backend remains disabled by default until
+the real-project acceptance suite passes.
+
+### Components and responsibilities
+
+The execution router owns backend selection from the effective profile frozen
+in the immutable Work snapshot and compatible capacity. The Routine default or
+manual Run override chooses that profile before admission. The router depends
+on configured backend profiles. It does not interpret runtime output or call
+cloud APIs, and it does not move an admitted Target to another backend.
+
+The cloud repository input resolver owns mutable-ref resolution for Cloud Run.
+It records the requested source ref, resolved full commit, resolver identity,
+and resolution time on each cloud Work Target before that Target can queue. A
+cloud retry never resolves the ref again. Persistent Workers keep the current
+`resolve_per_attempt` behavior in the first release, including resolving the
+base again on explicit retry. Work records the resolution policy so the
+difference is visible rather than implied to be uniform.
+
+One enabled Cloud Run profile projects into one stable synthetic Worker pool in
+the existing routing model. The pool advertises configured capabilities,
+health, and capacity, but it never enrolls, polls, or holds a remote Worker
+credential. The dispatcher claims and supervises work internally on its behalf.
+This preserves non-null Execution and Attempt worker attribution while making
+the different recovery contract explicit in the Worker and Attempt views.
+
+The persistent Worker backend is the current Worker manager and supervisor. It
+owns subscription-backed CLI sessions, repository caches, worktrees, process
+groups, and local recovery. It does not manage cloud resources.
+
+The Cloud Run dispatcher is a durable control-plane component. It owns dispatch
+records, Cloud Run API calls, Attempt lease renewal, authority refresh,
+event ingestion, artifact verification, cancellation, and restart
+reconciliation. It does not run an agent or make Cloud Run state authoritative.
+
+The Attempt gateway is a narrow authenticated Cloud Run service. It maps one
+Job identity plus one random run capability to one active Attempt and exposes only
+input read, authority read, conditional start-fence creation, bounded event
+append, and bounded output publication. Its service account, not the Job
+service account, accesses the artifact bucket. It rejects unknown, expired,
+terminal, mismatched, cross-prefix, conflicting, and oversized operations.
+
+The Job wrapper is the trusted container entrypoint. It owns input validation,
+the start fence, exact checkout, runtime supervision, authority checks, event
+normalization, artifact publication, and exit status. It does not choose work,
+retry an Attempt, or decide Factory's terminal outcome.
+
+The agent runtime owns model interaction and engineering tool use. It receives
+one prepared checkout and a bounded prompt. It does not receive control-plane
+credentials or authority to dispatch other Jobs.
+
+The artifact store holds immutable input, authority, event, and output objects.
+It is transport and recovery storage, not the source of Factory lifecycle
+truth. Factory remains able to rebuild its view from SQLite and reconcile
+nonterminal cloud dispatches.
+
+### Decisions
+
+#### Two backends, one product contract
+
+Persistent Workers and Cloud Run Jobs produce the same Work, Target, Attempt,
+event, result, cancellation, and retry experience. We reject a separate
+"cloud task" product because execution location must not split Routine history
+or metrics.
+
+#### Backend choice freezes on Work
+
+An existing Routine defaults to `persistent-auto`. A Routine may save another
+default, and a manual Run may override it without editing the Routine. The
+effective profile version freezes on Work admission and every Target and retry
+uses it. We reject automatic cross-backend failover because the credential,
+commit-resolution, and recovery contracts differ and a retry may repeat
+external effects.
+
+#### Backend, runtime, and model stay separate
+
+An execution profile combines compatible settings without making them one
+identity. We reject `deepseek_cloud` or similar backend names because Pi can
+use DeepSeek locally and a Cloud Run image can support other API-backed models.
+
+#### Outbound-only control
+
+The first integration uses outbound Google APIs and cloud storage. We reject a
+public callback into Factory because the operator API is loopback-only and the
+current product has no tenant authentication boundary. A later hosted Factory
+deployment may replace polling with an authenticated private callback or queue
+without changing Attempt identity.
+
+#### Factory owns retries
+
+Cloud Run task retries are zero. Every operator retry creates a new Factory
+Attempt, run nonce, and cloud execution while reusing the original frozen Work
+input. We reject native task retries because an agent may already have made
+external side effects and Factory must preserve one visible retry history.
+
+#### Durable artifact replaces retained worktree
+
+Persistent Workers keep the current retained-worktree contract. Cloud Jobs
+publish a recovery artifact because their filesystem is ephemeral. We reject
+success based only on exit code or logs because either can be present without
+recoverable Git output.
+
+#### Cloud Logging is a mirror
+
+Structured Cloud logs remain useful for live operator inspection and platform
+diagnosis. Ordered event objects and the verified final manifest drive Factory
+state. We reject parsing Cloud Logging as the event protocol because delivery,
+ordering, retention, and redaction are controlled outside Factory.
+
+#### Trusted repositories first
+
+The first release supports repositories and prompts trusted by the Factory
+operator. Cloud Run supplies disposable container isolation, not a promise that
+hostile code cannot read injected credentials, use the Job service account, or
+send network traffic. Arbitrary untrusted code requires a separate threat model
+and stronger controls.
+
+#### Immutable Job versions
+
+Cloud Run Run overrides cannot change an image or service identity. Every
+execution-profile edit that affects the image digest, service account, mounted
+secret version, resources, timeout, or wrapper configuration creates a new
+immutable profile version and a distinct versioned Job resource. Work freezes
+that version before dispatch. Referenced versions cannot be deleted. An
+explicit retry uses the same version; if it is unavailable, Factory blocks the
+retry instead of silently running different code.
+
+## 5. Invariants and requirements
+
+### Invariants
+
+- `INV-1`: Factory is the sole authority for Work, Attempt, retry,
+  cancellation, and terminal state.
+- `INV-2`: Every cloud Work Target freezes one full commit SHA, prompt, runtime,
+  provider, model, and execution-profile version before its first dispatch;
+  every cloud retry reuses them.
+- `INV-3`: At most one agent process can pass the start fence for one Attempt
+  and run nonce.
+- `INV-4`: Authority expiry starts process-group shutdown immediately and the
+  wrapper sends SIGKILL no later than ten seconds after expiry.
+- `INV-5`: Cloud Run task retries remain zero; Factory creates every retry.
+- `INV-6`: Event ingestion is ordered and idempotent by Attempt, run nonce,
+  sequence, and event ID.
+- `INV-7`: Factory accepts successful completion only after verifying the final
+  manifest and every required artifact.
+- `INV-8`: Cancellation recorded before verified completion cannot become
+  succeeded because of a late cloud result.
+- `INV-9`: A control-plane restart can identify, reconcile, and either resume
+  supervision or cancel every nonterminal cloud execution.
+- `INV-10`: The Job receives no operator API credential or broad cloud
+  administration role.
+- `INV-11`: Cloud and persistent backends use the same user-facing Routine,
+  Work, Target, result, retry, and cancellation concepts.
+- `INV-12`: Cloud execution never weakens the loopback-only operator API.
+- `INV-13`: A Job identity and run nonce can access only its own Attempt
+  protocol and cannot read or mutate a sibling Attempt.
+
+### Requirements
+
+- One backend profile has a stable ID and immutable versions. Each version has
+  a Google Cloud project and region, Job resource, image digest, service
+  account, dedicated model-secret resource, artifact gateway, capacity limit,
+  trust tier, and
+  supported runtime and provider capabilities.
+- A Routine stores an optional default backend profile. A manual Run may supply
+  a compatible override. The admitted Work snapshot records the effective
+  profile version, runtime, provider, model, timeout, resource class, and commit
+  resolution policy. Editing a Routine or profile does not change existing
+  Work.
+- Dispatch stores the Attempt ID, run nonce, state, immutable profile version,
+  every observed Cloud operation and execution name, timestamps, error, and
+  reconciliation deadline.
+- The Job input uses the full commit SHA. Branch names and mutable tags are
+  rejected.
+- Before every Run call, the dispatcher reads the Job and verifies its resource
+  name, template digest, image digest, service account, model-secret resource
+  and version, task count of one, and native retry count of zero against the
+  frozen profile version. Drift blocks dispatch. The wrapper repeats the
+  verifiable checks and binds the effective values into its final manifest.
+- Dispatch and reconciliation respect the profile capacity and Google Cloud
+  API, CPU, memory, and execution quotas. Quota pressure leaves work queued or
+  blocked with an actionable reason; it does not create extra executions.
+- Dispatch retries transient pre-launch failures after one second with jitter,
+  doubles to at most 30 seconds, and stops after the five-minute dispatch
+  deadline. The dispatcher polls running execution state at most five seconds
+  apart and event objects at most two seconds apart.
+- The wrapper checks authority at most five seconds apart. Authority remains
+  valid for no more than 30 seconds without a dispatcher refresh.
+- Event and completion sizes reuse the existing Attempt limits. Artifact size
+  defaults to 64 MiB and has a 512 MiB maximum. Completion is rejected when the
+  configured bound is exceeded.
+- Cloud execution status, model cost, compute duration, image digest, and
+  console log URL appear in Attempt detail.
+- Persistent Workers remain the default backend and require no Google Cloud
+  configuration.
+
+## 6. Interfaces and data
+
+### Backend profile
+
+The first proposed profile fields are:
+
+```text
+id
+name
+kind = cloud_run_job
+project
+region
+artifact_bucket
+gateway_url
+max_concurrent
+trust_tier = trusted_repository
+capabilities[] = runtime + provider + model selectors
+enabled
+```
+
+Each immutable profile version records `job`, `image_digest`,
+`job_service_account`, resource limits, timeout, wrapper configuration, and a
+dedicated model-secret resource with one enabled pinned version. Cloud
+credentials belong to the Factory process environment or host identity, not
+this record. Secret values belong in Secret Manager and are referenced by the
+versioned Job configuration.
+
+The dispatcher creates
+`attempts/<attempt-id>/gateway-registration.json` before launch. The immutable
+registration stores the expected Job service-account principal, SHA-256 digest
+of the run capability, exact Attempt prefix, input digest, protocol version,
+and absolute expiry. The Job sends the raw capability only to the gateway. The
+gateway hashes it, uses its own bucket identity to load the registration and
+authority, and never exposes list or arbitrary object operations. Authority
+revocation closes an otherwise valid registration immediately.
+
+### Naming and identity
+
+A backend profile receives one random stable ID when it is created. Its
+synthetic Worker ID is `cloud-run-<profile-id>` and never changes when the
+display name, image, region settings, or capabilities change. Deleting and
+recreating a profile creates a new identity. Existing Work continues to point
+at the frozen old profile and synthetic Worker record.
+
+The synthetic Worker cannot authenticate to the Worker HTTP API and cannot be
+claimed by an external process. The dispatcher uses an internal store
+transaction to create its Attempt and lease. Attempt and run nonce identify the
+dispatch protocol; the Google operation name, execution name, and image digest
+are immutable external observations after they become known.
+
+### Dispatch record
+
+```text
+attempt_id
+backend_profile_id
+run_nonce
+state
+cloud_operation_name
+cloud_execution_name
+image_digest
+input_object
+authority_object
+artifact_prefix
+last_reconciled_at
+reconciliation_deadline
+error
+```
+
+The singular names above are normalized into child observations in storage:
+one dispatch can have several operation and execution records. Each record
+stores its provider name, first and last observation, create time, effective
+override digest, state, and duplicate disposition. The winning execution name
+is set only from the create-only start fence. All other matching executions
+are retained as duplicate evidence and cancelled.
+
+`attempt_id` is the Factory identity. `run_nonce` is random and immutable for
+one dispatch. It is also the short-lived run capability described above and is
+stored in raw form only in the dispatcher's protected database and the active
+Cloud Run override; the artifact store keeps only its digest. Cloud operation
+and execution names are observations returned by Google and never replace
+Factory identity. Missing names keep the record in reconciliation; they do not
+authorize a second agent to pass the start fence.
+
+### Object layout
+
+```text
+attempts/<attempt-id>/gateway-registration.json
+attempts/<attempt-id>/<run-nonce>/
+  input.json
+  authority.json
+  started.json
+  events/<first-sequence>-<last-sequence>.json
+  output/result.json
+  output/git-status.txt
+  output/changes.patch
+  output/untracked.tar
+  output/manifest.json
+```
+
+Inputs are immutable. Authority is the only mutable object and uses generation
+preconditions. Event and output objects are create-only. The final manifest
+carries the complete provenance and checksum binding defined in section 4 and
+is published last.
+
+### Dispatch states
+
+The internal dispatch states are `dispatching`, `starting`, `running`,
+`cancel_requested`, `reconciling`, and `terminal`. They map onto the existing
+Attempt states and remain internal. A transient Google API failure moves a
+record to `reconciling`; it does not invent a second Attempt or user-facing
+lifecycle.
+
+### Normative state machine
+
+Factory is the only state-machine writer. GCS objects and Cloud Run status are
+evidence that permit one Factory transition; they never transition Work by
+themselves.
+
+| Factory dispatch state | Required evidence | Allowed next states |
+| --- | --- | --- |
+| `dispatching` | Committed Attempt, run nonce, immutable input | `starting`, `cancel_requested`, `terminal` |
+| `starting` | Accepted Run operation or matching start fence | `running`, `reconciling`, `cancel_requested`, `terminal` |
+| `running` | Matching start fence and valid authority generation | `reconciling`, `cancel_requested`, `terminal` |
+| `reconciling` | Incomplete or conflicting cloud observation | `starting`, `running`, `cancel_requested`, `terminal` |
+| `cancel_requested` | Durable cancellation time and revoked authority | `terminal` |
+| `terminal` | One stored Factory outcome | none |
+
+Before every external side effect, the dispatcher commits the intended state
+and immutable run nonce. A crash before the Run call leaves `dispatching` and
+may safely retry the same nonce. A crash after Google accepts the call but
+before its response leaves `dispatching`. Reconciliation pages every execution
+of the frozen Job version created since the recorded dispatch start, inspects
+its effective environment overrides, and persists every execution carrying the
+exact Attempt ID and run nonce before another Run call is allowed. Another call
+may still create a duplicate container. Every
+container must create the exact `started.json` object with
+`ifGenerationMatch=0` before checkout, model calls, Git writes, or external tool
+use. A fence winner whose Attempt, nonce, input digest, or authority is stale
+exits nonzero. A fence loser exits zero without running the agent.
+
+Cloud Run execution names are provider-assigned and cannot be deterministic.
+The Factory Attempt and run nonce provide deterministic dispatch identity.
+Factory stores every operation or execution name observed for that nonce
+immutably. The `started.json` winner names its `CLOUD_RUN_EXECUTION`; additional
+names are duplicate evidence and are cancelled. They never replace the winning
+identity. The prototype must prove that the v2 execution-list response exposes
+the effective overrides needed for this search. If it does not, durable launch
+is blocked until the design supplies another discoverable correlation key.
+
+Cancellation and completion use their committed Factory timestamps. Verified
+completion can win only when its manifest was fully ingested before
+`cancellation_requested_at`. Once cancellation is committed, no later cloud
+success can change the outcome. Terminal completion is idempotent and the
+stored outcome always wins.
+
+### Authority lease protocol
+
+The dispatcher is the single authority writer. `authority.json` contains the
+Attempt ID, run nonce, monotonically increasing revision, input digest,
+`valid_until`, cancellation flag, and previous object generation. Each refresh
+uses GCS `ifGenerationMatch` against the generation Factory last stored. A
+precondition failure moves the dispatch to `reconciling`, stops refresh, and
+revokes the Attempt because another writer or stale state exists.
+
+`valid_until` is computed from the control-plane clock and is 30 seconds after
+the successful refresh. The gateway returns its trusted server time with every
+authority read, and the wrapper uses that response to set a conservative
+monotonic deadline. It never extends validity from its wall clock. It
+fetches the object at most five seconds apart and verifies the object generation
+never moves backwards. A read error is not authority. The wrapper may continue
+only until the last verified `valid_until`; there is no grace period after that
+instant. Before checkout, agent start, every external publish action exposed by
+the wrapper, and final manifest upload, it requires current matching authority.
+On expiry or cancellation it sends SIGTERM to the process group immediately,
+waits ten seconds, sends SIGKILL, uploads only bounded failure evidence while
+the gateway still authorizes it, and exits nonzero.
+
+Factory refreshes authority only while the same Attempt lease and dispatch
+record remain active. A server shutdown, dispatcher crash, SQLite ownership
+loss, GCS generation conflict, or inability to prove state stops refresh. The
+first-release availability contract is explicit: a continuously available
+Factory controller is required for a continuously running Cloud Job.
+
+After Factory commits explicit cancellation, it revokes authority with one
+conditional write. A healthy wrapper observes that revocation within five
+seconds and kills a process that ignores SIGTERM within a further ten seconds.
+The product bound is 15 seconds after successful authority revocation, with a
+five-second allowance for dispatcher scheduling. If the controller disappears
+without revoking authority, the last 30-second authority window plus the
+ten-second kill grace bounds process survival to 40 seconds. Cloud Run may take
+longer to report the execution terminal, so Factory tracks that platform
+reconciliation separately with a two-minute deadline.
+
+## 7. Failure behavior and lifecycle
+
+If input upload fails, the Attempt remains preparing and dispatch retries after
+one second with jitter, doubling to at most 30 seconds until its five-minute
+dispatch deadline. No Cloud Job starts. Reaching the deadline fails the Attempt
+with an actionable storage or permission error.
+
+If the Run API accepts a request but its response is lost, Factory keeps the
+same run nonce and enumerates matching executions as specified in section 6.
+It persists and supervises the complete matching set. A repeated API call may
+create another container, but only the execution that creates `started.json`
+can launch the agent. Other executions exit successfully without agent side
+effects, are recorded as duplicates, and are cancelled if they remain active.
+
+If container startup exceeds 30 seconds, the dispatcher continues renewing the
+Factory lease and cloud authority while the execution is starting. The Job
+checks authority before starting the runtime.
+
+If event upload or ingestion fails, the wrapper retries bounded, immutable
+batches. Factory accepts a repeated batch only when its identity and bytes
+match. A conflicting batch fails the Attempt.
+
+If the agent, wrapper, or container crashes, Cloud Run does not retry it. The
+dispatcher retains partial artifacts, records the exit evidence, and fails the
+Attempt. An operator can create an explicit retry.
+
+If Factory loses Google API access temporarily, it keeps the dispatch in
+reconciling and continues authority only while it can still prove ownership and
+remain within the 30-second bound. Once authority expires, the wrapper stops the
+agent. Factory cancels the cloud execution when access returns and fails the
+Attempt rather than reviving it.
+
+If Factory restarts, it loads every nonterminal dispatch before admitting more
+cloud work. It verifies profile identity, authority generation, start fence,
+Cloud Run execution state, and artifacts. It resumes supervision only when the
+same Attempt still owns valid authority. Otherwise it revokes authority,
+cancels the execution, and records a failed or cancelled outcome.
+
+If cancellation races with completion, the first durable Factory decision
+wins. A verified completion stored before cancellation succeeds. A durable
+cancellation request stored first produces cancelled and retains any late
+artifact.
+
+Disabling a backend profile stops new dispatches. Existing executions continue
+under their frozen profile unless the operator explicitly cancels them. A
+profile cannot be deleted while nonterminal or retained cloud Attempts refer to
+it.
+
+Server shutdown stops new dispatch, revokes authority for active Jobs, requests
+Cloud Run cancellation, and waits for up to 30 seconds. On restart, Factory
+reconciles every nonterminal cloud dispatch before admitting new cloud work. If
+an execution still cannot be reconciled within two minutes, its expired
+authority keeps the agent stopped and Factory records a
+`cloud_reconciliation_timeout` failure with the external execution identity for
+operator cleanup.
+
+## 8. Security, privacy, and operations
+
+The initial trust boundary is one trusted Factory operator, trusted repository
+configuration, trusted Routine instructions, and untrusted external context
+embedded inside that prompt. The Job may execute repository code. That code can
+read credentials available to the agent process, request tokens for permissions
+granted to the Job service account, and use permitted network egress.
+
+Each trust tier uses dedicated dispatcher, gateway, and Job service accounts
+and preferably a separate Google Cloud project. The dispatcher can run the
+versioned Job and manage its executions. The gateway can access only the
+artifact bucket. The Job can invoke only the gateway and read its dedicated
+model-secret resource, which has one enabled pinned version. It receives no
+artifact-store permission, Cloud Run administration, project editor, or
+Factory control-plane credential.
+Repository credentials are short-lived and scoped to one repository when
+private checkout or publishing is added.
+
+Prompt text is stored in the encrypted artifact store rather than Cloud Run
+environment overrides. Identifiers placed in execution metadata are not
+secrets. Model keys are mounted from dedicated, single-version Secret Manager
+resources.
+Sanitized logs exclude prompts, secret values, raw model reasoning, and
+unbounded patches.
+
+Cloud Run Jobs use disposable second-generation containers with namespace and
+privilege restrictions. They are not gVisor sandboxes. The product must call
+this managed isolation, not safe execution of hostile code. Egress restriction,
+per-repository credentials, quota isolation, and a stronger sandbox remain
+required before accepting arbitrary repositories. See Google's
+[container runtime contract](https://docs.cloud.google.com/run/docs/container-contract).
+
+As measured on 2026-08-12, one 1 vCPU and 2 GiB Job costs about $0.00132
+per billable minute at the published default Jobs rates before the free tier.
+Jobs have a one-minute minimum, then bill in 100 ms increments. The
+published free tier is 240,000 vCPU-seconds and 450,000 GiB-seconds per billing
+account each month, equivalent to about 62.5 hours at that resource shape before
+other Cloud Run usage. Actual cost also includes model tokens, image builds and
+storage, logs, artifacts, Secret Manager, and network transfer. Region prices
+and quotas vary. Recheck the official [Cloud Run pricing](https://cloud.google.com/run/pricing)
+before using these figures for a budget.
+
+Cloud execution is elastic, not infinite. The dispatcher enforces a configured
+capacity below project and regional quotas and rate limits. It reports quota,
+billing, permission, image, secret, and artifact failures separately. Cost and
+usage alerts belong in the guided setup before a profile can be enabled. See
+the current [Cloud Run quotas](https://docs.cloud.google.com/run/quotas) when
+choosing profile capacity.
+
+Completed artifact prefixes use a configured retention period. Factory keeps
+the final manifest and digest after object expiry so history remains explicit
+about whether recovery bytes are still available. Cloud Run execution and
+Cloud Logging retention are diagnostic and are never the only retained record.
+
+## 9. Acceptance criteria
+
+- `AC-1`: One unchanged Routine can run through its persistent default or a
+  compatible Cloud Run manual override and produces the same user-facing Work
+  lifecycle. Existing Routines need no migration and remain persistent by
+  default.
+- `AC-2`: A cloud Attempt runs the frozen full commit and rejects a mutable or
+  mismatched Git reference.
+- `AC-3`: A lost launch response or duplicate execution starts at most one
+  agent process for the Attempt and run nonce.
+- `AC-4`: After Factory commits cancellation, it revokes authority within five
+  seconds; a healthy wrapper stops the agent within 15 more seconds, requests
+  Cloud Run cancellation, and reaches a stable cancelled outcome. Controller
+  loss starts shutdown by 30 seconds and kills the process by 40 seconds.
+- `AC-5`: Factory restart reconciles every nonterminal execution before it
+  admits new cloud work.
+- `AC-6`: Native Cloud Run retries are zero and only an explicit Factory retry
+  creates another Attempt.
+- `AC-7`: Events remain ordered, bounded, and duplicate-safe across delayed or
+  repeated object ingestion.
+- `AC-8`: Success requires a verified final manifest and recovery artifact;
+  missing, conflicting, corrupt, or oversized artifacts fail the Attempt.
+- `AC-9`: The Job receives only the configured least-privilege identity and no
+  operator API credential, durable cloud key, or secret prompt metadata.
+- `AC-10`: Attempt detail shows backend, execution identity, image digest,
+  timing, model cost, artifact availability, and diagnostic log link.
+- `AC-11`: Persistent Worker behavior and configuration, including
+  resolve-per-Attempt commit selection, remain compatible when no Cloud Run
+  profile exists.
+- `AC-12`: Documentation and setup describe Cloud Run as managed, elastic,
+  quota-bound isolation rather than free infrastructure or a hostile-code
+  sandbox.
+- `AC-13`: Two concurrent Attempts using one profile cannot read, overwrite,
+  fence, publish, or cancel each other's protocol data.
+
+## 10. Test approach
+
+State-machine tests will admit the same Routine once through its persistent
+default and once through a Cloud Run manual override. They will prove
+`INV-1`, `INV-5`, `INV-11`, `AC-1`, `AC-6`, and `AC-11`. Cloud-specific input
+tests will prove `INV-2` and `AC-2`, including exact-commit reuse on retry.
+
+Dispatcher tests will inject lost responses, duplicate executions, delayed
+startup, API outages, stale generations, restart, and quota failures to prove
+`INV-3`, `INV-4`, `INV-9`, `AC-3`, `AC-4`, and `AC-5`.
+
+Protocol tests will reorder, repeat, corrupt, truncate, and oversize event and
+artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.
+
+Security tests will inspect the deployed Job configuration, IAM policy, input
+metadata, structured logs, and container environment to prove `INV-10`,
+`INV-12`, `INV-13`, `AC-9`, `AC-12`, and `AC-13`. They will verify that
+repository code cannot use the Job identity to run or cancel Cloud Run
+resources or access a sibling Attempt through the gateway or storage API.
+
+A gated real-project integration test will build an immutable image, run one
+read-only and one patch-producing Attempt, cancel one long-running Attempt,
+restart the dispatcher during one Attempt, and verify the final UI/API evidence
+required by `AC-4`, `AC-5`, and `AC-10`.
+
+## 11. Risks and tradeoffs
+
+- Cold starts and repeated checkout make short Jobs slower than warm Workers.
+  Keep persistent Workers as the default and record backend timing separately.
+- API model usage can cost more than an existing subscription. Show model and
+  compute cost separately and allow per-profile budgets.
+- A control-plane outage can leave cloud compute briefly alive. The external
+  authority document bounds that window and the wrapper fails closed.
+- Ephemeral recovery is weaker than a retained worktree. Require a verified
+  artifact and show its expiry prominently.
+- The Job identity and mounted model credential are visible to code in its Job.
+  Separate trust tiers, pin the exact secret version, isolate artifact access
+  behind the per-Attempt gateway, and start with trusted repositories.
+- The Attempt gateway adds a managed service, cold-start latency, and request
+  cost. It is required to prevent a shared Job identity from reaching sibling
+  artifacts. Keep its API narrow and its deployment reproducible.
+- Polling storage adds latency and API cost. Keep bounded intervals and preserve
+  room for a private callback or queue in hosted deployments.
+- Google Cloud concepts could leak into the product. Keep them in backend
+  profile setup and Attempt diagnostics, not Routine authoring vocabulary.
+
+## 12. Open questions
+
+- Should the first release support private repositories and branch publishing?
+  This does not block the dispatcher and lifecycle work. The recommended first
+  slice is public or otherwise pre-authorized read-only checkout plus durable
+  patch artifacts, followed by short-lived repository-scoped GitHub App tokens.
+- Should a hosted Factory deployment replace storage polling with a private
+  callback or queue? This does not block the local-first design because the
+  event and artifact identities remain the same.
+- Should another managed job provider implement the same backend contract?
+  This does not block Cloud Run. Extract a provider interface only after a
+  second implementation proves the shared boundary.
+
+## 13. Out of scope
+
+- Replacing SQLite orchestration with Temporal or another durable workflow
+  engine.
+- Removing or deprecating local and VM Workers.
+- Running arbitrary untrusted repositories safely.
+- Automatic provider selection based only on price.
+- Native Cloud Run task fan-out for one Work Target.
+- GPU agents, interactive terminals, or long-lived cloud development
+  workspaces.
+- A general multi-cloud job abstraction before a second provider exists.

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -652,18 +652,29 @@ is blocked until the design supplies another discoverable correlation key.
 
 Artifact ingestion and verification do not decide the terminal race. Three
 SQLite transactions compete. Successful completion loads the verified manifest
-evidence, checks that neither cancellation nor timeout intent is committed, and
-writes terminal success atomically. Explicit cancellation checks that neither a
-terminal outcome nor timeout intent is committed and atomically records
-`cancellation_requested_at`. Timeout checks that neither a terminal outcome nor
-cancellation is committed and atomically records `timeout_requested_at` and the
-`timeout_requested` dispatch state. SQLite serialization makes one transaction
-the first durable Factory decision. If timeout intent wins, a later explicit
-cancel may accelerate the same gateway revocation and Cloud Run cleanup but
-cannot change the eventual timed-out outcome. If cancellation wins, later
-timeout observation cannot replace cancelled. If success wins, neither signal
-can replace succeeded. Terminal completion is idempotent and the stored outcome
-always wins.
+evidence and first obtains a fresh gateway authority-state response. Factory
+records local monotonic time immediately before that request and derives the
+conservative remaining Work duration from the returned gateway time and
+`work_deadline_at`. The single serialized SQLite statement that conditionally
+writes terminal success invokes a registered suspend-aware monotonic clock
+function and requires `now < deadline` together with the checks that neither
+cancellation nor timeout intent is committed. The clock uses an operating-system
+continuous-time source that includes host sleep. The deadline value is not a
+wall-clock comparison or a boolean computed before entering SQLite. If that
+atomic predicate fails, the same transaction records timeout intent instead of
+success. A stale, missing, delayed, or expired response also records timeout
+intent; prior manifest publication cannot extend the Work. Explicit
+cancellation checks that neither a terminal outcome nor timeout intent is
+committed and atomically records `cancellation_requested_at`. Timeout checks
+that neither a terminal outcome nor cancellation is committed and atomically
+records `timeout_requested_at` and the `timeout_requested` dispatch state.
+SQLite serialization makes one transaction the first durable Factory decision.
+If timeout intent wins, a later explicit cancel may accelerate the same gateway
+revocation and Cloud Run cleanup but cannot change the eventual timed-out
+outcome. If cancellation wins, later timeout observation cannot replace
+cancelled. If success wins before its deadline, neither signal can replace
+succeeded. Terminal completion is idempotent and the stored outcome always
+wins.
 
 ### Authority lease protocol
 
@@ -943,7 +954,11 @@ artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.
 They will force both SQLite transaction orderings for success versus
 cancellation, success versus timeout intent, and cancellation versus timeout
 intent. Each test proves that exactly one durable decision owns the outcome and
-that later signals can perform cleanup without replacing it.
+that later signals can perform cleanup without replacing it. Success tests will
+verify that a manifest published before the deadline is still rejected when
+gateway response delay, scheduler delay, SQLite contention, host suspension, or
+restart makes the conservative monotonic deadline expire before the conditional
+terminal write. Missing or stale gateway time must also reject success.
 
 Security tests will inspect the deployed Job configuration, IAM policy, input
 metadata, gateway request logs and traces, structured logs, and container

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -660,10 +660,12 @@ writes terminal success invokes a registered suspend-aware monotonic clock
 function and requires `now < deadline` together with the checks that neither
 cancellation nor timeout intent is committed. The clock uses an operating-system
 continuous-time source that includes host sleep. The deadline value is not a
-wall-clock comparison or a boolean computed before entering SQLite. If that
-atomic predicate fails, the same transaction records timeout intent instead of
-success. A stale, missing, delayed, or expired response also records timeout
-intent; prior manifest publication cannot extend the Work. Explicit
+wall-clock comparison or a boolean computed before entering SQLite. The
+serialized transaction first preserves any existing terminal, cancellation, or
+timeout owner. Only when no owner exists and the time predicate fails does it
+record timeout intent instead of success. A stale, missing, delayed, or expired
+response follows that same conditional timeout branch; it never replaces an
+existing owner. Prior manifest publication cannot extend the Work. Explicit
 cancellation checks that neither a terminal outcome nor timeout intent is
 committed and atomically records `cancellation_requested_at`. Timeout checks
 that neither a terminal outcome nor cancellation is committed and atomically

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -522,6 +522,8 @@ run_capability_ciphertext
 state
 work_started_at
 work_deadline_at
+provider_search_not_before
+provider_search_unbounded
 cloud_operation_name
 cloud_execution_name
 image_digest
@@ -606,10 +608,21 @@ themselves.
 Before every external side effect, the dispatcher commits the intended state
 and immutable run ID. A crash before the Run call leaves `dispatching` and may
 safely retry the same run ID and capability. A crash after Google accepts the
-call but before its response leaves `dispatching`. Reconciliation pages every
-execution of the frozen Job version created since the recorded dispatch start,
-inspects its effective environment overrides, and persists every execution
-carrying the exact Attempt ID and run ID before another Run call is allowed.
+call but before its response leaves `dispatching`. Immediately before each Run
+call, Factory obtains a Cloud Run provider timestamp from the preceding API
+response. Before the first Run, it durably initializes
+`provider_search_not_before` to that timestamp minus a 60-second provider-clock
+margin. Before a later Run, it may only broaden discovery by storing the earlier
+of the existing and new cutoffs. Reconciliation pages every execution of the
+frozen Job version with provider `createTime` at or after that bound, inspects
+its effective environment overrides, and persists every execution carrying the
+exact Attempt ID and run ID before another Run call is allowed. It never derives
+this cutoff from the Factory clock. If any Run call lacks a trustworthy provider
+timestamp, Factory durably sets `provider_search_unbounded`; that flag never
+returns to bounded for the dispatch, and reconciliation pages all retained
+executions for the frozen Job version. A retry remains blocked until a complete
+paginated search and the two-minute provider-discovery window both find no
+matching execution.
 Another call may still create a duplicate container. Before checkout, model
 calls, Git writes, or external tool use, every container asks the gateway for
 the start fence. The gateway conditionally updates `authority.json` with the
@@ -907,7 +920,13 @@ must persist timeout intent, race a late container start through one authority
 generation, confirm revocation before terminal timeout, and prevent any fence
 after that terminal commit. Delay tests anchor timers to the pre-request
 monotonic instant and prove startup and response transit cannot extend Work or
-authority deadlines.
+authority deadlines. Lost-launch tests skew the Factory clock in both
+directions, place the accepted execution inside the provider-clock margin, and
+remove the provider timestamp entirely. They must still discover the exact
+Attempt and run ID before another Run call; the no-timestamp case must fall back
+to a complete retained-execution scan. Multiple-lost-response tests must prove
+that a later provider timestamp cannot move the cutoff forward and that an
+unbounded fallback can never become bounded again.
 
 Protocol tests will reorder, repeat, corrupt, truncate, and oversize event and
 artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -100,7 +100,10 @@ The embedded Cloud Run dispatcher creates an Attempt and a backend dispatch
 record in one transaction. The record contains a random non-secret run ID and
 starts in `dispatching`. Factory writes the immutable input and gateway
 registration, then asks the gateway to create the initial short-lived authority
-document using the gateway clock and an object-generation precondition. Factory
+document using the gateway clock and an object-generation precondition. That
+response also fixes `work_started_at` to gateway server time and
+`work_deadline_at` to `work_started_at + timeout_seconds`; both are persisted in
+the dispatch before the Run call and bound into the authority object. Factory
 calls one immutable, versioned Cloud Run Job resource with the Attempt ID, run
 ID, and a separate random 256-bit run capability as bounded overrides. The
 capability is sensitive, excluded from logs, and visible only to identities
@@ -119,14 +122,16 @@ This prevents one profile's execution from reading or corrupting a sibling
 execution. It does not prevent trusted repository code from tampering with its
 own Attempt, which is part of the initial trusted-repository boundary.
 
-The Job wrapper starts a five-minute monotonic pre-fence timer when its process
-starts and exits without an agent if that timer expires. It records local
-monotonic time immediately before requesting the Attempt and run-ID start fence.
+The Job wrapper starts a monotonic pre-fence timer when its process starts and
+sets it to the smaller of five minutes and the trusted remaining Work duration.
+It exits without an agent if that timer expires. It records local monotonic time
+immediately before requesting the Attempt and run-ID start fence.
 If a lost API response causes Factory to launch a duplicate, only one execution
 can create that fence; every duplicate exits without running an agent. The
-successful response includes gateway server time. The wrapper anchors the
-frozen Work duration to the earlier pre-request monotonic instant, so response
-delay can shorten but never extend the deadline. The winning wrapper verifies
+successful response includes gateway server time and the persisted
+`work_deadline_at`. The wrapper anchors `work_deadline_at - server_time` to the
+earlier pre-request monotonic instant, so Cloud Run startup and response delay
+consume rather than extend the frozen Work timeout. The winning wrapper verifies
 the input, checks out only the frozen commit, and starts the selected runtime in
 the checkout. Checkout and agent execution share that deadline. After it
 expires, the wrapper has at most 60 seconds to kill the process group and
@@ -135,10 +140,11 @@ repository tool actions.
 
 The dispatcher requests an authority refresh every ten seconds while it owns
 the Attempt. The gateway performs the conditional write and computes
-`valid_until` from its own server clock. The wrapper checks authority before
-agent launch and at most every five seconds while the process runs. An expired,
-cancelled, mismatched, or timed-out Attempt starts shutdown of the runtime
-process group. This preserves
+`valid_until` as the earlier of 30 seconds from its own server clock and the
+frozen Work deadline. The wrapper checks authority before agent launch and at
+most every five seconds while the process runs. An expired, cancelled,
+mismatched, or timed-out Attempt starts shutdown of the runtime process group.
+This preserves
 fail-closed lease behavior without making the local Factory API reachable from
 the internet.
 Cloud execution therefore depends on one continuously running Factory control
@@ -377,7 +383,9 @@ retry instead of silently running different code.
 - `INV-12`: Cloud execution never weakens the loopback-only operator API.
 - `INV-13`: A Job identity and run capability can access only its own Attempt
   protocol and cannot read or mutate a sibling Attempt.
-- `INV-14`: The wrapper starts process-group shutdown at the frozen Work
+- `INV-14`: The gateway refuses to start an agent at or after the frozen Work
+  deadline. Factory times out and cancels an accepted execution that has not
+  started by then. A running wrapper starts process-group shutdown at the same
   deadline and sends SIGKILL no later than ten seconds afterward, independent
   of the longer profile or Cloud Run Job timeout.
 
@@ -396,7 +404,8 @@ retry instead of silently running different code.
 - Dispatch stores the Attempt ID, non-secret run ID, run-capability digest,
   envelope-encrypted run-capability ciphertext, state, immutable profile
   version, every observed Cloud operation and execution name, timestamps,
-  error, and reconciliation deadline.
+  gateway-derived `work_started_at` and `work_deadline_at`, error, and
+  reconciliation deadline.
 - The Job input uses the full commit SHA. Branch names and mutable tags are
   rejected.
 - Before every Run call, the dispatcher reads the Job and verifies its resource
@@ -414,14 +423,16 @@ retry instead of silently running different code.
 - The wrapper checks authority at most five seconds apart. Authority remains
   valid for no more than 30 seconds without a dispatcher refresh.
 - The immutable input includes `timeout_seconds`. The gateway start-fence
-  response supplies trusted server time. The wrapper anchors the frozen duration
+  response supplies trusted server time and the persisted `work_deadline_at`
+  established before the Run call. The wrapper anchors the remaining duration
   to the monotonic instant recorded before the request, producing a conservative
-  deadline shared by checkout and agent execution. At the deadline it applies
-  the ten-second process-group kill rule, records a timeout outcome, and permits
-  at most 60 seconds for bounded failure-evidence upload with no live agent. A
-  wrapper has at most five minutes from process start to acquire its fence. The
-  versioned Cloud Run Job timeout is at least five minutes plus the maximum Work
-  timeout plus 70 seconds and is a platform safety limit, not the Work timeout.
+  deadline shared by Cloud Run startup, checkout, and agent execution. At the
+  deadline it applies the ten-second process-group kill rule, records a timeout
+  outcome, and permits at most 60 seconds for bounded failure-evidence upload
+  with no live agent. A wrapper has no more than five minutes from process start
+  to acquire its fence and never beyond `work_deadline_at`. The versioned Cloud
+  Run Job timeout is at least the maximum Work timeout plus 70 seconds and is a
+  platform safety limit, not the Work timeout.
 - Event and completion sizes reuse the existing Attempt limits. Artifact size
   defaults to 64 MiB and has a 512 MiB maximum. Completion is rejected when the
   configured bound is exceeded.
@@ -495,6 +506,8 @@ run_id
 run_capability_digest
 run_capability_ciphertext
 state
+work_started_at
+work_deadline_at
 cloud_operation_name
 cloud_execution_name
 image_digest
@@ -569,7 +582,7 @@ themselves.
 | Factory dispatch state | Required evidence | Allowed next states |
 | --- | --- | --- |
 | `dispatching` | Committed Attempt, run ID, immutable input | `starting`, `cancel_requested`, `terminal` |
-| `starting` | Accepted Run operation or matching start fence | `running`, `reconciling`, `cancel_requested`, `terminal` |
+| `starting` | Accepted Run operation or matching start fence, before `work_deadline_at` | `running`, `reconciling`, `cancel_requested`, `terminal` |
 | `running` | Matching start fence and valid authority generation | `reconciling`, `cancel_requested`, `terminal` |
 | `reconciling` | Incomplete or conflicting cloud observation | `starting`, `running`, `cancel_requested`, `terminal` |
 | `cancel_requested` | Durable cancellation time and revoked authority | `terminal` |
@@ -611,13 +624,15 @@ is idempotent and the stored outcome always wins.
 The dispatcher is the sole authority decision-maker, and the gateway is the
 sole physical authority-object writer. `authority.json` contains the Attempt
 ID, run ID, run-capability digest, monotonically increasing revision, input
-digest, `valid_until`, cancellation flag, and previous object generation. An
-authenticated refresh request contains the expected generation and desired
-cancellation state, but no caller-supplied time. The gateway computes
-`valid_until` as 30 seconds after its own server time and writes with GCS
-`ifGenerationMatch`. A precondition failure moves the dispatch to
-`reconciling`, stops refresh, and revokes the Attempt because another writer or
-stale state exists.
+digest, `work_deadline_at`, `valid_until`, cancellation flag, and previous
+object generation. An authenticated refresh request contains the expected
+generation and desired cancellation state, but no caller-supplied time. The
+gateway computes `valid_until` as the earlier of 30 seconds after its own server
+time and `work_deadline_at`, then writes with GCS `ifGenerationMatch`. At or
+after `work_deadline_at`, it refuses refresh and start-fence requests and
+conditionally revokes any remaining authority. A precondition failure moves
+the dispatch to `reconciling`, stops refresh, and revokes the Attempt because
+another writer or stale state exists.
 
 Every refresh and authority-read response returns the gateway server time,
 `valid_until`, revision, and object generation from one operation. The wrapper
@@ -635,12 +650,18 @@ waits ten seconds, sends SIGKILL, uploads only bounded failure evidence while
 the gateway still authorizes it, and exits nonzero.
 
 Factory asks the gateway to refresh authority only while the same Attempt lease
-and dispatch record remain active. The gateway performs every initial,
-refresh, and revocation authority-object write using its clock and generation
-precondition. A server shutdown, dispatcher crash, SQLite ownership loss, GCS
-generation conflict, or inability to prove state stops refresh. The first-release
-availability contract is explicit: a continuously available Factory controller
-is required for a continuously running Cloud Job.
+and dispatch record remain active. Every gateway response includes server time.
+During dispatch and reconciliation, Factory uses that time to determine whether
+an accepted execution is still before `work_deadline_at`; it never uses its own
+wall clock to extend the Work. Once gateway time reaches the deadline, Factory
+stops refresh, records the same timed-out failure used by the persistent
+backend, and requests Cloud Run cancellation even when no start fence exists.
+The gateway performs every initial, refresh, and revocation authority-object
+write using its clock and generation precondition. A server shutdown,
+dispatcher crash, SQLite ownership loss, GCS generation conflict, or inability
+to prove state stops refresh. The first-release availability contract is
+explicit: a continuously available Factory controller is required for a
+continuously running Cloud Job.
 
 After Factory commits explicit cancellation, it asks the gateway to revoke
 authority with one conditional write. A healthy wrapper observes that
@@ -669,8 +690,12 @@ agent side effects, are recorded as duplicates, and are cancelled if they
 remain active.
 
 If container startup exceeds 30 seconds, the dispatcher continues renewing the
-Factory lease and cloud authority while the execution is starting. The Job
-checks authority before starting the runtime.
+Factory lease and cloud authority only while gateway time remains before the
+persisted `work_deadline_at`. The gateway caps every authority lease at that
+deadline. When the deadline arrives, Factory records a timed-out failure and
+requests Cloud Run cancellation even if the container has not started. A
+container that starts late cannot acquire the start fence or valid authority
+and exits without checkout or an agent process.
 
 If the frozen Work timeout expires during checkout or agent execution, the
 wrapper sends SIGTERM immediately and SIGKILL after ten seconds. It emits a
@@ -806,9 +831,11 @@ Cloud Logging retention are diagnostic and are never the only retained record.
   sandbox.
 - `AC-13`: Two concurrent Attempts using one profile cannot read, overwrite,
   fence, publish, or cancel each other's protocol data.
-- `AC-14`: A cloud Attempt that reaches its frozen Work timeout starts agent
-  shutdown immediately, kills the process group within ten seconds, publishes
-  no success, and cannot continue until the profile-wide Job timeout.
+- `AC-14`: Cloud Run startup, checkout, and agent execution share one frozen
+  Work timeout established before the Run call. At its deadline Factory times
+  out and cancels an accepted but unstarted execution, the gateway rejects a
+  late start fence, and a running wrapper starts agent shutdown immediately,
+  kills the process group within ten seconds, and publishes no success.
 
 ## 10. Test approach
 
@@ -821,9 +848,11 @@ Dispatcher tests will inject lost responses, duplicate executions, delayed
 startup, API outages, stale generations, restart with the encrypted capability,
 missing or invalid encryption keys, Factory clocks ahead of and behind the
 gateway, delayed gateway responses, and quota failures to prove `INV-3`,
-`INV-4`, `INV-9`, `AC-3`, `AC-4`, and `AC-5`. Delay tests anchor timers to the
-pre-request monotonic instant and prove response transit cannot extend Work or
-authority deadlines.
+`INV-4`, `INV-9`, `AC-3`, `AC-4`, and `AC-5`. A container-start delay beyond
+`work_deadline_at` must produce a timed-out Attempt, a Cloud Run cancellation
+request, no successful start fence, and no authority refresh beyond the
+deadline. Delay tests anchor timers to the pre-request monotonic instant and
+prove startup and response transit cannot extend Work or authority deadlines.
 
 Protocol tests will reorder, repeat, corrupt, truncate, and oversize event and
 artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -380,8 +380,9 @@ retry instead of silently running different code.
   resolution policy. Editing a Routine or profile does not change existing
   Work.
 - Dispatch stores the Attempt ID, non-secret run ID, run-capability digest,
-  state, immutable profile version, every observed Cloud operation and
-  execution name, timestamps, error, and reconciliation deadline.
+  envelope-encrypted run-capability ciphertext, state, immutable profile
+  version, every observed Cloud operation and execution name, timestamps,
+  error, and reconciliation deadline.
 - The Job input uses the full commit SHA. Branch names and mutable tags are
   rejected.
 - Before every Run call, the dispatcher reads the Job and verifies its resource
@@ -441,7 +442,12 @@ protocol version, and absolute expiry. The Job sends the raw capability only to
 the gateway. The gateway hashes it, uses its own bucket identity to load the
 registration and authority, and never exposes list or arbitrary object
 operations. Authority revocation closes an otherwise valid registration
-immediately.
+immediately. The Job sends the capability only over TLS in an authenticated
+request body. The Job and gateway redact request bodies and authorization data,
+never place the capability in a URL, header echoed by infrastructure, metric,
+trace, error, or log. The wrapper retains the capability only for the Job
+lifetime and clears its copy on shutdown. The gateway discards its request copy
+after each operation.
 
 ### Naming and identity
 
@@ -464,6 +470,7 @@ attempt_id
 backend_profile_id
 run_id
 run_capability_digest
+run_capability_ciphertext
 state
 cloud_operation_name
 cloud_execution_name
@@ -485,12 +492,21 @@ are retained as duplicate evidence and cancelled.
 
 `attempt_id` is the Factory identity. `run_id` is random, non-secret, and
 immutable for one dispatch. It is safe for object names, events, manifests,
-logs, and diagnostic URLs. The separate raw run capability is stored only in
-the dispatcher's protected database and the active Cloud Run override; the
-artifact store keeps only `run_capability_digest`. Cloud operation and
-execution names are observations returned by Google and never replace Factory
-identity. Missing names keep the record in reconciliation; they do not
-authorize a second agent to pass the start fence.
+logs, and diagnostic URLs. Factory envelope-encrypts the separate raw run
+capability before committing the dispatch. The encryption key comes from the
+host keyring or process environment and is never stored in SQLite. The raw
+value exists transiently in dispatcher, Job wrapper, TLS request, and gateway
+memory. Cloud Run retains the raw active execution override as provider-managed
+metadata for its documented execution-retention period, so permission to
+inspect executions is restricted to the dispatcher and operators who may
+inspect model credentials. Factory never stores raw plaintext: SQLite stores
+only `run_capability_ciphertext`, and the artifact store keeps only
+`run_capability_digest`. A restart decrypts the ciphertext to retry or reconcile
+the same dispatch. A missing or invalid encryption key blocks new cloud Work,
+revokes authority, and fails active dispatches closed rather than minting a new
+capability. Cloud operation and execution names are observations returned by
+Google and never replace Factory identity. Missing names keep the record in
+reconciliation; they do not authorize a second agent to pass the start fence.
 
 ### Object layout
 
@@ -760,8 +776,9 @@ default and once through a Cloud Run manual override. They will prove
 tests will prove `INV-2` and `AC-2`, including exact-commit reuse on retry.
 
 Dispatcher tests will inject lost responses, duplicate executions, delayed
-startup, API outages, stale generations, restart, and quota failures to prove
-`INV-3`, `INV-4`, `INV-9`, `AC-3`, `AC-4`, and `AC-5`.
+startup, API outages, stale generations, restart with the encrypted capability,
+missing or invalid encryption keys, and quota failures to prove `INV-3`,
+`INV-4`, `INV-9`, `AC-3`, `AC-4`, and `AC-5`.
 
 Protocol tests will reorder, repeat, corrupt, truncate, and oversize event and
 artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.
@@ -769,10 +786,15 @@ They will also force both SQLite transaction orderings after manifest
 verification to prove that cancellation and terminal success cannot both win.
 
 Security tests will inspect the deployed Job configuration, IAM policy, input
-metadata, structured logs, and container environment to prove `INV-10`,
-`INV-12`, `INV-13`, `AC-9`, `AC-12`, and `AC-13`. They will verify that
-repository code cannot use the Job identity to run or cancel Cloud Run
-resources or access a sibling Attempt through the gateway or storage API.
+metadata, gateway request logs and traces, structured logs, and container
+environment to prove `INV-10`, `INV-12`, `INV-13`, `AC-9`, `AC-12`, and
+`AC-13`. They will verify that raw capabilities never appear in Factory
+artifacts or telemetry, that Cloud Run execution inspection is restricted to
+the intended identities, and that repository code cannot use the Job identity
+to run or cancel Cloud Run resources or access a sibling Attempt through the
+gateway or storage API. The real-project prototype must measure how long Cloud
+Run retains completed execution overrides and feed that value into the profile
+retention and operator warning.
 
 A gated real-project integration test will build an immutable image, run one
 read-only and one patch-producing Attempt, cancel one long-running Attempt,

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -98,14 +98,14 @@ cloud Attempt and explicit retry for that Target reuses those inputs.
 
 The embedded Cloud Run dispatcher creates an Attempt and a backend dispatch
 record in one transaction. The record contains a random non-secret run ID and
-starts in `dispatching`. Factory writes an immutable input document and a
-short-lived authority document to cloud storage, then registers the Attempt and
-run ID with an Attempt gateway. Factory calls one immutable, versioned Cloud
-Run Job resource with the Attempt ID, run ID, and a separate random 256-bit run
-capability as bounded overrides. The capability is sensitive, excluded from
-logs, and visible only to identities already allowed to inspect Cloud Run
-executions. The prompt, model credential, and any cloud credential are not
-override values.
+starts in `dispatching`. Factory writes the immutable input and gateway
+registration, then asks the gateway to create the initial short-lived authority
+document using the gateway clock and an object-generation precondition. Factory
+calls one immutable, versioned Cloud Run Job resource with the Attempt ID, run
+ID, and a separate random 256-bit run capability as bounded overrides. The
+capability is sensitive, excluded from logs, and visible only to identities
+already allowed to inspect Cloud Run executions. The prompt, model credential,
+and any cloud credential are not override values.
 
 The Job service account has no access to the artifact bucket, Cloud Run
 administration, or sibling Attempts. Its only data permission is access to the
@@ -119,16 +119,26 @@ This prevents one profile's execution from reading or corrupting a sibling
 execution. It does not prevent trusted repository code from tampering with its
 own Attempt, which is part of the initial trusted-repository boundary.
 
-The Job wrapper obtains a start fence for the Attempt and run ID before it
-starts the agent. If a lost API response causes Factory to launch a duplicate,
-only one execution can create that fence; every duplicate exits without
-running an agent. The winning wrapper verifies the input, checks out only the
-frozen commit, and starts the selected runtime in the checkout.
+The Job wrapper starts a five-minute monotonic pre-fence timer when its process
+starts and exits without an agent if that timer expires. It records local
+monotonic time immediately before requesting the Attempt and run-ID start fence.
+If a lost API response causes Factory to launch a duplicate, only one execution
+can create that fence; every duplicate exits without running an agent. The
+successful response includes gateway server time. The wrapper anchors the
+frozen Work duration to the earlier pre-request monotonic instant, so response
+delay can shorten but never extend the deadline. The winning wrapper verifies
+the input, checks out only the frozen commit, and starts the selected runtime in
+the checkout. Checkout and agent execution share that deadline. After it
+expires, the wrapper has at most 60 seconds to kill the process group and
+publish bounded timeout evidence; it cannot restart the agent or perform
+repository tool actions.
 
-The dispatcher refreshes the authority document every ten seconds while it
-owns the Attempt. The wrapper checks authority before agent launch and at most
-every five seconds while the process runs. An expired, cancelled, or mismatched
-authority starts shutdown of the runtime process group. This preserves
+The dispatcher requests an authority refresh every ten seconds while it owns
+the Attempt. The gateway performs the conditional write and computes
+`valid_until` from its own server clock. The wrapper checks authority before
+agent launch and at most every five seconds while the process runs. An expired,
+cancelled, mismatched, or timed-out Attempt starts shutdown of the runtime
+process group. This preserves
 fail-closed lease behavior without making the local Factory API reachable from
 the internet.
 Cloud execution therefore depends on one continuously running Factory control
@@ -253,8 +263,9 @@ terminal, mismatched, cross-prefix, conflicting, and oversized operations.
 
 The Job wrapper is the trusted container entrypoint. It owns input validation,
 the start fence, exact checkout, runtime supervision, authority checks, event
-normalization, artifact publication, and exit status. It does not choose work,
-retry an Attempt, or decide Factory's terminal outcome.
+normalization, monotonic timeout enforcement, artifact publication, and exit
+status. It does not choose work, retry an Attempt, or decide Factory's terminal
+outcome.
 
 The agent runtime owns model interaction and engineering tool use. It receives
 one prepared checkout and a bounded prompt. It does not receive control-plane
@@ -366,6 +377,9 @@ retry instead of silently running different code.
 - `INV-12`: Cloud execution never weakens the loopback-only operator API.
 - `INV-13`: A Job identity and run capability can access only its own Attempt
   protocol and cannot read or mutate a sibling Attempt.
+- `INV-14`: The wrapper starts process-group shutdown at the frozen Work
+  deadline and sends SIGKILL no later than ten seconds afterward, independent
+  of the longer profile or Cloud Run Job timeout.
 
 ### Requirements
 
@@ -399,6 +413,15 @@ retry instead of silently running different code.
   apart and event objects at most two seconds apart.
 - The wrapper checks authority at most five seconds apart. Authority remains
   valid for no more than 30 seconds without a dispatcher refresh.
+- The immutable input includes `timeout_seconds`. The gateway start-fence
+  response supplies trusted server time. The wrapper anchors the frozen duration
+  to the monotonic instant recorded before the request, producing a conservative
+  deadline shared by checkout and agent execution. At the deadline it applies
+  the ten-second process-group kill rule, records a timeout outcome, and permits
+  at most 60 seconds for bounded failure-evidence upload with no live agent. A
+  wrapper has at most five minutes from process start to acquire its fence. The
+  versioned Cloud Run Job timeout is at least five minutes plus the maximum Work
+  timeout plus 70 seconds and is a platform safety limit, not the Work timeout.
 - Event and completion sizes reuse the existing Attempt limits. Artifact size
   defaults to 64 MiB and has a 512 MiB maximum. Completion is rejected when the
   configured bound is exceeded.
@@ -585,35 +608,44 @@ is idempotent and the stored outcome always wins.
 
 ### Authority lease protocol
 
-The dispatcher is the single authority writer. `authority.json` contains the
-Attempt ID, run ID, run-capability digest, monotonically increasing revision,
-input digest, `valid_until`, cancellation flag, and previous object generation.
-Each refresh uses GCS `ifGenerationMatch` against the generation Factory last stored. A
-precondition failure moves the dispatch to `reconciling`, stops refresh, and
-revokes the Attempt because another writer or stale state exists.
+The dispatcher is the sole authority decision-maker, and the gateway is the
+sole physical authority-object writer. `authority.json` contains the Attempt
+ID, run ID, run-capability digest, monotonically increasing revision, input
+digest, `valid_until`, cancellation flag, and previous object generation. An
+authenticated refresh request contains the expected generation and desired
+cancellation state, but no caller-supplied time. The gateway computes
+`valid_until` as 30 seconds after its own server time and writes with GCS
+`ifGenerationMatch`. A precondition failure moves the dispatch to
+`reconciling`, stops refresh, and revokes the Attempt because another writer or
+stale state exists.
 
-`valid_until` is computed from the control-plane clock and is 30 seconds after
-the successful refresh. The gateway returns its trusted server time with every
-authority read, and the wrapper uses that response to set a conservative
-monotonic deadline. It never extends validity from its wall clock. It
-fetches the object at most five seconds apart and verifies the object generation
-never moves backwards. A read error is not authority. The wrapper may continue
-only until the last verified `valid_until`; there is no grace period after that
+Every refresh and authority-read response returns the gateway server time,
+`valid_until`, revision, and object generation from one operation. The wrapper
+records local monotonic time immediately before every gateway request and sets
+the returned `valid_until - server_time` duration against that earlier instant.
+Network delay can shorten but never extend authority. Neither the Factory clock
+nor the wrapper wall clock can extend validity. It fetches authority at most
+five seconds apart and verifies the revision and generation never move
+backwards. A read error is not authority. The wrapper may continue only until
+the last verified monotonic deadline; there is no grace period after that
 instant. Before checkout, agent start, every external publish action exposed by
 the wrapper, and final manifest upload, it requires current matching authority.
 On expiry or cancellation it sends SIGTERM to the process group immediately,
 waits ten seconds, sends SIGKILL, uploads only bounded failure evidence while
 the gateway still authorizes it, and exits nonzero.
 
-Factory refreshes authority only while the same Attempt lease and dispatch
-record remain active. A server shutdown, dispatcher crash, SQLite ownership
-loss, GCS generation conflict, or inability to prove state stops refresh. The
-first-release availability contract is explicit: a continuously available
-Factory controller is required for a continuously running Cloud Job.
+Factory asks the gateway to refresh authority only while the same Attempt lease
+and dispatch record remain active. The gateway performs every initial,
+refresh, and revocation authority-object write using its clock and generation
+precondition. A server shutdown, dispatcher crash, SQLite ownership loss, GCS
+generation conflict, or inability to prove state stops refresh. The first-release
+availability contract is explicit: a continuously available Factory controller
+is required for a continuously running Cloud Job.
 
-After Factory commits explicit cancellation, it revokes authority with one
-conditional write. A healthy wrapper observes that revocation within five
-seconds and kills a process that ignores SIGTERM within a further ten seconds.
+After Factory commits explicit cancellation, it asks the gateway to revoke
+authority with one conditional write. A healthy wrapper observes that
+revocation within five seconds and kills a process that ignores SIGTERM within
+a further ten seconds.
 The product bound is 15 seconds after successful authority revocation, with a
 five-second allowance for dispatcher scheduling. If the controller disappears
 without revoking authority, the last 30-second authority window plus the
@@ -639,6 +671,13 @@ remain active.
 If container startup exceeds 30 seconds, the dispatcher continues renewing the
 Factory lease and cloud authority while the execution is starting. The Job
 checks authority before starting the runtime.
+
+If the frozen Work timeout expires during checkout or agent execution, the
+wrapper sends SIGTERM immediately and SIGKILL after ten seconds. It emits a
+timeout event and may publish bounded failure evidence for at most 60 seconds,
+then exits nonzero. Factory records the same timed-out failure semantics as the
+persistent backend. The profile-wide Cloud Run Job timeout remains only a final
+platform kill switch.
 
 If event upload or ingestion fails, the wrapper retries bounded, immutable
 batches. Factory accepts a repeated batch only when its identity and bytes
@@ -767,6 +806,9 @@ Cloud Logging retention are diagnostic and are never the only retained record.
   sandbox.
 - `AC-13`: Two concurrent Attempts using one profile cannot read, overwrite,
   fence, publish, or cancel each other's protocol data.
+- `AC-14`: A cloud Attempt that reaches its frozen Work timeout starts agent
+  shutdown immediately, kills the process group within ten seconds, publishes
+  no success, and cannot continue until the profile-wide Job timeout.
 
 ## 10. Test approach
 
@@ -777,8 +819,11 @@ tests will prove `INV-2` and `AC-2`, including exact-commit reuse on retry.
 
 Dispatcher tests will inject lost responses, duplicate executions, delayed
 startup, API outages, stale generations, restart with the encrypted capability,
-missing or invalid encryption keys, and quota failures to prove `INV-3`,
-`INV-4`, `INV-9`, `AC-3`, `AC-4`, and `AC-5`.
+missing or invalid encryption keys, Factory clocks ahead of and behind the
+gateway, delayed gateway responses, and quota failures to prove `INV-3`,
+`INV-4`, `INV-9`, `AC-3`, `AC-4`, and `AC-5`. Delay tests anchor timers to the
+pre-request monotonic instant and prove response transit cannot extend Work or
+authority deadlines.
 
 Protocol tests will reorder, repeat, corrupt, truncate, and oversize event and
 artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.
@@ -795,6 +840,11 @@ to run or cancel Cloud Run resources or access a sibling Attempt through the
 gateway or storage API. The real-project prototype must measure how long Cloud
 Run retains completed execution overrides and feed that value into the profile
 retention and operator warning.
+
+Wrapper tests will expire the frozen Work timeout during checkout and agent
+execution, expire the five-minute pre-fence window, delay start-fence responses,
+make the process ignore SIGTERM, and delay artifact upload to prove `INV-14`
+and `AC-14` independently from the profile-wide Job timeout.
 
 A gated real-project integration test will build an immutable image, run one
 read-only and one patch-producing Attempt, cancel one long-running Attempt,

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -617,8 +617,8 @@ themselves.
 | `starting` | Accepted Run operation or matching start fence, before `work_deadline_at` | `running`, `reconciling`, `timeout_requested`, `cancel_requested`, `terminal` |
 | `running` | Matching start fence and valid authority generation | `reconciling`, `timeout_requested`, `cancel_requested`, `terminal` |
 | `reconciling` | Incomplete or conflicting cloud observation; an unexpired Work deadline before returning to `starting` or `running` | `starting`, `running`, `timeout_requested`, `cancel_requested`, `terminal` |
-| `timeout_requested` | Expired conservative monotonic Work deadline; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed last verified authority deadline, or provider-terminal execution |
-| `cancel_requested` | Durable cancellation time; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed last verified authority deadline, or provider-terminal execution |
+| `timeout_requested` | Expired conservative monotonic Work deadline; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed last verified authority deadline, or provider-terminal proof for the matching execution set |
+| `cancel_requested` | Durable cancellation time; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed last verified authority deadline, or provider-terminal proof for the matching execution set |
 | `terminal` | One stored Factory outcome | none |
 
 Before every external side effect, the dispatcher commits the intended state
@@ -737,7 +737,7 @@ gateway to revoke authority even when no start fence exists. Fence and
 revocation requests compete through the same authority generation. On a
 generation conflict, Factory reads the new generation and retries revocation;
 it never refreshes authority. Confirmed revocation, a gateway response showing
-that the absolute deadline has arrived, provider-terminal execution, or expiry
+that the absolute deadline has arrived, provider-terminal proof, or expiry
 of the last verified authority deadline on Factory's suspend-aware monotonic
 clock permits Factory to commit the terminal outcome already owned by timeout or
 cancellation intent. The last case is sufficient because the gateway never
@@ -752,7 +752,16 @@ dispatch ownership and waits the full 30-second maximum authority lease from
 its suspend-aware monotonic startup instant. That conservative wait substitutes
 for the lost pre-restart anchor and may terminalize an already owned timeout or
 cancellation without a fresh gateway response; provider terminal state may do
-the same sooner. Gateway failure cannot revive the execution.
+the same sooner only when it satisfies the set-wide proof below. Gateway failure
+cannot revive the execution.
+
+Provider-terminal proof is set-wide, not evidence from any one duplicate. If a
+start-fence winner is known, its Cloud Run execution must be terminal and every
+other discovered matching execution must either be terminal or be proven unable
+to win the immutable fence. If no winner is known, every discovered matching
+execution must be terminal; otherwise Factory uses revocation or authority-
+expiry proof instead. Reconciliation completes pagination and the discovery
+window before declaring that set complete.
 The gateway performs every initial, refresh, and revocation authority-object
 write using its clock and generation precondition. A server shutdown,
 dispatcher crash, SQLite ownership loss, GCS generation conflict, or inability
@@ -843,10 +852,11 @@ reconciles every nonterminal cloud dispatch before admitting new cloud work.
 The two-minute reconciliation deadline never replaces a durable terminal owner
 or bypasses authority-expiry proof. A dispatch with timeout or cancellation
 intent remains nonterminal until the gateway confirms revocation or absolute
-expiry, the last verified suspend-aware authority deadline elapses, the provider
-reports terminal, or a restarted exclusive owner completes the full
-maximum-lease wait described above. It then commits the outcome already owned by
-that intent. Only a dispatch with neither intent that still cannot prove
+expiry, the last verified suspend-aware authority deadline elapses, set-wide
+provider-terminal proof completes as defined above, or a restarted exclusive
+owner completes the full maximum-lease wait described above. It then commits
+the outcome already owned by that intent. Only a dispatch with neither intent
+that still cannot prove
 ownership within two minutes records a `cloud_reconciliation_timeout` failure
 with the external execution identity for operator cleanup. Expired or revoked
 authority keeps the agent stopped throughout.
@@ -994,7 +1004,13 @@ After expiry it must reject success and take the conditional timeout branch.
 Authority tests will make the gateway permanently unreachable after timeout and
 cancellation intent, then prove that expiry of the last verified suspend-aware
 authority deadline terminalizes the owned outcome without another gateway
-response.
+response. A separate restart test discards the old monotonic anchor, makes the
+gateway unreachable, and proves terminalization remains blocked until Factory
+acquires exclusive dispatcher ownership and completes the full 30-second
+maximum-lease wait on a fresh suspend-aware clock, including host suspension
+during that wait. Duplicate tests must prove that one terminal execution cannot
+satisfy provider-terminal proof while the fence winner remains active, and that
+the no-winner case requires every matching execution to be terminal.
 
 Security tests will inspect the deployed Job configuration, IAM policy, input
 metadata, gateway request logs and traces, structured logs, and container

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -355,8 +355,8 @@ retry instead of silently running different code.
   sequence, and event ID.
 - `INV-7`: Factory accepts successful completion only after verifying the final
   manifest and every required artifact.
-- `INV-8`: Cancellation recorded before verified completion cannot become
-  succeeded because of a late cloud result.
+- `INV-8`: Cancellation committed before terminal success cannot become
+  succeeded because of prior artifact ingestion or a late cloud result.
 - `INV-9`: A control-plane restart can identify, reconcile, and either resume
   supervision or cancel every nonterminal cloud execution.
 - `INV-10`: The Job receives no operator API credential or broad cloud
@@ -558,11 +558,14 @@ identity. The prototype must prove that the v2 execution-list response exposes
 the effective overrides needed for this search. If it does not, durable launch
 is blocked until the design supplies another discoverable correlation key.
 
-Cancellation and completion use their committed Factory timestamps. Verified
-completion can win only when its manifest was fully ingested before
-`cancellation_requested_at`. Once cancellation is committed, no later cloud
-success can change the outcome. Terminal completion is idempotent and the
-stored outcome always wins.
+Artifact ingestion and verification do not decide the cancellation race. The
+successful-completion transaction loads the verified manifest evidence, checks
+that no cancellation is committed, and writes the terminal success atomically.
+The cancellation transaction checks that no terminal outcome is committed and
+atomically records `cancellation_requested_at`. SQLite serialization makes one
+of those transactions the first durable Factory decision. Once cancellation is
+committed, no later cloud success can change the outcome. Terminal completion
+is idempotent and the stored outcome always wins.
 
 ### Authority lease protocol
 
@@ -642,8 +645,9 @@ same Attempt still owns valid authority. Otherwise it revokes authority,
 cancels the execution, and records a failed or cancelled outcome.
 
 If cancellation races with completion, the first durable Factory decision
-wins. A verified completion stored before cancellation succeeds. A durable
-cancellation request stored first produces cancelled and retains any late
+wins. Manifest upload, ingestion, or verification alone does not win. A
+terminal-success transaction committed before cancellation succeeds. A durable
+cancellation request committed first produces cancelled and retains any late
 artifact.
 
 Disabling a backend profile stops new dispatches. Existing executions continue
@@ -761,6 +765,8 @@ startup, API outages, stale generations, restart, and quota failures to prove
 
 Protocol tests will reorder, repeat, corrupt, truncate, and oversize event and
 artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.
+They will also force both SQLite transaction orderings after manifest
+verification to prove that cancellation and terminal success cannot both win.
 
 Security tests will inspect the deployed Job configuration, IAM policy, input
 metadata, structured logs, and container environment to prove `INV-10`,

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -699,9 +699,12 @@ sole physical authority-object writer. `authority.json` contains the Attempt
 ID, run ID, run-capability digest, monotonically increasing revision, input
 digest, `work_deadline_at`, `valid_until`, winning execution identity when
 fenced, a complete `last_refresh_receipt`, revocation reason, and previous object
-generation. The receipt contains the request ID, expected and resulting
-generation, gateway processing time, and resulting `valid_until`. It is written
-atomically with the authority extension. Every later non-refresh authority
+generation. The receipt contains the request ID, expected storage generation,
+gateway processing time, resulting `valid_until`, and deterministic resulting
+logical authority revision. It does not claim the provider-assigned generation
+of the write that contains it, because GCS assigns that value only after
+accepting the payload. The receipt is written atomically with the authority
+extension. Every later non-refresh authority
 mutation, including fencing and revocation, copies it byte-for-byte; the next
 successful refresh atomically replaces it with its own receipt. It remains in
 `authority.json` for the dispatch retention period, so any gateway instance can
@@ -716,8 +719,11 @@ after its own server time and `work_deadline_at`, then writes the authority and
 receipt with one GCS `ifGenerationMatch`. Replaying the request ID in the current
 receipt returns that exact receipt and never performs another compare-and-set or
 extends authority again, including after a later revocation. An older resolved
-request ID is rejected without mutation. The stored response is historical
-evidence, not current authority state. Factory ignores such a replay after
+request ID is rejected without mutation. The gateway returns the logical
+receipt together with the separately read current storage generation, current
+logical revision, and revocation state. The receipt is historical evidence, not
+current authority state, and Factory never treats its expected generation as a
+current generation. Factory ignores such a replay after
 timeout or cancellation intent owns the outcome. Factory cannot issue the next
 request until it has received and persisted that result. Thus one lost or
 delayed refresh can extend authority at most one 30-second window beyond the
@@ -730,7 +736,8 @@ timeout or cancellation revocation then reads the new generation and retries
 until revocation is confirmed or the absolute deadline has arrived.
 
 Every refresh and authority-read response returns the gateway server time,
-`valid_until`, refresh request ID, revision, and object generation from one
+`valid_until`, refresh request ID, logical revision, and the storage generation
+observed on the current object from one
 operation. The wrapper and Factory record suspend-aware monotonic instants both
 immediately before sending and immediately after receiving the response. They
 set an early fail-closed deadline by adding `valid_until - server_time` to the
@@ -1065,7 +1072,12 @@ revocation must return the original response without changing the current
 generation, revocation marker, or deadline, and Factory must ignore it for
 state transitions. The same replay must work after gateway restart and from a
 different gateway instance by reading the receipt retained in `authority.json`;
-an older resolved request ID must be rejected without mutation. Duplicate tests
+an older resolved request ID must be rejected without mutation. A crash after
+the authority CAS succeeds but before response delivery, followed by fencing or
+revocation, gateway restart, and cross-instance replay must recover the logical
+receipt while returning the separately observed current generation and
+revocation state; no step may require embedding the provider-assigned resulting
+generation in the original receipt. Duplicate tests
 must prove that one terminal execution cannot
 satisfy provider-terminal proof while the fence winner remains active, and that
 the no-winner case requires every matching execution to be terminal.

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -104,6 +104,10 @@ document using the gateway clock and an object-generation precondition. That
 response also fixes `work_started_at` to gateway server time and
 `work_deadline_at` to `work_started_at + timeout_seconds`; both are persisted in
 the dispatch before the Run call and bound into the authority object. Factory
+records local monotonic time immediately before that gateway request and
+anchors the returned remaining Work duration to the earlier instant. That
+conservative monotonic deadline drives the live dispatcher even if later
+gateway responses are delayed or unavailable. Factory
 calls one immutable, versioned Cloud Run Job resource with the Attempt ID, run
 ID, and a separate random 256-bit run capability as bounded overrides. The
 capability is sensitive, excluded from logs, and visible only to identities
@@ -127,16 +131,19 @@ sets it to the smaller of five minutes and the trusted remaining Work duration.
 It exits without an agent if that timer expires. It records local monotonic time
 immediately before requesting the Attempt and run-ID start fence.
 If a lost API response causes Factory to launch a duplicate, only one execution
-can create that fence; every duplicate exits without running an agent. The
-successful response includes gateway server time and the persisted
+can win that fence; every duplicate exits without running an agent. The gateway
+serializes the fence and revocation through a conditional authority-object
+update, then publishes `started.json` as immutable evidence. The successful
+response includes gateway server time and the persisted
 `work_deadline_at`. The wrapper anchors `work_deadline_at - server_time` to the
 earlier pre-request monotonic instant, so Cloud Run startup and response delay
 consume rather than extend the frozen Work timeout. The winning wrapper verifies
 the input, checks out only the frozen commit, and starts the selected runtime in
 the checkout. Checkout and agent execution share that deadline. After it
-expires, the wrapper has at most 60 seconds to kill the process group and
-publish bounded timeout evidence; it cannot restart the agent or perform
-repository tool actions.
+expires, the wrapper kills the process group and exits nonzero. It cannot
+publish new evidence, restart the agent, or perform repository tool actions.
+Factory's durable timeout record is authoritative and may reference only
+bounded evidence uploaded before authority expired.
 
 The dispatcher requests an authority refresh every ten seconds while it owns
 the Attempt. The gateway performs the conditional write and computes
@@ -372,8 +379,10 @@ retry instead of silently running different code.
   sequence, and event ID.
 - `INV-7`: Factory accepts successful completion only after verifying the final
   manifest and every required artifact.
-- `INV-8`: Cancellation committed before terminal success cannot become
-  succeeded because of prior artifact ingestion or a late cloud result.
+- `INV-8`: Cancellation or timeout intent committed before terminal success
+  cannot become succeeded because of prior artifact ingestion or a late cloud
+  result. The first committed success, cancellation, or timeout intent owns the
+  outcome.
 - `INV-9`: A control-plane restart can identify, reconcile, and either resume
   supervision or cancel every nonterminal cloud execution.
 - `INV-10`: The Job receives no operator API credential or broad cloud
@@ -411,8 +420,10 @@ retry instead of silently running different code.
 - Before every Run call, the dispatcher reads the Job and verifies its resource
   name, template digest, image digest, service account, model-secret resource
   and version, task count of one, and native retry count of zero against the
-  frozen profile version. Drift blocks dispatch. The wrapper repeats the
-  verifiable checks and binds the effective values into its final manifest.
+  frozen profile version. It also requires current authority and a conservative
+  monotonic Work deadline that has not expired. Drift or expiry blocks dispatch.
+  The wrapper repeats the verifiable checks and binds the effective values into
+  its final manifest.
 - Dispatch and reconciliation respect the profile capacity and Google Cloud
   API, CPU, memory, and execution quotas. Quota pressure leaves work queued or
   blocked with an actionable reason; it does not create extra executions.
@@ -428,11 +439,10 @@ retry instead of silently running different code.
   to the monotonic instant recorded before the request, producing a conservative
   deadline shared by Cloud Run startup, checkout, and agent execution. At the
   deadline it applies the ten-second process-group kill rule, records a timeout
-  outcome, and permits at most 60 seconds for bounded failure-evidence upload
-  with no live agent. A wrapper has no more than five minutes from process start
-  to acquire its fence and never beyond `work_deadline_at`. The versioned Cloud
-  Run Job timeout is at least the maximum Work timeout plus 70 seconds and is a
-  platform safety limit, not the Work timeout.
+  outcome, and stops all gateway writes. A wrapper has no more than five minutes
+  from process start to acquire its fence and never beyond `work_deadline_at`.
+  The versioned Cloud Run Job timeout is at least the maximum Work timeout plus
+  ten seconds and is a platform safety limit, not the Work timeout.
 - Event and completion sizes reuse the existing Attempt limits. Artifact size
   defaults to 64 MiB and has a 512 MiB maximum. Completion is rejected when the
   configured bound is exceeded.
@@ -472,16 +482,18 @@ The dispatcher creates
 `attempts/<attempt-id>/gateway-registration.json` before launch. The immutable
 registration stores the expected Job service-account principal, SHA-256 digest
 of the run capability, non-secret run ID, exact Attempt prefix, input digest,
-protocol version, and absolute expiry. The Job sends the raw capability only to
-the gateway. The gateway hashes it, uses its own bucket identity to load the
-registration and authority, and never exposes list or arbitrary object
-operations. Authority revocation closes an otherwise valid registration
-immediately. The Job sends the capability only over TLS in an authenticated
-request body. The Job and gateway redact request bodies and authorization data,
-never place the capability in a URL, header echoed by infrastructure, metric,
-trace, error, or log. The wrapper retains the capability only for the Job
-lifetime and clears its copy on shutdown. The gateway discards its request copy
-after each operation.
+frozen `timeout_seconds`, protocol version, and absolute registration expiry.
+The gateway uses that registered duration and its own server time to establish
+`work_started_at` and `work_deadline_at`; neither the Job nor a later refresh can
+change them. The Job sends the raw capability only to the gateway. The gateway
+hashes it, uses its own bucket identity to load the registration and authority,
+and never exposes list or arbitrary object operations. Authority revocation
+closes an otherwise valid registration immediately. The Job sends the
+capability only over TLS in an authenticated request body. The Job and gateway
+redact request bodies and authorization data, never place the capability in a
+URL, header echoed by infrastructure, metric, trace, error, or log. The wrapper
+retains the capability only for the Job lifetime and clears its copy on
+shutdown. The gateway discards its request copy after each operation.
 
 ### Naming and identity
 
@@ -568,10 +580,10 @@ is published last.
 ### Dispatch states
 
 The internal dispatch states are `dispatching`, `starting`, `running`,
-`cancel_requested`, `reconciling`, and `terminal`. They map onto the existing
-Attempt states and remain internal. A transient Google API failure moves a
-record to `reconciling`; it does not invent a second Attempt or user-facing
-lifecycle.
+`timeout_requested`, `cancel_requested`, `reconciling`, and `terminal`. They map
+onto the existing Attempt states and remain internal. A transient Google API
+failure moves a record to `reconciling`; it does not invent a second Attempt or
+user-facing lifecycle.
 
 ### Normative state machine
 
@@ -581,10 +593,11 @@ themselves.
 
 | Factory dispatch state | Required evidence | Allowed next states |
 | --- | --- | --- |
-| `dispatching` | Committed Attempt, run ID, immutable input | `starting`, `cancel_requested`, `terminal` |
-| `starting` | Accepted Run operation or matching start fence, before `work_deadline_at` | `running`, `reconciling`, `cancel_requested`, `terminal` |
-| `running` | Matching start fence and valid authority generation | `reconciling`, `cancel_requested`, `terminal` |
-| `reconciling` | Incomplete or conflicting cloud observation | `starting`, `running`, `cancel_requested`, `terminal` |
+| `dispatching` | Committed Attempt, run ID, immutable input; after authority creation, an unexpired monotonic Work deadline | `starting`, `timeout_requested`, `cancel_requested`, `terminal` |
+| `starting` | Accepted Run operation or matching start fence, before `work_deadline_at` | `running`, `reconciling`, `timeout_requested`, `cancel_requested`, `terminal` |
+| `running` | Matching start fence and valid authority generation | `reconciling`, `timeout_requested`, `cancel_requested`, `terminal` |
+| `reconciling` | Incomplete or conflicting cloud observation; an unexpired Work deadline before returning to `starting` or `running` | `starting`, `running`, `timeout_requested`, `cancel_requested`, `terminal` |
+| `timeout_requested` | Expired conservative monotonic Work deadline; refresh and Run calls disabled | `terminal` after confirmed authority revocation or absolute gateway deadline |
 | `cancel_requested` | Durable cancellation time and revoked authority | `terminal` |
 | `terminal` | One stored Factory outcome | none |
 
@@ -595,11 +608,15 @@ call but before its response leaves `dispatching`. Reconciliation pages every
 execution of the frozen Job version created since the recorded dispatch start,
 inspects its effective environment overrides, and persists every execution
 carrying the exact Attempt ID and run ID before another Run call is allowed.
-Another call may still create a duplicate container. Every container must
-create the exact `started.json` object with
-`ifGenerationMatch=0` before checkout, model calls, Git writes, or external tool
-use. A fence winner whose Attempt, run ID, input digest, or authority is stale
-exits nonzero. A fence loser exits zero without running the agent.
+Another call may still create a duplicate container. Before checkout, model
+calls, Git writes, or external tool use, every container asks the gateway for
+the start fence. The gateway conditionally updates `authority.json` with the
+winning execution identity and then creates the exact `started.json` object
+with `ifGenerationMatch=0`. A retry after a failure between those writes
+completes the same winner's immutable evidence. Revocation and start-fence
+authority updates use the same generation compare-and-swap, so their order is
+unambiguous. A fence winner whose Attempt, run ID, input digest, or authority is
+stale exits nonzero. A fence loser exits zero without running the agent.
 
 Cloud Run execution names are provider-assigned and cannot be deterministic.
 The Factory Attempt and run ID provide deterministic dispatch identity.
@@ -610,29 +627,37 @@ identity. The prototype must prove that the v2 execution-list response exposes
 the effective overrides needed for this search. If it does not, durable launch
 is blocked until the design supplies another discoverable correlation key.
 
-Artifact ingestion and verification do not decide the cancellation race. The
-successful-completion transaction loads the verified manifest evidence, checks
-that no cancellation is committed, and writes the terminal success atomically.
-The cancellation transaction checks that no terminal outcome is committed and
-atomically records `cancellation_requested_at`. SQLite serialization makes one
-of those transactions the first durable Factory decision. Once cancellation is
-committed, no later cloud success can change the outcome. Terminal completion
-is idempotent and the stored outcome always wins.
+Artifact ingestion and verification do not decide the terminal race. Three
+SQLite transactions compete. Successful completion loads the verified manifest
+evidence, checks that neither cancellation nor timeout intent is committed, and
+writes terminal success atomically. Explicit cancellation checks that neither a
+terminal outcome nor timeout intent is committed and atomically records
+`cancellation_requested_at`. Timeout checks that neither a terminal outcome nor
+cancellation is committed and atomically records `timeout_requested_at` and the
+`timeout_requested` dispatch state. SQLite serialization makes one transaction
+the first durable Factory decision. If timeout intent wins, a later explicit
+cancel may accelerate the same gateway revocation and Cloud Run cleanup but
+cannot change the eventual timed-out outcome. If cancellation wins, later
+timeout observation cannot replace cancelled. If success wins, neither signal
+can replace succeeded. Terminal completion is idempotent and the stored outcome
+always wins.
 
 ### Authority lease protocol
 
 The dispatcher is the sole authority decision-maker, and the gateway is the
 sole physical authority-object writer. `authority.json` contains the Attempt
 ID, run ID, run-capability digest, monotonically increasing revision, input
-digest, `work_deadline_at`, `valid_until`, cancellation flag, and previous
-object generation. An authenticated refresh request contains the expected
-generation and desired cancellation state, but no caller-supplied time. The
+digest, `work_deadline_at`, `valid_until`, winning execution identity when
+fenced, revocation reason, and previous object generation. An authenticated
+refresh request contains the expected generation and desired revocation state,
+but no caller-supplied time. The
 gateway computes `valid_until` as the earlier of 30 seconds after its own server
 time and `work_deadline_at`, then writes with GCS `ifGenerationMatch`. At or
 after `work_deadline_at`, it refuses refresh and start-fence requests and
 conditionally revokes any remaining authority. A precondition failure moves
-the dispatch to `reconciling`, stops refresh, and revokes the Attempt because
-another writer or stale state exists.
+the dispatch to `reconciling` and stops refresh because another writer or stale
+state exists. A timeout or cancellation revocation then reads the new generation
+and retries until revocation is confirmed or the absolute deadline has arrived.
 
 Every refresh and authority-read response returns the gateway server time,
 `valid_until`, revision, and object generation from one operation. The wrapper
@@ -646,16 +671,29 @@ the last verified monotonic deadline; there is no grace period after that
 instant. Before checkout, agent start, every external publish action exposed by
 the wrapper, and final manifest upload, it requires current matching authority.
 On expiry or cancellation it sends SIGTERM to the process group immediately,
-waits ten seconds, sends SIGKILL, uploads only bounded failure evidence while
-the gateway still authorizes it, and exits nonzero.
+waits ten seconds, sends SIGKILL, and exits nonzero. Any bounded failure
+evidence must already have been uploaded while the gateway still authorized
+it; timeout does not grant a post-expiry write window.
 
 Factory asks the gateway to refresh authority only while the same Attempt lease
 and dispatch record remain active. Every gateway response includes server time.
-During dispatch and reconciliation, Factory uses that time to determine whether
-an accepted execution is still before `work_deadline_at`; it never uses its own
-wall clock to extend the Work. Once gateway time reaches the deadline, Factory
-stops refresh, records the same timed-out failure used by the persistent
-backend, and requests Cloud Run cancellation even when no start fence exists.
+Factory records local monotonic time immediately before every request and
+anchors `work_deadline_at - server_time` to that earlier instant. During
+dispatch and reconciliation, the shortest such monotonic deadline determines
+whether an accepted execution may continue; neither Factory wall time nor a
+delayed response can extend the Work. Once that deadline arrives, Factory stops
+refresh and Run calls, atomically records `timeout_requested`, and asks the
+gateway to revoke authority even when no start fence exists. Fence and
+revocation requests compete through the same authority generation. On a
+generation conflict, Factory reads the new generation and retries revocation;
+it never refreshes authority. Only confirmed revocation, or a gateway response
+showing that the absolute deadline has arrived, permits Factory to commit the
+terminal timed-out failure. It then requests Cloud Run cancellation as platform
+cleanup. Therefore no container can acquire a valid fence after Factory records
+the terminal timeout. After a Factory restart, no refresh or Run retry is
+allowed until a fresh gateway response establishes a new conservative
+monotonic deadline. Failure to obtain one leaves the execution without authority
+and fails closed through reconciliation rather than reviving it.
 The gateway performs every initial, refresh, and revocation authority-object
 write using its clock and generation precondition. A server shutdown,
 dispatcher crash, SQLite ownership loss, GCS generation conflict, or inability
@@ -684,25 +722,27 @@ with an actionable storage or permission error.
 If the Run API accepts a request but its response is lost, Factory keeps the
 same run ID and capability and enumerates matching executions as specified in
 section 6. It persists and supervises the complete matching set. A repeated API
-call may create another container, but only the execution that creates
-`started.json` can launch the agent. Other executions exit successfully without
-agent side effects, are recorded as duplicates, and are cancelled if they
-remain active.
+call is allowed only before the same monotonic Work deadline and may create
+another container, but only the execution that creates `started.json` can
+launch the agent. Other executions exit successfully without agent side
+effects, are recorded as duplicates, and are cancelled if they remain active.
 
 If container startup exceeds 30 seconds, the dispatcher continues renewing the
 Factory lease and cloud authority only while gateway time remains before the
-persisted `work_deadline_at`. The gateway caps every authority lease at that
-deadline. When the deadline arrives, Factory records a timed-out failure and
-requests Cloud Run cancellation even if the container has not started. A
-container that starts late cannot acquire the start fence or valid authority
-and exits without checkout or an agent process.
+persisted `work_deadline_at` and Factory's conservative monotonic deadline has
+not expired. The gateway caps every authority lease at that deadline. When the
+monotonic deadline arrives, Factory records timeout intent and conditionally
+revokes gateway authority. After revocation is confirmed, it records the
+timed-out failure and requests Cloud Run cancellation even if the container has
+not started. A container that starts after that terminal decision cannot
+acquire the start fence or valid authority and exits without checkout or an
+agent process.
 
 If the frozen Work timeout expires during checkout or agent execution, the
-wrapper sends SIGTERM immediately and SIGKILL after ten seconds. It emits a
-timeout event and may publish bounded failure evidence for at most 60 seconds,
-then exits nonzero. Factory records the same timed-out failure semantics as the
-persistent backend. The profile-wide Cloud Run Job timeout remains only a final
-platform kill switch.
+wrapper sends SIGTERM immediately, sends SIGKILL after ten seconds, and exits
+nonzero without attempting a final event. Factory's durable record supplies the
+same timed-out failure semantics as the persistent backend. The profile-wide
+Cloud Run Job timeout remains only a final platform kill switch.
 
 If event upload or ingestion fails, the wrapper retries bounded, immutable
 batches. Factory accepts a repeated batch only when its identity and bytes
@@ -722,12 +762,15 @@ If Factory restarts, it loads every nonterminal dispatch before admitting more
 cloud work. It verifies profile identity, authority generation, start fence,
 Cloud Run execution state, and artifacts. It resumes supervision only when the
 same Attempt still owns valid authority. Otherwise it revokes authority,
-cancels the execution, and records a failed or cancelled outcome.
+cancels the execution, and records the outcome owned by the durable decision:
+timed out for stored timeout intent, cancelled for stored cancellation, or
+failed when neither exists and ownership cannot be proved.
 
-If cancellation races with completion, the first durable Factory decision
-wins. Manifest upload, ingestion, or verification alone does not win. A
-terminal-success transaction committed before cancellation succeeds. A durable
-cancellation request committed first produces cancelled and retains any late
+If cancellation or timeout races with completion, the first durable Factory
+decision wins. Manifest upload, ingestion, or verification alone does not win.
+A terminal-success transaction committed first succeeds. Cancellation committed
+first produces cancelled. Timeout intent committed first produces timed out
+after authority revocation. Either non-success outcome retains any late
 artifact.
 
 Disabling a backend profile stops new dispatches. Existing executions continue
@@ -737,11 +780,15 @@ it.
 
 Server shutdown stops new dispatch, revokes authority for active Jobs, requests
 Cloud Run cancellation, and waits for up to 30 seconds. On restart, Factory
-reconciles every nonterminal cloud dispatch before admitting new cloud work. If
-an execution still cannot be reconciled within two minutes, its expired
-authority keeps the agent stopped and Factory records a
-`cloud_reconciliation_timeout` failure with the external execution identity for
-operator cleanup.
+reconciles every nonterminal cloud dispatch before admitting new cloud work.
+The two-minute reconciliation deadline never replaces a durable terminal owner
+or bypasses gateway confirmation. A dispatch with timeout intent remains
+nonterminal until the gateway confirms revocation or absolute expiry, then
+becomes timed out. A dispatch with cancellation intent becomes cancelled after
+the same confirmation. Only a dispatch with neither intent that still cannot
+prove ownership within two minutes records a `cloud_reconciliation_timeout`
+failure with the external execution identity for operator cleanup. Expired or
+revoked authority keeps the agent stopped throughout.
 
 ## 8. Security, privacy, and operations
 
@@ -851,13 +898,19 @@ gateway, delayed gateway responses, and quota failures to prove `INV-3`,
 `INV-4`, `INV-9`, `AC-3`, `AC-4`, and `AC-5`. A container-start delay beyond
 `work_deadline_at` must produce a timed-out Attempt, a Cloud Run cancellation
 request, no successful start fence, and no authority refresh beyond the
-deadline. Delay tests anchor timers to the pre-request monotonic instant and
-prove startup and response transit cannot extend Work or authority deadlines.
+deadline. A delayed gateway response that shortens Factory's monotonic deadline
+must persist timeout intent, race a late container start through one authority
+generation, confirm revocation before terminal timeout, and prevent any fence
+after that terminal commit. Delay tests anchor timers to the pre-request
+monotonic instant and prove startup and response transit cannot extend Work or
+authority deadlines.
 
 Protocol tests will reorder, repeat, corrupt, truncate, and oversize event and
 artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.
-They will also force both SQLite transaction orderings after manifest
-verification to prove that cancellation and terminal success cannot both win.
+They will force both SQLite transaction orderings for success versus
+cancellation, success versus timeout intent, and cancellation versus timeout
+intent. Each test proves that exactly one durable decision owns the outcome and
+that later signals can perform cleanup without replacing it.
 
 Security tests will inspect the deployed Job configuration, IAM policy, input
 metadata, gateway request logs and traces, structured logs, and container

--- a/docs/cloud-run-agents/design.md
+++ b/docs/cloud-run-agents/design.md
@@ -170,7 +170,15 @@ commit, canonical input digest, image digest, runtime and model, Cloud
 execution identity, and byte length and SHA-256 digest of every required
 output. It is written last. Factory rejects an object or manifest whose storage
 generation, prefix, identity, digest, or immutable input does not match the
-dispatch record. Partial artifacts remain visible on failure.
+dispatch record. Transport checks are not enough for success. In a temporary
+verification checkout at the frozen commit, Factory applies a patch with
+`git apply --check` before applying it, or verifies a Git bundle, its advertised
+tip, and the frozen commit as the expected base. It extracts untracked content
+only after rejecting absolute paths, `..` traversal, links, devices, excess file
+counts, and excess expanded bytes. Factory then compares the reconstructed Git
+status and working-tree manifest with the wrapper's manifest. Any malformed,
+non-applicable, incomplete, or semantically mismatched recovery artifact fails
+the Attempt. Partial artifacts remain visible on failure.
 
 Cancellation first records Factory's intent and revokes authority. The
 dispatcher then calls the Cloud Run cancellation API and keeps reconciling
@@ -609,8 +617,8 @@ themselves.
 | `starting` | Accepted Run operation or matching start fence, before `work_deadline_at` | `running`, `reconciling`, `timeout_requested`, `cancel_requested`, `terminal` |
 | `running` | Matching start fence and valid authority generation | `reconciling`, `timeout_requested`, `cancel_requested`, `terminal` |
 | `reconciling` | Incomplete or conflicting cloud observation; an unexpired Work deadline before returning to `starting` or `running` | `starting`, `running`, `timeout_requested`, `cancel_requested`, `terminal` |
-| `timeout_requested` | Expired conservative monotonic Work deadline; refresh and Run calls disabled | `terminal` after confirmed authority revocation or absolute gateway deadline |
-| `cancel_requested` | Durable cancellation time and revoked authority | `terminal` |
+| `timeout_requested` | Expired conservative monotonic Work deadline; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed last verified authority deadline, or provider-terminal execution |
+| `cancel_requested` | Durable cancellation time; refresh and Run calls disabled | `terminal` after confirmed revocation, elapsed last verified authority deadline, or provider-terminal execution |
 | `terminal` | One stored Factory outcome | none |
 
 Before every external side effect, the dispatcher commits the intended state
@@ -663,9 +671,13 @@ continuous-time source that includes host sleep. The deadline value is not a
 wall-clock comparison or a boolean computed before entering SQLite. The
 serialized transaction first preserves any existing terminal, cancellation, or
 timeout owner. Only when no owner exists and the time predicate fails does it
-record timeout intent instead of success. A stale, missing, delayed, or expired
-response follows that same conditional timeout branch; it never replaces an
-existing owner. Prior manifest publication cannot extend the Work. Explicit
+record timeout intent instead of success. A stale, missing, or failed gateway
+read does not by itself own the outcome. While the last trusted suspend-aware
+Work deadline remains unexpired, Factory leaves completion in `reconciling` and
+retries the authority read without accepting success. Once that deadline has
+expired, the same conditional timeout branch applies. An expired response also
+uses that branch. None can replace an existing owner. Prior manifest publication
+cannot extend the Work. Explicit
 cancellation checks that neither a terminal outcome nor timeout intent is
 committed and atomically records `cancellation_requested_at`. Timeout checks
 that neither a terminal outcome nor cancellation is committed and atomically
@@ -724,14 +736,23 @@ refresh and Run calls, atomically records `timeout_requested`, and asks the
 gateway to revoke authority even when no start fence exists. Fence and
 revocation requests compete through the same authority generation. On a
 generation conflict, Factory reads the new generation and retries revocation;
-it never refreshes authority. Only confirmed revocation, or a gateway response
-showing that the absolute deadline has arrived, permits Factory to commit the
-terminal timed-out failure. It then requests Cloud Run cancellation as platform
+it never refreshes authority. Confirmed revocation, a gateway response showing
+that the absolute deadline has arrived, provider-terminal execution, or expiry
+of the last verified authority deadline on Factory's suspend-aware monotonic
+clock permits Factory to commit the terminal outcome already owned by timeout or
+cancellation intent. The last case is sufficient because the gateway never
+grants authority beyond that anchored instant; another gateway response is not
+required merely to restate expiry. Factory durably records which proof
+terminalized the outcome, then requests Cloud Run cancellation as platform
 cleanup. Therefore no container can acquire a valid fence after Factory records
 the terminal timeout. After a Factory restart, no refresh or Run retry is
-allowed until a fresh gateway response establishes a new conservative
-monotonic deadline. Failure to obtain one leaves the execution without authority
-and fails closed through reconciliation rather than reviving it.
+allowed until a fresh gateway response establishes a new conservative monotonic
+deadline. If the gateway is unreachable, Factory first proves exclusive
+dispatch ownership and waits the full 30-second maximum authority lease from
+its suspend-aware monotonic startup instant. That conservative wait substitutes
+for the lost pre-restart anchor and may terminalize an already owned timeout or
+cancellation without a fresh gateway response; provider terminal state may do
+the same sooner. Gateway failure cannot revive the execution.
 The gateway performs every initial, refresh, and revocation authority-object
 write using its clock and generation precondition. A server shutdown,
 dispatcher crash, SQLite ownership loss, GCS generation conflict, or inability
@@ -820,13 +841,15 @@ Server shutdown stops new dispatch, revokes authority for active Jobs, requests
 Cloud Run cancellation, and waits for up to 30 seconds. On restart, Factory
 reconciles every nonterminal cloud dispatch before admitting new cloud work.
 The two-minute reconciliation deadline never replaces a durable terminal owner
-or bypasses gateway confirmation. A dispatch with timeout intent remains
-nonterminal until the gateway confirms revocation or absolute expiry, then
-becomes timed out. A dispatch with cancellation intent becomes cancelled after
-the same confirmation. Only a dispatch with neither intent that still cannot
-prove ownership within two minutes records a `cloud_reconciliation_timeout`
-failure with the external execution identity for operator cleanup. Expired or
-revoked authority keeps the agent stopped throughout.
+or bypasses authority-expiry proof. A dispatch with timeout or cancellation
+intent remains nonterminal until the gateway confirms revocation or absolute
+expiry, the last verified suspend-aware authority deadline elapses, the provider
+reports terminal, or a restarted exclusive owner completes the full
+maximum-lease wait described above. It then commits the outcome already owned by
+that intent. Only a dispatch with neither intent that still cannot prove
+ownership within two minutes records a `cloud_reconciliation_timeout` failure
+with the external execution identity for operator cleanup. Expired or revoked
+authority keeps the agent stopped throughout.
 
 ## 8. Security, privacy, and operations
 
@@ -904,8 +927,10 @@ Cloud Logging retention are diagnostic and are never the only retained record.
   creates another Attempt.
 - `AC-7`: Events remain ordered, bounded, and duplicate-safe across delayed or
   repeated object ingestion.
-- `AC-8`: Success requires a verified final manifest and recovery artifact;
-  missing, conflicting, corrupt, or oversized artifacts fail the Attempt.
+- `AC-8`: Success requires Factory to reconstruct a verified final manifest and
+  recovery artifact against the frozen commit; missing, non-applicable,
+  conflicting, corrupt, unsafe, incomplete, or oversized artifacts fail the
+  Attempt.
 - `AC-9`: The Job receives only the configured least-privilege identity and no
   operator API credential, durable cloud key, or secret prompt metadata.
 - `AC-10`: Attempt detail shows backend, execution identity, image digest,
@@ -953,6 +978,9 @@ unbounded fallback can never become bounded again.
 
 Protocol tests will reorder, repeat, corrupt, truncate, and oversize event and
 artifact objects to prove `INV-6`, `INV-7`, `INV-8`, `AC-7`, and `AC-8`.
+They will supply a hash-valid patch that does not apply, an invalid bundle base,
+unsafe and incomplete untracked archives, and a reconstructed Git status that
+differs from the manifest; none may reach success.
 They will force both SQLite transaction orderings for success versus
 cancellation, success versus timeout intent, and cancellation versus timeout
 intent. Each test proves that exactly one durable decision owns the outcome and
@@ -960,7 +988,13 @@ that later signals can perform cleanup without replacing it. Success tests will
 verify that a manifest published before the deadline is still rejected when
 gateway response delay, scheduler delay, SQLite contention, host suspension, or
 restart makes the conservative monotonic deadline expire before the conditional
-terminal write. Missing or stale gateway time must also reject success.
+terminal write. Before the trusted Work deadline, a transient missing or stale
+gateway response must remain `reconciling` and retry rather than record timeout.
+After expiry it must reject success and take the conditional timeout branch.
+Authority tests will make the gateway permanently unreachable after timeout and
+cancellation intent, then prove that expiry of the last verified suspend-aware
+authority deadline terminalizes the owned outcome without another gateway
+response.
 
 Security tests will inspect the deployed Job configuration, IAM policy, input
 metadata, gateway request logs and traces, structured logs, and container


### PR DESCRIPTION
## Summary

- rewrite `ARCHITECTURE.md` against the current Routines and Work implementation
- add a production-oriented Cloud Run agent backend design based on the experiment in #275
- update the README and documentation index with the product direction from persistent local or VM agents to optional elastic agents

## Key decisions

- keep persistent Workers as the default for subscription auth, warm caches, and retained worktrees
- allow a manual Run to select a compatible Cloud Run profile without rewriting the Routine
- freeze backend profile versions on Work and keep Cloud Run native retries at zero
- preserve current persistent Worker commit resolution while cloud Targets freeze an exact commit across retries
- keep Factory authoritative for Attempts, cancellation, events, artifacts, and terminal outcomes
- isolate shared Job identities from sibling Attempts through a narrow per-Attempt gateway
- require bounded authority, duplicate-start fencing, restart reconciliation, and a verified recovery artifact before success
- describe Cloud Run as managed and elastic, not free, infinite, or a hostile-code sandbox

## Experiment evidence

PR #275 proved pinned container execution, exact checkout, Pi with DeepSeek V4 Flash through OpenRouter, structured output, patch production, and cost reporting. This design records what that experiment did not prove and defines the production boundaries.

## Verification

- `GOTOOLCHAIN=go1.26.5 just check`
- local Markdown link validation
- focused documentation contract checks
- `git diff --check`
- independent architecture review: approved with no remaining material findings