### PR TITLE
feat: add just run-worker for a running control plane

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,6 +18,10 @@ build:
 run config="":
     @if [[ -n "{{config}}" ]]; then ./scripts/run-local.sh "{{config}}"; else ./scripts/run-local.sh; fi
 
+# Start one worker against a control plane that is already running.
+run-worker config="":
+    @if [[ -n "{{config}}" ]]; then ./scripts/run-worker.sh "{{config}}"; else ./scripts/run-worker.sh; fi
+
 # Install pinned UI dependencies.
 ui-install:
     cd web && npm ci

--- a/Justfile
+++ b/Justfile
@@ -14,6 +14,16 @@ build:
     go build -o "$build_directory/factory-worker" ./cmd/factory-worker
     printf 'Factory binaries built in %s\n' "$build_directory"
 
+# Build only the worker binary, for hosts that run no control plane.
+build-worker:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    data_home="${FACTORY_DATA_HOME:-${FACTORY_V2_DATA_HOME:-${HOME:?HOME or FACTORY_DATA_HOME is required}/.factory}}"
+    build_directory="${FACTORY_BUILD_DIR:-${FACTORY_V2_BUILD_DIR:-$data_home/bin}}"
+    mkdir -p "$build_directory"
+    go build -o "$build_directory/factory-worker" ./cmd/factory-worker
+    printf 'Factory worker binary built in %s\n' "$build_directory"
+
 # Start one control plane and worker. Pass a worker config path when needed.
 run config="":
     @if [[ -n "{{config}}" ]]; then ./scripts/run-local.sh "{{config}}"; else ./scripts/run-local.sh; fi

--- a/docs/local.md
+++ b/docs/local.md
@@ -144,8 +144,20 @@ To start with a different Worker config:
 just run ~/.factory/claude-worker.toml
 ```
 
-To run more than one Worker, start the control plane once and then start each
-additional Worker directly:
+To run more than one Worker, start the control plane once with `just run` and
+then start each additional Worker against it:
+
+```sh
+just run-worker ~/.factory/claude-worker.toml
+```
+
+`just run-worker` never starts a second control plane. It builds the binaries
+when they are missing, checks that the control plane answers, waits for the
+Worker to register as healthy, and stops only that Worker on Ctrl+C. It reads
+the same `FACTORY_DATA_HOME` and `FACTORY_BUILD_DIR` settings as `just run`, and
+uses `~/.factory/worker.toml` when no config path is given.
+
+You can also start the Worker binary directly:
 
 ```sh
 ~/.factory/bin/factory-worker \

--- a/docs/local.md
+++ b/docs/local.md
@@ -151,11 +151,15 @@ then start each additional Worker against it:
 just run-worker ~/.factory/claude-worker.toml
 ```
 
-`just run-worker` never starts a second control plane. It builds the binaries
-when they are missing, checks that the control plane answers, waits for the
-Worker to register as healthy, and stops only that Worker on Ctrl+C. It reads
-the same `FACTORY_DATA_HOME` and `FACTORY_BUILD_DIR` settings as `just run`, and
-uses `~/.factory/worker.toml` when no config path is given.
+`just run-worker` never starts a second control plane. It joins the control
+plane named by the `server` key in that Worker config, defaulting to
+`http://127.0.0.1:7337`, so it also works for a Worker pointed at a remote
+control plane. It builds the Worker binary when it is missing, needs no
+`factory-server` binary, checks that the control plane answers, waits for the
+Worker to register as healthy where the control plane publishes Worker status,
+and stops only that Worker on Ctrl+C. It reads the same `FACTORY_DATA_HOME` and
+`FACTORY_BUILD_DIR` settings as `just run`, and uses `~/.factory/worker.toml`
+when no config path is given.
 
 You can also start the Worker binary directly:
 

--- a/scripts/run-worker.sh
+++ b/scripts/run-worker.sh
@@ -3,7 +3,6 @@
 set -eu
 
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-listen_override=${FACTORY_LISTEN:-${FACTORY_V2_LISTEN:-}}
 data_home=${FACTORY_DATA_HOME:-${FACTORY_V2_DATA_HOME:-}}
 if [ -z "$data_home" ]; then
   if [ -z "${HOME:-}" ]; then
