### PR TITLE
test: cover the worker supervisor and event upload paths

### DIFF
--- a/internal/worker/events_test.go
+++ b/internal/worker/events_test.go
@@ -1,0 +1,323 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+type wrappedEventPayload struct {
+	Stream    string `json:"stream"`
+	Text      string `json:"text"`
+	Truncated bool   `json:"truncated"`
+}
+
+func TestEventPayloadPassesThroughRuntimeJSON(t *testing.T) {
+	text := `{"type":"result","result":"done"}`
+	payload := eventPayload("stdout", text, false)
+	if string(payload) != text {
+		t.Fatalf("payload = %s, want the runtime line verbatim", payload)
+	}
+}
+
+func TestEventPayloadWrapsOtherOutput(t *testing.T) {
+	cases := []struct {
+		name          string
+		stream        string
+		text          string
+		truncated     bool
+		wantTruncated bool
+	}{
+		{name: "stderr json", stream: "stderr", text: `{"ok":true}`},
+		{name: "stdout plain text", stream: "stdout", text: "building the project"},
+		{name: "stdout invalid json", stream: "stdout", text: `{"unterminated":`},
+		{name: "stdout empty", stream: "stdout", text: ""},
+		{name: "already truncated", stream: "stdout", text: `{"ok":true}`, truncated: true, wantTruncated: true},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			payload := eventPayload(testCase.stream, testCase.text, testCase.truncated)
+			var wrapped wrappedEventPayload
+			if err := json.Unmarshal(payload, &wrapped); err != nil {
+				t.Fatalf("decode payload %s: %v", payload, err)
+			}
+			if wrapped.Stream != testCase.stream || wrapped.Text != testCase.text {
+				t.Fatalf("payload = %+v, want stream %q and the original text", wrapped, testCase.stream)
+			}
+			if wrapped.Truncated != testCase.wantTruncated {
+				t.Fatalf("payload truncated = %v, want %v", wrapped.Truncated, testCase.wantTruncated)
+			}
+		})
+	}
+}
+
+func TestEventPayloadWrapsOversizedRuntimeJSON(t *testing.T) {
+	text := `{"type":"result","result":"` + strings.Repeat("a", protocol.MaxEventBytes) + `"}`
+	payload := eventPayload("stdout", text, false)
+	if len(payload) > protocol.MaxEventBytes {
+		t.Fatalf("payload is %d bytes, want at most %d", len(payload), protocol.MaxEventBytes)
+	}
+	var wrapped wrappedEventPayload
+	if err := json.Unmarshal(payload, &wrapped); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if !wrapped.Truncated || !strings.HasPrefix(text, wrapped.Text) {
+		t.Fatalf("payload = truncated %v, %d bytes of text", wrapped.Truncated, len(wrapped.Text))
+	}
+}
+
+func TestEventPayloadBinarySearchesEscapeHeavyText(t *testing.T) {
+	// A NUL byte encodes as a six-character escape, so the first attempt at
+	// MaxEventBytes-256 characters overflows the limit and the binary search
+	// has to find the largest prefix that fits.
+	text := strings.Repeat("\x00", protocol.MaxEventBytes)
+	payload := eventPayload("stdout", text, false)
+	if len(payload) > protocol.MaxEventBytes {
+		t.Fatalf("payload is %d bytes, want at most %d", len(payload), protocol.MaxEventBytes)
+	}
+	var wrapped wrappedEventPayload
+	if err := json.Unmarshal(payload, &wrapped); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if !wrapped.Truncated {
+		t.Fatal("escape-heavy payload was not marked truncated")
+	}
+	if len(wrapped.Text) == 0 {
+		t.Fatal("escape-heavy payload kept no text")
+	}
+	if !strings.HasPrefix(text, wrapped.Text) {
+		t.Fatal("escape-heavy payload kept text the runtime did not emit")
+	}
+	// The search must return the largest prefix that fits, so one more character
+	// has to overflow.
+	larger, err := json.Marshal(map[string]any{
+		"stream": "stdout", "text": text[:len(wrapped.Text)+1], "truncated": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(larger) <= protocol.MaxEventBytes {
+		t.Fatalf("payload kept %d characters but %d also fit", len(wrapped.Text), len(wrapped.Text)+1)
+	}
+}
+
+func TestEventPayloadKeepsValidUTF8WhenTruncating(t *testing.T) {
+	text := strings.Repeat("\x00", protocol.MaxEventBytes) + strings.Repeat("\U0001F600", 1024)
+	payload := eventPayload("stderr", text, false)
+	if len(payload) > protocol.MaxEventBytes {
+		t.Fatalf("payload is %d bytes, want at most %d", len(payload), protocol.MaxEventBytes)
+	}
+	if !utf8.Valid(payload) {
+		t.Fatal("payload is not valid UTF-8")
+	}
+	var wrapped wrappedEventPayload
+	if err := json.Unmarshal(payload, &wrapped); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if !utf8.ValidString(wrapped.Text) {
+		t.Fatal("payload text is not valid UTF-8")
+	}
+}
+
+func TestEnqueueNumbersEventsAndStopsWhenTheQueueIsFull(t *testing.T) {
+	sender := &eventSender{
+		kind:  protocol.RuntimeCodex,
+		input: make(chan protocol.AttemptEvent, 2),
+		done:  make(chan struct{}),
+	}
+
+	sender.enqueue("stdout", "first", false)
+	sender.enqueue("stderr", "second", false)
+	sender.enqueue("stdout", "dropped", false)
+
+	if !sender.disabled {
+		t.Fatal("sender stayed enabled after its queue overflowed")
+	}
+	if sender.next != 2 {
+		t.Fatalf("sender numbered %d events, want 2", sender.next)
+	}
+	if len(sender.input) != 2 {
+		t.Fatalf("queue holds %d events, want 2", len(sender.input))
+	}
+
+	first := <-sender.input
+	second := <-sender.input
+	if first.Sequence != 0 || second.Sequence != 1 {
+		t.Fatalf("sequences = %d, %d; want 0, 1", first.Sequence, second.Sequence)
+	}
+	if first.Kind != protocol.RuntimeCodex || second.Kind != protocol.RuntimeCodex {
+		t.Fatalf("kinds = %q, %q", first.Kind, second.Kind)
+	}
+	var wrapped wrappedEventPayload
+	if err := json.Unmarshal(second.Payload, &wrapped); err != nil {
+		t.Fatal(err)
+	}
+	if wrapped.Stream != "stderr" || wrapped.Text != "second" {
+		t.Fatalf("second payload = %+v", wrapped)
+	}
+
+	// A disabled sender drops later output instead of queueing it again.
+	sender.enqueue("stdout", "after overflow", false)
+	if len(sender.input) != 0 {
+		t.Fatal("disabled sender queued more output")
+	}
+}
+
+func TestCloseAndWaitGivesUpAfterItsTimeout(t *testing.T) {
+	sender := &eventSender{input: make(chan protocol.AttemptEvent, 1), done: make(chan struct{})}
+
+	start := time.Now()
+	sender.closeAndWait(50 * time.Millisecond)
+	if elapsed := time.Since(start); elapsed < 40*time.Millisecond {
+		t.Fatalf("closeAndWait returned after %s, want it to wait for its timeout", elapsed)
+	}
+	if !sender.closed {
+		t.Fatal("closeAndWait did not record the close")
+	}
+
+	// Closing twice must not close the input channel twice.
+	sender.closeAndWait(time.Millisecond)
+
+	sender.enqueue("stdout", "after close", false)
+	if len(sender.input) != 0 {
+		t.Fatal("closed sender queued more output")
+	}
+}
+
+func TestEventSenderDeliversEventsInOrder(t *testing.T) {
+	var mutex sync.Mutex
+	var received []protocol.AttemptEvent
+	var tokens []string
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var input protocol.EventBatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		mutex.Lock()
+		received = append(received, input.Events...)
+		tokens = append(tokens, input.LeaseToken)
+		paths = append(paths, r.URL.Path)
+		mutex.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	sender := newEventSender(context.Background(), newClient(server.URL, server.Client()),
+		"attempt-1", "lease-token", protocol.RuntimeCodex)
+	sender.enqueue("stdout", "one", false)
+	sender.enqueue("stderr", "two", false)
+	sender.closeAndWait(5 * time.Second)
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	if len(received) != 2 {
+		t.Fatalf("control plane received %d events, want 2", len(received))
+	}
+	if received[0].Sequence != 0 || received[1].Sequence != 1 {
+		t.Fatalf("sequences = %d, %d", received[0].Sequence, received[1].Sequence)
+	}
+	for index, token := range tokens {
+		if token != "lease-token" {
+			t.Fatalf("request %d carried lease token %q", index, token)
+		}
+		if paths[index] != "/api/v1/attempts/attempt-1/events" {
+			t.Fatalf("request %d used path %q", index, paths[index])
+		}
+	}
+}
+
+func TestEventSenderRetriesServerFailures(t *testing.T) {
+	var mutex sync.Mutex
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mutex.Lock()
+		attempts++
+		count := attempts
+		mutex.Unlock()
+		if count < 3 {
+			http.Error(w, `{"error":{"code":"internal","message":"try again"}}`, http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	sender := newEventSender(context.Background(), newClient(server.URL, server.Client()),
+		"attempt-1", "lease-token", protocol.RuntimeCodex)
+	sender.enqueue("stdout", "one", false)
+	sender.closeAndWait(10 * time.Second)
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	if attempts != 3 {
+		t.Fatalf("sender made %d attempts, want 3", attempts)
+	}
+	sender.mutex.Lock()
+	defer sender.mutex.Unlock()
+	if sender.disabled {
+		t.Fatal("sender disabled itself after a retry succeeded")
+	}
+}
+
+func TestEventSenderStopsAfterClientError(t *testing.T) {
+	var mutex sync.Mutex
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mutex.Lock()
+		requests++
+		mutex.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":{"code":"lease_lost","message":"lease no longer held"}}`))
+	}))
+	defer server.Close()
+
+	sender := newEventSender(context.Background(), newClient(server.URL, server.Client()),
+		"attempt-1", "lease-token", protocol.RuntimeCodex)
+	sender.enqueue("stdout", "one", false)
+	select {
+	case <-sender.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sender kept running after a client error")
+	}
+
+	sender.enqueue("stdout", "two", false)
+	sender.closeAndWait(time.Second)
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	if requests != 1 {
+		t.Fatalf("sender made %d requests, want 1", requests)
+	}
+}
+
+func TestEventSenderStopsWhenItsContextIsCancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"code":"internal","message":"try again"}}`, http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sender := newEventSender(ctx, newClient(server.URL, server.Client()),
+		"attempt-1", "lease-token", protocol.RuntimeCodex)
+	sender.enqueue("stdout", "one", false)
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-sender.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sender kept retrying after its context was cancelled")
+	}
+	sender.closeAndWait(time.Second)
+}

--- a/internal/worker/supervisor_process_test.go
+++ b/internal/worker/supervisor_process_test.go
@@ -318,15 +318,16 @@ func TestRunSupervisorCancelsARunningRuntime(t *testing.T) {
 func TestRunSupervisorStopsARuntimeAtItsTimeout(t *testing.T) {
 	t.Parallel()
 	directory := t.TempDir()
-	pidPath := filepath.Join(directory, "runtime.pid")
-	script := writeRuntimeScript(t, directory, "runtime",
-		"echo $$ > '"+pidPath+"'\nsleep 300\n")
+	script := writeRuntimeScript(t, directory, "runtime", "sleep 300\n")
+	// The runtime is stopped one second after it starts, which is too early to
+	// wait on anything the fake runtime writes, so this test asserts on the
+	// process group rather than on an individual runtime process. The
+	// cancellation and parent-lost tests cover per-process reaping.
 	init := newSupervisorInit(t, protocol.RuntimePi, script, 1)
 
 	session := startSupervisorSession(t, init)
 	ready := session.awaitReady()
 	session.send("start")
-	runtimePID := readRuntimePID(t, pidPath)
 
 	exit, err := session.awaitExit()
 	if err != nil {
@@ -335,9 +336,6 @@ func TestRunSupervisorStopsARuntimeAtItsTimeout(t *testing.T) {
 	if exit.Reason != "timeout" || exit.Error != "Work timeout reached" {
 		t.Fatalf("exit message = %+v", exit)
 	}
-	waitFor(t, 30*time.Second, "the runtime process to be reaped", func() bool {
-		return !processAlive(runtimePID)
-	})
 	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
 		return !processGroupAlive(int(ready.ProcessGroupID))
 	})
@@ -372,7 +370,7 @@ func TestRunSupervisorStopsWhenItsParentGoesAway(t *testing.T) {
 	})
 }
 
-func TestRunSupervisorStopsWhenTheLeaseDeadlinePasses(t *testing.T) {
+func TestRunSupervisorStopsWhenTheLeaseDeadlinePassesBeforeStart(t *testing.T) {
 	t.Parallel()
 	directory := t.TempDir()
 	script := writeRuntimeScript(t, directory, "runtime", "sleep 300\n")
@@ -395,24 +393,92 @@ func TestRunSupervisorStopsWhenTheLeaseDeadlinePasses(t *testing.T) {
 	})
 }
 
-func TestRunSupervisorReportsPreparationFailureBeforeStart(t *testing.T) {
-	t.Parallel()
-	directory := t.TempDir()
-	script := writeRuntimeScript(t, directory, "runtime", "sleep 300\n")
-	session := startSupervisorSession(t, newSupervisorInit(t, protocol.RuntimePi, script, 600))
-	ready := session.awaitReady()
+func TestRunSupervisorHandlesStopCommandsBeforeStart(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		reason  string
+		message string
+	}{
+		{name: "cancel", command: "cancel", reason: "cancelled", message: "attempt cancelled"},
+		{name: "lease lost", command: "lease_lost", reason: "lease_lost", message: "control-plane lease was lost"},
+		{name: "preparation failure", command: "fail", reason: "supervisor_error", message: "attempt preparation failed"},
+		{name: "timeout", command: "timeout", reason: "timeout", message: "Work timeout reached"},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			directory := t.TempDir()
+			script := writeRuntimeScript(t, directory, "runtime", "sleep 300\n")
+			session := startSupervisorSession(t, newSupervisorInit(t, protocol.RuntimePi, script, 600))
+			ready := session.awaitReady()
 
-	session.send("fail")
-	exit, err := session.awaitExit()
-	if err != nil {
-		t.Fatal(err)
+			session.send(testCase.command)
+			exit, err := session.awaitExit()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exit.Reason != testCase.reason || exit.Error != testCase.message {
+				t.Fatalf("exit message = %+v", exit)
+			}
+			waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+				return !processGroupAlive(int(ready.ProcessGroupID))
+			})
+		})
 	}
-	if exit.Reason != "supervisor_error" || exit.Error != "attempt preparation failed" {
-		t.Fatalf("exit message = %+v", exit)
+}
+
+func TestRunSupervisorHandlesStopCommandsWhileRunning(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		reason  string
+		message string
+	}{
+		{name: "preparation failure", command: "fail", reason: "supervisor_error", message: "attempt supervisor failed"},
+		{
+			name:    "lease lost",
+			command: "lease_lost",
+			reason:  "lease_lost",
+			message: "control-plane lease renewal deadline passed",
+		},
+		{
+			// A renewal this short leaves no room for the termination grace, so
+			// the lease deadline passes almost immediately.
+			name:    "renewal deadline",
+			command: "renew 1",
+			reason:  "lease_lost",
+			message: "control-plane lease renewal deadline passed",
+		},
 	}
-	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
-		return !processGroupAlive(int(ready.ProcessGroupID))
-	})
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			directory := t.TempDir()
+			pidPath := filepath.Join(directory, "runtime.pid")
+			script := writeRuntimeScript(t, directory, "runtime",
+				"echo $$ > '"+pidPath+"'\nsleep 300\n")
+			session := startSupervisorSession(t, newSupervisorInit(t, protocol.RuntimePi, script, 600))
+			ready := session.awaitReady()
+			session.send("start")
+			runtimePID := readRuntimePID(t, pidPath)
+
+			session.send(testCase.command)
+			exit, err := session.awaitExit()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if exit.Reason != testCase.reason || exit.Error != testCase.message {
+				t.Fatalf("exit message = %+v", exit)
+			}
+			waitFor(t, 30*time.Second, "the runtime process to be reaped", func() bool {
+				return !processAlive(runtimePID)
+			})
+			waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+				return !processGroupAlive(int(ready.ProcessGroupID))
+			})
+		})
+	}
 }
 
 func TestRunSupervisorRejectsAnUnknownControlCommand(t *testing.T) {
@@ -689,7 +755,9 @@ func startTestProcessGroup(t *testing.T) (*exec.Cmd, string, int) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		if anchor.Process != nil {
+		// Only signal a group that is still alive, so a reaped group's recycled
+		// process-group ID is never signalled by mistake.
+		if anchor.Process != nil && processGroupAlive(anchor.Process.Pid) {
 			_ = forceStopStartedProcessGroup(anchor.Process.Pid)
 		}
 	})
@@ -725,6 +793,9 @@ func TestWaitForSupervisorCommand(t *testing.T) {
 			t.Fatal(err)
 		}
 		pid := command.Process.Pid
+		// waitForSupervisorCommand kills the process, not its group, so the
+		// forked sleep would otherwise outlive the test.
+		t.Cleanup(func() { _ = forceStopStartedProcessGroup(pid) })
 		err := waitForSupervisorCommand(command, 100*time.Millisecond)
 		if err == nil || !strings.Contains(err.Error(), "did not exit within") {
 			t.Fatalf("waitForSupervisorCommand returned %v", err)

--- a/internal/worker/supervisor_process_test.go
+++ b/internal/worker/supervisor_process_test.go
@@ -1,0 +1,867 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package worker
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+// supervisorSession drives a real RunSupervisor over its control pipe and
+// collects the protocol messages it writes.
+type supervisorSession struct {
+	t        *testing.T
+	control  *os.File
+	output   *os.File
+	decoded  chan supervisorMessage
+	result   chan error
+	ready    supervisorMessage
+	finished bool
+}
+
+func startSupervisorSession(t *testing.T, init supervisorInit) *supervisorSession {
+	t.Helper()
+	controlRead, controlWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputRead, outputWrite, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := json.Marshal(init)
+	if err != nil {
+		t.Fatal(err)
+	}
+	session := &supervisorSession{
+		t:       t,
+		control: controlWrite,
+		output:  outputWrite,
+		decoded: make(chan supervisorMessage, 1024),
+		result:  make(chan error, 1),
+	}
+	go func() {
+		session.result <- RunSupervisor(controlRead, bytes.NewReader(input), outputWrite,
+			newLimitBuffer(maxSupervisorErrorBytes))
+		controlRead.Close()
+	}()
+	go func() {
+		defer close(session.decoded)
+		defer outputRead.Close()
+		decoder := json.NewDecoder(outputRead)
+		for {
+			var message supervisorMessage
+			if err := decoder.Decode(&message); err != nil {
+				return
+			}
+			session.decoded <- message
+		}
+	}()
+	t.Cleanup(func() {
+		_ = controlWrite.Close()
+		if !session.finished {
+			select {
+			case <-session.result:
+			case <-time.After(30 * time.Second):
+				t.Error("supervisor did not exit after its control pipe closed")
+			}
+			_ = outputWrite.Close()
+		}
+	})
+	return session
+}
+
+func (session *supervisorSession) awaitReady() supervisorMessage {
+	session.t.Helper()
+	message := session.await("ready")
+	if message.Type != "ready" || message.SupervisorPID <= 0 || message.ProcessGroupID <= 0 ||
+		message.ProcessIdentity == "" || message.GroupIdentity == "" {
+		session.t.Fatalf("readiness message = %+v", message)
+	}
+	session.ready = message
+	return message
+}
+
+func (session *supervisorSession) await(description string) supervisorMessage {
+	session.t.Helper()
+	select {
+	case message, ok := <-session.decoded:
+		if !ok {
+			session.t.Fatalf("supervisor closed its output before sending %s", description)
+		}
+		return message
+	case <-time.After(60 * time.Second):
+		session.t.Fatalf("supervisor did not send %s", description)
+		return supervisorMessage{}
+	}
+}
+
+func (session *supervisorSession) send(command string) {
+	session.t.Helper()
+	if _, err := io.WriteString(session.control, command+"\n"); err != nil {
+		session.t.Fatal(err)
+	}
+}
+
+func (session *supervisorSession) closeControl() {
+	session.t.Helper()
+	if err := session.control.Close(); err != nil {
+		session.t.Fatal(err)
+	}
+}
+
+// awaitExit waits for the terminal message and for RunSupervisor to return.
+func (session *supervisorSession) awaitExit() (supervisorMessage, error) {
+	session.t.Helper()
+	var exit supervisorMessage
+	for {
+		message := session.await("an exit message")
+		if message.Type == "exit" {
+			exit = message
+			break
+		}
+	}
+	return exit, session.awaitReturn()
+}
+
+func (session *supervisorSession) awaitReturn() error {
+	session.t.Helper()
+	select {
+	case err := <-session.result:
+		session.finished = true
+		_ = session.output.Close()
+		return err
+	case <-time.After(60 * time.Second):
+		session.t.Fatal("RunSupervisor did not return")
+		return nil
+	}
+}
+
+func writeRuntimeScript(t *testing.T, directory, name, body string) string {
+	t.Helper()
+	path := filepath.Join(directory, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func newSupervisorInit(t *testing.T, runtime, executable string, timeoutSeconds int) supervisorInit {
+	t.Helper()
+	worktree := t.TempDir()
+	return supervisorInit{
+		Runtime:           runtime,
+		RuntimeExecutable: executable,
+		Worktree:          worktree,
+		ResultPath:        filepath.Join(worktree, "result"),
+		Prompt:            "do the work",
+		TimeoutSeconds:    timeoutSeconds,
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, description string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", description)
+}
+
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func readRuntimePID(t *testing.T, path string) int {
+	t.Helper()
+	waitFor(t, 30*time.Second, "the fake runtime to report its process", func() bool {
+		body, err := os.ReadFile(path)
+		return err == nil && strings.TrimSpace(string(body)) != ""
+	})
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pid
+}
+
+func TestRunSupervisorRejectsInvalidInput(t *testing.T) {
+	valid := supervisorInit{
+		Runtime: protocol.RuntimeCodex, RuntimeExecutable: "/bin/true",
+		Worktree: "/tmp", ResultPath: "/tmp/result", TimeoutSeconds: 60,
+	}
+	cases := []struct {
+		name   string
+		mutate func(*supervisorInit)
+		body   string
+	}{
+		{name: "unknown runtime", mutate: func(init *supervisorInit) { init.Runtime = "unknown" }},
+		{name: "no executable", mutate: func(init *supervisorInit) { init.RuntimeExecutable = "" }},
+		{name: "no worktree", mutate: func(init *supervisorInit) { init.Worktree = "" }},
+		{name: "no result path", mutate: func(init *supervisorInit) { init.ResultPath = "" }},
+		{name: "no timeout", mutate: func(init *supervisorInit) { init.TimeoutSeconds = 0 }},
+		{name: "negative timeout", mutate: func(init *supervisorInit) { init.TimeoutSeconds = -1 }},
+		{
+			name:   "timeout above the maximum",
+			mutate: func(init *supervisorInit) { init.TimeoutSeconds = int(protocol.MaxTimeout/time.Second) + 1 },
+		},
+		{name: "work without target", mutate: func(init *supervisorInit) { init.WorkID = "work-1" }},
+		{name: "target without work", mutate: func(init *supervisorInit) { init.WorkTargetID = "target-1" }},
+		{name: "undecodable input", body: "{"},
+		{name: "unknown field", body: `{"runtime":"codex","surprise":true}`},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			body := testCase.body
+			if body == "" {
+				init := valid
+				testCase.mutate(&init)
+				encoded, err := json.Marshal(init)
+				if err != nil {
+					t.Fatal(err)
+				}
+				body = string(encoded)
+			}
+			control, writer, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer control.Close()
+			defer writer.Close()
+			output := &bytes.Buffer{}
+			if err := RunSupervisor(control, strings.NewReader(body), output,
+				newLimitBuffer(maxSupervisorErrorBytes)); err == nil {
+				t.Fatal("RunSupervisor accepted invalid input")
+			}
+			if output.Len() != 0 {
+				t.Fatalf("RunSupervisor wrote %q before validating its input", output.String())
+			}
+		})
+	}
+}
+
+func TestRunSupervisorRequiresAControlPipe(t *testing.T) {
+	err := RunSupervisor(nil, strings.NewReader("{}"), &bytes.Buffer{}, newLimitBuffer(maxSupervisorErrorBytes))
+	if err == nil || !strings.Contains(err.Error(), "control pipe") {
+		t.Fatalf("RunSupervisor without a control pipe returned %v", err)
+	}
+}
+
+func TestRunSupervisorDefaultsToCodex(t *testing.T) {
+	directory := t.TempDir()
+	init := newSupervisorInit(t, "", writeRuntimeScript(t, directory, "runtime", "exit 0\n"), 60)
+	init.Runtime = ""
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "exited" || exit.ExitCode != 0 {
+		t.Fatalf("exit message = %+v", exit)
+	}
+}
+
+func TestRunSupervisorCancelsARunningRuntime(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	pidPath := filepath.Join(directory, "runtime.pid")
+	script := writeRuntimeScript(t, directory, "runtime",
+		"echo $$ > '"+pidPath+"'\necho working\nsleep 300\n")
+	init := newSupervisorInit(t, protocol.RuntimePi, script, 600)
+
+	session := startSupervisorSession(t, init)
+	ready := session.awaitReady()
+	session.send("start")
+	runtimePID := readRuntimePID(t, pidPath)
+
+	session.send("cancel")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "cancelled" || exit.Error != "attempt cancelled" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+
+	// Cancellation must tear the whole process group down, not just the runtime.
+	waitFor(t, 30*time.Second, "the runtime process to be reaped", func() bool {
+		return !processAlive(runtimePID)
+	})
+	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+		return !processGroupAlive(int(ready.ProcessGroupID))
+	})
+}
+
+func TestRunSupervisorStopsARuntimeAtItsTimeout(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	pidPath := filepath.Join(directory, "runtime.pid")
+	script := writeRuntimeScript(t, directory, "runtime",
+		"echo $$ > '"+pidPath+"'\nsleep 300\n")
+	init := newSupervisorInit(t, protocol.RuntimePi, script, 1)
+
+	session := startSupervisorSession(t, init)
+	ready := session.awaitReady()
+	session.send("start")
+	runtimePID := readRuntimePID(t, pidPath)
+
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "timeout" || exit.Error != "Work timeout reached" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+	waitFor(t, 30*time.Second, "the runtime process to be reaped", func() bool {
+		return !processAlive(runtimePID)
+	})
+	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+		return !processGroupAlive(int(ready.ProcessGroupID))
+	})
+}
+
+func TestRunSupervisorStopsWhenItsParentGoesAway(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	pidPath := filepath.Join(directory, "runtime.pid")
+	script := writeRuntimeScript(t, directory, "runtime",
+		"echo $$ > '"+pidPath+"'\nsleep 300\n")
+	init := newSupervisorInit(t, protocol.RuntimePi, script, 600)
+
+	session := startSupervisorSession(t, init)
+	ready := session.awaitReady()
+	session.send("start")
+	runtimePID := readRuntimePID(t, pidPath)
+
+	session.closeControl()
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "parent_lost" || exit.Error != "worker parent process exited" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+	waitFor(t, 30*time.Second, "the runtime process to be reaped", func() bool {
+		return !processAlive(runtimePID)
+	})
+	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+		return !processGroupAlive(int(ready.ProcessGroupID))
+	})
+}
+
+func TestRunSupervisorStopsWhenTheLeaseDeadlinePasses(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime", "sleep 300\n")
+	init := newSupervisorInit(t, protocol.RuntimePi, script, 600)
+
+	session := startSupervisorSession(t, init)
+	ready := session.awaitReady()
+	// A one-millisecond lease leaves no room for the termination grace, so the
+	// supervisor stops the attempt almost immediately.
+	session.send("renew 1")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "lease_lost" || exit.Error != "control-plane lease renewal deadline passed" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+		return !processGroupAlive(int(ready.ProcessGroupID))
+	})
+}
+
+func TestRunSupervisorReportsPreparationFailureBeforeStart(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime", "sleep 300\n")
+	session := startSupervisorSession(t, newSupervisorInit(t, protocol.RuntimePi, script, 600))
+	ready := session.awaitReady()
+
+	session.send("fail")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "supervisor_error" || exit.Error != "attempt preparation failed" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+		return !processGroupAlive(int(ready.ProcessGroupID))
+	})
+}
+
+func TestRunSupervisorRejectsAnUnknownControlCommand(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime", "sleep 300\n")
+	session := startSupervisorSession(t, newSupervisorInit(t, protocol.RuntimePi, script, 600))
+	ready := session.awaitReady()
+
+	session.send("detonate")
+	err := session.awaitReturn()
+	if err == nil || !strings.Contains(err.Error(), "unknown supervisor command") {
+		t.Fatalf("RunSupervisor returned %v", err)
+	}
+	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+		return !processGroupAlive(int(ready.ProcessGroupID))
+	})
+}
+
+func TestRunSupervisorReportsARuntimeThatCannotStart(t *testing.T) {
+	directory := t.TempDir()
+	init := newSupervisorInit(t, protocol.RuntimePi, filepath.Join(directory, "absent-runtime"), 60)
+
+	session := startSupervisorSession(t, init)
+	ready := session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "supervisor_error" || exit.ExitCode != -1 {
+		t.Fatalf("exit message = %+v", exit)
+	}
+	if !strings.Contains(exit.Error, "start Pi") {
+		t.Fatalf("exit error = %q", exit.Error)
+	}
+	waitFor(t, 30*time.Second, "the attempt process group to be torn down", func() bool {
+		return !processGroupAlive(int(ready.ProcessGroupID))
+	})
+}
+
+func TestRunSupervisorCapturesPiResultAndOutput(t *testing.T) {
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime",
+		"cat > '"+filepath.Join(directory, "prompt")+"'\nprintf 'final answer\\n'\n")
+	init := newSupervisorInit(t, protocol.RuntimePi, script, 60)
+
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "exited" || exit.ExitCode != 0 || exit.Error != "" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+	if exit.Result != "final answer" || exit.Truncated {
+		t.Fatalf("exit result = %q, truncated %v", exit.Result, exit.Truncated)
+	}
+	prompt, err := os.ReadFile(filepath.Join(directory, "prompt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(prompt) != init.Prompt {
+		t.Fatalf("runtime received prompt %q, want %q", prompt, init.Prompt)
+	}
+}
+
+func TestRunSupervisorReportsAnEmptyPiResult(t *testing.T) {
+	directory := t.TempDir()
+	init := newSupervisorInit(t, protocol.RuntimePi, writeRuntimeScript(t, directory, "runtime", "exit 0\n"), 60)
+
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "exited" || exit.Error != "Pi returned no result" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+}
+
+func TestRunSupervisorReportsRuntimeFailureWithItsStderrTail(t *testing.T) {
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime", "echo 'runtime blew up' >&2\nexit 3\n")
+	init := newSupervisorInit(t, protocol.RuntimePi, script, 60)
+
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "exited" || exit.ExitCode != 3 {
+		t.Fatalf("exit message = %+v", exit)
+	}
+	if !strings.Contains(exit.Error, "exit status 3") || !strings.Contains(exit.Error, "runtime blew up") {
+		t.Fatalf("exit error = %q", exit.Error)
+	}
+}
+
+func TestRunSupervisorReadsTheCodexResultFile(t *testing.T) {
+	directory := t.TempDir()
+	worktree := t.TempDir()
+	resultPath := filepath.Join(worktree, "result")
+	script := writeRuntimeScript(t, directory, "runtime", "printf 'codex answer' > '"+resultPath+"'\n")
+	init := supervisorInit{
+		Runtime: protocol.RuntimeCodex, RuntimeExecutable: script, Worktree: worktree,
+		ResultPath: resultPath, Prompt: "do the work", TimeoutSeconds: 60,
+		WorkID: "work-1", WorkTargetID: "target-1",
+	}
+
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "exited" || exit.Result != "codex answer" || exit.Truncated {
+		t.Fatalf("exit message = %+v", exit)
+	}
+	if _, err := os.Stat(resultPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("supervisor left the result file behind: %v", err)
+	}
+}
+
+func TestRunSupervisorCapturesTheClaudeCodeResultEvent(t *testing.T) {
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime",
+		"echo '{\"type\":\"system\",\"subtype\":\"init\"}'\n"+
+			"echo '{\"type\":\"result\",\"result\":\"claude answer\",\"is_error\":false}'\n")
+	init := newSupervisorInit(t, protocol.RuntimeClaudeCode, script, 60)
+
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "exited" || exit.Result != "claude answer" || exit.Error != "" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+}
+
+func TestRunSupervisorReportsAMissingClaudeCodeResultEvent(t *testing.T) {
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime", "echo '{\"type\":\"system\"}'\n")
+	init := newSupervisorInit(t, protocol.RuntimeClaudeCode, script, 60)
+
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "exited" || exit.Error != "Claude Code returned no terminal result event" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+}
+
+func TestRunSupervisorReportsAClaudeCodeTerminalError(t *testing.T) {
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime",
+		"echo '{\"type\":\"result\",\"result\":\"the model refused\",\"is_error\":true}'\n")
+	init := newSupervisorInit(t, protocol.RuntimeClaudeCode, script, 60)
+
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+	exit, err := session.awaitExit()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exit.Reason != "exited" || exit.Error != "the model refused" {
+		t.Fatalf("exit message = %+v", exit)
+	}
+}
+
+func TestRunSupervisorForwardsRuntimeOutputAsEvents(t *testing.T) {
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "runtime",
+		"echo standard output\necho standard error >&2\nprintf 'result\\n'\n")
+	init := newSupervisorInit(t, protocol.RuntimePi, script, 60)
+
+	session := startSupervisorSession(t, init)
+	session.awaitReady()
+	session.send("start")
+
+	streams := map[string][]string{}
+	for {
+		message := session.await("runtime output")
+		if message.Type == "exit" {
+			break
+		}
+		if message.Type != "output" {
+			t.Fatalf("unexpected message %+v", message)
+		}
+		streams[message.Stream] = append(streams[message.Stream], message.Text)
+	}
+	if err := session.awaitReturn(); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(streams["stdout"], "|"); got != "standard output|result" {
+		t.Fatalf("stdout events = %q", got)
+	}
+	if got := strings.Join(streams["stderr"], "|"); got != "standard error" {
+		t.Fatalf("stderr events = %q", got)
+	}
+}
+
+func TestStopStartedSupervisorGroupTearsDownTheWholeGroup(t *testing.T) {
+	t.Parallel()
+	anchor, identity, childPID := startTestProcessGroup(t)
+	groupID := anchor.Process.Pid
+
+	if err := stopStartedSupervisorGroup(anchor, identity, 100*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if err := anchor.Wait(); err == nil {
+		t.Fatal("anchor exited cleanly after being stopped")
+	}
+	waitFor(t, 30*time.Second, "the group child to exit", func() bool {
+		return !processAlive(childPID)
+	})
+	waitFor(t, 30*time.Second, "the process group to be torn down", func() bool {
+		return !processGroupAlive(groupID)
+	})
+}
+
+func TestStopStartedSupervisorGroupForceStopsAnUnverifiedGroup(t *testing.T) {
+	t.Parallel()
+	anchor, _, childPID := startTestProcessGroup(t)
+	groupID := anchor.Process.Pid
+
+	// A mismatched identity means the supervisor refuses to signal the group by
+	// identity, but it still force-stops a group it started itself.
+	if err := stopStartedSupervisorGroup(anchor, "not the recorded identity", terminationGrace); err != nil {
+		t.Fatal(err)
+	}
+	_ = anchor.Wait()
+	waitFor(t, 30*time.Second, "the group child to exit", func() bool {
+		return !processAlive(childPID)
+	})
+	waitFor(t, 30*time.Second, "the process group to be torn down", func() bool {
+		return !processGroupAlive(groupID)
+	})
+}
+
+func TestStopStartedSupervisorGroupRejectsAnUnstartedAnchor(t *testing.T) {
+	if err := stopStartedSupervisorGroup(nil, "identity", 0); err == nil {
+		t.Fatal("stopStartedSupervisorGroup accepted a nil anchor")
+	}
+	if err := stopStartedSupervisorGroup(exec.Command("/bin/true"), "identity", 0); err == nil {
+		t.Fatal("stopStartedSupervisorGroup accepted an unstarted anchor")
+	}
+}
+
+// startTestProcessGroup starts an anchor that ignores SIGTERM, plus a child in
+// the same group, mirroring how the supervisor anchors an attempt.
+func startTestProcessGroup(t *testing.T) (*exec.Cmd, string, int) {
+	t.Helper()
+	directory := t.TempDir()
+	pidPath := filepath.Join(directory, "child.pid")
+	anchor := exec.Command("/bin/sh", "-c", "trap '' TERM; while :; do sleep 3600; done")
+	configureNewProcessGroup(anchor)
+	if err := anchor.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if anchor.Process != nil {
+			_ = forceStopStartedProcessGroup(anchor.Process.Pid)
+		}
+	})
+	identity, err := processIdentity(anchor.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	child := exec.Command("/bin/sh", "-c", "echo $$ > '"+pidPath+"'; sleep 300")
+	configureExistingProcessGroup(child, anchor.Process.Pid)
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = child.Wait() }()
+	return anchor, identity, readRuntimePID(t, pidPath)
+}
+
+func TestWaitForSupervisorCommand(t *testing.T) {
+	t.Parallel()
+	t.Run("exits on its own", func(t *testing.T) {
+		command := exec.Command("/bin/sh", "-c", "exit 0")
+		if err := command.Start(); err != nil {
+			t.Fatal(err)
+		}
+		if err := waitForSupervisorCommand(command, 30*time.Second); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("is killed after the timeout", func(t *testing.T) {
+		command := exec.Command("/bin/sh", "-c", "trap '' TERM; while :; do sleep 3600; done")
+		configureNewProcessGroup(command)
+		if err := command.Start(); err != nil {
+			t.Fatal(err)
+		}
+		pid := command.Process.Pid
+		err := waitForSupervisorCommand(command, 100*time.Millisecond)
+		if err == nil || !strings.Contains(err.Error(), "did not exit within") {
+			t.Fatalf("waitForSupervisorCommand returned %v", err)
+		}
+		waitFor(t, 30*time.Second, "the command to be killed", func() bool {
+			return !processAlive(pid)
+		})
+	})
+}
+
+func TestWaitForSupervisorReaders(t *testing.T) {
+	t.Parallel()
+	t.Run("readers finish", func(t *testing.T) {
+		stdout, stdoutWriter, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stderr, stderrWriter, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer closeAll(stdout, stdoutWriter, stderr, stderrWriter)
+		readers := &sync.WaitGroup{}
+		readers.Add(1)
+		go readers.Done()
+		if err := waitForSupervisorReaders(readers, stdout, stderr, 30*time.Second); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("stuck readers are released by closing their pipes", func(t *testing.T) {
+		stdout, stdoutWriter, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stderr, stderrWriter, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer closeAll(stdoutWriter, stderrWriter)
+		readers := &sync.WaitGroup{}
+		readers.Add(2)
+		for _, pipe := range []*os.File{stdout, stderr} {
+			go func(pipe *os.File) {
+				defer readers.Done()
+				_, _ = io.Copy(io.Discard, pipe)
+			}(pipe)
+		}
+		err = waitForSupervisorReaders(readers, stdout, stderr, 100*time.Millisecond)
+		if err == nil || !strings.Contains(err.Error(), "remained open") {
+			t.Fatalf("waitForSupervisorReaders returned %v", err)
+		}
+	})
+}
+
+func closeAll(files ...*os.File) {
+	for _, file := range files {
+		_ = file.Close()
+	}
+}
+
+func TestStartSupervisorRunsTheControlProtocol(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	script := writeRuntimeScript(t, directory, "supervisor",
+		"cat > '"+filepath.Join(directory, "init.json")+"'\n"+
+			"printf '{\"type\":\"ready\",\"supervisor_pid\":%s,\"process_identity\":\"identity\","+
+			"\"process_group_id\":%s,\"group_identity\":\"group\"}\\n' \"$$\" \"$$\"\n"+
+			"while IFS= read -r line <&3; do\n"+
+			"  if [ \"$line\" = \"cancel\" ]; then break; fi\n"+
+			"done\n"+
+			"printf '{\"type\":\"exit\",\"reason\":\"cancelled\",\"error\":\"attempt cancelled\"}\\n'\n"+
+			"echo 'supervisor finished' >&2\n")
+	init := supervisorInit{
+		Runtime: protocol.RuntimeCodex, RuntimeExecutable: "/bin/true", Worktree: directory,
+		ResultPath: filepath.Join(directory, "result"), Prompt: "do the work", TimeoutSeconds: 60,
+	}
+
+	errorOutput := newLimitBuffer(maxSupervisorErrorBytes)
+	process, err := startSupervisor([]string{script}, init, errorOutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := process.awaitReady(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if process.supervisorPID <= 0 || process.processGroupID <= 0 ||
+		process.supervisorIdentity != "identity" || process.groupIdentity != "group" {
+		t.Fatalf("supervisor readiness = %+v", process)
+	}
+
+	if err := process.send("cancel"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case message := <-process.messages:
+		if message.Type != "exit" || message.Reason != "cancelled" {
+			t.Fatalf("exit message = %+v", message)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("supervisor did not report an exit")
+	}
+	if err := process.closeControl(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-process.wait:
+		if err != nil {
+			t.Fatalf("supervisor exited with %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("supervisor did not exit")
+	}
+
+	body, err := os.ReadFile(filepath.Join(directory, "init.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var received supervisorInit
+	if err := json.Unmarshal(body, &received); err != nil {
+		t.Fatal(err)
+	}
+	if received != init {
+		t.Fatalf("supervisor received %+v, want %+v", received, init)
+	}
+	waitFor(t, 30*time.Second, "the supervisor stderr to be mirrored", func() bool {
+		return strings.Contains(errorOutput.String(), "supervisor finished")
+	})
+}
+
+func TestStartSupervisorRejectsBadCommandLines(t *testing.T) {
+	init := supervisorInit{Runtime: protocol.RuntimeCodex}
+	if _, err := startSupervisor(nil, init, newLimitBuffer(1024)); err == nil {
+		t.Fatal("startSupervisor accepted an empty command line")
+	}
+	missing := filepath.Join(t.TempDir(), "absent")
+	if _, err := startSupervisor([]string{missing}, init, newLimitBuffer(1024)); err == nil {
+		t.Fatal("startSupervisor accepted a missing executable")
+	}
+}

--- a/internal/worker/supervisor_test.go
+++ b/internal/worker/supervisor_test.go
@@ -337,9 +337,9 @@ func TestClaudeResultCapture(t *testing.T) {
 		},
 		{
 			name:       "escape sequences",
-			lines:      []string{`{"type":"result","result":"a\nb\tc\\d\"e\/fA"}`},
+			lines:      []string{`{"type":"result","result":"a\nb\tc\\d\"e\/f\u0041"}`},
 			wantFound:  true,
-			wantResult: "a\nb\tc\\d\"e/f" + "A",
+			wantResult: "a\nb\tc\\d\"e/fA",
 		},
 		{
 			name:       "control escapes",
@@ -349,7 +349,7 @@ func TestClaudeResultCapture(t *testing.T) {
 		},
 		{
 			name:       "surrogate pair",
-			lines:      []string{`{"type":"result","result":"😀"}`},
+			lines:      []string{`{"type":"result","result":"\ud83d\ude00"}`},
 			wantFound:  true,
 			wantResult: "\U0001F600",
 		},
@@ -740,19 +740,37 @@ func TestAwaitReady(t *testing.T) {
 		}
 	})
 
-	invalid := []supervisorMessage{
-		{Type: "output", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: "g"},
-		{Type: "ready", SupervisorPID: 0, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: "g"},
-		{Type: "ready", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 0, GroupIdentity: "g"},
-		{Type: "ready", SupervisorPID: 11, ProcessIdentity: "", ProcessGroupID: 12, GroupIdentity: "g"},
-		{Type: "ready", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: ""},
+	invalid := []struct {
+		name    string
+		message supervisorMessage
+	}{
+		{
+			name:    "wrong message type",
+			message: supervisorMessage{Type: "output", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: "g"},
+		},
+		{
+			name:    "no supervisor pid",
+			message: supervisorMessage{Type: "ready", SupervisorPID: 0, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: "g"},
+		},
+		{
+			name:    "no process group",
+			message: supervisorMessage{Type: "ready", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 0, GroupIdentity: "g"},
+		},
+		{
+			name:    "no process identity",
+			message: supervisorMessage{Type: "ready", SupervisorPID: 11, ProcessIdentity: "", ProcessGroupID: 12, GroupIdentity: "g"},
+		},
+		{
+			name:    "no group identity",
+			message: supervisorMessage{Type: "ready", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: ""},
+		},
 	}
-	for index, message := range invalid {
-		t.Run("invalid readiness", func(t *testing.T) {
+	for _, testCase := range invalid {
+		t.Run(testCase.name, func(t *testing.T) {
 			process := newTestSupervisorProcess()
-			process.messages <- message
+			process.messages <- testCase.message
 			if err := process.awaitReady(context.Background()); err == nil {
-				t.Fatalf("case %d accepted %+v", index, message)
+				t.Fatalf("awaitReady accepted %+v", testCase.message)
 			}
 		})
 	}

--- a/internal/worker/supervisor_test.go
+++ b/internal/worker/supervisor_test.go
@@ -1,0 +1,855 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestIsSupervisorCommand(t *testing.T) {
+	cases := []struct {
+		name      string
+		arguments []string
+		want      bool
+	}{
+		{name: "no arguments", arguments: nil, want: false},
+		{name: "supervisor", arguments: []string{supervisorCommand}, want: true},
+		{name: "supervisor with extra", arguments: []string{supervisorCommand, "extra"}, want: true},
+		{name: "other command", arguments: []string{"run"}, want: false},
+		{name: "not first", arguments: []string{"run", supervisorCommand}, want: false},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := IsSupervisorCommand(testCase.arguments); got != testCase.want {
+				t.Fatalf("IsSupervisorCommand(%q) = %v, want %v", testCase.arguments, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestParseControlCommand(t *testing.T) {
+	cases := []struct {
+		name         string
+		command      string
+		wantAction   string
+		wantDuration time.Duration
+		wantError    bool
+	}{
+		{name: "start", command: "start", wantAction: "start"},
+		{name: "cancel", command: "cancel", wantAction: "cancel"},
+		{name: "lease lost", command: "lease_lost", wantAction: "lease_lost"},
+		{name: "fail", command: "fail", wantAction: "fail"},
+		{name: "timeout", command: "timeout", wantAction: "timeout"},
+		{name: "surrounding space", command: "  cancel  ", wantAction: "cancel"},
+		{name: "renew", command: "renew 1500", wantAction: "renew", wantDuration: 1500 * time.Millisecond},
+		{name: "renew minimum", command: "renew 1", wantAction: "renew", wantDuration: time.Millisecond},
+		{
+			name:         "renew maximum",
+			command:      "renew " + itoa(protocol.LeaseDuration.Milliseconds()),
+			wantAction:   "renew",
+			wantDuration: protocol.LeaseDuration,
+		},
+		{name: "renew above maximum", command: "renew " + itoa(protocol.LeaseDuration.Milliseconds()+1), wantError: true},
+		{name: "renew zero", command: "renew 0", wantError: true},
+		{name: "renew negative", command: "renew -1", wantError: true},
+		{name: "renew not a number", command: "renew soon", wantError: true},
+		{name: "renew missing duration", command: "renew", wantError: true},
+		{name: "renew extra field", command: "renew 100 100", wantError: true},
+		{name: "empty", command: "", wantError: true},
+		{name: "unknown", command: "explode", wantError: true},
+		{name: "start with argument", command: "start now", wantError: true},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			action, duration, err := parseControlCommand(testCase.command)
+			if testCase.wantError {
+				if err == nil {
+					t.Fatalf("parseControlCommand(%q) returned no error", testCase.command)
+				}
+				if action != "" || duration != 0 {
+					t.Fatalf("parseControlCommand(%q) = %q, %s on error", testCase.command, action, duration)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseControlCommand(%q): %v", testCase.command, err)
+			}
+			if action != testCase.wantAction || duration != testCase.wantDuration {
+				t.Fatalf("parseControlCommand(%q) = %q, %s; want %q, %s",
+					testCase.command, action, duration, testCase.wantAction, testCase.wantDuration)
+			}
+		})
+	}
+}
+
+func TestLeaseStopDelay(t *testing.T) {
+	cases := []struct {
+		name      string
+		remaining time.Duration
+		want      time.Duration
+	}{
+		{name: "full lease", remaining: protocol.LeaseDuration, want: protocol.LeaseDuration - terminationGrace},
+		{name: "above grace", remaining: terminationGrace + 2*time.Millisecond, want: 2 * time.Millisecond},
+		{name: "one millisecond above grace", remaining: terminationGrace + time.Millisecond, want: time.Millisecond},
+		{name: "at grace", remaining: terminationGrace, want: time.Millisecond},
+		{name: "below grace", remaining: time.Second, want: time.Millisecond},
+		{name: "zero", remaining: 0, want: time.Millisecond},
+		{name: "negative", remaining: -time.Minute, want: time.Millisecond},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := leaseStopDelay(testCase.remaining); got != testCase.want {
+				t.Fatalf("leaseStopDelay(%s) = %s, want %s", testCase.remaining, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestResetTimerDrainsExpiredTimer(t *testing.T) {
+	timer := time.NewTimer(time.Millisecond)
+	defer timer.Stop()
+	<-time.After(20 * time.Millisecond)
+
+	start := time.Now()
+	resetTimer(timer, 80*time.Millisecond)
+	<-timer.C
+	if elapsed := time.Since(start); elapsed < 40*time.Millisecond {
+		t.Fatalf("reset timer fired after %s, want at least 40ms", elapsed)
+	}
+}
+
+func TestResetTimerReschedulesPendingTimer(t *testing.T) {
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
+
+	resetTimer(timer, 10*time.Millisecond)
+	select {
+	case <-timer.C:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reset timer never fired")
+	}
+}
+
+func TestBoundedText(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		limit int
+		want  string
+	}{
+		{name: "below limit", value: "hello", limit: 10, want: "hello"},
+		{name: "at limit", value: "hello", limit: 5, want: "hello"},
+		{name: "above limit", value: "hello", limit: 3, want: "hel"},
+		{name: "zero limit", value: "hello", limit: 0, want: ""},
+		{name: "empty", value: "", limit: 0, want: ""},
+		{name: "splits multi byte rune", value: "héllo", limit: 2, want: "h"},
+		{name: "keeps whole multi byte rune", value: "héllo", limit: 3, want: "hé"},
+		{name: "splits four byte rune", value: "😀", limit: 3, want: ""},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := boundedText(testCase.value, testCase.limit); got != testCase.want {
+				t.Fatalf("boundedText(%q, %d) = %q, want %q", testCase.value, testCase.limit, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestReadBoundedText(t *testing.T) {
+	directory := t.TempDir()
+
+	t.Run("missing file", func(t *testing.T) {
+		text, truncated, err := readBoundedText(filepath.Join(directory, "absent"), 128)
+		if err != nil || text != "" || truncated {
+			t.Fatalf("readBoundedText = %q, %v, %v", text, truncated, err)
+		}
+	})
+
+	t.Run("within limit", func(t *testing.T) {
+		path := filepath.Join(directory, "small")
+		writeTestFile(t, path, "result body")
+		text, truncated, err := readBoundedText(path, 128)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if text != "result body" || truncated {
+			t.Fatalf("readBoundedText = %q, %v", text, truncated)
+		}
+	})
+
+	t.Run("at limit", func(t *testing.T) {
+		path := filepath.Join(directory, "exact")
+		writeTestFile(t, path, "abcd")
+		text, truncated, err := readBoundedText(path, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if text != "abcd" || truncated {
+			t.Fatalf("readBoundedText = %q, %v", text, truncated)
+		}
+	})
+
+	t.Run("above limit", func(t *testing.T) {
+		path := filepath.Join(directory, "large")
+		writeTestFile(t, path, strings.Repeat("a", 100))
+		text, truncated, err := readBoundedText(path, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if text != strings.Repeat("a", 10) || !truncated {
+			t.Fatalf("readBoundedText = %q, %v", text, truncated)
+		}
+	})
+
+	t.Run("truncation splits a multi byte rune", func(t *testing.T) {
+		// readBoundedText cuts the body to the limit before calling boundedText,
+		// which only trims when the value is longer than the limit, so the tail
+		// rune can be split. Tracked in #322; recorded here as current behaviour
+		// so a fix has to update this expectation deliberately.
+		path := filepath.Join(directory, "utf8")
+		writeTestFile(t, path, "aa\U0001F600bb")
+		text, truncated, err := readBoundedText(path, 3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if text != "aa\xf0" || !truncated {
+			t.Fatalf("readBoundedText = %q, %v", text, truncated)
+		}
+	})
+
+	t.Run("unreadable path", func(t *testing.T) {
+		_, _, err := readBoundedText(directory, 10)
+		if err == nil {
+			t.Fatal("readBoundedText on a directory returned no error")
+		}
+	})
+}
+
+func TestExitCode(t *testing.T) {
+	if got := exitCode(nil); got != 0 {
+		t.Fatalf("exitCode(nil) = %d, want 0", got)
+	}
+	if got := exitCode(errors.New("boom")); got != -1 {
+		t.Fatalf("exitCode(generic) = %d, want -1", got)
+	}
+	err := exec.Command("/bin/sh", "-c", "exit 7").Run()
+	if got := exitCode(err); got != 7 {
+		t.Fatalf("exitCode(exit 7) = %d, want 7", got)
+	}
+	if got := exitCode(errors.Join(errors.New("wrapped"), err)); got != 7 {
+		t.Fatalf("exitCode(joined exit 7) = %d, want 7", got)
+	}
+}
+
+func TestTailBuffer(t *testing.T) {
+	buffer := &tailBuffer{limit: 8}
+	if got := buffer.String(); got != "" {
+		t.Fatalf("empty tail buffer = %q", got)
+	}
+	if _, err := buffer.Write([]byte("abc")); err != nil {
+		t.Fatal(err)
+	}
+	if got := buffer.String(); got != "abc" {
+		t.Fatalf("tail buffer = %q, want %q", got, "abc")
+	}
+	if _, err := buffer.Write([]byte("defghijkl")); err != nil {
+		t.Fatal(err)
+	}
+	if got := buffer.String(); got != "efghijkl" {
+		t.Fatalf("tail buffer = %q, want %q", got, "efghijkl")
+	}
+}
+
+func TestPlainResultCapture(t *testing.T) {
+	capture := &plainResultCapture{}
+	capture.capture([]byte("first"), false)
+	capture.capture([]byte(" line"), true)
+	capture.capture([]byte("second"), true)
+	if capture.result == nil {
+		t.Fatal("plain capture recorded no result")
+	}
+	if got := capture.result.String(); got != "first line\nsecond\n" {
+		t.Fatalf("plain capture = %q", got)
+	}
+	if capture.result.Truncated() {
+		t.Fatal("plain capture reported truncation for a small result")
+	}
+}
+
+func TestPlainResultCaptureTruncates(t *testing.T) {
+	capture := &plainResultCapture{}
+	capture.capture(bytes.Repeat([]byte("a"), protocol.MaxResultBytes+64), true)
+	if !capture.result.Truncated() {
+		t.Fatal("plain capture did not report truncation")
+	}
+	if got := len(capture.result.String()); got != protocol.MaxResultBytes {
+		t.Fatalf("plain capture kept %d bytes, want %d", got, protocol.MaxResultBytes)
+	}
+}
+
+func TestClaudeResultCapture(t *testing.T) {
+	cases := []struct {
+		name          string
+		lines         []string
+		wantFound     bool
+		wantResult    string
+		wantIsError   bool
+		wantTruncated bool
+	}{
+		{
+			name:       "terminal result",
+			lines:      []string{`{"type":"result","result":"all done","is_error":false}`},
+			wantFound:  true,
+			wantResult: "all done",
+		},
+		{
+			name:        "terminal error",
+			lines:       []string{`{"type":"result","result":"it failed","is_error":true}`},
+			wantFound:   true,
+			wantResult:  "it failed",
+			wantIsError: true,
+		},
+		{
+			name:      "non terminal event",
+			lines:     []string{`{"type":"assistant","result":"ignored"}`},
+			wantFound: false,
+		},
+		{
+			name:      "invalid json",
+			lines:     []string{`{"type":"result","result":`},
+			wantFound: false,
+		},
+		{
+			name:      "unterminated result string",
+			lines:     []string{`{"type":"result","result":"open`},
+			wantFound: false,
+		},
+		{
+			name:       "escape sequences",
+			lines:      []string{`{"type":"result","result":"a\nb\tc\\d\"e\/fA"}`},
+			wantFound:  true,
+			wantResult: "a\nb\tc\\d\"e/f" + "A",
+		},
+		{
+			name:       "control escapes",
+			lines:      []string{`{"type":"result","result":"a\bb\fc\rd"}`},
+			wantFound:  true,
+			wantResult: "a\bb\fc\rd",
+		},
+		{
+			name:       "surrogate pair",
+			lines:      []string{`{"type":"result","result":"😀"}`},
+			wantFound:  true,
+			wantResult: "\U0001F600",
+		},
+		{
+			name:       "lone high surrogate",
+			lines:      []string{`{"type":"result","result":"\ud83dx"}`},
+			wantFound:  true,
+			wantResult: "�x",
+		},
+		{
+			name:       "lone low surrogate",
+			lines:      []string{`{"type":"result","result":"\udc00x"}`},
+			wantFound:  true,
+			wantResult: "�x",
+		},
+		{
+			name:       "nested result key is ignored",
+			lines:      []string{`{"type":"result","payload":{"result":"inner"},"result":"outer"}`},
+			wantFound:  true,
+			wantResult: "outer",
+		},
+		{
+			name:       "result key with escaped name",
+			lines:      []string{`{"type":"result","\u0072esult":"escaped key"}`},
+			wantFound:  true,
+			wantResult: "escaped key",
+		},
+		{
+			name:       "non string result value",
+			lines:      []string{`{"type":"result","result":null}`},
+			wantFound:  true,
+			wantResult: "",
+		},
+		{
+			name: "last result line wins",
+			lines: []string{
+				`{"type":"system","subtype":"init"}`,
+				`{"type":"result","result":"first"}`,
+				`{"type":"result","result":"second"}`,
+			},
+			wantFound:  true,
+			wantResult: "second",
+		},
+		{
+			name:      "invalid escape",
+			lines:     []string{`{"type":"result","result":"a\qb"}`},
+			wantFound: false,
+		},
+		{
+			name:      "invalid unicode escape",
+			lines:     []string{`{"type":"result","result":"a\u00zz"}`},
+			wantFound: false,
+		},
+		{
+			name:      "raw control byte in result",
+			lines:     []string{"{\"type\":\"result\",\"result\":\"a\x01b\"}"},
+			wantFound: false,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			capture := &claudeResultCapture{}
+			for _, line := range testCase.lines {
+				capture.capture([]byte(line), true)
+			}
+			if capture.found != testCase.wantFound {
+				t.Fatalf("found = %v, want %v", capture.found, testCase.wantFound)
+			}
+			if capture.result != testCase.wantResult {
+				t.Fatalf("result = %q, want %q", capture.result, testCase.wantResult)
+			}
+			if capture.isError != testCase.wantIsError {
+				t.Fatalf("isError = %v, want %v", capture.isError, testCase.wantIsError)
+			}
+			if capture.truncated != testCase.wantTruncated {
+				t.Fatalf("truncated = %v, want %v", capture.truncated, testCase.wantTruncated)
+			}
+		})
+	}
+}
+
+func TestClaudeResultCaptureAcceptsFragments(t *testing.T) {
+	line := `{"type":"result","result":"chunked 😀 output","is_error":false}`
+	capture := &claudeResultCapture{}
+	for index := 0; index < len(line); index += 3 {
+		end := index + 3
+		if end > len(line) {
+			end = len(line)
+		}
+		capture.capture([]byte(line[index:end]), false)
+	}
+	capture.capture(nil, true)
+	if !capture.found || capture.result != "chunked \U0001F600 output" {
+		t.Fatalf("fragmented capture = %q, found %v", capture.result, capture.found)
+	}
+}
+
+func TestClaudeResultCaptureTruncatesLargeResult(t *testing.T) {
+	line := `{"type":"result","result":"` + strings.Repeat("a", protocol.MaxResultBytes+512) + `"}`
+	capture := &claudeResultCapture{}
+	capture.capture([]byte(line), true)
+	if !capture.found {
+		t.Fatal("large result was not captured")
+	}
+	if !capture.truncated {
+		t.Fatal("large result was not reported as truncated")
+	}
+	if len(capture.result) != protocol.MaxResultBytes {
+		t.Fatalf("captured %d bytes, want %d", len(capture.result), protocol.MaxResultBytes)
+	}
+}
+
+func TestClaudeResultCaptureRejectsOversizedLine(t *testing.T) {
+	line := `{"type":"result","padding":"` + strings.Repeat("a", maxSupervisorLineBytes) + `","result":"late"}`
+	capture := &claudeResultCapture{}
+	capture.capture([]byte(line), true)
+	if capture.found {
+		t.Fatalf("oversized line was captured as %q", capture.result)
+	}
+}
+
+func TestHexDigit(t *testing.T) {
+	cases := map[byte]struct {
+		value byte
+		ok    bool
+	}{
+		'0': {value: 0, ok: true},
+		'9': {value: 9, ok: true},
+		'a': {value: 10, ok: true},
+		'f': {value: 15, ok: true},
+		'A': {value: 10, ok: true},
+		'F': {value: 15, ok: true},
+		'g': {value: 0, ok: false},
+		' ': {value: 0, ok: false},
+	}
+	for input, want := range cases {
+		value, ok := hexDigit(input)
+		if value != want.value || ok != want.ok {
+			t.Fatalf("hexDigit(%q) = %d, %v; want %d, %v", input, value, ok, want.value, want.ok)
+		}
+	}
+}
+
+func TestStreamSupervisorOutput(t *testing.T) {
+	output := &bytes.Buffer{}
+	writer := &synchronizedEncoder{encoder: json.NewEncoder(output)}
+	tail := &tailBuffer{limit: protocol.MaxErrorBytes}
+	capture := &plainResultCapture{}
+
+	streamSupervisorOutput(strings.NewReader("first\n\nsecond\nthird"), "stdout", writer, tail, capture.capture)
+
+	messages := decodeSupervisorMessages(t, output.Bytes())
+	if len(messages) != 3 {
+		t.Fatalf("streamed %d messages, want 3: %+v", len(messages), messages)
+	}
+	wantText := []string{"first", "second", "third"}
+	for index, message := range messages {
+		if message.Type != "output" || message.Stream != "stdout" || message.Truncated {
+			t.Fatalf("message %d = %+v", index, message)
+		}
+		if message.Text != wantText[index] {
+			t.Fatalf("message %d text = %q, want %q", index, message.Text, wantText[index])
+		}
+	}
+	if got := tail.String(); got != "first\nsecond\nthird\n" {
+		t.Fatalf("tail = %q", got)
+	}
+	if got := capture.result.String(); got != "first\nsecond\nthird\n" {
+		t.Fatalf("capture = %q", got)
+	}
+}
+
+func TestStreamSupervisorOutputTruncatesLongLine(t *testing.T) {
+	output := &bytes.Buffer{}
+	writer := &synchronizedEncoder{encoder: json.NewEncoder(output)}
+	line := strings.Repeat("a", maxSupervisorLineBytes+1024)
+
+	streamSupervisorOutput(strings.NewReader(line+"\nshort\n"), "stderr", writer, nil, nil)
+
+	messages := decodeSupervisorMessages(t, output.Bytes())
+	if len(messages) != 2 {
+		t.Fatalf("streamed %d messages, want 2", len(messages))
+	}
+	if !messages[0].Truncated || len(messages[0].Text) != maxSupervisorLineBytes {
+		t.Fatalf("long line message truncated=%v length=%d", messages[0].Truncated, len(messages[0].Text))
+	}
+	if messages[1].Truncated || messages[1].Text != "short" {
+		t.Fatalf("second message = %+v", messages[1])
+	}
+}
+
+func TestStreamSupervisorOutputIgnoresEmptyStream(t *testing.T) {
+	output := &bytes.Buffer{}
+	writer := &synchronizedEncoder{encoder: json.NewEncoder(output)}
+	streamSupervisorOutput(strings.NewReader(""), "stdout", writer, nil, nil)
+	if output.Len() != 0 {
+		t.Fatalf("empty stream produced %q", output.String())
+	}
+}
+
+func TestRuntimeEnvironment(t *testing.T) {
+	t.Setenv("FACTORY_WORK_ID", "stale-work")
+	t.Setenv("FACTORY_WORK_TARGET_ID", "stale-target")
+	t.Setenv("FACTORY_TEST_MARKER", "kept")
+
+	withIdentity := runtimeEnvironment("work-1", "target-1")
+	if countEnvironment(withIdentity, "FACTORY_WORK_ID=") != 1 ||
+		countEnvironment(withIdentity, "FACTORY_WORK_TARGET_ID=") != 1 {
+		t.Fatalf("environment did not replace stale identity values: %v", identityValues(withIdentity))
+	}
+	if !containsEnvironment(withIdentity, "FACTORY_WORK_ID=work-1") ||
+		!containsEnvironment(withIdentity, "FACTORY_WORK_TARGET_ID=target-1") {
+		t.Fatalf("environment missing supplied identity: %v", identityValues(withIdentity))
+	}
+	if !containsEnvironment(withIdentity, "FACTORY_TEST_MARKER=kept") {
+		t.Fatal("environment dropped unrelated variables")
+	}
+
+	withoutIdentity := runtimeEnvironment("", "")
+	if countEnvironment(withoutIdentity, "FACTORY_WORK_ID=") != 0 ||
+		countEnvironment(withoutIdentity, "FACTORY_WORK_TARGET_ID=") != 0 {
+		t.Fatalf("environment kept identity values: %v", identityValues(withoutIdentity))
+	}
+}
+
+func TestSupervisorCommandLine(t *testing.T) {
+	got := supervisorCommandLine("/usr/local/bin/factory-worker")
+	want := []string{"/usr/local/bin/factory-worker", supervisorCommand}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("supervisorCommandLine = %v, want %v", got, want)
+	}
+}
+
+func TestResultPath(t *testing.T) {
+	const attemptID = "123e4567-e89b-12d3-a456-426614174000"
+	directory := t.TempDir()
+
+	path, err := resultPath(directory, attemptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(directory, "tmp", attemptID+"-result"); path != want {
+		t.Fatalf("resultPath = %q, want %q", path, want)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("result file mode = %v, want 0600", info.Mode().Perm())
+	}
+	temporary, err := os.Stat(filepath.Join(directory, "tmp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if temporary.Mode().Perm() != 0o700 {
+		t.Fatalf("temporary directory mode = %v, want 0700", temporary.Mode().Perm())
+	}
+
+	if _, err := resultPath(directory, attemptID); err == nil {
+		t.Fatal("resultPath reused an existing result file")
+	}
+	if _, err := resultPath(directory, "not-a-uuid"); err == nil {
+		t.Fatal("resultPath accepted an invalid attempt ID")
+	}
+
+	symlinked := t.TempDir()
+	if err := os.Symlink(t.TempDir(), filepath.Join(symlinked, "tmp")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resultPath(symlinked, attemptID); err == nil {
+		t.Fatal("resultPath accepted a symlinked temporary directory")
+	}
+
+	file := filepath.Join(t.TempDir(), "data")
+	writeTestFile(t, file, "not a directory")
+	if _, err := resultPath(file, attemptID); err == nil {
+		t.Fatal("resultPath accepted a file as the data directory")
+	}
+}
+
+func TestSupervisorStartRequestAndSummary(t *testing.T) {
+	process := &supervisorProcess{
+		supervisorPID:      4242,
+		supervisorIdentity: "supervisor-identity",
+		processGroupID:     4243,
+		groupIdentity:      "group-identity",
+	}
+	request := supervisorStartRequest(process, "lease-token")
+	if request.LeaseToken != "lease-token" || request.ProcessIdentity != "supervisor-identity" {
+		t.Fatalf("start request = %+v", request)
+	}
+	if request.SupervisorPID == nil || *request.SupervisorPID != 4242 {
+		t.Fatalf("start request supervisor pid = %v", request.SupervisorPID)
+	}
+	if request.ProcessGroupID == nil || *request.ProcessGroupID != 4243 {
+		t.Fatalf("start request process group = %v", request.ProcessGroupID)
+	}
+	if got := processSummary(process); got != "supervisor=4242 process_group=4243" {
+		t.Fatalf("processSummary = %q", got)
+	}
+}
+
+func TestSupervisorProcessControl(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	process := &supervisorProcess{control: writer}
+
+	if err := process.send("cancel"); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.renew(time.Now().Add(protocol.LeaseDuration * 4)); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.renew(time.Now().Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.renew(time.Now().Add(time.Nanosecond)); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.closeControl(); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.closeControl(); err != nil {
+		t.Fatalf("second closeControl: %v", err)
+	}
+	if err := process.send("cancel"); err == nil {
+		t.Fatal("send on a closed control pipe returned no error")
+	}
+
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := strings.Split(strings.TrimSuffix(string(body), "\n"), "\n")
+	if len(commands) != 4 {
+		t.Fatalf("control pipe carried %d commands: %q", len(commands), commands)
+	}
+	if commands[0] != "cancel" {
+		t.Fatalf("first command = %q", commands[0])
+	}
+	if want := "renew " + itoa(protocol.LeaseDuration.Milliseconds()); commands[1] != want {
+		t.Fatalf("clamped renew = %q, want %q", commands[1], want)
+	}
+	if commands[2] != "lease_lost" {
+		t.Fatalf("expired lease command = %q", commands[2])
+	}
+	// A sub-millisecond lease can expire between the caller reading the clock and
+	// the supervisor process comparing it, so both outcomes are correct here.
+	if commands[3] != "renew 1" && commands[3] != "lease_lost" {
+		t.Fatalf("sub millisecond renew = %q, want \"renew 1\" or \"lease_lost\"", commands[3])
+	}
+
+	for _, command := range commands {
+		if _, _, err := parseControlCommand(command); err != nil {
+			t.Fatalf("supervisor cannot parse the command it is sent %q: %v", command, err)
+		}
+	}
+}
+
+func TestSupervisorProcessStoppedFlag(t *testing.T) {
+	process := &supervisorProcess{}
+	if process.isStopped() {
+		t.Fatal("new supervisor process reported a verified stop")
+	}
+	process.markStopped()
+	if !process.isStopped() {
+		t.Fatal("markStopped did not record a verified stop")
+	}
+}
+
+func TestAwaitReady(t *testing.T) {
+	t.Run("valid readiness", func(t *testing.T) {
+		process := newTestSupervisorProcess()
+		process.messages <- supervisorMessage{
+			Type: "ready", SupervisorPID: 11, ProcessIdentity: "supervisor",
+			ProcessGroupID: 12, GroupIdentity: "group",
+		}
+		if err := process.awaitReady(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if process.supervisorPID != 11 || process.processGroupID != 12 ||
+			process.supervisorIdentity != "supervisor" || process.groupIdentity != "group" {
+			t.Fatalf("readiness fields = %+v", process)
+		}
+	})
+
+	invalid := []supervisorMessage{
+		{Type: "output", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: "g"},
+		{Type: "ready", SupervisorPID: 0, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: "g"},
+		{Type: "ready", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 0, GroupIdentity: "g"},
+		{Type: "ready", SupervisorPID: 11, ProcessIdentity: "", ProcessGroupID: 12, GroupIdentity: "g"},
+		{Type: "ready", SupervisorPID: 11, ProcessIdentity: "s", ProcessGroupID: 12, GroupIdentity: ""},
+	}
+	for index, message := range invalid {
+		t.Run("invalid readiness", func(t *testing.T) {
+			process := newTestSupervisorProcess()
+			process.messages <- message
+			if err := process.awaitReady(context.Background()); err == nil {
+				t.Fatalf("case %d accepted %+v", index, message)
+			}
+		})
+	}
+
+	t.Run("decode failure", func(t *testing.T) {
+		process := newTestSupervisorProcess()
+		if _, err := process.stderr.Write([]byte("supervisor stderr")); err != nil {
+			t.Fatal(err)
+		}
+		process.decodeErrors <- io.ErrUnexpectedEOF
+		err := process.awaitReady(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "supervisor stderr") {
+			t.Fatalf("decode failure error = %v", err)
+		}
+	})
+
+	t.Run("early exit", func(t *testing.T) {
+		process := newTestSupervisorProcess()
+		process.wait <- errors.New("exit status 2")
+		err := process.awaitReady(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "exited before readiness") {
+			t.Fatalf("early exit error = %v", err)
+		}
+	})
+
+	t.Run("cancelled context", func(t *testing.T) {
+		process := newTestSupervisorProcess()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if err := process.awaitReady(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancelled context error = %v", err)
+		}
+	})
+}
+
+func newTestSupervisorProcess() *supervisorProcess {
+	return &supervisorProcess{
+		messages:     make(chan supervisorMessage, 1),
+		decodeErrors: make(chan error, 1),
+		wait:         make(chan error, 1),
+		stderr:       newLimitBuffer(maxSupervisorErrorBytes),
+	}
+}
+
+func decodeSupervisorMessages(t *testing.T, body []byte) []supervisorMessage {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	var messages []supervisorMessage
+	for {
+		var message supervisorMessage
+		err := decoder.Decode(&message)
+		if errors.Is(err, io.EOF) {
+			return messages
+		}
+		if err != nil {
+			t.Fatalf("decode supervisor messages: %v", err)
+		}
+		messages = append(messages, message)
+	}
+}
+
+func writeTestFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func containsEnvironment(environment []string, entry string) bool {
+	for _, value := range environment {
+		if value == entry {
+			return true
+		}
+	}
+	return false
+}
+
+func countEnvironment(environment []string, prefix string) int {
+	count := 0
+	for _, value := range environment {
+		if strings.HasPrefix(value, prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+func identityValues(environment []string) []string {
+	var values []string
+	for _, value := range environment {
+		if strings.HasPrefix(value, "FACTORY_WORK_") {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func itoa(value int64) string {
+	return strconv.FormatInt(value, 10)
+}


### PR DESCRIPTION
Closes #298.

`internal/worker/supervisor.go` and `internal/worker/events.go` had no test
coverage across any function. This adds tests only; production code is unchanged.

## Coverage, from `go tool cover -func`

| Scope | Before | After |
| --- | --- | --- |
| `internal/worker` package | 23.0% | 41.2% |
| `supervisor.go` statements | 1/636 (0.2%) | 570/636 (89.6%) |
| `events.go` statements | 0/61 (0.0%) | 60/61 (98.4%) |

Every function in both files was at 0.0% before. None is now. The single
pre-existing covered statement in `supervisor.go` was an early return reached by
another test.

## What the tests cover

**Pure functions** (`supervisor_test.go`, `events_test.go`), no processes:

- `parseControlCommand`: every accepted action, `renew` bounds at 1 ms and the
  lease duration, and the rejected forms (zero, negative, non-numeric, missing
  and extra fields, unknown commands).
- `eventPayload`: runtime JSON passthrough, wrapping for stderr, plain text,
  invalid JSON and already-truncated output, the oversized-line path, and the
  binary search. The search test asserts the payload fits `MaxEventBytes` and
  that one more character would not, so an off-by-one in either direction fails.
- `boundedText`, `readBoundedText`, `tailBuffer`, `leaseStopDelay`, `resetTimer`,
  `exitCode`, `hexDigit`, `runtimeEnvironment`, `resultPath`,
  `supervisorStartRequest`, `processSummary`.
- Result capture: `plainResultCapture` and the `claudeResultCapture` scanner,
  including escapes, surrogate pairs, lone surrogates, fragmented input, nested
  `result` keys, oversized results and lines, and malformed input.
- `eventSender`: sequence numbering, queue overflow disabling the sender,
  `closeAndWait` timeout and double-close, in-order delivery, 5xx retry, 4xx
  shutdown, and context cancellation, against an `httptest` server.

**Process paths** (`supervisor_process_test.go`, Unix build tags), driving a real
`RunSupervisor` over its control pipe with fake runtime scripts:

- Cancellation and the work timeout, as the issue asks, plus a lost parent, an
  expired lease deadline, an unknown control command, and a runtime that cannot
  start. Table tests cover every control command the supervisor accepts both
  before the runtime starts (cancel, lease_lost, fail, timeout) and while it runs
  (fail, lease_lost, and a renewal that expires under it).
- **Process-group teardown** is asserted in every stopping path: the recorded
  runtime PID is gone and the attempt process group is no longer alive after the
  supervisor returns. `stopStartedSupervisorGroup` is also tested directly,
  including the force-stop path taken when the group identity no longer verifies,
  and the unstarted-anchor error.
- Result capture end to end for Pi, Codex (result file, then its removal) and
  Claude Code, stderr tail attachment on a non-zero exit, runtime output
  forwarded as events, and `startSupervisor` plus `awaitReady` against a fake
  supervisor binary.
- Reaper helpers `waitForSupervisorCommand` and `waitForSupervisorReaders`,
  including their timeout and forced-close branches.

## Bug found

`TestReadBoundedText` records that `readBoundedText` can return a split
multi-byte rune, because it cuts the body to the limit before calling
`boundedText`, which only trims when the value is longer than the limit.
`tailBuffer.String` has the same shape. Impact is low: the value is JSON-encoded
downstream and `boundedCompletionRequest` runs `strings.ToValidUTF8` before it
reaches the control plane, so the visible effect is a replacement character at
the boundary. Fixing it changes production behaviour, which is out of scope for
a tests-only issue, so it is filed as #322 and the test pins current behaviour
with a pointer to that issue.

## Verification

- `go test ./internal/worker` with `go tool cover -func`, before and after, per
  the table above.
- `just test-worker-race`: passes, 180 tests under the race detector.
- `just test`, `just format-check`, `just vet`, `just staticcheck`, `just boundary`:
  all pass.
- Flakiness probing: `go test -race -count=1 ./internal/worker` (the CI command)
  six times and `go test -race -count=3 ./internal/worker`, all clean.

The package test time goes from about 3s to about 23s. The stopping paths cost
the real 5-second termination grace, because the process-group anchor ignores
SIGTERM by design, so those tests run in parallel with each other.


## Review round

An independent reviewer found one blocking flake and several smaller gaps, all
fixed in the second commit:

- `TestRunSupervisorStopsARuntimeAtItsTimeout` raced its own fake runtime. With a
  one-second attempt timeout, the runtime could be torn down before it wrote its
  PID file, and the test then waited 30s for a file that never appeared. The
  reviewer reproduced it at 1 failure in 6 runs of the CI race command and 3 in 4
  at `-count=3`. It now asserts on the process group, which does not depend on
  that race; the cancellation and parent-lost tests still assert per-process
  reaping and read the PID before sending their stop command. Six clean runs of
  the CI command and a clean `-count=3` race run confirm the fix.
- `TestWaitForSupervisorCommand` leaked an orphan `sleep` per run, because the
  helper under test kills the process rather than its group. Now cleaned up.
- The Claude Code surrogate-pair case embedded a literal emoji, so it took the
  plain byte path and never reached the pair-combining arithmetic in
  `appendUnicode`, which was at 44.4%. It now sends the escaped pair and that
  function is at 100%.
- Named the `awaitReady` invalid-readiness cases, and `startTestProcessGroup` now
  only signals a group that is still alive.
