### PR TITLE
fix: default the primary worker runtime from runtimes

### DIFF
--- a/docs/local.md
+++ b/docs/local.md
@@ -80,9 +80,11 @@ when local CPU, memory, or provider limits require it.
 
 The optional legacy `runtime` field is the default for older clients that do
 not select a runtime. Existing single-runtime files continue to work without a
-`runtimes` field. New configurations can list several runtimes. Factory reports
-each one as ready, missing, unauthenticated, or unhealthy, and the Worker stays
-available while Git and at least one configured runtime are ready.
+`runtimes` field. New configurations can list several runtimes and may omit
+`runtime`, in which case the first listed runtime becomes the primary one.
+Factory reports each one as ready, missing, unauthenticated, or unhealthy, and
+the Worker stays available while Git and at least one configured runtime are
+ready.
 
 Factory migrates existing SQLite databases to the expanded worker capacity
 range when the control plane starts.

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -24,10 +24,11 @@ host = "laptop"
 
 `runtimes` lists the coding agents the Worker should discover. Supported values
 are `pi`, `codex`, and `claude-code`. `runtime` remains the primary capability
-and preserves compatibility with existing single-runtime configurations. Each
-task selects one ready capability and launches a fresh runtime process with its
-own worktree, manifest, lease, and supervisor process group. `max_concurrent`
-accepts values from 1 through 100;
+and preserves compatibility with existing single-runtime configurations. When
+`runtime` is omitted it defaults to the first entry in `runtimes`, or to `codex`
+when neither field is set. Each task selects one ready capability and launches a
+fresh runtime process with its own worktree, manifest, lease, and supervisor
+process group. `max_concurrent` accepts values from 1 through 100;
 preparing attempts consume slots as well as running attempts.
 
 Factory migrates existing SQLite databases to the expanded worker capacity

--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -75,10 +75,10 @@ func LoadConfig(path string) (Config, error) {
 	for index := range config.Runtimes {
 		config.Runtimes[index] = strings.ToLower(strings.TrimSpace(config.Runtimes[index]))
 	}
-	if config.Runtime == "" {
-		config.Runtime = protocol.RuntimeCodex
-	}
 	config.Runtimes = configuredRuntimes(config)
+	if config.Runtime == "" {
+		config.Runtime = config.Runtimes[0]
+	}
 	if !metadata.IsDefined("max_concurrent") {
 		config.MaxConcurrent = defaultMaxConcurrent
 	}

--- a/internal/worker/config_test.go
+++ b/internal/worker/config_test.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -44,7 +46,7 @@ func TestLoadConfigAcceptsSeveralCodingAgentRuntimes(t *testing.T) {
 	}
 }
 