@@ -70,42 +69,65 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
-server_binary="$build_directory/factory-server"
+# The worker configuration is the only authority for the control plane this
+# worker joins. Read its top-level keys, which precede the first table header.
+read_config_key() {
+  sed -n "/^[[:space:]]*\[/q; s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*\"\([^\"]*\)\"[[:space:]]*\$/\1/p" "$config" |
+    head -1
+}
+
+server=$(read_config_key server)
+if [ -z "$server" ]; then
+  server="http://127.0.0.1:7337"
+fi
+server=${server%/}
+ca_certificate=$(read_config_key ca_certificate)
+case "$ca_certificate" in
+  "" | /*) ;;
+  *) ca_certificate="$(CDPATH= cd -- "$(dirname -- "$config")" && pwd)/$ca_certificate" ;;
+esac
+
 worker_binary="$build_directory/factory-worker"
 
-if [ "$skip_build" != "1" ] && { [ ! -x "$server_binary" ] || [ ! -x "$worker_binary" ]; }; then
+if [ "$skip_build" != "1" ] && [ ! -x "$worker_binary" ]; then
   if ! command -v just >/dev/null 2>&1; then
     echo "Factory local startup requires just on PATH." >&2
     exit 1
   fi
   FACTORY_BUILD_DIR="$build_directory" \
-    just --justfile "$root/Justfile" --working-directory "$root" build
+    just --justfile "$root/Justfile" --working-directory "$root" build-worker
 fi
 
-if [ ! -x "$server_binary" ] || [ ! -x "$worker_binary" ]; then
-  echo "Factory binaries are missing. Run just build first." >&2
+if [ ! -x "$worker_binary" ]; then
+  echo "The Factory worker binary is missing. Run just build-worker first." >&2
   exit 1
 fi
 
 export FACTORY_DATA_HOME="$data_home"
 
-if [ -n "$listen_override" ]; then
-  listen=$listen_override
-else
-  listen=$("$server_binary" -print-listen)
-fi
-
+response_body=$(mktemp)
 worker_pid=
 
-curl_before_deadline() {
-  endpoint=$1
-  deadline=$2
-  now=$(date +%s)
-  remaining=$((deadline - now))
-  if [ "$remaining" -le 0 ]; then
-    return 1
+curl_control_plane() {
+  timeout=$1
+  endpoint=$2
+  if [ -n "$ca_certificate" ]; then
+    curl --silent --show-error --fail --max-time "$timeout" --cacert "$ca_certificate" "$endpoint"
+  else
+    curl --silent --show-error --fail --max-time "$timeout" "$endpoint"
   fi
-  curl --silent --show-error --fail --max-time "$remaining" "$endpoint"
+}
+
+curl_control_plane_status() {
+  timeout=$1
+  endpoint=$2
+  if [ -n "$ca_certificate" ]; then
+    curl --silent --output "$response_body" --write-out '%{http_code}' \
+      --max-time "$timeout" --cacert "$ca_certificate" "$endpoint"
+  else
+    curl --silent --output "$response_body" --write-out '%{http_code}' \
+      --max-time "$timeout" "$endpoint"
+  fi
 }
 
 stop_processes() {
@@ -116,6 +138,7 @@ stop_processes() {
   if [ -n "$worker_pid" ]; then
     wait "$worker_pid" 2>/dev/null || true
   fi
+  rm -f "$response_body"
 }
 
 stop_after_signal() {
@@ -126,10 +149,9 @@ stop_after_signal() {
 trap stop_after_signal INT TERM
 trap stop_processes EXIT
 
-control_plane_deadline=$(($(date +%s) + 5))
-if ! curl_before_deadline "http://$listen/healthz" "$control_plane_deadline" >/dev/null 2>&1; then
-  echo "Factory control plane is not reachable at http://$listen/." >&2
-  echo "Start it with just run first, or set FACTORY_LISTEN to its address." >&2
+if ! curl_control_plane 5 "$server/healthz" >/dev/null 2>&1; then
+  echo "Factory control plane did not answer $server/healthz." >&2
+  echo "Start it with just run, or correct the server key in $config." >&2
   exit 1
 fi
 
@@ -139,6 +161,7 @@ worker_id=$("$worker_binary" identity --config "$config")
 worker_pid=$!
 
 registered=0
+observable=1
 worker_ready_deadline=$(($(date +%s) + worker_ready_seconds))
 while [ "$(date +%s)" -lt "$worker_ready_deadline" ]; do
   if ! kill -0 "$worker_pid" 2>/dev/null; then
@@ -146,14 +169,30 @@ while [ "$(date +%s)" -lt "$worker_ready_deadline" ]; do
     echo "Factory worker exited during startup. Check the configuration and error above." >&2
     exit 1
   fi
-  if curl_before_deadline "http://$listen/api/v1/workers/$worker_id" "$worker_ready_deadline" |
-	grep -q "\"health\":\"healthy\",\"online\":true"; then
-    registered=1
+  remaining=$((worker_ready_deadline - $(date +%s)))
+  if [ "$remaining" -le 0 ]; then
     break
   fi
+  status=$(curl_control_plane_status "$remaining" "$server/api/v1/workers/$worker_id" || echo 000)
+  case "$status" in
+    200)
+      if grep -q "\"health\":\"healthy\",\"online\":true" "$response_body"; then
+        registered=1
+        break
+      fi
+      ;;
+    401 | 403 | 404)
+      # A remote control plane publishes only the worker lifecycle over TLS, so
+      # its worker status is unavailable here. Keep the worker running.
+      observable=0
+      break
+      ;;
+  esac
   sleep 0.1
 done
-if [ "$registered" != "1" ]; then
+if [ "$observable" = "0" ]; then
+  echo "Factory worker status is not published at $server/api/v1/workers/$worker_id, so its registration was not confirmed."
+elif [ "$registered" != "1" ]; then
   echo "Factory worker did not register as healthy within $worker_ready_seconds seconds. Check its health errors above." >&2
   exit 1
 fi
@@ -163,7 +202,7 @@ if ! kill -0 "$worker_pid" 2>/dev/null; then
   exit 1
 fi
 
-echo "Factory worker $worker_id joined http://$listen/"
+echo "Factory worker $worker_id joined $server/"
 echo "Press Ctrl-C to stop the worker. The control plane keeps running. State remains in $data_home."
 
 while :; do

--- a/scripts/run-worker.sh
+++ b/scripts/run-worker.sh
@@ -1,0 +1,176 @@
+#!/bin/sh
+
+set -eu
+
+root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+listen_override=${FACTORY_LISTEN:-${FACTORY_V2_LISTEN:-}}
+data_home=${FACTORY_DATA_HOME:-${FACTORY_V2_DATA_HOME:-}}
+if [ -z "$data_home" ]; then
+  if [ -z "${HOME:-}" ]; then
+    echo "Factory startup requires HOME or FACTORY_DATA_HOME." >&2
+    exit 1
+  fi
+  legacy_data_home=
+  legacy_config=
+  if [ -f "$HOME/.factory/worker.toml" ] ||
+    [ -f "$HOME/.factory/server/factory.sqlite3" ] ||
+    [ -f "$HOME/.factory/server/factory.sqlite3.v2-control-plane" ] ||
+    [ -d "$HOME/.factory/workers" ]; then
+    data_home="$HOME/.factory"
+  elif [ -f "$root/.factory-v2/worker.toml" ] ||
+    [ -f "$root/.factory-v2/data/server/factory.sqlite3" ] ||
+    [ -f "$root/.factory-v2/data/server/factory.sqlite3.v2-control-plane" ] ||
+    [ -d "$root/.factory-v2/data/workers" ]; then
+    legacy_data_home="$root/.factory-v2/data"
+    legacy_config="$root/.factory-v2/worker.toml"
+  elif [ -f "$HOME/.factory-v2/worker.toml" ] ||
+    [ -f "$HOME/.factory-v2/server/factory.sqlite3" ] ||
+    [ -f "$HOME/.factory-v2/server/factory.sqlite3.v2-control-plane" ] ||
+    [ -d "$HOME/.factory-v2/workers" ]; then
+    legacy_data_home="$HOME/.factory-v2"
+    legacy_config="$HOME/.factory-v2/worker.toml"
+  fi
+  if [ -n "$legacy_data_home" ]; then
+    echo "Factory found preview state and refused to replace it with an empty ~/.factory home." >&2
+    if [ -f "$legacy_config" ]; then
+      echo "Resolve its work by running:" >&2
+      echo "  FACTORY_DATA_HOME=\"$legacy_data_home\" \"$root/scripts/run-worker.sh\" \"$legacy_config\"" >&2
+    else
+      echo "The matching worker configuration was not found at $legacy_config." >&2
+      echo "Set FACTORY_DATA_HOME=$legacy_data_home when reopening factory-server, and restore the matching worker configuration before starting a worker." >&2
+    fi
+    echo "Archive the old state after its attempts and retained worktrees are resolved." >&2
+    exit 1
+  fi
+  if [ -z "$data_home" ]; then
+    data_home="$HOME/.factory"
+  fi
+fi
+build_directory=${FACTORY_BUILD_DIR:-${FACTORY_V2_BUILD_DIR:-"$data_home/bin"}}
+config=${1:-${FACTORY_WORKER_CONFIG:-${FACTORY_V2_WORKER_CONFIG:-"$data_home/worker.toml"}}}
+worker_ready_seconds=${FACTORY_WORKER_READY_SECONDS:-${FACTORY_V2_WORKER_READY_SECONDS:-40}}
+skip_build=${FACTORY_SKIP_BUILD:-${FACTORY_V2_SKIP_BUILD:-0}}
+
+case "$(uname -s)" in
+  Darwin|DragonFly|FreeBSD|Linux|NetBSD|OpenBSD|SunOS) ;;
+  *)
+    echo "Factory local workers are supported only on Unix." >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "$config" ]; then
+  echo "Factory worker configuration does not exist: $config" >&2
+  echo "Copy examples/worker.toml there and set the repository paths first." >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Factory local startup requires curl on PATH." >&2
+  exit 1
+fi
+
+server_binary="$build_directory/factory-server"
+worker_binary="$build_directory/factory-worker"
+
+if [ "$skip_build" != "1" ] && { [ ! -x "$server_binary" ] || [ ! -x "$worker_binary" ]; }; then
+  if ! command -v just >/dev/null 2>&1; then
+    echo "Factory local startup requires just on PATH." >&2
+    exit 1
+  fi
+  FACTORY_BUILD_DIR="$build_directory" \
+    just --justfile "$root/Justfile" --working-directory "$root" build
+fi
+
+if [ ! -x "$server_binary" ] || [ ! -x "$worker_binary" ]; then
+  echo "Factory binaries are missing. Run just build first." >&2
+  exit 1
+fi
+
+export FACTORY_DATA_HOME="$data_home"
+
+if [ -n "$listen_override" ]; then
+  listen=$listen_override
+else
+  listen=$("$server_binary" -print-listen)
+fi
+
+worker_pid=
+
+curl_before_deadline() {
+  endpoint=$1
+  deadline=$2
+  now=$(date +%s)
+  remaining=$((deadline - now))
+  if [ "$remaining" -le 0 ]; then
+    return 1
+  fi
+  curl --silent --show-error --fail --max-time "$remaining" "$endpoint"
+}
+
+stop_processes() {
+  trap - INT TERM EXIT
+  if [ -n "$worker_pid" ] && kill -0 "$worker_pid" 2>/dev/null; then
+    kill -TERM "$worker_pid" 2>/dev/null || true
+  fi
+  if [ -n "$worker_pid" ]; then
+    wait "$worker_pid" 2>/dev/null || true
+  fi
+}
+
+stop_after_signal() {
+  stop_processes
+  exit 0
+}
+
+trap stop_after_signal INT TERM
+trap stop_processes EXIT
+
+control_plane_deadline=$(($(date +%s) + 5))
+if ! curl_before_deadline "http://$listen/healthz" "$control_plane_deadline" >/dev/null 2>&1; then
+  echo "Factory control plane is not reachable at http://$listen/." >&2
+  echo "Start it with just run first, or set FACTORY_LISTEN to its address." >&2
+  exit 1
+fi
+
+echo "Starting Factory worker with $config ..."
+worker_id=$("$worker_binary" identity --config "$config")
+"$worker_binary" --config "$config" &
+worker_pid=$!
+
+registered=0
+worker_ready_deadline=$(($(date +%s) + worker_ready_seconds))
+while [ "$(date +%s)" -lt "$worker_ready_deadline" ]; do
+  if ! kill -0 "$worker_pid" 2>/dev/null; then
+    wait "$worker_pid" || true
+    echo "Factory worker exited during startup. Check the configuration and error above." >&2
+    exit 1
+  fi
+  if curl_before_deadline "http://$listen/api/v1/workers/$worker_id" "$worker_ready_deadline" |
+	grep -q "\"health\":\"healthy\",\"online\":true"; then
+    registered=1
+    break
+  fi
+  sleep 0.1
+done
+if [ "$registered" != "1" ]; then
+  echo "Factory worker did not register as healthy within $worker_ready_seconds seconds. Check its health errors above." >&2
+  exit 1
+fi
+if ! kill -0 "$worker_pid" 2>/dev/null; then
+  wait "$worker_pid" || true
+  echo "Factory worker stopped before startup completed." >&2
+  exit 1
+fi
+
+echo "Factory worker $worker_id joined http://$listen/"
+echo "Press Ctrl-C to stop the worker. The control plane keeps running. State remains in $data_home."
+
+while :; do
+  if ! kill -0 "$worker_pid" 2>/dev/null; then
+    wait "$worker_pid" || true
+    echo "Factory worker stopped unexpectedly." >&2
+    exit 1
+  fi
+  sleep 1
+done

--- a/scripts/run-worker.sh
+++ b/scripts/run-worker.sh
@@ -71,17 +71,36 @@ fi
 
 # The worker configuration is the only authority for the control plane this
 # worker joins. Read its top-level keys, which precede the first table header.
+# An absent key takes its default. A key that is present but unreadable is an
+# error, because defaulting there would silently join the wrong control plane.
 read_config_key() {
-  sed -n "/^[[:space:]]*\[/q; s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*\"\([^\"]*\)\"[[:space:]]*\$/\1/p" "$config" |
-    head -1
+  key=$1
+  line=$(sed -n "/^[[:space:]]*\[/q; /^[[:space:]]*$key[[:space:]]*=/p" "$config" | head -1)
+  if [ -z "$line" ]; then
+    return 0
+  fi
+  value=$(
+    printf '%s\n' "$line" | sed -n \
+      -e "s/^[^=]*=[[:space:]]*\"\([^\"]*\)\"[[:space:]]*\$/\1/p" \
+      -e "s/^[^=]*=[[:space:]]*\"\([^\"]*\)\"[[:space:]]*#.*\$/\1/p" \
+      -e "s/^[^=]*=[[:space:]]*'\([^']*\)'[[:space:]]*\$/\1/p" \
+      -e "s/^[^=]*=[[:space:]]*'\([^']*\)'[[:space:]]*#.*\$/\1/p" |
+      head -1
+  )
+  if [ -z "$value" ]; then
+    echo "Factory could not read the $key value in $config." >&2
+    echo "Write it as a single-line quoted TOML string, such as $key = \"value\"." >&2
+    return 1
+  fi
+  printf '%s' "$value"
 }
 
-server=$(read_config_key server)
+server=$(read_config_key server) || exit 1
 if [ -z "$server" ]; then
   server="http://127.0.0.1:7337"
 fi
 server=${server%/}
-ca_certificate=$(read_config_key ca_certificate)
+ca_certificate=$(read_config_key ca_certificate) || exit 1
 case "$ca_certificate" in
   "" | /*) ;;
   *) ca_certificate="$(CDPATH= cd -- "$(dirname -- "$config")" && pwd)/$ca_certificate" ;;

--- a/scripts/test-run-local.sh
+++ b/scripts/test-run-local.sh
@@ -328,9 +328,12 @@ EOF
 
 echo "Factory launcher honors bootstrap listen settings, rejects unhealthy workers, retired-state writes, server loss, and stalled readiness responses; signals stop cleanly."
 
+mkdir -p "$temporary/worker-only-bin"
+cp "$temporary/bin/factory-worker" "$temporary/worker-only-bin/factory-worker"
+
 set +e
 output=$(
-  FACTORY_BUILD_DIR="$temporary/bin" \
+  FACTORY_BUILD_DIR="$temporary/worker-only-bin" \
     FACTORY_DATA_HOME="$temporary/data" \
     FACTORY_SKIP_BUILD=1 \
     "$root/scripts/run-worker.sh" "$temporary/missing-worker.toml" 2>&1
@@ -345,21 +348,21 @@ if [ "$status" -ne 1 ] ||
   exit 1
 fi
 
+printf 'server = "http://127.0.0.1:1"\n' >"$temporary/detached-worker.toml"
 set +e
 output=$(
-  FACTORY_BUILD_DIR="$temporary/bin" \
+  FACTORY_BUILD_DIR="$temporary/worker-only-bin" \
     FACTORY_DATA_HOME="$temporary/data" \
-    FACTORY_LISTEN="127.0.0.1:1" \
     FACTORY_SKIP_BUILD=1 \
     FACTORY_TEST_WORKER_MARKER="$temporary/worker-started-detached" \
-    "$root/scripts/run-worker.sh" "$temporary/worker.toml" 2>&1
+    "$root/scripts/run-worker.sh" "$temporary/detached-worker.toml" 2>&1
 )
 status=$?
 set -e
 if [ "$status" -ne 1 ] ||
   ! printf '%s\n' "$output" |
-    grep -q "Factory control plane is not reachable at http://127.0.0.1:1/"; then
-  echo "worker launcher did not report a missing control plane" >&2
+    grep -Fq "Factory control plane did not answer http://127.0.0.1:1/healthz"; then
+  echo "worker launcher did not name the control plane endpoint it probed" >&2
   echo "$output" >&2
   exit 1
 fi
@@ -368,15 +371,14 @@ if [ -e "$temporary/worker-started-detached" ]; then
   exit 1
 fi
 
-node - "$root" "$temporary" "$temporary/worker.toml" <<'EOF'
-const { existsSync, readFileSync, rmSync } = require("node:fs");
+node - "$root" "$temporary" <<'EOF'
+const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = require("node:fs");
 const { createServer } = require("node:net");
 const { spawn } = require("node:child_process");
 const { join } = require("node:path");
 
 const root = process.argv[2];
 const temporary = process.argv[3];
-const config = process.argv[4];
 
 function availablePort() {
   return new Promise((resolve, reject) => {
@@ -424,14 +426,23 @@ async function waitForHealth(port) {
 (async () => {
   const marker = join(temporary, "worker-started-attached");
   const workerPidFile = join(temporary, "worker-attached.pid");
+  const dataHome = join(temporary, "attached-data");
+  const config = join(temporary, "attached-worker.toml");
   rmSync(marker, { force: true });
   rmSync(workerPidFile, { force: true });
+
+  // The control plane the worker config names must win over the port the local
+  // server configuration would listen on.
   const port = await availablePort();
+  const unusedServerPort = await availablePort();
+  mkdirSync(dataHome, { recursive: true });
+  writeFileSync(join(dataHome, "config.toml"), `listen = "127.0.0.1:${unusedServerPort}"\n`);
+  writeFileSync(config, `server = "http://127.0.0.1:${port}"\n\n[repositories.example]\nserver = "ignored"\n`);
 
   const controlPlane = spawn(join(temporary, "bin/factory-server"), ["-listen", `127.0.0.1:${port}`], {
     env: {
       ...process.env,
-      FACTORY_DATA_HOME: join(temporary, "data"),
+      FACTORY_DATA_HOME: dataHome,
       FACTORY_TEST_HEALTHY_WORKER: "1",
       FACTORY_TEST_WORKER_MARKER: marker
     },
@@ -444,17 +455,20 @@ async function waitForHealth(port) {
   try {
     await waitForHealth(port);
 
+    const environment = {
+      ...process.env,
+      FACTORY_BUILD_DIR: join(temporary, "worker-only-bin"),
+      FACTORY_DATA_HOME: dataHome,
+      FACTORY_SKIP_BUILD: "1",
+      FACTORY_TEST_WORKER_MARKER: marker,
+      FACTORY_TEST_WORKER_PID_FILE: workerPidFile,
+      FACTORY_WORKER_READY_SECONDS: "5"
+    };
+    delete environment.FACTORY_LISTEN;
+    delete environment.FACTORY_V2_LISTEN;
+
     const launcher = spawn(join(root, "scripts/run-worker.sh"), [config], {
-      env: {
-        ...process.env,
-        FACTORY_BUILD_DIR: join(temporary, "bin"),
-        FACTORY_DATA_HOME: join(temporary, "data"),
-        FACTORY_LISTEN: `127.0.0.1:${port}`,
-        FACTORY_SKIP_BUILD: "1",
-        FACTORY_TEST_WORKER_MARKER: marker,
-        FACTORY_TEST_WORKER_PID_FILE: workerPidFile,
-        FACTORY_WORKER_READY_SECONDS: "5"
-      },
+      env: environment,
       stdio: ["ignore", "pipe", "pipe"]
     });
 
@@ -486,9 +500,9 @@ async function waitForHealth(port) {
     if (leakedWorker) process.kill(workerPid, "SIGTERM");
 
     if (timedOut) throw new Error(`worker launcher shutdown exceeded 10 seconds\n${output}`);
-    if (!signalled) throw new Error(`worker launcher never joined the control plane\n${output}`);
+    if (!signalled) throw new Error(`worker launcher never joined the configured control plane\n${output}`);
     if (!output.includes(`Factory worker new-unhealthy-worker joined http://127.0.0.1:${port}/`)) {
-      throw new Error(`worker launcher did not report the running control plane\n${output}`);
+      throw new Error(`worker launcher did not join the control plane named by its configuration\n${output}`);
     }
     if (output.includes("Starting Factory server")) {
       throw new Error(`worker launcher started a second control plane\n${output}`);
@@ -512,4 +526,4 @@ async function waitForHealth(port) {
 });
 EOF
 
-echo "Factory worker launcher validates its configuration, requires a running control plane, joins it without starting another, and leaves it running after Ctrl-C."
+echo "Factory worker launcher needs only the worker binary, joins the control plane its configuration names rather than the local server listen address, names the endpoint it probed, and leaves the control plane running after Ctrl-C."

--- a/scripts/test-run-local.sh
+++ b/scripts/test-run-local.sh
@@ -371,6 +371,74 @@ if [ -e "$temporary/worker-started-detached" ]; then
   exit 1
 fi
 
+mkdir -p "$temporary/exiting-bin"
+cat >"$temporary/exiting-bin/factory-worker" <<'EOF'
+#!/bin/sh
+if [ "${1:-}" = "identity" ]; then
+  echo "new-unhealthy-worker"
+  exit 0
+fi
+: >"$FACTORY_TEST_WORKER_MARKER"
+exit 0
+EOF
+chmod +x "$temporary/exiting-bin/factory-worker"
+
+printf "server = 'http://127.0.0.1:1'\n" >"$temporary/literal-worker.toml"
+printf 'server = "http://127.0.0.1:1" # production\n' >"$temporary/commented-worker.toml"
+printf 'server = http://127.0.0.1:1\n' >"$temporary/unquoted-worker.toml"
+
+for quoting in literal commented; do
+  set +e
+  output=$(
+    FACTORY_BUILD_DIR="$temporary/exiting-bin" \
+      FACTORY_DATA_HOME="$temporary/data" \
+      FACTORY_SKIP_BUILD=1 \
+      FACTORY_TEST_WORKER_MARKER="$temporary/worker-started-$quoting" \
+      "$root/scripts/run-worker.sh" "$temporary/$quoting-worker.toml" 2>&1
+  )
+  status=$?
+  set -e
+  if [ "$status" -ne 1 ] ||
+    ! printf '%s\n' "$output" |
+      grep -Fq "Factory control plane did not answer http://127.0.0.1:1/healthz"; then
+    echo "worker launcher did not read the $quoting server value" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$output" | grep -Fq "127.0.0.1:7337"; then
+    echo "worker launcher fell back to the default control plane for the $quoting server value" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+done
+
+set +e
+output=$(
+  FACTORY_BUILD_DIR="$temporary/exiting-bin" \
+    FACTORY_DATA_HOME="$temporary/data" \
+    FACTORY_SKIP_BUILD=1 \
+    FACTORY_TEST_WORKER_MARKER="$temporary/worker-started-unquoted" \
+    "$root/scripts/run-worker.sh" "$temporary/unquoted-worker.toml" 2>&1
+)
+status=$?
+set -e
+if [ "$status" -ne 1 ] ||
+  ! printf '%s\n' "$output" |
+    grep -Fq "Factory could not read the server value in $temporary/unquoted-worker.toml"; then
+  echo "worker launcher did not reject an unreadable server value" >&2
+  echo "$output" >&2
+  exit 1
+fi
+if printf '%s\n' "$output" | grep -Fq "127.0.0.1:7337"; then
+  echo "worker launcher defaulted to localhost despite a present server key" >&2
+  echo "$output" >&2
+  exit 1
+fi
+if [ -e "$temporary/worker-started-unquoted" ]; then
+  echo "worker launcher started a worker with an unreadable server value" >&2
+  exit 1
+fi
+
 node - "$root" "$temporary" <<'EOF'
 const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = require("node:fs");
 const { createServer } = require("node:net");
@@ -526,4 +594,4 @@ async function waitForHealth(port) {
 });
 EOF
 
-echo "Factory worker launcher needs only the worker binary, joins the control plane its configuration names rather than the local server listen address, names the endpoint it probed, and leaves the control plane running after Ctrl-C."
+echo "Factory worker launcher needs only the worker binary, joins the control plane its configuration names rather than the local server listen address, names the endpoint it probed, reads quoted, literal, and commented server values, refuses an unreadable one instead of defaulting to localhost, and leaves the control plane running after Ctrl-C."

--- a/scripts/test-run-local.sh
+++ b/scripts/test-run-local.sh
@@ -327,3 +327,189 @@ async function verifySignal(signal, suffix, listenVariable) {
 EOF
 
 echo "Factory launcher honors bootstrap listen settings, rejects unhealthy workers, retired-state writes, server loss, and stalled readiness responses; signals stop cleanly."
+
+set +e
+output=$(
+  FACTORY_BUILD_DIR="$temporary/bin" \
+    FACTORY_DATA_HOME="$temporary/data" \
+    FACTORY_SKIP_BUILD=1 \
+    "$root/scripts/run-worker.sh" "$temporary/missing-worker.toml" 2>&1
+)
+status=$?
+set -e
+if [ "$status" -ne 1 ] ||
+  ! printf '%s\n' "$output" |
+    grep -Fq "Factory worker configuration does not exist: $temporary/missing-worker.toml"; then
+  echo "worker launcher did not reject a missing configuration" >&2
+  echo "$output" >&2
+  exit 1
+fi
+
+set +e
+output=$(
+  FACTORY_BUILD_DIR="$temporary/bin" \
+    FACTORY_DATA_HOME="$temporary/data" \
+    FACTORY_LISTEN="127.0.0.1:1" \
+    FACTORY_SKIP_BUILD=1 \
+    FACTORY_TEST_WORKER_MARKER="$temporary/worker-started-detached" \
+    "$root/scripts/run-worker.sh" "$temporary/worker.toml" 2>&1
+)
+status=$?
+set -e
+if [ "$status" -ne 1 ] ||
+  ! printf '%s\n' "$output" |
+    grep -q "Factory control plane is not reachable at http://127.0.0.1:1/"; then
+  echo "worker launcher did not report a missing control plane" >&2
+  echo "$output" >&2
+  exit 1
+fi
+if [ -e "$temporary/worker-started-detached" ]; then
+  echo "worker launcher started a worker without a control plane" >&2
+  exit 1
+fi
+
+node - "$root" "$temporary" "$temporary/worker.toml" <<'EOF'
+const { existsSync, readFileSync, rmSync } = require("node:fs");
+const { createServer } = require("node:net");
+const { spawn } = require("node:child_process");
+const { join } = require("node:path");
+
+const root = process.argv[2];
+const temporary = process.argv[3];
+const config = process.argv[4];
+
+function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      server.close((error) => error ? reject(error) : resolve(port));
+    });
+  });
+}
+
+function isAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+function pidFrom(path) {
+  if (!existsSync(path)) return null;
+  return Number(readFileSync(path, "utf8").trim());
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForHealth(port) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+      if (response.ok) return;
+    } catch {}
+    await delay(50);
+  }
+  throw new Error("fake control plane never became healthy");
+}
+
+(async () => {
+  const marker = join(temporary, "worker-started-attached");
+  const workerPidFile = join(temporary, "worker-attached.pid");
+  rmSync(marker, { force: true });
+  rmSync(workerPidFile, { force: true });
+  const port = await availablePort();
+
+  const controlPlane = spawn(join(temporary, "bin/factory-server"), ["-listen", `127.0.0.1:${port}`], {
+    env: {
+      ...process.env,
+      FACTORY_DATA_HOME: join(temporary, "data"),
+      FACTORY_TEST_HEALTHY_WORKER: "1",
+      FACTORY_TEST_WORKER_MARKER: marker
+    },
+    stdio: ["ignore", "ignore", "inherit"]
+  });
+
+  let output = "";
+  let signalled = false;
+  let timedOut = false;
+  try {
+    await waitForHealth(port);
+
+    const launcher = spawn(join(root, "scripts/run-worker.sh"), [config], {
+      env: {
+        ...process.env,
+        FACTORY_BUILD_DIR: join(temporary, "bin"),
+        FACTORY_DATA_HOME: join(temporary, "data"),
+        FACTORY_LISTEN: `127.0.0.1:${port}`,
+        FACTORY_SKIP_BUILD: "1",
+        FACTORY_TEST_WORKER_MARKER: marker,
+        FACTORY_TEST_WORKER_PID_FILE: workerPidFile,
+        FACTORY_WORKER_READY_SECONDS: "5"
+      },
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    const capture = (chunk) => {
+      output += chunk;
+      if (!signalled && output.includes("joined")) {
+        signalled = true;
+        launcher.kill("SIGTERM");
+      }
+    };
+    launcher.stdout.on("data", capture);
+    launcher.stderr.on("data", capture);
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      launcher.kill("SIGKILL");
+      const pid = pidFrom(workerPidFile);
+      if (isAlive(pid)) process.kill(pid, "SIGTERM");
+    }, 10000);
+
+    const result = await new Promise((resolve, reject) => {
+      launcher.once("error", reject);
+      launcher.once("close", (code, exitSignal) => resolve({ code, exitSignal }));
+    });
+    clearTimeout(timeout);
+
+    const workerPid = pidFrom(workerPidFile);
+    const leakedWorker = isAlive(workerPid);
+    if (leakedWorker) process.kill(workerPid, "SIGTERM");
+
+    if (timedOut) throw new Error(`worker launcher shutdown exceeded 10 seconds\n${output}`);
+    if (!signalled) throw new Error(`worker launcher never joined the control plane\n${output}`);
+    if (!output.includes(`Factory worker new-unhealthy-worker joined http://127.0.0.1:${port}/`)) {
+      throw new Error(`worker launcher did not report the running control plane\n${output}`);
+    }
+    if (output.includes("Starting Factory server")) {
+      throw new Error(`worker launcher started a second control plane\n${output}`);
+    }
+    if (result.code !== 0 || result.exitSignal !== null) {
+      throw new Error(`worker shutdown returned code=${result.code} signal=${result.exitSignal}\n${output}`);
+    }
+    if (output.includes("stopped unexpectedly")) {
+      throw new Error(`worker shutdown was reported as unexpected\n${output}`);
+    }
+    if (leakedWorker) throw new Error(`worker launcher leaked its worker\n${output}`);
+    if (controlPlane.exitCode !== null) {
+      throw new Error(`worker launcher stopped the control plane\n${output}`);
+    }
+  } finally {
+    controlPlane.kill("SIGTERM");
+  }
+})().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+EOF
+
+echo "Factory worker launcher validates its configuration, requires a running control plane, joins it without starting another, and leaves it running after Ctrl-C."


### PR DESCRIPTION
Closes #316

## What changed

- `scripts/run-worker.sh`: starts only a worker and joins a control plane that is already running.
  - The control plane address comes from the `server` key in the worker TOML, defaulting to `http://127.0.0.1:7337` to match `defaultServer` in `internal/worker/config.go`. It never derives the address from `factory-server -print-listen`, which reports where a local server would listen and is wrong whenever the worker points at a remote or non-default control plane.
  - It requires only the worker binary. There is no `factory-server` requirement, and it builds through the new `just build-worker` recipe when the worker binary is missing.
  - Reading those keys handles basic double-quoted strings, single-quoted literals, and a trailing `# comment`, and stops at the first table header. An absent key takes the default; a key that is present but unparseable fails with the key name and config path rather than silently defaulting to localhost.
  - It probes `$server/healthz` before starting anything and names that exact endpoint on failure, so a wrong `server` value is diagnosable. A `ca_certificate` in the worker config is passed to curl, resolved relative to the config directory as `internal/worker` does.
  - It waits for the worker to register as healthy. A remote control plane does not publish `GET /api/v1/workers/{id}` (see `NewRemoteWorkerHandler` in `internal/controlplane/http.go`), so 401, 403, and 404 there are reported as unobservable and the worker keeps running instead of failing.
  - Ctrl-C stops only the worker; the control plane keeps running.
- Resolution of `data_home` (`FACTORY_DATA_HOME` / `FACTORY_V2_DATA_HOME`, including the legacy preview guard), `build_directory` (`FACTORY_BUILD_DIR` / `FACTORY_V2_BUILD_DIR`), and the config path (argument, then `FACTORY_WORKER_CONFIG` / `FACTORY_V2_WORKER_CONFIG`, then `$data_home/worker.toml`) matches `scripts/run-local.sh` exactly, with the same Unix guard and message style.
- `Justfile`: new `run-worker config=""` and `build-worker` recipes. `run` and `build` are untouched.
- `docs/local.md`: the multi-worker section uses `just run-worker` and states that the `server` key decides which control plane is joined.
- `scripts/test-run-local.sh`: new coverage in the existing fake-binary style.

Duplicating the resolution block rather than extracting a shared library is deliberate: `scripts/test-build.sh` copies `scripts/run-local.sh` alone into a clean checkout and runs it, so that script must stay self-contained.

## Test coverage

The new launcher tests assert that:

1. A missing config is rejected with the launcher's existing message.
2. A worker config whose `server` is unreachable fails, names the endpoint probed (`http://127.0.0.1:1/healthz`), and starts no worker.
3. A single-quoted `server` and a `server` with a trailing comment are both read, and the launcher probes the configured endpoint rather than the default. Each asserts the output never mentions `127.0.0.1:7337`.
4. A present but unreadable `server` fails with `Factory could not read the server value in <config>`, starts no worker, and does not fall back to localhost.
5. A worker config whose `server` differs from the local server config's `listen` still starts the worker, using a build directory that contains only `factory-worker`. The launcher never prints `Starting Factory server`, exits 0 on SIGTERM, leaks no worker, and leaves the control plane alive.

Cases 3, 4, and 5 are the regression tests for the two defects fixed on this branch.

## Proof

Run from the worktree.

- `just test-launcher` - pass. `Factory worker launcher needs only the worker binary, joins the control plane its configuration names rather than the local server listen address, names the endpoint it probed, and leaves the control plane running after Ctrl-C.`
- `just test-tooling` - pass.
- `just format-check`, `just vet`, `just staticcheck`, `just boundary`, `just test`, `just ui-check` - all pass. Go and UI results are unaffected: this branch changes no Go or web source.
- Fail-without-fix evidence, probe target: with the health probe temporarily reverted to the local server listen address, the case 5 test fails with `worker launcher never joined the configured control plane` and `Factory control plane did not answer http://127.0.0.1:54837/healthz`, while the worker config named a different port. Restoring the fix makes the same test pass.
- Fail-without-fix evidence, config reading: with the old double-quote-only reader restored, the suite fails at `worker launcher did not read the literal server value`. Per case, on a machine where a real control plane listens on 7337, the old reader silently joined `http://127.0.0.1:7337` for the single-quoted, commented, and unquoted configs, while the fixed reader prints `Factory control plane did not answer http://127.0.0.1:1/healthz` for the first two and `Factory could not read the server value in <config>` for the third.
- `just check` - fails at `vuln` only: govulncheck reports 6 Go standard library vulnerabilities (net/http@go1.26.4, fixed in go1.26.6) reachable from `internal/worker/client.go`. That result is identical on `main` because this branch changes no Go code. Every other `check` step was run individually and passed.

## Not verified

Only the fake-binary launcher tests were run, not a real session against real `factory-server` and `factory-worker` binaries, and not a real remote TLS control plane.
