### PR TITLE
fix: run real worker tests under the race detector

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -63,7 +63,17 @@ test:
 
 # Race-check worker coordination and process cancellation paths.
 test-worker-race:
-    go test -timeout 5m -race ./internal/worker -run '^(TestPeriodicRegistrationCannotOvertakeRetainedCapacityHandoff|TestConfigurationStableIdentityLockAndHealthRecovery|TestHealthFailureCancelsRetryingClaimBeforeServerRecovery|TestCommittedClaimBecomesFailedWhenHealthChangesBeforeResponse|TestCancellationStopsCompleteProcessGroup)$'
+    #!/usr/bin/env bash
+    set -euo pipefail
+    log="$(mktemp)"
+    trap 'rm -f "$log"' EXIT
+    go test -timeout 5m -race -v ./internal/worker 2>&1 | tee "$log"
+    count="$(grep -c '^=== RUN   Test' "$log" || true)"
+    if [[ "$count" -eq 0 ]]; then
+        printf 'test-worker-race selected zero tests in ./internal/worker\n' >&2
+        exit 1
+    fi
+    printf 'test-worker-race ran %s tests with the race detector\n' "$count"
 
 # Test the Node-free build and Just command surface.
 test-tooling:

--- a/Justfile
+++ b/Justfile
@@ -61,13 +61,13 @@ boundary:
 test:
     go test -timeout 5m ./...
 
-# Race-check worker coordination and process cancellation paths.
+# Race-check the worker package, including coordination and process cancellation.
 test-worker-race:
     #!/usr/bin/env bash
     set -euo pipefail
     log="$(mktemp)"
     trap 'rm -f "$log"' EXIT
-    go test -timeout 5m -race -v ./internal/worker 2>&1 | tee "$log"
+    go test -timeout 5m -race -count=1 -v ./internal/worker 2>&1 | tee "$log"
     count="$(grep -c '^=== RUN   Test' "$log" || true)"
     if [[ "$count" -eq 0 ]]; then
         printf 'test-worker-race selected zero tests in ./internal/worker\n' >&2


### PR DESCRIPTION
Closes #297

## Problem

`just test-worker-race` filtered on five test names that do not exist in the repository, so it printed `ok internal/worker [no tests to run]` and passed. CI runs that recipe, so no race-detector coverage of worker concurrency had run.

## Change

`test-worker-race` now runs the whole `./internal/worker` package under `-race -v`, and fails if the run selects zero tests. No other recipe or CI step changed; `.github/workflows/ci.yml` already invokes `just test-worker-race` on both macOS architectures.

## Verification

- `just test-worker-race` — 28 tests, race detector clean, prints `test-worker-race ran 28 tests with the race detector`. No data race reported, so there is nothing to fix or defer.
- Zero-test guard: the same recipe body with `-run '^(TestDoesNotExist)$'` exits 1 with `test-worker-race selected zero tests in ./internal/worker` (previously this case exited 0).
- Failing-test path: with a temporary always-failing test in `internal/worker`, `just test-worker-race` exits 1 (the `tee` pipeline does not mask the failure). The temporary test was removed and is not committed.
- `just test`, `just format-check`, `just vet`, `just boundary`, `just test-tooling` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded worker test execution to cover the full test package with verbose race detection.
  * Added validation to ensure tests actually run and report the number executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->