-func TestLoadConfigPreservesCodexPrimaryWhenAddingRuntimes(t *testing.T) {
+func TestLoadConfigDefaultsPrimaryToFirstConfiguredRuntime(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "worker.toml")
 	body := "name = \"local\"\nruntimes = [\"pi\", \"codex\", \"claude-code\"]\n"
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
@@ -55,8 +57,38 @@ func TestLoadConfigPreservesCodexPrimaryWhenAddingRuntimes(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []string{protocol.RuntimePi, protocol.RuntimeCodex, protocol.RuntimeClaudeCode}
+	if config.Runtime != protocol.RuntimePi || !reflect.DeepEqual(config.Runtimes, want) {
+		t.Fatalf("upgraded multi-runtime config = %q %#v, want pi %#v", config.Runtime, config.Runtimes, want)
+	}
+}
+
+func TestLoadConfigAcceptsRuntimesWithoutRuntime(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "worker.toml")
+	if err := os.WriteFile(path, []byte("name = \"w\"\nruntimes = [\"pi\"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{protocol.RuntimePi}
+	if config.Runtime != protocol.RuntimePi || !reflect.DeepEqual(config.Runtimes, want) {
+		t.Fatalf("runtimes-only config = %q %#v, want pi %#v", config.Runtime, config.Runtimes, want)
+	}
+}
+
+func TestLoadConfigDefaultsBothRuntimeFieldsToCodex(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "worker.toml")
+	if err := os.WriteFile(path, []byte("name = \"w\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{protocol.RuntimeCodex}
 	if config.Runtime != protocol.RuntimeCodex || !reflect.DeepEqual(config.Runtimes, want) {
-		t.Fatalf("upgraded multi-runtime config = %q %#v, want codex %#v", config.Runtime, config.Runtimes, want)
+		t.Fatalf("empty runtime config = %q %#v, want codex %#v", config.Runtime, config.Runtimes, want)
 	}
 }
 
@@ -108,5 +140,21 @@ func TestLoadConfigRejectsExplicitZeroCapacity(t *testing.T) {
 	}
 	if _, err := LoadConfig(path); err == nil || !strings.Contains(err.Error(), "between 1 and 100") {
 		t.Fatalf("explicit zero max_concurrent error = %v", err)
+	}
+}
+
+func TestNewDefaultsPrimaryToFirstConfiguredRuntime(t *testing.T) {
+	codexPath := filepath.Join(t.TempDir(), "codex")
+	writeFakeCodex(t, codexPath)
+	manager, err := New(Config{
+		Server: defaultServer, Name: "runtimes-only", Runtimes: []string{protocol.RuntimePi}, MaxConcurrent: 1,
+		DataDirectory: filepath.Join(t.TempDir(), "worker"),
+	}, testOptions(codexPath), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = manager.Close() })
+	if manager.config.Runtime != protocol.RuntimePi {
+		t.Fatalf("primary runtime = %q, want pi", manager.config.Runtime)
 	}
 }

--- a/internal/worker/manager.go
+++ b/internal/worker/manager.go
@@ -95,10 +95,10 @@ func New(config Config, options Options, logger *slog.Logger) (*Manager, error) 
 	if err := ensureSupportedPlatform(); err != nil {
 		return nil, err
 	}
-	if config.Runtime == "" {
-		config.Runtime = protocol.RuntimeCodex
-	}
 	config.Runtimes = configuredRuntimes(config)
+	if config.Runtime == "" {
+		config.Runtime = config.Runtimes[0]
+	}
 	if err := validateConfig(config); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

A worker config that sets `runtimes` but not `runtime` fails to load:

```toml
name = "w"
runtimes = ["pi"]
```

```
err=runtime must also appear in runtimes when both fields are set
```

`LoadConfig` (`internal/worker/config.go:78`) and `Manager.New` (`internal/worker/manager.go:99`) set `config.Runtime = protocol.RuntimeCodex` before validation, so validation compared codex against `["pi"]`. The fallback in `validateConfig` that was meant to cover this was unreachable from those paths.

## Fix

Both call sites now resolve `Runtimes` first and default `Runtime` to `Runtimes[0]`. When neither field is set, `configuredRuntimes` still yields codex, so existing single-runtime configs are unchanged.

## Behaviour change worth noting

A config listing `runtimes = ["pi", "codex", "claude-code"]` with no `runtime` now gets `pi` as its primary runtime instead of codex. That follows the issue's suggested fix (first configured runtime wins) and is what the field ordering implies. `TestLoadConfigPreservesCodexPrimaryWhenAddingRuntimes` is renamed and updated to assert the new rule.

## Tests

- `TestLoadConfigAcceptsRuntimesWithoutRuntime` covers the issue repro.
- `TestLoadConfigDefaultsBothRuntimeFieldsToCodex` covers neither field set.
- `TestNewDefaultsPrimaryToFirstConfiguredRuntime` covers the `Manager.New` path.

Docs in `docs/worker.md` and `docs/local.md` note the defaulting rule.

`just format-check vet staticcheck boundary`, `go test ./...`, and `just test-worker-race` all pass locally.

Fixes #329

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker configurations can now omit the primary runtime when a runtime list is provided; the first listed runtime is selected automatically.
  * If no runtime settings are provided, Codex remains the default.
  * Documentation now explains runtime fallback behavior and per-task process isolation.

* **Tests**
  * Added coverage for runtime selection and default configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->