### PR TITLE
feat: add Factory open-source front door

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Public site
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - site/**
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site
+      - name: Deploy public site
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -1,201 +1,137 @@
 # Factory
 
-**Developer preview**
+**Run repeatable software work through AI coding agents across repositories and machines.**
 
-Factory is currently in *developer preview* and is iterating rapidly.
-**THERE WILL BE COMPATIBILITY-BREAKING CHANGES.**
+[![CI](https://github.com/owainlewis/factory/actions/workflows/ci.yml/badge.svg)](https://github.com/owainlewis/factory/actions/workflows/ci.yml)
+[![MIT license](https://img.shields.io/badge/license-MIT-white.svg)](LICENSE)
+[![Developer preview](https://img.shields.io/badge/status-developer%20preview-5b7cfa.svg)](#project-status)
 
-Factory runs repeatable software-engineering Runs across Git repositories and
-compute. Operators save prompts as Tasks, run them now, or schedule them
-across one or more repositories. Its Go control plane coordinates Runs and a
-fleet of Workers that provide Pi, Codex, or Claude Code runtimes.
+[Website](https://owainlewis.github.io/factory/) ·
+[Quick start](#quick-start) ·
+[Documentation](docs/README.md) ·
+[Architecture](ARCHITECTURE.md) ·
+[Contributing](CONTRIBUTING.md)
 
-The browser UI provides:
+Factory is an open-source, local-first control plane for coding agents. Define
+software work once, run it across one or many Git repositories, and see every
+agent, worktree, result, failure, and retry in one place.
 
-- an operational overview of active, completed, and attention-needed Runs;
-- Tasks with prompts, repositories, runtime settings, and optional schedules;
-- table, list, and board views of Runs, with per-repository Session details;
-- registered worker and repository status;
+It is designed for builders who have outgrown a collection of terminal windows
+but still want agents to run on infrastructure and credentials they control.
 
-Factory is local-first. Its browser and operator API accept loopback connections
-only. An optional, separate TLS-authenticated endpoint accepts Workers on remote
-VMs.
+```text
+Define work  ->  Dispatch repositories  ->  Run agents  ->  Inspect outcomes
+                       |                       |
+                       +-- Git worktrees       +-- Pi, Codex, Claude Code
+                       +-- local or VM Workers +-- bounded concurrency
+```
 
-Factory starts with coding agents on machines you control and is intended to
-scale to elastic cloud execution without rewriting a Task or splitting its
-Run history. Existing Tasks remain persistent by default. Once the proposed
-cloud backend is implemented, a manual run will be able to select a compatible
-elastic profile. Persistent local and VM Workers remain the rich path for
-subscription authentication, warm repository caches, and inspectable
-worktrees. A proposed
-Cloud Run backend adds disposable, API-backed agent containers for bursty and
-parallel Runs. Read the
-[Cloud Run agent backend design](docs/cloud-run-agents/design.md) for the
-planned boundary, security model, and rollout.
+## What Factory gives you
 
-Read the [product vision](docs/software-factory/vision.md), the
-[current implementation architecture](ARCHITECTURE.md), and the active
-[Cloud Run backend design](docs/cloud-run-agents/design.md). Planned work
-follows the [project workflow](WORKFLOW.md). Superseded proposals remain
-available through the [documentation index](docs/README.md).
+- **Repeatable software work.** Save a prompt, repository scope, runtime,
+  schedule, and execution settings as one Task.
+- **One operational view.** Follow active Runs, repository Sessions, Attempts,
+  agent events, results, failures, and retained worktrees from the browser.
+- **A worker fleet you control.** Run Pi, Codex, or Claude Code on a laptop,
+  workstation, or remote VM without exposing the operator API publicly.
+- **Git-native isolation.** Every Attempt runs in its own worktree. Clean work
+  is reclaimed while unpublished or failed work remains inspectable.
+- **Durable coordination.** SQLite state, leases, heartbeats, retries,
+  cancellation, schedules, and bounded APIs survive process restarts.
 
 ## Quick start
 
 Requirements:
 
 - Go 1.25.13 or newer on the 1.25 release line, or Go 1.26.6 or newer
-- Git
-- `curl`
-- `just`
-- Codex CLI or Claude Code CLI, authenticated on the worker host
-
-Node.js is only needed when changing the UI. Normal builds use the committed,
-embedded UI assets.
-
-Managed GitHub repository checkout and Tasks that allow the `gh` tool depend
-on the GitHub CLI. Factory does not include a separate GitHub API client.
-Install and authenticate [`gh`](https://cli.github.com/) on the control-plane
-host and each eligible Worker host:
+- Git, `curl`, and `just`
+- An authenticated Pi, Codex, or Claude Code CLI on the Worker host
+- GitHub CLI when using managed GitHub repositories
 
 ```sh
-gh --version
-gh auth status
-```
-
-```sh
+git clone https://github.com/owainlewis/factory.git
+cd factory
 just build
 mkdir -p ~/.factory
 cp examples/worker.toml ~/.factory/worker.toml
-```
-
-Edit `~/.factory/worker.toml` to select any installed `pi`, `codex`, and
-`claude-code` agents. Workers need no repository list. They probe local `gh`
-access and acquire centrally managed GitHub repositories on demand. Then start
-the server and Worker:
-
-```sh
 just run
 ```
 
-Open [http://127.0.0.1:7337](http://127.0.0.1:7337).
+Open [http://127.0.0.1:7337](http://127.0.0.1:7337). Edit
+`~/.factory/worker.toml` to enable the agent runtimes installed on your machine.
+The [local guide](docs/local.md) covers authentication, repository setup, and
+the complete first Run.
 
-Database migration 27 converts supported pre-launch Definitions, schedules,
-and execution history into the current lifecycle model after the database is
-backed up, and migration 30 renames that schema and its records to Tasks, Runs,
-and Sessions. Unsupported legacy provider admission is blocked and reported
-instead of being silently discarded.
+Node.js is only required when changing the browser UI. Normal builds use the
+committed embedded assets.
 
-One Worker has one stable identity, a configurable set of coding-agent
-capabilities, and a pool of independent sessions. The pool defaults to ten
-slots. A single local Worker can advertise Pi, Codex, and Claude Code:
+## How it works
 
-```sh
-FACTORY_WORKER_CONFIG=~/.factory/worker.toml \
-  ~/.factory/bin/factory-worker
-```
-
-See the [local guide](docs/local.md) for a complete setup and the
-[worker guide](docs/worker.md) for runtime and worktree behavior. Use the
-[remote VM guide](docs/remote-workers.md) to enroll a Worker outside the server
-host. Tagged binary
-installation, upgrades, compatibility, rollback, and release verification are
-covered by the [release guide](docs/release.md).
-
-## Architecture
+The Go control plane owns Tasks, Runs, schedules, durable state, and admission.
+Workers poll for eligible Sessions, prepare isolated Git worktrees, supervise
+the selected coding-agent runtime, and report bounded events and results.
 
 ```text
 Browser
    |
-   | HTTP + JSON
+   | loopback HTTP + JSON
    v
-Go control plane
-  SQLite, Task scheduler, Run admission, embedded UI
+Factory control plane
+  SQLite, scheduler, Run admission, embedded UI
    ^
-   | registration, claim, heartbeat, events, completion
+   | authenticated polling, leases, events, completion
    |
-Go Workers
-  one identity + ready runtime capabilities + N agent slots + repository cache
+Factory Workers
+  repository cache, isolated worktrees, agent slots
    |
-   +-- Pi CLI
-   +-- Codex CLI
-   `-- Claude Code CLI
+   +-- Pi
+   +-- Codex
+   `-- Claude Code
 ```
 
-The control plane owns durable coordination. Workers own execution and Git
-worktrees. Workers poll the API, so the system does not require WebSockets or
-inbound connections to worker hosts.
+The operator surface stays on loopback. Remote Workers use a separate,
+TLS-authenticated endpoint. The control plane stores coordination metadata,
+while Workers retain Git contents, runtime credentials, and worktrees. Read the
+[architecture](ARCHITECTURE.md) and [security policy](SECURITY.md) before
+running untrusted code.
 
-The future execution model keeps three choices independent:
+## Project status
 
-```text
-Execution backend     Agent runtime              Provider and model
------------------     -------------              ------------------
-Persistent Worker  +  Pi, Codex, Claude Code  +  subscription or API
-Cloud Run Job      +  Pi, Codex, Claude Code  +  API-backed model
-```
+Factory is in **developer preview**. Compatibility-breaking changes are
+expected while the product model settles.
 
-Cloud Run is a proposed execution backend, not a DeepSeek-specific product.
-For example, the completed experiment ran the Pi runtime in Cloud Run with
-DeepSeek V4 Flash through OpenRouter. Cloud execution is managed and elastic,
-but not infrastructure-free, infinitely scalable, or a hostile-code sandbox.
+Implemented today:
 
-All default state is below `~/.factory`:
+- Go control-plane API and embedded React UI
+- durable Tasks, Runs, Sessions, Attempts, leases, events, and cancellation
+- manual and scheduled work across one or many repositories
+- Pi, Codex, and Claude Code Worker capabilities
+- managed repository catalog, Worker caches, and isolated Git worktrees
+- table, list, and Kanban Run views with repository-level detail
+- local Workers and authenticated remote VM Workers
 
-```text
-~/.factory/
-  bin/
-  server/factory.sqlite3
-  config.toml       optional control-plane bootstrap only
-  worker.toml
-  workers/
-```
-
-Read the [architecture](ARCHITECTURE.md) for the contracts and
-security boundaries.
-
-## Current scope
-
-Implemented:
-
-- Go control-plane API and embedded React UI;
-- durable Tasks, Runs, Sessions, executions, attempts, leases, events, and
-  cancellation;
-- Pi, Codex, and Claude Code Worker capabilities;
-- manual and scheduled Task admission across one or more repositories;
-- versioned Task prompts, execution settings, repository scope, and optional
-  schedules;
-- a central managed-repository catalog, bounded worker caches, and isolated Git
-  worktrees;
-- bounded list APIs and retained-data metrics;
-- automatic cleanup of clean unchanged or published work and preservation of
-  unpublished branches.
-
-Designed but not implemented: a unified `factory` CLI and an elastic Cloud Run
-agent backend.
-
-See the [documentation index](docs/README.md) for current guides and proposed
-designs.
+Active product work is moving Factory toward ordered software pipelines and a
+software-work graph while keeping general business tracking outside the
+product. See the [software pipelines proposal](https://github.com/owainlewis/factory/pull/333)
+and the [product vision](docs/software-factory/vision.md).
 
 ## Development
-
-Backend:
 
 ```sh
 just test
 just vet
-```
-
-UI:
-
-```sh
-just ui-install
 just ui-check
 ```
 
-After changing the UI, rebuild the committed assets:
+Browser-facing changes are proven against a real Go server with:
 
 ```sh
-just ui-build 0
+just test-browser
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full check set.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full check set and project
+workflow. Proposed and historical designs are indexed in [docs](docs/README.md).
+
+## License
+
+Factory is available under the [MIT License](LICENSE).

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#0d0f12"/>
+  <path d="M13 18 25 12l12 6-12 6-12-6Zm0 14 12-6 12 6-12 6-12-6Zm0 14 12-6 12 6-12 6-12-6ZM39 25l12-6v14l-12 6V25Zm0 16 12-6v11l-12 6V41Z" fill="none" stroke="#e9eaec" stroke-width="3" stroke-linejoin="round"/>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,216 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#090a0c" />
+    <meta
+      name="description"
+      content="Factory is an open-source, local-first control plane for running repeatable software work through AI coding agents."
+    />
+    <meta property="og:title" content="Factory | A control plane for coding agents" />
+    <meta
+      property="og:description"
+      content="Run repeatable software work across repositories and machines. See every agent, worktree, result, and failure in one place."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://owainlewis.github.io/factory/" />
+    <meta name="twitter:card" content="summary" />
+    <link rel="canonical" href="https://owainlewis.github.io/factory/" />
+    <link rel="icon" href="favicon.svg" type="image/svg+xml" />
+    <link rel="stylesheet" href="styles.css" />
+    <title>Factory | A control plane for coding agents</title>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <a class="wordmark" href="#top" aria-label="Factory home">
+        <span class="brand-mark" aria-hidden="true">
+          <span></span><span></span><span></span>
+        </span>
+        <span>Factory</span>
+        <span class="preview-label">Developer preview</span>
+      </a>
+      <nav aria-label="Primary navigation">
+        <a href="#workflow">Workflow</a>
+        <a href="#architecture">Architecture</a>
+        <a href="https://github.com/owainlewis/factory/tree/main/docs">Docs</a>
+        <a class="header-github" href="https://github.com/owainlewis/factory">GitHub</a>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section class="hero" id="top">
+        <div class="hero-copy">
+          <p class="eyebrow"><span></span> Open source · local first · MIT licensed</p>
+          <h1>Software work,<br /><em>under control.</em></h1>
+          <p class="hero-lede">
+            Factory is a control plane for coding agents. Define work once, run it across
+            repositories and machines, and inspect every agent, worktree, result, and failure
+            from one place.
+          </p>
+          <div class="hero-actions">
+            <a class="button button-primary" href="https://github.com/owainlewis/factory">View on GitHub</a>
+            <a class="button button-secondary" href="#quick-start">Run it locally</a>
+          </div>
+          <dl class="hero-facts" aria-label="Project facts">
+            <div><dt>Control plane</dt><dd>Go + SQLite</dd></div>
+            <div><dt>Agent runtimes</dt><dd>Pi · Codex · Claude Code</dd></div>
+            <div><dt>Execution</dt><dd>Local + remote Workers</dd></div>
+          </dl>
+        </div>
+
+        <div class="product-window" aria-label="Example Factory Run overview">
+          <div class="window-bar">
+            <div class="window-brand"><span class="brand-mark brand-mark-small" aria-hidden="true"><span></span><span></span><span></span></span> Factory</div>
+            <div class="window-status"><i></i> 4 Workers online</div>
+          </div>
+          <div class="window-body">
+            <aside aria-label="Example navigation">
+              <b>Work</b>
+              <span>Overview</span>
+              <span class="active">Runs <small>6</small></span>
+              <span>Tasks</span>
+              <span>Workers <small>4</small></span>
+              <span>Repositories</span>
+            </aside>
+            <div class="run-view">
+              <div class="run-heading">
+                <div><small>ACTIVE RUN</small><strong>Ship checkout reliability fixes</strong></div>
+                <span>3 repositories</span>
+              </div>
+              <div class="run-summary">
+                <span><i class="blue"></i> 1 running</span>
+                <span><i class="amber"></i> 1 blocked</span>
+                <span><i class="green"></i> 1 succeeded</span>
+              </div>
+              <article class="work-card running-card">
+                <div class="card-state"><i class="blue"></i> Running <span>06:12</span></div>
+                <h2>factory</h2>
+                <p>Review the checkout flow and fix the failing integration test.</p>
+                <div class="agent-row"><span>Codex</span><span>Inspecting payment handler</span></div>
+                <div class="progress"><span></span></div>
+              </article>
+              <article class="work-card blocked-card">
+                <div class="card-state"><i class="amber"></i> Blocked <span>just now</span></div>
+                <h2>storefront</h2>
+                <p>No compatible Worker is currently eligible for this repository.</p>
+                <div class="detail-row"><span>Required runtime: Codex</span><b>View details →</b></div>
+              </article>
+              <article class="work-card complete-card">
+                <div class="card-state"><i class="green"></i> Succeeded <span>4m ago</span></div>
+                <h2>payments-sdk</h2>
+                <p>Updated retry documentation and added examples.</p>
+                <div class="agent-row"><span>Pi</span><span>Worktree retained for review</span></div>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="signal-strip" aria-label="Factory principles">
+        <span>Repeatable work</span><i></i><span>Isolated Git worktrees</span><i></i><span>Durable coordination</span><i></i><span>Infrastructure you control</span>
+      </section>
+
+      <section class="section workflow" id="workflow">
+        <div class="section-intro">
+          <p class="section-kicker">How it works</p>
+          <h2>From a saved task to inspectable code.</h2>
+          <p>Factory coordinates the work around coding agents without hiding the Git repository or the machine doing the execution.</p>
+        </div>
+        <ol class="workflow-grid">
+          <li><span>01</span><h3>Define</h3><p>Save the prompt, runtime, repository scope, schedule, and execution settings.</p></li>
+          <li><span>02</span><h3>Dispatch</h3><p>Create one Run and route each repository Session to an eligible Worker.</p></li>
+          <li><span>03</span><h3>Execute</h3><p>Run Pi, Codex, or Claude Code inside a fresh Git worktree with bounded concurrency.</p></li>
+          <li><span>04</span><h3>Inspect</h3><p>Review events, output, failures, branches, retries, and retained work from one browser.</p></li>
+        </ol>
+      </section>
+
+      <section class="section feature-section">
+        <div class="section-intro compact">
+          <p class="section-kicker">Built for real software work</p>
+          <h2>Coordination without surrendering control.</h2>
+        </div>
+        <div class="feature-grid">
+          <article><span class="feature-icon">↻</span><h3>Repeatable by default</h3><p>Tasks preserve prompts and execution settings. Run them now, on a schedule, or across many repositories.</p></article>
+          <article><span class="feature-icon">⌘</span><h3>One operational surface</h3><p>See queued, active, blocked, failed, and completed work without reconstructing state from terminals.</p></article>
+          <article><span class="feature-icon">⑂</span><h3>Git-native isolation</h3><p>Attempts use independent worktrees. Failed and unpublished work stays available for inspection.</p></article>
+          <article><span class="feature-icon">⌁</span><h3>Fleet-aware execution</h3><p>Workers advertise healthy runtimes and capacity from local machines or authenticated remote VMs.</p></article>
+          <article><span class="feature-icon">◎</span><h3>Local-first authority</h3><p>The browser and operator API stay on loopback. Repository data and runtime credentials stay on Workers.</p></article>
+          <article><span class="feature-icon">◫</span><h3>Honest observability</h3><p>Attempts, leases, events, results, cancellation, and retained work remain explicit rather than magical.</p></article>
+        </div>
+      </section>
+
+      <section class="section architecture" id="architecture">
+        <div class="architecture-copy">
+          <p class="section-kicker">Architecture</p>
+          <h2>A small control plane.<br />Workers do the work.</h2>
+          <p>
+            Factory keeps durable coordination in a Go service backed by SQLite. Workers poll for
+            eligible work, prepare repositories, supervise agents, and report bounded results.
+          </p>
+          <a href="https://github.com/owainlewis/factory/blob/main/ARCHITECTURE.md">Read the architecture →</a>
+        </div>
+        <div class="architecture-diagram" aria-label="Factory architecture flow">
+          <div class="diagram-node browser-node"><small>OPERATOR</small><strong>Browser + API</strong><span>Loopback only</span></div>
+          <div class="connector"><span>HTTP + JSON</span></div>
+          <div class="diagram-node control-node"><small>CONTROL PLANE</small><strong>Factory server</strong><span>Tasks · Runs · SQLite · scheduler</span></div>
+          <div class="connector"><span>Leases + events</span></div>
+          <div class="worker-nodes">
+            <div class="diagram-node"><small>WORKER 01</small><strong>Local machine</strong><span>Codex · 4 slots</span></div>
+            <div class="diagram-node"><small>WORKER 02</small><strong>Remote VM</strong><span>Pi · Claude Code · 10 slots</span></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section status-section">
+        <div class="status-card">
+          <div>
+            <p class="section-kicker">Developer preview</p>
+            <h2>Useful now. Still changing.</h2>
+            <p>Factory already runs durable, scheduled coding work across Worker fleets. Compatibility-breaking changes are expected while the product moves toward ordered software pipelines and a software-work graph.</p>
+          </div>
+          <div class="status-columns">
+            <div><h3>Available today</h3><ul><li>Tasks and scheduled Runs</li><li>Multi-repository execution</li><li>Pi, Codex, and Claude Code</li><li>Local and remote Workers</li><li>Run table, list, and Kanban</li></ul></div>
+            <div><h3>Active direction</h3><ul><li>Ordered agent stages</li><li>Repository pipeline tracks</li><li>Software-work graph</li><li>Clear needs-you states</li><li>Delivery evidence</li></ul></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section quick-start" id="quick-start">
+        <div>
+          <p class="section-kicker">Run it locally</p>
+          <h2>Your agents. Your machines.<br />One control plane.</h2>
+          <p>Factory is open source under the MIT license. Start with one local Worker, then add machines when the work demands it.</p>
+        </div>
+        <div class="terminal" aria-label="Factory installation commands">
+          <div class="terminal-bar"><span></span><span></span><span></span><b>terminal</b></div>
+          <pre><code><i>$</i> git clone https://github.com/owainlewis/factory.git
+<i>$</i> cd factory
+<i>$</i> just build
+<i>$</i> mkdir -p ~/.factory
+<i>$</i> cp examples/worker.toml ~/.factory/worker.toml
+<i>$</i> just run</code></pre>
+          <p>Open <strong>127.0.0.1:7337</strong></p>
+        </div>
+      </section>
+
+      <section class="final-cta">
+        <p class="section-kicker">Build in the open</p>
+        <h2>Make software work visible.</h2>
+        <p>Try Factory, inspect the architecture, and help shape an open-source control plane for coding agents.</p>
+        <div class="hero-actions">
+          <a class="button button-primary" href="https://github.com/owainlewis/factory">Explore Factory on GitHub</a>
+          <a class="button button-secondary" href="https://github.com/owainlewis/factory/blob/main/CONTRIBUTING.md">Contribute</a>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <a class="wordmark" href="#top"><span class="brand-mark brand-mark-small" aria-hidden="true"><span></span><span></span><span></span></span><span>Factory</span></a>
+      <p>Open source software under the MIT License.</p>
+      <nav aria-label="Footer navigation"><a href="https://github.com/owainlewis/factory">GitHub</a><a href="https://github.com/owainlewis/factory/tree/main/docs">Docs</a><a href="https://github.com/owainlewis/factory/blob/main/SECURITY.md">Security</a></nav>
+    </footer>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -40,7 +40,7 @@
       </nav>
     </header>
 
-    <main id="main">
+    <main id="main" tabindex="-1">
       <section class="hero" id="top">
         <div class="hero-copy">
           <p class="eyebrow"><span></span> Open source · local first · MIT licensed</p>

--- a/site/styles.css
+++ b/site/styles.css
@@ -12,11 +12,12 @@
   --green: #61bc8c;
   --amber: #d7a552;
   --radius: 12px;
-  --mono: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
-  --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: ui-monospace, "SFMono-Regular", menlo, consolas, monospace;
+  --sans: inter, ui-sans-serif, -apple-system, blinkmacsystemfont, "Segoe UI", sans-serif;
+
   font-family: var(--sans);
   font-synthesis: none;
-  text-rendering: optimizeLegibility;
+  text-rendering: optimizelegibility;
   background: var(--bg);
   color: var(--text);
 }
@@ -164,6 +165,7 @@ main { overflow: hidden; }
 .product-window {
   position: relative;
   width: 700px;
+  max-width: 100%;
   border: 1px solid #30343c;
   border-radius: var(--radius);
   background: #0b0c0f;

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,359 @@
+:root {
+  color-scheme: dark;
+  --bg: #090a0c;
+  --surface: #101216;
+  --surface-2: #15181d;
+  --line: #252930;
+  --line-bright: #363b45;
+  --text: #eceef1;
+  --muted: #9a9fa9;
+  --quiet: #858b96;
+  --blue: #7b96ff;
+  --green: #61bc8c;
+  --amber: #d7a552;
+  --radius: 12px;
+  --mono: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: var(--sans);
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  background: var(--bg);
+  color: var(--text);
+}
+
+* { box-sizing: border-box; }
+html { min-width: 320px; scroll-behavior: smooth; }
+body { margin: 0; min-width: 320px; overflow-x: hidden; background: var(--bg); color: var(--text); }
+a { color: inherit; text-decoration: none; }
+a:focus-visible { outline: 2px solid var(--blue); outline-offset: 4px; border-radius: 3px; }
+p, h1, h2, h3, dl, dd { margin-top: 0; }
+
+.skip-link {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 100;
+  padding: 9px 12px;
+  border-radius: 7px;
+  background: var(--text);
+  color: var(--bg);
+  transform: translateY(-160%);
+  transition: transform 120ms ease;
+}
+.skip-link:focus { transform: translateY(0); }
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  width: min(1180px, calc(100% - 40px));
+  height: 68px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(255, 255, 255, .1);
+  background: rgba(9, 10, 12, .88);
+  backdrop-filter: blur(16px);
+}
+.wordmark { display: inline-flex; align-items: center; gap: 10px; font-weight: 650; letter-spacing: -.02em; }
+.brand-mark {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  align-items: end;
+  gap: 2px;
+  padding: 6px;
+  border: 1px solid var(--line-bright);
+  border-radius: 7px;
+  background: var(--surface);
+}
+.brand-mark span { display: block; border: 1px solid #a9adb4; border-radius: 1px; }
+.brand-mark span:nth-child(1) { height: 8px; }
+.brand-mark span:nth-child(2) { height: 14px; }
+.brand-mark span:nth-child(3) { height: 11px; }
+.brand-mark-small { width: 23px; height: 23px; padding: 5px; border-radius: 6px; }
+.brand-mark-small span:nth-child(1) { height: 6px; }
+.brand-mark-small span:nth-child(2) { height: 11px; }
+.brand-mark-small span:nth-child(3) { height: 8px; }
+.preview-label {
+  margin-left: 5px;
+  padding: 3px 6px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+.site-header nav, footer nav { display: flex; align-items: center; gap: 26px; font-size: 13px; color: var(--muted); }
+.site-header nav a:hover, footer nav a:hover { color: var(--text); }
+.site-header .header-github { padding: 8px 12px; border: 1px solid var(--line-bright); border-radius: 7px; color: var(--text); }
+
+main { overflow: hidden; }
+.hero {
+  position: relative;
+  width: min(1180px, calc(100% - 40px));
+  min-height: 720px;
+  margin: 0 auto;
+  padding: 105px 0 92px;
+  display: grid;
+  grid-template-columns: minmax(0, .83fr) minmax(570px, 1.17fr);
+  align-items: center;
+  gap: 58px;
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  top: -240px;
+  left: 25%;
+  width: 760px;
+  height: 600px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(91, 124, 250, .12), transparent 68%);
+  pointer-events: none;
+}
+.eyebrow, .section-kicker {
+  margin-bottom: 19px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.eyebrow { display: flex; align-items: center; gap: 9px; }
+.eyebrow span { width: 6px; height: 6px; border-radius: 50%; background: var(--green); box-shadow: 0 0 0 4px rgba(97, 188, 140, .08); }
+.hero h1 {
+  margin-bottom: 26px;
+  font-size: clamp(54px, 6vw, 80px);
+  line-height: .97;
+  letter-spacing: -.065em;
+  font-weight: 650;
+}
+.hero h1 em { font-style: normal; color: #838995; }
+.hero-lede { max-width: 610px; margin-bottom: 31px; font-size: 18px; line-height: 1.67; color: #adb2bc; }
+.hero-actions { display: flex; flex-wrap: wrap; gap: 10px; }
+.button {
+  min-height: 44px;
+  padding: 0 17px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  transition: transform 140ms ease, background 140ms ease, border-color 140ms ease;
+}
+.button:hover { transform: translateY(-1px); }
+.button-primary { background: var(--text); color: #0a0b0d; }
+.button-primary:hover { background: white; }
+.button-secondary { border-color: var(--line-bright); background: rgba(255, 255, 255, .025); color: var(--text); }
+.button-secondary:hover { border-color: #515762; background: rgba(255, 255, 255, .05); }
+.hero-facts { margin: 52px 0 0; display: grid; gap: 13px; }
+.hero-facts div { display: grid; grid-template-columns: 118px 1fr; gap: 12px; font-family: var(--mono); font-size: 11px; }
+.hero-facts dt { color: var(--quiet); }
+.hero-facts dd { margin: 0; color: var(--muted); }
+
+.product-window {
+  position: relative;
+  width: 700px;
+  border: 1px solid #30343c;
+  border-radius: var(--radius);
+  background: #0b0c0f;
+  box-shadow: 0 45px 100px rgba(0, 0, 0, .45), 0 0 0 8px rgba(255, 255, 255, .015);
+  overflow: hidden;
+}
+.product-window::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 1px rgba(255, 255, 255, .035);
+  pointer-events: none;
+}
+.window-bar { height: 52px; padding: 0 16px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid #202329; font-size: 12px; }
+.window-brand { display: flex; align-items: center; gap: 8px; font-weight: 600; }
+.window-status { display: flex; align-items: center; gap: 7px; font-family: var(--mono); font-size: 9px; color: var(--quiet); }
+.window-status i { width: 5px; height: 5px; border-radius: 50%; background: var(--green); }
+.window-body { min-height: 510px; display: grid; grid-template-columns: 138px 1fr; }
+.window-body aside { padding: 23px 10px; border-right: 1px solid #202329; display: flex; flex-direction: column; gap: 5px; color: var(--quiet); font-size: 11px; }
+.window-body aside b { padding: 0 9px 10px; font-family: var(--mono); font-size: 9px; letter-spacing: .08em; text-transform: uppercase; color: var(--quiet); }
+.window-body aside span { padding: 8px 9px; border-radius: 5px; }
+.window-body aside span small { float: right; font-family: var(--mono); font-size: 9px; }
+.window-body aside .active { color: #dcdee3; background: #17191e; box-shadow: inset 0 0 0 1px #24272d; }
+.run-view { padding: 24px; background: linear-gradient(180deg, #0d0f12, #0a0b0e); }
+.run-heading { margin-bottom: 15px; display: flex; align-items: end; justify-content: space-between; }
+.run-heading div { display: grid; gap: 6px; }
+.run-heading small { font-family: var(--mono); font-size: 8px; letter-spacing: .09em; color: var(--quiet); }
+.run-heading strong { font-size: 14px; letter-spacing: -.01em; }
+.run-heading > span { font-family: var(--mono); font-size: 9px; color: var(--quiet); }
+.run-summary { padding: 9px 11px; display: flex; gap: 15px; border: 1px solid #202329; border-radius: 6px; font-family: var(--mono); font-size: 8px; color: var(--quiet); }
+.run-summary span, .card-state { display: flex; align-items: center; gap: 6px; }
+.run-summary i, .card-state i { width: 5px; height: 5px; border-radius: 50%; }
+.blue { background: var(--blue); }
+.amber { background: var(--amber); }
+.green { background: var(--green); }
+.work-card { margin-top: 10px; padding: 14px 15px; border: 1px solid #24272d; border-radius: 7px; background: #13151a; }
+.running-card { border-left: 2px solid var(--blue); }
+.blocked-card { border-left: 2px solid var(--amber); }
+.complete-card { border-left: 2px solid var(--green); }
+.card-state { margin-bottom: 9px; font-family: var(--mono); font-size: 8px; color: #8b9099; }
+.card-state span { margin-left: auto; color: var(--quiet); }
+.work-card h2 { margin-bottom: 5px; font-size: 12px; font-weight: 650; }
+.work-card p { margin-bottom: 12px; font-size: 10px; line-height: 1.5; color: var(--quiet); }
+.agent-row, .detail-row { display: flex; justify-content: space-between; font-family: var(--mono); font-size: 8px; color: var(--quiet); }
+.agent-row span:first-child { color: #9ca1ab; }
+.detail-row { padding-top: 9px; border-top: 1px solid #24272d; }
+.detail-row b { color: #d9b778; font-weight: 500; }
+.progress { height: 2px; margin-top: 11px; border-radius: 2px; background: #242831; overflow: hidden; }
+.progress span { display: block; width: 62%; height: 100%; background: var(--blue); }
+
+.signal-strip {
+  min-height: 70px;
+  padding: 20px max(20px, calc((100% - 1180px) / 2));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: #0c0d10;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--quiet);
+}
+.signal-strip i { width: 3px; height: 3px; border-radius: 50%; background: #3c414a; }
+
+.section { width: min(1180px, calc(100% - 40px)); margin: 0 auto; padding: 130px 0; }
+.section-intro { max-width: 670px; margin-bottom: 62px; }
+.section-intro.compact { max-width: 740px; }
+.section-kicker { margin-bottom: 15px; color: var(--quiet); }
+.section h2, .final-cta h2 { margin-bottom: 20px; font-size: clamp(34px, 4.3vw, 58px); line-height: 1.06; letter-spacing: -.045em; font-weight: 620; }
+.section-intro > p:last-child, .architecture-copy > p, .quick-start > div > p:last-child, .final-cta > p:not(.section-kicker) { font-size: 17px; line-height: 1.7; color: var(--muted); }
+
+.workflow-grid { margin: 0; padding: 0; display: grid; grid-template-columns: repeat(4, 1fr); list-style: none; counter-reset: workflow; border-top: 1px solid var(--line); }
+.workflow-grid li { position: relative; min-height: 255px; padding: 27px 26px 25px 0; border-bottom: 1px solid var(--line); }
+.workflow-grid li:not(:last-child) { border-right: 1px solid var(--line); margin-right: 26px; }
+.workflow-grid li > span { display: block; margin-bottom: 82px; font-family: var(--mono); font-size: 10px; color: var(--quiet); }
+.workflow-grid li:not(:last-child)::after { content: "→"; position: absolute; right: -7px; top: 23px; padding: 0 5px; background: var(--bg); color: #4b5059; font-size: 12px; }
+.workflow-grid h3 { margin-bottom: 10px; font-size: 19px; letter-spacing: -.02em; }
+.workflow-grid p { margin: 0; font-size: 13px; line-height: 1.65; color: var(--muted); }
+
+.feature-section { border-top: 1px solid var(--line); }
+.feature-grid { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--line); border-left: 1px solid var(--line); }
+.feature-grid article { min-height: 255px; padding: 28px; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: linear-gradient(140deg, rgba(255, 255, 255, .018), transparent 55%); }
+.feature-icon { width: 34px; height: 34px; margin-bottom: 70px; display: grid; place-items: center; border: 1px solid var(--line-bright); border-radius: 7px; font-family: var(--mono); color: #b6bac2; background: var(--surface); }
+.feature-grid h3 { margin-bottom: 9px; font-size: 16px; letter-spacing: -.015em; }
+.feature-grid p { margin: 0; font-size: 13px; line-height: 1.65; color: var(--muted); }
+
+.architecture { display: grid; grid-template-columns: .8fr 1.2fr; gap: 100px; align-items: center; border-top: 1px solid var(--line); }
+.architecture-copy > p { max-width: 520px; }
+.architecture-copy > a { display: inline-block; margin-top: 8px; font-size: 14px; color: #c6c9cf; }
+.architecture-copy > a:hover { color: white; }
+.architecture-diagram { padding: 34px; border: 1px solid var(--line); border-radius: var(--radius); background: linear-gradient(145deg, #111318, #0c0e11); }
+.diagram-node { padding: 16px 18px; display: grid; gap: 5px; border: 1px solid #2d3139; border-radius: 8px; background: #15181d; }
+.diagram-node small { font-family: var(--mono); font-size: 8px; letter-spacing: .09em; color: var(--quiet); }
+.diagram-node strong { font-size: 14px; }
+.diagram-node span { font-family: var(--mono); font-size: 9px; color: var(--quiet); }
+.control-node { border-color: #455071; background: #171b27; }
+.connector { height: 56px; display: grid; place-items: center; position: relative; font-family: var(--mono); font-size: 8px; color: var(--quiet); }
+.connector::before { content: ""; position: absolute; top: 0; bottom: 0; left: 50%; border-left: 1px dashed #343943; }
+.connector span { position: relative; padding: 4px 8px; background: #0f1115; }
+.worker-nodes { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+
+.status-section { padding-top: 70px; }
+.status-card { padding: 58px; display: grid; grid-template-columns: .9fr 1.1fr; gap: 80px; border: 1px solid var(--line); border-radius: var(--radius); background: #0e1013; }
+.status-card > div > p:last-child { margin: 0; max-width: 490px; font-size: 15px; line-height: 1.75; color: var(--muted); }
+.status-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 34px; }
+.status-columns h3 { margin-bottom: 18px; font-family: var(--mono); font-size: 11px; letter-spacing: .07em; text-transform: uppercase; color: #a7abb3; }
+.status-columns ul { margin: 0; padding: 0; display: grid; gap: 12px; list-style: none; font-size: 13px; color: var(--muted); }
+.status-columns li::before { content: "·"; margin-right: 9px; color: #555b65; }
+
+.quick-start { display: grid; grid-template-columns: .9fr 1.1fr; gap: 90px; align-items: center; border-top: 1px solid var(--line); }
+.terminal { border: 1px solid #30343c; border-radius: var(--radius); background: #101216; box-shadow: 0 30px 70px rgba(0, 0, 0, .25); overflow: hidden; }
+.terminal-bar { height: 43px; padding: 0 14px; display: flex; align-items: center; gap: 6px; border-bottom: 1px solid #24272d; }
+.terminal-bar span { width: 7px; height: 7px; border-radius: 50%; background: #363b44; }
+.terminal-bar b { margin-left: auto; font-family: var(--mono); font-size: 8px; font-weight: 500; color: var(--quiet); }
+.terminal pre { margin: 0; padding: 24px; overflow-x: auto; font-family: var(--mono); font-size: 11px; line-height: 1.85; color: #c6cad1; }
+.terminal code i { color: var(--green); font-style: normal; }
+.terminal > p { margin: 0; padding: 12px 24px; border-top: 1px solid #24272d; font-family: var(--mono); font-size: 9px; color: var(--quiet); }
+.terminal > p strong { color: #9ba0aa; font-weight: 500; }
+
+.final-cta { width: min(920px, calc(100% - 40px)); margin: 10px auto 140px; padding: 86px 50px; text-align: center; border: 1px solid var(--line); border-radius: var(--radius); background: radial-gradient(circle at 50% 0%, rgba(123, 150, 255, .11), transparent 58%), #0e1013; }
+.final-cta > p:not(.section-kicker) { max-width: 640px; margin: 0 auto 30px; }
+.final-cta .hero-actions { justify-content: center; }
+
+footer { width: min(1180px, calc(100% - 40px)); min-height: 110px; margin: 0 auto; display: flex; align-items: center; gap: 30px; border-top: 1px solid var(--line); }
+footer p { margin: 0 auto; font-family: var(--mono); font-size: 9px; color: var(--quiet); }
+
+@media (max-width: 1050px) {
+  .hero { grid-template-columns: 1fr; padding-top: 90px; }
+  .hero-copy { max-width: 750px; }
+  .product-window { width: 100%; }
+  .workflow-grid { grid-template-columns: repeat(2, 1fr); }
+  .workflow-grid li:nth-child(2) { border-right: 0; margin-right: 0; }
+  .workflow-grid li:nth-child(2)::after { display: none; }
+  .feature-grid { grid-template-columns: repeat(2, 1fr); }
+  .architecture, .quick-start { grid-template-columns: 1fr; gap: 50px; }
+  .architecture-copy, .quick-start > div:first-child { max-width: 690px; }
+  .status-card { grid-template-columns: 1fr; gap: 50px; }
+}
+
+@media (max-width: 720px) {
+  .site-header { width: min(100% - 28px, 1180px); height: 62px; }
+  .site-header nav { gap: 8px; }
+  .site-header nav > a:not(.header-github) { display: none; }
+  .preview-label { display: none; }
+  .hero { width: min(100% - 28px, 1180px); min-height: 0; padding: 76px 0 68px; gap: 52px; }
+  .hero h1 { font-size: clamp(48px, 15vw, 66px); }
+  .hero-lede { font-size: 16px; }
+  .hero-facts { margin-top: 40px; }
+  .product-window { width: 100%; min-width: 0; }
+  .window-bar { padding: 0 11px; }
+  .window-body { grid-template-columns: 78px minmax(0, 1fr); }
+  .window-body aside { padding: 16px 5px; font-size: 8px; }
+  .window-body aside b { padding: 0 5px 8px; font-size: 7px; }
+  .window-body aside span { padding: 7px 5px; }
+  .run-view { min-width: 0; padding: 14px 10px; }
+  .run-heading { align-items: start; gap: 8px; }
+  .run-heading strong { font-size: 11px; }
+  .run-heading > span { display: none; }
+  .run-summary { gap: 8px; padding: 8px; font-size: 7px; }
+  .work-card { padding: 12px; }
+  .signal-strip { display: grid; grid-template-columns: 1fr 1fr; justify-content: stretch; gap: 12px 20px; white-space: normal; line-height: 1.5; }
+  .signal-strip i { display: none; }
+  .section { width: min(100% - 28px, 1180px); padding: 90px 0; }
+  .section-intro { margin-bottom: 42px; }
+  .workflow-grid { grid-template-columns: 1fr; }
+  .workflow-grid li, .workflow-grid li:not(:last-child) { min-height: 0; margin: 0; padding: 24px 0 30px; border-right: 0; }
+  .workflow-grid li > span { margin-bottom: 34px; }
+  .workflow-grid li::after { display: none; }
+  .feature-grid { grid-template-columns: 1fr; }
+  .feature-grid article { min-height: 225px; padding: 24px; }
+  .feature-icon { margin-bottom: 54px; }
+  .architecture-diagram { padding: 18px; }
+  .worker-nodes { grid-template-columns: 1fr; }
+  .status-section { padding-top: 35px; }
+  .status-card { padding: 30px 24px; }
+  .status-columns { grid-template-columns: 1fr; }
+  .quick-start { gap: 42px; }
+  .terminal pre { font-size: 9px; padding: 20px 16px; }
+  .final-cta { width: min(100% - 28px, 920px); margin-bottom: 90px; padding: 62px 22px; }
+  footer { width: min(100% - 28px, 1180px); padding: 26px 0; flex-wrap: wrap; gap: 18px; }
+  footer p { order: 3; width: 100%; }
+  footer nav { margin-left: auto; gap: 16px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { transition-duration: .01ms !important; }
+}

--- a/web/e2e/site-server.mjs
+++ b/web/e2e/site-server.mjs
@@ -1,0 +1,40 @@
+import { createReadStream } from "node:fs";
+import { access } from "node:fs/promises";
+import { createServer } from "node:http";
+import { extname, resolve, sep } from "node:path";
+
+const siteRoot = resolve(import.meta.dirname, "../../site");
+const contentTypes = new Map([
+  [".css", "text/css; charset=utf-8"],
+  [".html", "text/html; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+]);
+
+const server = createServer(async (request, response) => {
+  const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+  const relativePath = pathname === "/" ? "index.html" : pathname.slice(1);
+  const filePath = resolve(siteRoot, relativePath);
+  if (!filePath.startsWith(`${siteRoot}${sep}`)) {
+    response.writeHead(400).end("Invalid path");
+    return;
+  }
+  try {
+    await access(filePath);
+    response.writeHead(200, {
+      "cache-control": "no-store",
+      "content-type": contentTypes.get(extname(filePath)) ?? "application/octet-stream",
+    });
+    createReadStream(filePath).pipe(response);
+  } catch {
+    response.writeHead(404).end("Not found");
+  }
+});
+
+server.listen(17438, "127.0.0.1");
+
+function stop() {
+  server.close(() => process.exit(0));
+}
+
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);

--- a/web/e2e/site.spec.ts
+++ b/web/e2e/site.spec.ts
@@ -9,6 +9,9 @@ function capturePageFailures(page: Page) {
   });
   page.on("pageerror", (error) => failures.push(`page: ${error.message}`));
   page.on("requestfailed", (request) => failures.push(`request: ${request.url()} ${request.failure()?.errorText ?? "failed"}`));
+  page.on("response", (response) => {
+    if (response.status() >= 400) failures.push(`response: ${response.status()} ${response.url()}`);
+  });
   return failures;
 }
 
@@ -116,6 +119,20 @@ test("public site is keyboard accessible", async ({ page }) => {
   await expect(skipLink).toBeVisible();
   await page.keyboard.press("Enter");
   await expect(page).toHaveURL(`${siteURL}/#main`);
+  await expect(page.locator("main")).toBeFocused();
+});
+
+test("public site preserves the product window at intermediate widths", async ({ page }) => {
+  await page.setViewportSize({ width: 1120, height: 900 });
+  await page.goto(siteURL);
+
+  const windowBounds = await page.locator(".product-window").boundingBox();
+  expect(windowBounds).not.toBeNull();
+  expect((windowBounds?.x ?? 0) + (windowBounds?.width ?? 0)).toBeLessThanOrEqual(1120);
+  const viewport = await page.evaluate<{ width: number; scrollWidth: number }>(
+    "({ width: document.documentElement.clientWidth, scrollWidth: document.documentElement.scrollWidth })",
+  );
+  expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.width);
 });
 
 test("public site remains usable at 390 pixels", async ({ page }) => {

--- a/web/e2e/site.spec.ts
+++ b/web/e2e/site.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const siteURL = "http://127.0.0.1:17438";
+
+function capturePageFailures(page: Page) {
+  const failures: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") failures.push(`console: ${message.text()}`);
+  });
+  page.on("pageerror", (error) => failures.push(`page: ${error.message}`));
+  page.on("requestfailed", (request) => failures.push(`request: ${request.url()} ${request.failure()?.errorText ?? "failed"}`));
+  return failures;
+}
+
+type ContrastFailure = {
+  element: string;
+  ratio: number;
+  text: string;
+};
+
+async function findContrastFailures(page: Page) {
+  return page.evaluate<ContrastFailure[]>(`(() => {
+    const parseColor = (value) => {
+      const match = value.match(/rgba?\\(([^)]+)\\)/);
+      if (!match) return null;
+      const parts = match[1].split(/[ ,/]+/).filter(Boolean).map(Number);
+      return [parts[0], parts[1], parts[2], parts.length > 3 ? parts[3] : 1];
+    };
+    const composite = (foreground, background) => {
+      const alpha = foreground[3] + background[3] * (1 - foreground[3]);
+      if (alpha === 0) return [0, 0, 0, 0];
+      return [
+        (foreground[0] * foreground[3] + background[0] * background[3] * (1 - foreground[3])) / alpha,
+        (foreground[1] * foreground[3] + background[1] * background[3] * (1 - foreground[3])) / alpha,
+        (foreground[2] * foreground[3] + background[2] * background[3] * (1 - foreground[3])) / alpha,
+        alpha,
+      ];
+    };
+    const backgroundFor = (element) => {
+      const layers = [];
+      for (let current = element; current; current = current.parentElement) {
+        const color = parseColor(getComputedStyle(current).backgroundColor);
+        if (color && color[3] > 0) layers.push(color);
+      }
+      let background = [9, 10, 12, 1];
+      for (const layer of layers.reverse()) background = composite(layer, background);
+      return background;
+    };
+    const luminance = (color) => {
+      const channels = color.slice(0, 3).map((channel) => {
+        const value = channel / 255;
+        return value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
+      });
+      return channels[0] * 0.2126 + channels[1] * 0.7152 + channels[2] * 0.0722;
+    };
+    const failures = [];
+    for (const element of document.querySelectorAll('body *')) {
+      const text = Array.from(element.childNodes)
+        .filter((node) => node.nodeType === Node.TEXT_NODE)
+        .map((node) => node.textContent || '')
+        .join(' ')
+        .replace(/\\s+/g, ' ')
+        .trim();
+      if (!text) continue;
+      const styles = getComputedStyle(element);
+      const bounds = element.getBoundingClientRect();
+      if (styles.display === 'none' || styles.visibility === 'hidden' || bounds.width === 0 || bounds.height === 0) continue;
+      let foreground = parseColor(styles.color);
+      if (!foreground) continue;
+      const background = backgroundFor(element);
+      foreground = composite(foreground, background);
+      const light = luminance(foreground);
+      const dark = luminance(background);
+      const ratio = (Math.max(light, dark) + 0.05) / (Math.min(light, dark) + 0.05);
+      if (ratio < 4.5) {
+        failures.push({
+          element: element.tagName.toLowerCase() + (element.className ? '.' + String(element.className).trim().replace(/\\s+/g, '.') : ''),
+          ratio: Math.round(ratio * 100) / 100,
+          text: text.slice(0, 80),
+        });
+      }
+    }
+    return failures;
+  })()`);
+}
+
+test("public site explains Factory and exposes the main project paths", async ({ page }) => {
+  const failures = capturePageFailures(page);
+  await page.goto(siteURL, { waitUntil: "networkidle" });
+
+  await expect(page).toHaveTitle("Factory | A control plane for coding agents");
+  await expect(page.getByRole("heading", { level: 1, name: "Software work, under control." })).toBeVisible();
+  await expect(page.getByText("Factory is a control plane for coding agents.")).toBeVisible();
+  await expect(page.getByRole("link", { name: "View on GitHub" })).toHaveAttribute("href", "https://github.com/owainlewis/factory");
+  await expect(page.getByRole("heading", { name: "From a saved task to inspectable code." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "A small control plane. Workers do the work." })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Useful now. Still changing." })).toBeVisible();
+  await expect(page.getByText("Run table, list, and Kanban")).toBeVisible();
+  await expect(page.locator(".product-window")).toContainText("Blocked");
+  await expect(page.locator(".product-window")).not.toContainText("Needs you");
+
+  await page.screenshot({ path: "test-results/screenshots/site-desktop.png", fullPage: true });
+  expect(failures).toEqual([]);
+});
+
+test("public site text meets WCAG AA contrast", async ({ page }) => {
+  await page.goto(siteURL);
+  expect(await findContrastFailures(page)).toEqual([]);
+});
+
+test("public site is keyboard accessible", async ({ page }) => {
+  await page.goto(siteURL);
+  await page.keyboard.press("Tab");
+  const skipLink = page.getByRole("link", { name: "Skip to content" });
+  await expect(skipLink).toBeFocused();
+  await expect(skipLink).toBeVisible();
+  await page.keyboard.press("Enter");
+  await expect(page).toHaveURL(`${siteURL}/#main`);
+});
+
+test("public site remains usable at 390 pixels", async ({ page }) => {
+  const failures = capturePageFailures(page);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto(siteURL, { waitUntil: "networkidle" });
+
+  await expect(page.getByRole("heading", { level: 1, name: "Software work, under control." })).toBeVisible();
+  await expect(page.getByRole("link", { name: "GitHub", exact: true }).first()).toBeVisible();
+  await expect(page.getByRole("link", { name: "Run it locally" })).toBeVisible();
+  const viewport = await page.evaluate<{ width: number; scrollWidth: number }>(
+    "({ width: document.documentElement.clientWidth, scrollWidth: document.documentElement.scrollWidth })",
+  );
+  expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.width);
+
+  await page.screenshot({ path: "test-results/screenshots/site-narrow.png", fullPage: true });
+  expect(failures).toEqual([]);
+});

--- a/web/e2e/site.spec.ts
+++ b/web/e2e/site.spec.ts
@@ -128,6 +128,7 @@ test("public site preserves the product window at intermediate widths", async ({
 
   const windowBounds = await page.locator(".product-window").boundingBox();
   expect(windowBounds).not.toBeNull();
+  expect(windowBounds?.x ?? 0).toBeGreaterThanOrEqual(0);
   expect((windowBounds?.x ?? 0) + (windowBounds?.width ?? 0)).toBeLessThanOrEqual(1120);
   const viewport = await page.evaluate<{ width: number; scrollWidth: number }>(
     "({ width: document.documentElement.clientWidth, scrollWidth: document.documentElement.scrollWidth })",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -20,10 +20,18 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 1000 } },
     },
   ],
-  webServer: {
-    command: "node e2e/server.mjs",
-    url: "http://127.0.0.1:17437/healthz",
-    reuseExistingServer: false,
-    timeout: 120_000,
-  },
+  webServer: [
+    {
+      command: "node e2e/server.mjs",
+      url: "http://127.0.0.1:17437/healthz",
+      reuseExistingServer: false,
+      timeout: 120_000,
+    },
+    {
+      command: "node e2e/site-server.mjs",
+      url: "http://127.0.0.1:17438",
+      reuseExistingServer: false,
+      timeout: 10_000,
+    },
+  ],
 });


### PR DESCRIPTION
## Summary\n\n- give Factory a clear open-source front door with a focused GitHub Pages site\n- rewrite the README around the current control-plane product, quick start, architecture, and status\n- test the public site at desktop, intermediate, and 390px widths, including keyboard focus transfer, HTTP and browser failures, horizontal overflow, and WCAG AA text contrast\n- add a pinned, permission-scoped GitHub Pages deployment workflow\n\n## Product boundary\n\nThis presents Factory as the software execution layer: repeatable Tasks, repository Runs, Workers, worktrees, agent runtimes, and inspectable outcomes. General business tracking remains outside Factory. Ordered pipelines and the software-work graph are described as active direction, not shipped behavior.\n\n## Verification\n\n- just format-check\n- just boundary\n- just test\n- npm run lint\n- npm run typecheck\n- just test-browser (8 passed)\n- actionlint .github/workflows/pages.yml\n- independent implementation review: approved after fixes\n- GitHub CI: Linux, macOS arm64, and macOS amd64 passed\n\nAll concrete automated review findings were fixed, replied to with verification evidence, and resolved.\n\nGitHub Pages is configured for workflow deployment. The public URL will deploy after this reaches main.