### PR TITLE
docs: design agent-directed software factory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,13 +2,14 @@
 
 > **Status:** Current implementation
 >
-> **Verification basis:** `origin/main` at commit `003ed8f`
+> **Verification basis:** `origin/main` at commit `e767947`
 >
 > **Future direction:** The proposed
+> [agent-directed software factory](docs/software-factory/design.md) adds
+> work-item admission and agent-owned semantic status while preserving the
+> current Worker lifecycle. The proposed
 > [Cloud Run agent backend](docs/cloud-run-agents/design.md) adds elastic
-> execution without changing Factory's product lifecycle. The Software Factory
-> target architecture is a historical proposal superseded by Tasks and Runs.
-> This document describes code that exists today.
+> execution. This document describes only code that exists today.
 
 ## 1. Executive summary
 
@@ -213,9 +214,10 @@ most 64 KiB; one Attempt stores at most 10 MiB of events. Results are at most
 
 ### Browser UI
 
-`web/src` is a React and TypeScript single-page application. It exposes
-Overview, Tasks, Runs, Workers, and Repositories, with detail views for each
-operational resource. It polls the same-origin API.
+`web/src` is a React and TypeScript single-page application. It exposes Work,
+Tasks, Overview, Workers, and Repositories, with detail views for each
+operational resource. Work presents Run history as a board or table and polls
+the same-origin API.
 
 `web/dist` is generated, committed, and embedded by `web/embed.go`. The server
 uses an SPA fallback, immutable caching for versioned assets, and restrictive

--- a/README.md
+++ b/README.md
@@ -110,10 +110,12 @@ Implemented today:
 - table, list, and Kanban Run views with repository-level detail
 - local Workers and authenticated remote VM Workers
 
-Active product work is moving Factory toward ordered software pipelines and a
-software-work graph while keeping general business tracking outside the
-product. See the [software pipelines proposal](https://github.com/owainlewis/factory/pull/333)
-and the [product vision](docs/software-factory/vision.md).
+Active product work is moving Factory toward an agent-directed queue for work
+items and repository fleets. Existing coding agents own engineering judgment;
+Factory owns repeatable procedures, Worker capacity, durable state, and one
+view of the work. See the
+[target design](docs/software-factory/design.md) and
+[product vision](docs/software-factory/vision.md).
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,9 @@ Start with the root [README](../README.md) to run Factory.
 
 ## Active design work
 
+- [Agent-directed software factory](software-factory/design.md): proposed
+  work-item queue, repository fleet Runs, agent update capability, and first
+  useful CLI.
 - [Cloud Run agent backend](cloud-run-agents/design.md): proposed elastic,
   API-backed execution alongside persistent local and VM Workers.
 - [Software Factory vision](software-factory/vision.md): product thesis, scope,
@@ -48,10 +51,9 @@ Start with the root [README](../README.md) to run Factory.
   Runs.
 - [Coding automation experience](automation-experience/design.md): implemented
   Runbook-first UX record, superseded by Tasks and Runs.
-- [Software Factory target architecture](software-factory/design.md): proposed
-  Definitions, Triggers, Runs, and Jobs, superseded by Tasks and Runs.
 - [Unified CLI](cli/design.md): useful process-boundary record whose resource
-  names and command contract must be revised against Tasks and Runs.
+  names and command contract are superseded by the agent-directed target
+  design.
 
 Current behavior belongs in the root `ARCHITECTURE.md`. Proposed behavior belongs
 in a focused design until it is implemented.

--- a/docs/cli/design.md
+++ b/docs/cli/design.md
@@ -1,8 +1,9 @@
 # Factory command-line interface
 
 > **Status:** Superseded command contract, not implemented. Its process
-> boundaries remain useful, but its resource names and commands must be revised
-> against the [Software Factory target architecture](../software-factory/design.md).
+> boundaries remain useful, but the
+> [agent-directed software factory](../software-factory/design.md) owns the
+> current proposed command surface.
 
 > **Automation boundary:** The external `factory ingest github` role and
 > standalone schedule resource in earlier revisions are superseded by

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -467,6 +467,10 @@ Worker Attempt before taking manual ownership.
 - Every update invocation has a random request ID. A transport retry with the
   same Attempt and request ID, or the same operator Work and request ID, returns
   the stored response.
+- Agent update handling first verifies that the presented token digest belongs
+  to the Attempt, then checks for a stored `(attempt_id, request_id)` response.
+  An exact stored request returns that response before lease-expiry or lifecycle
+  rejection. Expiry never authorizes a new request ID or different fields.
 - An admission request key returns the original Run only when its canonical
   caller-input fingerprint matches. This lookup occurs before repository,
   Procedure, default, state-dependent validation, or predecessor selection.
@@ -582,9 +586,10 @@ The socket is created below the Worker data directory with mode `0600`. The
 random update token is valid only while the Attempt owns its active lease. The
 Worker stores only its digest and never forwards the token to the control
 plane. For each invocation, the helper creates a random request ID and reuses it
-for bounded transport retries. The Worker validates the token, Work and Attempt
-identity, request ID, current lifecycle, status, message, and optional PR URL
-before forwarding a typed update under the Worker lease.
+for bounded transport retries. The Worker validates the token digest and Work
+and Attempt identity, performs the exact stored-request lookup, then validates
+the active lease, current lifecycle, request ID, status, message, and optional PR
+URL before forwarding a new typed update under the Worker lease.
 
 The token is a scope and accidental-misuse guard, not a sandbox boundary. V1
 trusts processes running as the Worker operating-system user with the same host
@@ -728,10 +733,12 @@ identifies prior updates, known PR, publish ref, and duplicate-effect risk.
 Factory never force-pushes or deletes the ref. If the ref moves while an Attempt
 is active, the agent must reconcile a normal push or report `needs-input`.
 
-An agent update request with an expired or wrong token is rejected. An exact
-transport retry returns the stored update. A second identical Attempt-ending
-report returns the stored outcome, while a different outcome report conflicts.
-Progress after an outcome report conflicts.
+An agent update request with a wrong token is always rejected. A request with
+the correct but expired token can only return an exact stored update with the
+same request ID and fields; new or different requests are rejected. This replay
+lookup occurs before lease and lifecycle checks. A second identical
+Attempt-ending report returns the stored outcome, while a different outcome
+report conflicts. Progress after an outcome report conflicts.
 
 For `ready`, the Worker performs a bounded GitHub and remote-ref check before
 accepting the report provisionally. A timeout or provider outage returns a
@@ -802,10 +809,11 @@ credentials.
 
 The Attempt update token is separate from the Worker credential and lease. It
 is random, short-lived, stored only as a digest, scoped to one Attempt, removed
-from stale inherited environments, and invalid after process stop, cancellation,
-or lease loss. It prevents accidental cross-Work updates through the injected
-tool; it does not constrain a malicious process with the Worker user's broader
-authority. Update events and messages may contain source code or private ticket
+from stale inherited environments, and invalid for new updates after process
+stop, cancellation, or lease loss. Its retained digest may authenticate only an
+exact stored-response replay. It prevents accidental cross-Work updates through
+the injected tool; it does not constrain a malicious process with the Worker
+user's broader authority. Update events and messages may contain source code or private ticket
 context and receive the same local-data protection as current prompts and agent
 events.
 
@@ -852,7 +860,8 @@ remains visible and never silently drops an outcome.
   exists.
 - `AC-11`: Replaying an admission or update after a lost response returns the
   original stored result without duplication, including when a new CLI process
-  reuses a generated key from its pending-admission journal.
+  reuses a generated key from its pending-admission journal and when an exact
+  stored agent update is retried after its lease expires.
 - `AC-12`: Local and enrolled VM Workers use the same scoped update protocol
   without transmitting the operator credential, Worker credential, or Attempt
   lease token in that protocol.
@@ -893,7 +902,8 @@ normalization, message limits, cursor bounds, and operator updates for `AC-1`,
 
 Worker and supervisor tests prove `INV-5` through `INV-8`, `INV-11`, `INV-17`,
 and `INV-18` with
-wrong tokens, expired leases, terminal-report races, cancellation, forced exit,
+wrong tokens, expired-lease exact replay, expired-lease new-request rejection,
+terminal-report races, cancellation, forced exit,
 parent loss, stable publish continuation, preflight and post-stop PR identity
 validation, provider outage, branch movement after report, the 199-progress
 limit with a reserved outcome slot, dirty needs-input rejection, pushed and

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -432,8 +432,9 @@ Worker Attempt before taking manual ownership.
   only the smallest fairness rule its tests require.
 - Progress messages are non-empty UTF-8 text of at most 2 KiB.
 - Outcome messages are non-empty UTF-8 text of at most 8 KiB.
-- One Attempt stores at most 200 accepted agent updates. A later progress call
-  receives a visible limit error; one outcome update remains allowed.
+- One Attempt stores at most 200 accepted agent updates: up to 199 progress
+  updates and one reserved outcome update. A later progress call receives a
+  visible limit error while the required outcome slot remains available.
 - Agent update statuses are `running`, `ready`, `needs-input`, `failed`, and
   `no-change`.
 - Agent-owned `ready` requires one HTTPS GitHub pull-request URL whose
@@ -746,9 +747,9 @@ events.
 
 Existing Worker capacity, repository-cache, event, prompt, result, timeout, and
 retained-worktree limits continue to apply. A Run may add at most 100 Work
-targets. Update history adds at most 200 records per Attempt and at most 8 KiB
-per outcome message. Limit failure remains visible and never silently drops an
-outcome.
+targets. Update history adds at most 200 records per Attempt, including its
+reserved outcome record, and at most 8 KiB per outcome message. Limit failure
+remains visible and never silently drops an outcome.
 
 ## 9. Acceptance criteria
 
@@ -821,7 +822,8 @@ Worker and supervisor tests prove `INV-5` through `INV-8`, `INV-11`, and
 `INV-17` with
 wrong tokens, expired leases, terminal-report races, cancellation, forced exit,
 parent loss, stable publish continuation, preflight and post-stop PR identity
-validation, provider outage, branch movement after report, and cleanup.
+validation, provider outage, branch movement after report, the 199-progress
+limit with a reserved outcome slot, and cleanup.
 They verify `AC-5`, `AC-7`, `AC-8`, `AC-10`, `AC-12`, and `AC-13`, including
 the race detector.
 They also prove that every valid semantic outcome completes the Attempt while

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -108,6 +108,11 @@ opaque reference such as `LINEAR-123` requires `--repo` in V1. Factory does not
 fetch Linear. The agent reads the live item with tools available on its Worker,
 or reports `needs-input` when it cannot obtain enough context.
 
+When `--repo` is present, it scopes every opaque reference and every GitHub URL
+in the batch must resolve to that same managed repository. A mismatch rejects
+the complete admission. Omitting `--repo` permits GitHub-only targets from
+multiple managed repositories; it never permits an opaque reference.
+
 The immutable target contains the source reference, repository, and any
 operator-supplied context, not a copy of live provider content. GitHub or Linear
 content read by the agent may change between Attempts. Historical Work records
@@ -403,8 +408,10 @@ model.
   operator explicitly converts its outcome contract.
 - `INV-17`: Agent-owned Work becomes ready only from delivery evidence
   revalidated after its process group has stopped.
-- `INV-18`: An answered Work starts from the exact checkpoint revalidated after
-  the needs-input process group stopped.
+- `INV-18`: Once Work enters `needs-input`, it retains the exact checkpoint
+  revalidated after the process group stopped until an Attempt successfully
+  starts from it. Answer, cancellation, retry, or preparation failure cannot
+  fall back from it.
 - `INV-19`: A Work that has been replaced cannot be retried, and retry admission
   cannot create a second nonterminal Work target for the same retry identity.
 
@@ -459,7 +466,9 @@ Worker Attempt before taking manual ownership.
   expected repository and records the provider-reported branch and SHA.
 - Agent-owned `needs-input` requires a clean worktree and a checkpoint SHA. A
   changed HEAD must equal the fetched publish ref; an unchanged Work uses its
-  exact base SHA. The Worker revalidates after process stop.
+  exact base SHA. The Worker revalidates after process stop, then stores that
+  commit as both historical `checkpoint_sha` and authoritative
+  `pending_resume_sha`.
 - `needs-input`, `failed`, and `no-change` require a message. `needs-input`
   exposes the message as the current operator question.
 - Exactly one Attempt-ending agent report can win. Repeating the same report is
@@ -643,6 +652,7 @@ context_snapshot
 publish_branch
 predecessor_work_id
 checkpoint_sha
+pending_resume_sha
 state
 execution_owner: none | worker_attempt | operator
 waiting_reason
@@ -716,7 +726,9 @@ arrives in a later invocation; a different outcome report conflicts.
 
 Admission validates the complete target set before writing anything. Unknown,
 disabled, duplicate, empty, malformed, or oversized targets create no Run. An
-opaque reference without an explicit repository creates no Run.
+opaque reference without an explicit repository creates no Run. With an
+explicit repository, any GitHub URL for another repository rejects the whole
+batch.
 
 Work waits visibly when no compatible Worker has capacity. A Worker that loses
 its lease stops the agent process group. Infrastructure failure before or after
@@ -727,9 +739,11 @@ opened a pull request.
 
 Retry first transactionally proves that no replacement names this Work as its
 predecessor and that no other nonterminal Work with the retry identity defined
-above exists. Each accepted retry then creates a fresh local worktree. If the
-stable remote publish branch exists, preparation starts from its current fetched
-head. Otherwise it starts from the repository base only when no PR is recorded.
+above exists. Each accepted retry then creates a fresh local worktree. A stored
+`pending_resume_sha` always takes precedence and preparation must start from
+that exact commit. Without one, preparation uses the current fetched head of an
+existing stable remote publish branch, or the repository base only when no PR
+is recorded.
 A missing publish branch for known PR Work fails preparation with a fixed
 recovery message that identifies the PR, ref, and recorded trusted PR head SHA.
 It tells the operator to restore the ref to exactly that SHA or admit warned
@@ -782,12 +796,16 @@ report not already finalized. Cancelling a Run cancels each nonterminal Work
 target without changing terminal siblings.
 
 An operator answer to `needs-input` appends trusted context and requeues the
-same Work. The next Worker claim creates a new Attempt. The agent receives the
-original frozen Procedure, original context, prior question, answer, updates,
-known branch, checkpoint SHA, and PR metadata. Worktree preparation starts from
-that exact checkpoint. A missing or unreachable checkpoint fails preparation
-visibly instead of falling back to repository base. Archiving a Procedure
-prevents new Runs but does not cancel admitted Work.
+same Work while retaining its authoritative `pending_resume_sha`.
+The next Worker claim creates a new Attempt. The agent receives the original
+frozen Procedure, original context, prior question, answer, updates, known
+branch, checkpoint SHA, and PR metadata. Worktree preparation starts from that
+exact checkpoint. A missing or unreachable checkpoint fails preparation visibly
+instead of falling back to the publish ref or repository base. Cancellation,
+failed preparation, and explicit retry retain `pending_resume_sha`. It is cleared
+only after an Attempt successfully starts from that commit; the historical
+`checkpoint_sha` and update remain stored. Archiving a Procedure prevents new
+Runs but does not cancel admitted Work.
 
 Control-plane shutdown stops admission before HTTP shutdown. Workers continue
 until lease renewal fails, then stop active processes. Restart sweeps expired
@@ -860,7 +878,8 @@ remains visible and never silently drops an outcome.
 - `AC-9`: Answering a needs-input question requeues Work with the answer and
   prior history while preserving the original Procedure and context; only the
   next Worker claim creates an Attempt, starting from the revalidated
-  checkpoint SHA.
+  checkpoint SHA. Cancellation, failed preparation, and retry keep that SHA
+  authoritative until an Attempt successfully starts from it.
 - `AC-10`: A warned retry after process start continues from the stable remote
   publish branch when one exists and does not create a second Work record. It is
   rejected without state change when replacement or matching nonterminal Work
@@ -914,7 +933,8 @@ process-exit update rejection, terminal-report races, cancellation, forced exit,
 parent loss, stable publish continuation, preflight and post-stop PR identity
 validation, provider outage, branch movement after report, the 199-progress
 limit with a reserved outcome slot, dirty needs-input rejection, pushed and
-unchanged checkpoints, answer continuation, and cleanup.
+unchanged checkpoints, answer continuation, answer then cancellation or failed
+preparation then retry with moved and missing refs, and cleanup.
 They verify `AC-5`, `AC-7`, `AC-8`, `AC-10`, `AC-12`, and `AC-13`, including
 the race detector.
 They also prove that every valid semantic outcome completes the Attempt while
@@ -926,6 +946,9 @@ prompt size for `AC-4`.
 
 Admission tests prove the exact opaque-reference grammar and reject whitespace,
 prose, Unicode, empty, and overlength values without creating partial Work.
+They prove an explicit repository accepts only matching GitHub URLs, rejects a
+mixed-repository batch transactionally, and that GitHub-only multi-repository
+admission works when `--repo` is absent.
 
 CLI tests use a real loopback server to prove multi-reference admission,
 explicit and generated-key replay across separate CLI processes, pending-journal

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -74,7 +74,7 @@ flowchart LR
 ```
 
 The control plane owns Run and Work records, target identity, scheduling,
-immutable input, update history, and user-visible state. A Worker owns its
+immutable Factory-supplied input, update history, and user-visible state. A Worker owns its
 repository cache, Attempt lease, worktree, supervisor, agent process, and the
 local update endpoint. The coding agent owns engineering judgment and external
 actions performed with Worker-host tools. GitHub, Linear, and other systems
@@ -102,8 +102,13 @@ may use the same repository.
 GitHub issue URLs derive their repository and canonical source identity. An
 opaque reference such as `LINEAR-123` requires `--repo` in V1. Factory does not
 fetch Linear. The agent reads the live item with tools available on its Worker,
-or reports `needs-input` when it cannot obtain enough context. Manual text can
-be supplied with an explicit repository and receives a random source identity.
+or reports `needs-input` when it cannot obtain enough context.
+
+The immutable target contains the source reference, repository, and any
+operator-supplied context, not a copy of live provider content. GitHub or Linear
+content read by the agent may change between Attempts. Historical Work records
+the exact reference and read time where runtime events expose it, but V1 does
+not claim to preserve the exact external item body the agent observed.
 
 A Worker claims eligible Work, prepares an isolated worktree, and starts its
 resolved Pi, Codex, or Claude Code runtime. The operator configures one default
@@ -290,12 +295,14 @@ comments or other agent side effects.
 
 The Claim and prompt contain the immutable publish ref. The standard Procedure
 requires the agent to push local `HEAD` to that ref and use it as the pull
-request head. Before accepting `ready`, the Worker verifies that local `HEAD`,
-the fetched remote publish ref, and the PR head SHA match, and that the PR head
-branch and repository match the Work. A mismatch returns actionable validation
-feedback and leaves the Attempt running. Factory never force-pushes or deletes
-the remote publish branch. A normal non-fast-forward push is for the agent to
-reconcile or report as `needs-input`.
+request head. Before accepting the report provisionally, the Worker verifies
+that local `HEAD`, the fetched remote publish ref, and the PR head SHA match,
+and that the PR head branch and repository match the Work. A mismatch returns
+actionable validation feedback and leaves the Attempt running. After the
+process group stops, the Worker repeats every check before making Work ready.
+Factory never force-pushes or deletes the remote publish branch. A normal
+non-fast-forward push is for the agent to reconcile or report as
+`needs-input`.
 
 #### Built-in standard Build Procedure
 
@@ -322,8 +329,9 @@ Those additions require separate credential, namespace, and mapping decisions.
 #### Ready stops before merge
 
 `ready` means the agent reports that a pull request is ready for a human. The
-report includes a PR URL and message, and Factory may validate that the URL
-belongs to the expected repository. GitHub owns review, mergeability, and
+report includes a PR URL and message. Factory must validate the URL, expected
+repository, immutable branch, remote ref, and head SHA after the agent process
+group stops. GitHub owns review, mergeability, and
 merge. We reject automatic merge and a durable `complete` state in V1 because
 both require ongoing provider observation and repository policy.
 
@@ -369,12 +377,16 @@ model.
 - `INV-12`: Retrying one Work never replays a terminal sibling.
 - `INV-13`: Work-item and repository content cannot change the trusted
   Procedure or choose a repository clone source.
-- `INV-14`: Historical Work identifies the exact Procedure, context, target,
-  runtime, Worker, updates, Attempts, and outcome used.
+- `INV-14`: Historical Work identifies the exact Procedure, Factory-supplied
+  context, source reference, target, runtime, Worker, updates, Attempts, and
+  outcome used. It does not claim an immutable copy of external content read by
+  the agent.
 - `INV-15`: Factory does not claim exactly-once external side effects performed
   by an agent.
 - `INV-16`: A legacy Task keeps its process-exit completion behavior until an
   operator explicitly converts its outcome contract.
+- `INV-17`: Agent-owned Work becomes ready only from delivery evidence
+  revalidated after its process group has stopped.
 
 ### Work state transitions
 
@@ -437,6 +449,9 @@ manual ownership.
   process previously started.
 - Setup requires one valid default Build runtime. `factory build --runtime`
   accepts only a configured runtime and admission freezes the resolved choice.
+- An opaque work-item reference is 1 to 64 ASCII characters matching
+  `[A-Za-z0-9][A-Za-z0-9._-]*`. Whitespace, prose, and other characters are
+  rejected before admission.
 - A trusted operator may update Work only when it has no active Attempt.
 - Queue, Work, update, Attempt, and Worker list APIs remain bounded and cursor
   paginated.
@@ -514,10 +529,11 @@ stop. The supervisor allows ten seconds for normal exit, then stops the process
 group. The Worker reports terminal Attempt completion only after it proves the
 process group stopped. Cancellation received before completion wins.
 
-On completion, a valid outcome report maps to a `succeeded` Attempt and its
-reported Work outcome. No report or an infrastructure error maps to a `failed`
-Attempt and failed Work. This keeps process execution evidence separate from
-the agent's semantic judgment.
+On completion, a valid non-ready outcome report maps to a `succeeded` Attempt
+and its reported Work outcome. A ready report maps to succeeded and ready only
+after post-stop delivery revalidation. No report, an infrastructure error, or
+failed post-stop validation maps to a `failed` Attempt and failed Work. This
+keeps process execution evidence separate from the agent's semantic judgment.
 
 ### Stored resources
 
@@ -539,7 +555,7 @@ target_key
 target_kind: work_item | repository
 repository_id
 repository_identity
-source_kind: github_issue | opaque | manual | repository
+source_kind: github_issue | opaque | repository
 source_key
 source_reference
 context_snapshot
@@ -575,9 +591,9 @@ derived from its immutable Work ID and is bounded to a Git-safe value such as
 
 A GitHub issue URL normalizes to
 `github:<lowercase-owner>/<lowercase-repository>:issue:<number>`. An opaque
-reference normalizes Unicode whitespace but otherwise preserves case and is
-scoped to its managed repository. Manual text uses a random source key. A
-repository target uses the managed repository ID.
+reference preserves case, must match `[A-Za-z0-9][A-Za-z0-9._-]{0,63}`, and is
+scoped to its managed repository. A repository target uses the managed
+repository ID.
 
 `target_key` is the source key plus repository ID for a work item and the
 repository ID for a fleet target. It is unique inside one Run. The admission
@@ -595,8 +611,8 @@ arrives in a later invocation; a different outcome report conflicts.
 ## 7. Failure behavior and lifecycle
 
 Admission validates the complete target set before writing anything. Unknown,
-disabled, duplicate, empty, or oversized targets create no Run. An opaque
-reference without an explicit repository creates no Run.
+disabled, duplicate, empty, malformed, or oversized targets create no Run. An
+opaque reference without an explicit repository creates no Run.
 
 Work waits visibly when no compatible Worker has capacity. A Worker that loses
 its lease stops the agent process group. Infrastructure failure before or after
@@ -620,8 +636,12 @@ report returns the stored outcome, while a different outcome report conflicts.
 Progress after an outcome report conflicts.
 
 For `ready`, the Worker performs a bounded GitHub and remote-ref check before
-accepting the report. A timeout or provider outage returns a retriable validation
-error and leaves the Attempt running. Factory validates delivery identity, not
+accepting the report provisionally. A timeout or provider outage returns a
+retriable validation error and leaves the Attempt running. After the process
+group stops, the Worker repeats the repository, branch, local HEAD, remote ref,
+and PR head SHA checks. A mismatch or provider outage at that point fails the
+Attempt and Work with stored delivery evidence and a fixed postflight reason;
+it never marks stale evidence ready. Factory validates delivery identity, not
 CI success or semantic correctness; the agent remains responsible for both.
 
 If the agent process exits without an outcome report, the Worker fails the
@@ -708,7 +728,8 @@ outcome.
 - `AC-7`: An agent that exits without a terminal update produces the fixed
   visible failure reason and no inferred success.
 - `AC-8`: A ready update cannot make Work ready until the Worker proves the
-  agent process stopped and verifies the immutable branch and head SHA;
+  agent process stopped and then revalidates the repository, immutable branch,
+  remote ref, local HEAD, and PR head SHA;
   cancellation wins over a late report.
 - `AC-9`: Answering a needs-input question requeues Work with the answer and
   prior history while preserving the original Procedure and context; only the
@@ -744,9 +765,11 @@ legacy completion cases. HTTP tests prove CLI admission validation, source
 normalization, message limits, cursor bounds, and operator updates for `AC-1`,
 `AC-3`, `AC-11`, `AC-15`, `AC-17`, and `AC-18`.
 
-Worker and supervisor tests prove `INV-5` through `INV-8` and `INV-11` with
+Worker and supervisor tests prove `INV-5` through `INV-8`, `INV-11`, and
+`INV-17` with
 wrong tokens, expired leases, terminal-report races, cancellation, forced exit,
-parent loss, stable publish continuation, PR identity validation, and cleanup.
+parent loss, stable publish continuation, preflight and post-stop PR identity
+validation, provider outage, branch movement after report, and cleanup.
 They verify `AC-5`, `AC-7`, `AC-8`, `AC-10`, `AC-12`, and `AC-13`, including
 the race detector.
 They also prove that every valid semantic outcome completes the Attempt while
@@ -755,6 +778,9 @@ only `ready` makes the Work ready.
 Prompt boundary tests prove `INV-10` and `INV-13`, the exact Procedure snapshot,
 trusted and untrusted sections, injected update instructions, and maximum final
 prompt size for `AC-4`.
+
+Admission tests prove the exact opaque-reference grammar and reject whitespace,
+prose, Unicode, empty, and overlength values without creating partial Work.
 
 CLI tests use a real loopback server to prove multi-reference admission,
 request replay, human and JSON output, `--wait`, opaque-reference repository
@@ -778,6 +804,10 @@ real Worker-local update endpoint.
 - An agent may forget to call `factory update`. The standard wrapper makes the
   requirement short and explicit. Missing reports fail visibly instead of
   being inferred from prose.
+- A live GitHub or Linear item may change between Attempts. V1 records its
+  stable reference but does not snapshot provider content. Provider history is
+  the source for auditing those edits; a later integration may freeze content
+  at admission when credentials and identity are designed.
 - Waiting for CI consumes a Worker slot. V1 measures wait duration and timeout
   frequency before adding durable external waiting and continuation.
 - Stable publish branches reduce duplicate PRs but cannot make comments,

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -379,8 +379,8 @@ model.
 - `INV-4`: Two Work targets in one Run may use the same repository but cannot
   have the same target identity.
 - `INV-5`: One active Attempt lease owns one agent process.
-- `INV-6`: The injected agent update capability accepts updates only for its
-  current Work and Attempt.
+- `INV-6`: Only an `agent_update` Attempt receives the injected update
+  capability, which accepts updates only for its current Work and Attempt.
 - `INV-7`: The update protocol never contains a Worker credential, operator
   credential, or Attempt lease token.
 - `INV-8`: An Attempt-ending agent report becomes final only after its agent
@@ -479,6 +479,8 @@ Worker Attempt before taking manual ownership.
   or needs-input.
 - Under `outcome_contract=agent_update`, a process exit without an outcome
   report fails with a fixed reason. `process_exit` Runs retain legacy behavior.
+- A `process_exit` Attempt receives no update environment or prompt instruction,
+  and the Worker-local update endpoint rejects it from semantic agent updates.
 - An operator answer is non-empty UTF-8 text of at most 8 KiB and requeues Work
   without changing the frozen Procedure or original context. The next Worker
   claim creates the Attempt.
@@ -573,7 +575,7 @@ validation below.
 
 ### Agent update contract
 
-The Worker injects:
+For only an `agent_update` Attempt, the Worker injects:
 
 ```text
 FACTORY_WORK_ID
@@ -588,8 +590,10 @@ Worker stores only its digest and never forwards the token to the control
 plane. For each invocation, the helper creates a random request ID and reuses it
 for bounded transport retries. The Worker validates the token digest and Work
 and Attempt identity, performs the exact stored-request lookup, then validates
-the active lease, current lifecycle, request ID, status, message, and optional PR
-URL before forwarding a new typed update under the Worker lease.
+the frozen `agent_update` outcome contract, active lease, current lifecycle,
+request ID, status, message, and optional PR URL before forwarding a new typed
+update under the Worker lease. A `process_exit` Attempt has no token or socket
+and is rejected if it reaches this endpoint.
 
 The token is a scope and accidental-misuse guard, not a sandbox boundary. V1
 trusts processes running as the Worker operating-system user with the same host
@@ -873,7 +877,7 @@ remains visible and never silently drops an outcome.
   override both resolve before admission and remain frozen in historical Work.
 - `AC-16`: An unconverted legacy Task's next manual and scheduled Runs retain
   their existing repository selection and exit-based success behavior without
-  requiring `factory update`.
+  receiving or accepting the injected `factory update` capability.
 - `AC-17`: Every Run freezes `outcome_contract`; converting a legacy Procedure
   increments its generation and cannot change admitted Runs.
 - `AC-18`: A manual ready update resolves or accepts operator PR head evidence,
@@ -903,7 +907,7 @@ normalization, message limits, cursor bounds, and operator updates for `AC-1`,
 Worker and supervisor tests prove `INV-5` through `INV-8`, `INV-11`, `INV-17`,
 and `INV-18` with
 wrong tokens, expired-lease exact replay, expired-lease new-request rejection,
-terminal-report races, cancellation, forced exit,
+process-exit update rejection, terminal-report races, cancellation, forced exit,
 parent loss, stable publish continuation, preflight and post-stop PR identity
 validation, provider outage, branch movement after report, the 199-progress
 limit with a reserved outcome slot, dirty needs-input rejection, pushed and

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -424,7 +424,7 @@ not an agent update status and does not imply a pull request.
 | `running` | Worker Attempt | unchanged | agent `running` progress update |
 | `running` | Worker Attempt | `ready`, `needs-input`, `failed`, `no-change` | accepted outcome followed by stopped process |
 | `running` | Worker Attempt | `succeeded` or `failed` | legacy `process_exit` completion |
-| `running` | operator | `ready`, `failed`, `no-change` | trusted operator update |
+| `running` | operator | `ready`, `failed`, `no-change` | trusted operator update for `agent_update` Work |
 | `running` | either | `cancelled` | operator cancellation |
 | `needs-input` | none | `queued` | operator answer appends context; the next Worker claim creates the Attempt |
 | `needs-input` | none | `running` | trusted operator claims manual ownership |
@@ -499,6 +499,8 @@ Worker Attempt before taking manual ownership.
   `[A-Za-z0-9][A-Za-z0-9._-]*`. Whitespace, prose, and other characters are
   rejected before admission.
 - A trusted operator may update Work only when it has no active Attempt.
+- Semantic operator updates are accepted only for Work whose frozen outcome
+  contract is `agent_update`; they cannot convert a legacy `process_exit` Run.
 - A trusted operator cannot report `needs-input`; that outcome requires a
   Worker-owned checkpoint.
 - Queue, Work, update, Attempt, and Worker list APIs remain bounded and cursor
@@ -529,7 +531,8 @@ factory server start [--config PATH]
 Finite operator commands call the loopback API and never open SQLite or Worker
 directories. `factory update` detects an injected Attempt context and uses the
 Worker-local capability. Without that context it is a trusted operator command
-and requires `--id`.
+and requires `--id`. Both paths reject Work whose frozen outcome contract is
+`process_exit`; legacy completion remains owned by its existing controls.
 
 `--request-key` is optional for the operator, not for admission. When it is
 omitted, the CLI creates a random key and durably records it with the server
@@ -877,7 +880,7 @@ remains visible and never silently drops an outcome.
   override both resolve before admission and remain frozen in historical Work.
 - `AC-16`: An unconverted legacy Task's next manual and scheduled Runs retain
   their existing repository selection and exit-based success behavior without
-  receiving or accepting the injected `factory update` capability.
+  receiving or accepting agent or operator semantic `factory update` calls.
 - `AC-17`: Every Run freezes `outcome_contract`; converting a legacy Procedure
   increments its generation and cannot change admitted Runs.
 - `AC-18`: A manual ready update resolves or accepts operator PR head evidence,

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -1,475 +1,822 @@
-# Software Factory target architecture
+# Agent-directed software factory
 
-> **Status:** Proposed revision
+> **Status:** Proposed for review
 
 ## 1. Executive summary
 
-Factory is an orchestration system for software-engineering agents. A user
-configures a Worker, adds Git repositories, saves a prompt as a Definition, and
-runs that Definition against one or many repositories. Factory starts the
-agents, tracks their lifecycle, and reports the outcome.
+Factory currently runs saved prompts across repositories, but a developer who
+wants several coding tasks completed still has to create and monitor separate
+agent conversations. The target product lets that developer submit work-item
+references or select a repository fleet, then rely on Factory to queue the
+work, assign coding agents, apply consistent instructions, and collect progress
+and outcomes in one place.
 
-The current product has separate Workflow, revision, Automation, Occurrence,
-Task, Execution, Attempt, and worker concepts. The target product has five
-concepts: **Definition**, **Trigger**, **Run**, **Job**, and **Worker**.
+The design keeps Factory out of the coding-agent business. A capable existing
+agent owns refinement, implementation, tests, subagents, review, pull-request
+creation, and CI repair. Factory gives the agent a small scoped capability to
+report progress, readiness, questions, failure, or no change. Factory owns the
+durable outer loop: admission, frozen input, capacity, leases, process safety,
+history, and visibility.
 
-V1 is local-first. It supports manual and scheduled Runs on local agent
-Workers, repository fan-out, and operational metrics. Pi, Codex, and Claude
-Code are initial runtime examples. Remote VM Workers are the next scaling step.
-GitHub webhook Triggers follow later. Kubernetes is a possible future Worker
-target, but it is not on the active roadmap.
-
-The built-in SQLite orchestration path remains the first-class V1 backend. A
-later production deployment may select Temporal or a similar durable workflow
-engine behind the same product model. Definitions and the Worker-facing product
-contract must not depend on that choice. The architecture decision, history
-migration, and same-Definition prototype remain tracked in
-[#259](https://github.com/owainlewis/factory/issues/259); they are not part of
-this V1 implementation.
-
-The main tradeoff is trust. The agent uses the tools and credentials available
-on its Worker, including authenticated `gh`. Factory does not intermediate
-comments, branches, issues, or pull requests and cannot promise exactly-once
-external side effects.
+The main downside is that V1 trusts an agent's semantic status report. Factory
+validates identity, scope, transition shape, and cheap external facts, but it
+does not attempt to prove the implementation correct. This is deliberate. The
+first version tests whether agent-directed status plus durable coordination is
+more useful than managing many terminal sessions.
 
 ## 2. Context and scope
 
-The current [architecture](../../ARCHITECTURE.md) already has useful execution
-machinery: durable tasks, isolated worktrees, leases, events, cancellation,
-cleanup, runtime supervision, and a repository catalog. It also already lets an
-agent use authenticated `gh` from the Worker host.
+The current [architecture](../../ARCHITECTURE.md) already supplies durable
+Tasks, Runs, repository Sessions, Attempts, leases, local and VM Workers,
+isolated worktrees, cancellation, events, retries, and retained failure state.
+The browser now presents Runs as Work, but admission is still centered on a
+saved Task with a fixed repository set. An invocation cannot supply several
+work-item targets, and an agent can only return arbitrary result text when its
+process exits.
 
-The problem is the product model. A user who wants to run one prompt must
-understand Workflows, revisions, Tasks, and workers. Scheduled work adds
-Automations and Occurrences. Running the same prompt across five repositories
-is not one visible operation.
+Two user needs motivate the change:
 
-This revision keeps the reliable execution machinery and simplifies the
-operator experience. It covers the V1 journey and the boundaries later Worker
-and Trigger types must preserve. It does not design a generic automation
-platform or a deterministic GitHub action gateway.
+```sh
+factory build LINEAR-123 LINEAR-124 --repo github.com/acme/api
+factory run bug-fix --repos all
+```
+
+The first queues existing software tasks. The second applies one reusable
+engineering procedure to a repository fleet. Both need the same scheduling,
+isolation, agent runtime, progress, cancellation, result, and retry machinery.
+
+This design covers one local single-operator control plane, local and enrolled
+VM Workers, a unified CLI, manual work-item admission, repository fleet
+admission, a built-in standard Build procedure, saved Procedures, and the
+agent update capability. It does not add a public team service, a provider
+plugin system, a general pipeline graph, central CI waiting, or automatic
+merge.
 
 ## 3. System context
 
 ```mermaid
 flowchart LR
-    U["Operator"] --> D["Definition: saved prompt"]
-    T["Manual or schedule Trigger"] --> R["Run: one invocation"]
-    D --> R
-    R --> J1["Job: repository A"]
-    R --> J2["Job: repository B"]
-    J1 --> RN["Worker"]
-    J2 --> RN
-    RN --> A["Pi, Codex, Claude Code, or another coding agent"]
-    A --> G["Git and GitHub CLI"]
-    J1 --> M["Lifecycle and metrics"]
-    J2 --> M
+    O["Developer"] --> CLI["Factory CLI or browser"]
+    GH["GitHub issue URL"] --> CLI
+    LR["Opaque reference such as LINEAR-123"] --> CLI
+    CLI --> CP["Factory control plane"]
+    P["Built-in or saved Procedure"] --> CP
+    CP --> R["Run with frozen targets"]
+    R --> W1["Work: repository and optional item"]
+    R --> W2["Work: repository and optional item"]
+    W1 --> WK["Local or VM Worker"]
+    W2 --> WK
+    WK --> A["Existing coding-agent runtime"]
+    A --> FT["Attempt-scoped Factory update tool"]
+    A --> EXT["Git, GitHub CLI, tests, and other tools"]
+    FT --> WK
+    WK --> CP
 ```
 
-Factory owns Definitions, Triggers, Runs, Jobs, Worker coordination, repository
-targets, lifecycle events, results, and metrics. The Worker owns the execution
-environment, worktree, agent process, and available tools. The agent owns the
-engineering work it performs with those tools. GitHub remains the source of
-issues, pull requests, reviews, and repository state.
+The control plane owns Run and Work records, target identity, scheduling,
+immutable input, update history, and user-visible state. A Worker owns its
+repository cache, Attempt lease, worktree, supervisor, agent process, and the
+local update endpoint. The coding agent owns engineering judgment and external
+actions performed with Worker-host tools. GitHub, Linear, and other systems
+remain sources of work and delivery state, not Factory databases.
 
 ## 4. Proposed design
 
-### V1 user journey
+### How it works
 
-#### Configure a local Worker
+#### Build work items
 
-As an operator, I want to connect a local agent Worker so Factory can run Pi,
-Codex, Claude Code, or another supported coding agent on my machine.
+A developer runs:
 
-One local launcher command starts the control plane and a local Worker process.
-On first start, the Worker creates a durable random identity at
-`~/.factory/worker/id`, then registers with the control plane. Restarting the
-launcher reuses that identity.
+```sh
+factory build LINEAR-123 LINEAR-124 --repo github.com/acme/api
+```
 
-The Worker performs bounded, non-interactive health checks for Git,
-authenticated `gh`, and installed agent runtimes such as Pi, Codex, and Claude
-Code. The setup screen shows each capability as ready, missing,
-unauthenticated, or unhealthy. One host may advertise several runtimes. A
-Definition selects the runtime and required tools; each Job still launches one
-isolated agent process. V1 configuration does not install or authenticate
-third-party CLIs for the user.
+The CLI resolves the managed repository and sends one idempotent admission
+request containing the ordered references. The control plane selects the
+built-in `standard-build` Procedure, freezes its current generation, and
+creates one Run with two Work targets. Each Work has its own identity,
+repository, context, state, progress history, result, and Attempts. Two targets
+may use the same repository.
 
-#### Configure repositories
+GitHub issue URLs derive their repository and canonical source identity. An
+opaque reference such as `LINEAR-123` requires `--repo` in V1. Factory does not
+fetch Linear. The agent reads the live item with tools available on its Worker,
+or reports `needs-input` when it cannot obtain enough context. Manual text can
+be supplied with an explicit repository and receives a random source identity.
 
-As an operator, I want to add the GitHub repositories my team works on so I can
-choose where a Definition runs.
+A Worker claims eligible Work, prepares an isolated worktree, and starts its
+resolved Pi, Codex, or Claude Code runtime. The operator configures one default
+Build runtime during setup and may override it with `--runtime`; admission
+freezes the resolved choice. The final prompt contains a short
+Factory safety preamble, the frozen standard Build Procedure, repository and
+branch metadata, the untrusted work-item context, and the update-tool contract.
+The agent chooses how to refine, build, test, use subagents, review, open a pull
+request, and repair CI.
 
-Factory stores canonical repository identities and enabled state. Workers
-acquire a configured repository on demand and never clone a URL supplied by a
-prompt or webhook payload.
+During execution the agent may report progress:
 
-#### Save a shared Definition
+```sh
+factory update --status=running --message="Waiting for integration CI"
+```
 
-As an operator, I want to save a prompt such as `Find bugs`, `Triage issues`, or
-`Review pull request` so everyone using the same trusted Factory instance runs
-the same instructions.
+Before finishing it reports exactly one Attempt-ending outcome:
 
-A Definition stores a name, prompt, required runtime, timeout, and execution
-defaults. Definitions edit in place. Each Run stores the complete Definition
-snapshot it used, so historical Runs remain understandable without exposing a
-revision library.
+```sh
+factory update --status=ready --pr=<url> --message="Ready for human review"
+factory update --status=needs-input --message="Which API behavior is correct?"
+factory update --status=failed --message="The required service is unavailable"
+```
 
-#### Run once on one repository
+The local helper validates the Attempt-scoped capability and forwards the
+typed update through the Worker. An Attempt-ending update becomes final only after the
+agent process stops and the Worker completes the Attempt under its existing
+lease. A process that exits without an outcome update fails with the visible
+reason `Agent exited without reporting an outcome.` Factory never parses the
+agent's final prose to infer status.
 
-As an operator, I want to select a Definition and repository and press **Run
-once** so an agent completes the work end to end.
+Attempt lifecycle and Work outcome are deliberately separate. When an agent
+reports any valid Attempt-ending outcome and then stops, the Attempt is `succeeded`
+because the runtime completed its contract. The Work becomes the reported
+`ready`, `needs-input`, `failed`, or `no-change` outcome. A runtime, lease, or
+missing-report failure makes the Attempt `failed` and the Work `failed` with an
+infrastructure reason. `needs-input` pauses rather than terminates the Work.
+Cancellation makes both records cancelled.
 
-Factory creates one Run containing one Job. The Job moves through pending,
-blocked, queued, preparing, running, and then succeeded, failed, cancelled, or
-skipped. Attempt history, events, and cleanup remain implementation details
-shown inside the Job when useful.
+#### Run a Procedure across repositories
 
-#### Run once across repositories
+A developer runs:
 
-As an operator, I want to select five repositories and press **Run once** so the
-same Definition runs independently against all five.
+```sh
+factory run bug-fix --repos all
+```
 
-Factory freezes the complete target list and creates one Job per repository.
-Jobs can run concurrently, fail independently, and be retried individually.
-The Run shows aggregate progress without hiding per-repository outcomes.
+Factory freezes the current `bug-fix` Procedure and the enabled managed
+repository set, then creates one Work target per repository. The Procedure asks
+the agent to find and fix one concrete bug, or report `no-change` when no
+defensible change exists. Work is admitted up to the Run concurrency limit and
+Worker capacity. The Run shows aggregate counts without hiding each target.
 
-#### Track the software factory
+The same update contract applies:
 
-As an operator, I want a dashboard showing what is running, what failed, and
-how long work takes so I can understand the factory rather than inspect process
-logs.
+```sh
+factory update --status=no-change --message="No reproducible bug was found"
+```
 
-V1 reports queued and running Jobs, success and failure counts, queue time,
-cycle time, throughput, and Worker health. Metrics can be filtered by
-Definition, repository, Worker, and time window.
+Retry, cancel, events, timeouts, and retained worktrees remain per Work target.
 
-Queue time runs from `admitted_at` to `started_at`. Cycle time runs from
-`admitted_at` to `terminal_at`. Throughput is the number of Jobs with a
-`terminal_at` in a time window. Success rate is succeeded Jobs divided by
-succeeded plus failed Jobs; cancelled and skipped Jobs are excluded.
+#### Answer a question
 
-#### Run on a schedule
+When an agent reports `needs-input`, Factory stores the exact question and
+makes the Work visible in the attention column. The developer answers through
+the CLI or browser. The answer is stored as trusted operator context and a new
+Attempt starts in the same Work history. Factory does not keep an idle agent
+process alive while waiting for a person.
 
-As an operator, I want to schedule a Definition across selected repositories so
-routine engineering work runs without manual action.
+### Components and responsibilities
 
-A schedule is a Trigger attached to a Definition. At each due instant it creates
-the same Run and Jobs as **Run once**. For example, a Monday `Find bugs`
-Definition can inspect five repositories. The agents may use `gh` to create
-issues or pull requests as instructed.
+#### Procedure store
 
-### Later user journeys
+The Procedure store owns names, trusted instructions, runtime, timeout,
+concurrency, outcome contract, mutable generation, archive state, and the built-in
+`standard-build` Procedure. It snapshots a complete Procedure into every Run.
+It does not own work-item content, repositories selected for an ad-hoc
+invocation, agent skills, or external provider state. A saved Procedure may
+retain a default repository set used by its existing schedule.
 
-An operator can add a Worker on a remote VM without changing a Definition. This
-is the first scaling path beyond the local machine. A later GitHub webhook
-Trigger creates a Run when an issue or pull request event arrives,
-such as running a shared `Review pull request` Definition when a pull request is
-opened.
+`standard-build` has a stable built-in key and a version shipped with the
+binary and always uses `outcome_contract=agent_update`. It is read-only through
+operator surfaces. Its runtime resolves from
+the configured default Build runtime or an explicit invocation override. A
+binary update may change the version used by future Runs, but every admitted
+Run retains the exact prior text, version, and resolved runtime. The standard
+Build Procedure is not schedulable in V1.
 
-Kubernetes and other execution targets may be added through the same Worker
-contract later. They are not active roadmap milestones.
+Existing Tasks remain on their current process-exit completion contract and
+keep the same IDs, generations, repository selection, and schedules. They may
+appear as legacy Procedures in operator surfaces, but do not require
+`factory update` until an operator explicitly converts them to the new outcome
+contract. `outcome_contract` is `process_exit` or `agent_update`; conversion
+increments the Procedure generation. Their next scheduled occurrence behaves
+exactly as it does today.
 
-These paths must create the same Run and Job records. They are not different
-automation products.
+New Procedures default to `agent_update`. `process_exit` exists only to retain
+unconverted legacy behavior. Every Run snapshot stores the selected contract,
+so later conversion cannot change admitted or historical Work.
 
-After the local and VM Worker experience is stable, a production-scale
-orchestration backend may move durable timers, retries, cancellation, fan-out,
-and recovery to Temporal. Factory remains the product and API boundary. The
-selected backend is an operational choice, not a Definition authoring choice.
-The detailed design must decide whether Workers continue to use Factory's
-lifecycle API or consume backend task queues directly while preserving
-outbound-only connections and the existing trust model. Internal Worker
-transport and configuration may vary, but identity, capability, capacity,
-lifecycle, and trust semantics remain stable.
+#### Admission service
 
-### Agent-owned GitHub work
+The admission service owns request idempotency, source normalization, target
+validation, repository resolution, target limits, and transactional Run and
+Work creation. It does not fetch opaque provider references or start agents.
 
-The agent reads and changes GitHub through `gh`, just as it does when run
-directly by a developer. Factory does not define typed comment, branch, issue,
-or pull-request actions. It does not publish patches or reconcile provider
-side effects.
+#### Work service
 
-For a trusted local or VM Worker, the agent uses the Worker user's authenticated
-`gh`. A later managed Worker profile may inject a short-lived,
-repository-scoped `GH_TOKEN` for the Job. The token disappears when the agent
-process ends.
+The Work service owns user-visible state, update events, questions and answers,
+result metadata, PR URL, stable publish branch, cancellation, and explicit
+retry. It depends on the existing Execution and Attempt lifecycle but does not
+own agent processes or worktrees.
 
-Factory supplies stable `FACTORY_RUN_ID` and `FACTORY_JOB_ID` environment
-values. Definitions can use those values in branch names, comments, or other
-markers when retry-safe behavior matters. The Job result may report issue or
-pull-request URLs, but Factory treats them as agent output rather than provider
-state it owns.
+#### Worker and supervisor
 
-### Component boundaries
+The Worker owns routing compatibility, repository acquisition, Attempt-local
+branches, a stable remote publish branch, the Attempt-scoped update endpoint,
+process supervision, leases, event forwarding, cancellation, and cleanup. It
+does not transmit its Worker credential or lease token through the update
+protocol. V1 does not treat the agent process as isolated from other files and
+services available to the Worker operating-system user. The Worker does not
+decide whether the engineering task is semantically complete.
 
-The control plane owns saved configuration, admission, target snapshots,
-scheduling, leases, results, and metrics. It never runs an agent process and
-does not interpret prompt output as commands.
+#### Agent runtime
 
-The Worker owns runtime discovery, repository preparation, process supervision,
-events, cancellation, and cleanup. It does not decide which repositories a Run
-targets.
+The agent runtime owns model interaction, repository exploration, planning,
+subagents, implementation, tests, review, provider tools, pull-request work,
+and semantic status selection. It may update only its current Work through the
+scoped capability. Factory does not implement a competing model loop.
 
-The agent runtime owns model interaction and engineering tool use. Factory does
-not reproduce tools already available to Pi, Codex, Claude Code, or another
-configured coding agent.
+#### Operator surfaces
 
-The browser and future CLI use the same API. The primary navigation is
-Overview, Definitions, Runs, Repositories, and Workers. A Job is viewed inside
-its Run. Triggers are configured on a Definition.
+The CLI and browser use the same local operator API. They own presentation and
+operator actions, not scheduling or state derivation. The main browser surface
+is Work, with Run aggregation, Work detail, latest progress, question answering,
+retry, cancellation, Worker visibility, and Procedure management.
 
 ### Decisions
 
-#### Five product concepts
+#### One execution primitive for items and fleets
 
-Definition, Trigger, Run, Job, and Worker are sufficient. Attempt remains Job
-history, Repository remains configured infrastructure, and GitHub connection
-details remain settings. We reject separate Runbook, Workflow revision,
-Automation, Occurrence, and Provider Action product resources.
+A Run contains frozen targets, and each target becomes Work. A work-item target
+contains one repository plus a source reference. A fleet target contains one
+repository. We reject separate queue, batch, campaign, and fleet-run models
+because their execution behavior is the same. The cost is that Work target
+identity must replace the current assumption that a Run contains at most one
+Session per repository.
 
-#### One Job per repository
+#### Agent-directed semantic state
 
-A Run may fan out, but each Job owns one repository and optional work item.
-This keeps worktrees, retries, credentials, cost, and results independent.
+The agent reports progress and an Attempt-ending outcome through a typed Factory
+capability. We reject parsing final text and reject deterministic code as the
+sole judge of completion. The agent can interpret acceptance criteria,
+repository conventions, tests, and external feedback more effectively. The
+cost is that a capable but mistaken agent may report `ready` too early. Factory
+records evidence and can return obvious validation feedback, but V1 accepts
+that semantic trust boundary.
 
-#### One execution path
+#### Worker-owned process completion
 
-Manual, API, schedule, and later webhook admission create the same Run and Job
-records. A Trigger decides when to admit work. It does not execute an agent.
+Agent updates do not carry the Worker lease and do not directly complete an
+Attempt. The Worker remains the only component that finalizes process state
+after the process stops. We reject exposing the control-plane operator or
+Worker credential through the update protocol. The cost is a small two-part lifecycle: an
+agent outcome report followed by Worker process completion.
 
-#### Agents use their tools
+#### One agent process owns the inner development loop
 
-The Worker gives the agent a prepared repository and its configured tools.
-Factory does not become a GitHub client on behalf of the agent. This preserves
-the capability of the underlying agent and avoids a second action language.
+The standard Build agent owns refinement, implementation, tests, subagent
+review, PR creation, and CI repair in one Attempt. Factory shows these as
+progress, not durable stages. We reject a Build, Review, Test, and Merge DAG in
+V1. The cost is that an agent may occupy a Worker slot while waiting for CI.
+Measured slot waste or timeout frequency can justify a later event-driven
+continuation design.
 
-#### Backend-neutral orchestration
+#### Stable remote branch, unique local Attempt branches
 
-SQLite-backed orchestration is the default and supported local product, not a
-temporary demo. A future durable backend must preserve Definition snapshots,
-Run and Job identities, idempotent admission, per-Job history, cancellation,
-and the retry warning for agent-owned external effects. Factory must keep the
-same operator API and product vocabulary across backends. Temporal workflow,
-activity, task-queue, and retry-policy concepts stay out of normal Definition
-authoring.
+Every Work derives one stable remote publish branch. Every Attempt still uses
+a unique local branch and worktree. A retry starts from the current remote
+publish head when it exists and pushes back to the same remote branch. We
+reject reusing one local branch because failed worktrees are intentionally
+retained. This reduces duplicate PR risk but cannot provide exactly-once issue
+comments or other agent side effects.
 
-This direction does not assert that the current store already implements a
-backend interface. [Issue #259](https://github.com/owainlewis/factory/issues/259)
-owns the architecture decision, state-ownership boundary, mixed-version
-migration and rollback plan, operational requirements, and a prototype that
-runs one unchanged Definition on both backends.
+The Claim and prompt contain the immutable publish ref. The standard Procedure
+requires the agent to push local `HEAD` to that ref and use it as the pull
+request head. Before accepting `ready`, the Worker verifies that local `HEAD`,
+the fetched remote publish ref, and the PR head SHA match, and that the PR head
+branch and repository match the Work. A mismatch returns actionable validation
+feedback and leaves the Attempt running. Factory never force-pushes or deletes
+the remote publish branch. A normal non-fast-forward push is for the agent to
+reconcile or report as `needs-input`.
+
+#### Built-in standard Build Procedure
+
+V1 ships one read-only, versioned standard Build Procedure. It asks the agent
+to follow repository instructions, refine the work, implement completely,
+test, use a fresh review subagent, fix valid findings, open or update one pull
+request, handle CI, and report through Factory. We reject a skill registry and
+prompt marketplace. Installed skills remain runtime behavior, while the exact
+Procedure text and generation are frozen for audit.
+
+The prompt must also state that the Work is unfinished until the agent has
+called `factory update`, list every allowed status, require a PR URL for
+`ready`, explain that `needs-input` ends the current Attempt, and tell the agent
+to use progress updates only when they help an operator. These are Procedure
+requirements, not a transcript parser or a Factory-owned reasoning loop.
+
+#### GitHub URLs and explicit repositories first
+
+V1 parses GitHub issue URLs because they contain repository identity. Opaque
+references require an explicit managed repository. We reject a Linear client,
+provider plugin interface, and automatic team mapping in the first slice.
+Those additions require separate credential, namespace, and mapping decisions.
+
+#### Ready stops before merge
+
+`ready` means the agent reports that a pull request is ready for a human. The
+report includes a PR URL and message, and Factory may validate that the URL
+belongs to the expected repository. GitHub owns review, mergeability, and
+merge. We reject automatic merge and a durable `complete` state in V1 because
+both require ongoing provider observation and repository policy.
+
+#### Product names can move before internal table names
+
+The user-facing model becomes Procedure, Run, Work, and Worker. The current
+Task, Run, Session, Execution, and Attempt tables may evolve incrementally.
+Implementation must not perform a broad schema rename merely to ship the first
+vertical slice. Historical API and database names remain internal until a
+separate migration can preserve every record and link.
+
+Initially, the existing Task record can back a legacy Procedure and the
+existing Session and Execution records can back Work execution. Legacy
+schedules keep creating Runs from their configured repository selection and
+retain exit-based success. New fields and adapters must preserve current Task,
+Run, Session, Attempt, event, and schedule behavior; renaming storage or
+converting completion contracts is not a prerequisite for testing the product
+model.
 
 ## 5. Invariants and requirements
 
 ### Invariants
 
-1. Every invocation creates one Run and at least one Job.
-2. A Run freezes one Definition and one complete target set.
-3. Every Job belongs to one Run and one repository.
-4. Editing a Definition or Trigger never changes an existing Run.
-5. Replaying one admission identity creates no duplicate Run or Job.
-6. One active Attempt lease owns one agent process.
-7. Worker loss cannot erase Job history or a retained recovery artifact.
-8. One large Run cannot prevent an unrelated compatible Run from progressing.
-9. Factory never claims exactly-once external effects performed by an agent.
+- `INV-1`: Every admitted command creates one Run and at least one Work target
+  in one transaction.
+- `INV-2`: A Run freezes one complete Procedure generation and ordered target
+  set.
+- `INV-3`: Every Work belongs to one Run and one managed repository.
+- `INV-4`: Two Work targets in one Run may use the same repository but cannot
+  have the same target identity.
+- `INV-5`: One active Attempt lease owns one agent process.
+- `INV-6`: The injected agent update capability accepts updates only for its
+  current Work and Attempt.
+- `INV-7`: The update protocol never contains a Worker credential, operator
+  credential, or Attempt lease token.
+- `INV-8`: An Attempt-ending agent report becomes final only after its agent
+  process has stopped.
+- `INV-9`: Cancellation prevents a later agent report from making Work ready.
+- `INV-10`: Factory never derives semantic success by parsing arbitrary agent
+  output.
+- `INV-11`: One Work has one stable remote publish branch and each Attempt has
+  one unique local branch.
+- `INV-12`: Retrying one Work never replays a terminal sibling.
+- `INV-13`: Work-item and repository content cannot change the trusted
+  Procedure or choose a repository clone source.
+- `INV-14`: Historical Work identifies the exact Procedure, context, target,
+  runtime, Worker, updates, Attempts, and outcome used.
+- `INV-15`: Factory does not claim exactly-once external side effects performed
+  by an agent.
+- `INV-16`: A legacy Task keeps its process-exit completion behavior until an
+  operator explicitly converts its outcome contract.
+
+### Work state transitions
+
+Progress is an event, not a durable workflow state change. `running` means an
+execution owner exists. `needs-input` ends the current Attempt but pauses the
+Work, so it is not terminal. Capacity and routing waits remain `queued` with a
+visible `waiting_reason`; V1 does not add a separate blocked state.
+
+| Current state | Owner | Allowed transition | Cause |
+| --- | --- | --- | --- |
+| `queued` | none | `running` | Worker claim creates an Attempt, or trusted operator claims manual ownership |
+| `queued` | none | `cancelled` | operator cancellation |
+| `running` | Worker Attempt | unchanged | agent `running` progress update |
+| `running` | Worker Attempt | `ready`, `needs-input`, `failed`, `no-change` | accepted outcome followed by stopped process |
+| `running` | operator | `ready`, `needs-input`, `failed`, `no-change` | trusted operator update |
+| `running` | either | `cancelled` | operator cancellation |
+| `needs-input` | none | `queued` | operator answer appends context; the next Worker claim creates the Attempt |
+| `needs-input` | none | `running` | trusted operator claims manual ownership |
+| `needs-input` | none | `cancelled` | operator cancellation |
+| `failed` or `cancelled` | none | `queued` | explicit warned retry |
+
+`ready`, `failed`, `no-change`, and `cancelled` are terminal outcomes unless an
+explicit retry rule above applies. A manual `running` update atomically records
+operator ownership and removes the Work from Worker eligibility. A direct
+manual terminal update from queued Work performs that claim and completion in
+one transaction. An operator must cancel an active Worker Attempt before taking
+manual ownership.
 
 ### Requirements
 
-- A manual Run can target one or up to 500 configured repositories.
-- Invalid, duplicate, disabled, empty, or oversized target sets create no Run.
-- A Run defaults to at most 20 active Jobs with fair admission across Runs.
-- A Job can be cancelled or retried without replaying successful siblings.
-- A failure before the agent process starts may retry under a bounded
-  infrastructure policy. Any failure after process start requires an explicit
-  warned retry.
-- Retrying any Job after its agent started warns that external effects may
-  already have happened.
-- A Job waiting for a compatible Worker stays visible as blocked.
-- Dashboard aggregates never hide the underlying Jobs.
+- One admission accepts 1 to 100 Work targets.
+- A Run defaults to at most 10 executing Work targets and accepts a configured
+  limit from 1 to 100.
+- Scheduling must not let one large Run starve older eligible Work in another
+  compatible Run. The implementation may reuse the current scheduler and add
+  only the smallest fairness rule its tests require.
+- Progress messages are non-empty UTF-8 text of at most 2 KiB.
+- Outcome messages are non-empty UTF-8 text of at most 8 KiB.
+- One Attempt stores at most 200 accepted agent updates. A later progress call
+  receives a visible limit error; one outcome update remains allowed.
+- Agent update statuses are `running`, `ready`, `needs-input`, `failed`, and
+  `no-change`.
+- Agent-owned `ready` requires one HTTPS GitHub pull-request URL whose
+  repository, head branch, and head SHA match the Work repository, immutable
+  publish ref, remote ref, and local `HEAD`. Manual `ready` requires the
+  expected repository and records the provider-reported branch and SHA.
+- `needs-input`, `failed`, and `no-change` require a message. `needs-input`
+  exposes the message as the current operator question.
+- Exactly one Attempt-ending agent report can win. Repeating the same report is
+  idempotent; a different outcome report conflicts.
+- Every update invocation has a random request ID. A transport retry with the
+  same Attempt and request ID, or the same operator Work and request ID, returns
+  the stored response.
+- A process exit without an outcome report fails with a fixed reason.
+- An operator answer is non-empty UTF-8 text of at most 8 KiB and requeues Work
+  without changing the frozen Procedure or original context. The next Worker
+  claim creates the Attempt.
+- V1 performs no automatic execution retry. Every failed or cancelled Work
+  retry is explicit and warns about duplicate external effects if an agent
+  process previously started.
+- Setup requires one valid default Build runtime. `factory build --runtime`
+  accepts only a configured runtime and admission freezes the resolved choice.
+- A trusted operator may update Work only when it has no active Attempt.
+- Queue, Work, update, Attempt, and Worker list APIs remain bounded and cursor
+  paginated.
+- The local operator API remains loopback-only. Remote Workers continue to use
+  the separate authenticated TLS listener.
 
 ## 6. Interfaces and data
 
-| Resource | Owns |
-|---|---|
-| Definition | name, prompt, runtime and tool requirements, timeout, defaults, generation |
-| Trigger | Definition, kind, enabled state, schedule or later event rule, target repositories, context, timeout override |
-| Run | source identity, Definition snapshot, parameters, frozen target set, aggregate state |
-| Job | Run, repository, ref or work item, Worker requirement, state, timestamps, result, metrics |
-| Worker | stable identity, runtime and tool capabilities, capacity, health |
+### CLI
 
-Attempt records remain behind Job and store leases, process identity, events,
-timestamps, outcomes, and recovery state.
+```text
+factory build [--repo REPOSITORY] [--runtime RUNTIME] [--request-key KEY] [--wait] REFERENCE...
+factory run PROCEDURE --repos REPOSITORY...|all [--request-key KEY] [--wait]
+factory status [--run RUN_ID]
+factory show WORK_ID
+factory answer WORK_ID MESSAGE
+factory retry WORK_ID
+factory cancel WORK_ID
+factory update [--id WORK_ID] --status STATUS --message MESSAGE [--pr URL] [--head-branch BRANCH] [--head-sha SHA]
 
-The control plane owns Job state. A Worker reports preparation, process start,
-events, and completion under its Attempt lease; the control plane validates the
-lease before applying a transition.
+factory procedures
+factory workers
+factory worker start [--config PATH]
+factory server start [--config PATH]
+```
 
-- `pending`: admitted but held by the Run concurrency limit.
-- `blocked`: no healthy Worker satisfies the runtime, tools, or repository.
-- `queued`: eligible for a compatible Worker to claim.
-- `preparing`: claimed while the Worker prepares the repository and process.
-- `running`: the agent process has started.
-- `succeeded`, `failed`, `cancelled`, and `skipped`: terminal outcomes.
+Finite operator commands call the loopback API and never open SQLite or Worker
+directories. `factory update` detects an injected Attempt context and uses the
+Worker-local capability. Without that context it is a trusted operator command
+and requires `--id`.
 
-The Run state is derived from its Jobs. It is `running` while any Job is
-preparing or running, `blocked` when all remaining Jobs are blocked, `queued`
-when work remains but none is active, and `cancelling` after cancellation is
-requested while work remains. Once every Job is terminal, the Run is `failed`
-if any Job failed, `cancelled` if none failed and any Job was cancelled, and
-otherwise `succeeded`. Per-state Job counts remain visible for mixed outcomes.
+An operator `running` update atomically claims manual ownership when the Work
+has no active Attempt. Later operator updates require that ownership. A direct
+terminal update from queued Work claims and completes it in one transaction.
+An operator who wants to take over active agent Work must cancel its Attempt
+first. This makes manual and agent-driven Work share one history without
+creating a second completion model or a claim race.
 
-Every Job stores `admitted_at`, optional `started_at`, and `terminal_at` when it
-finishes. A Worker is online when its last valid registration is no more than 30
-seconds old. It is degraded when online but none of its enabled runtimes is
-healthy, and offline after 30 seconds without registration.
+A manual `ready` update is not required to have a Factory worktree or publish
+branch. The CLI uses the operator's local GitHub credentials to resolve the PR
+head branch and SHA, or accepts explicit `--head-branch` and `--head-sha`
+evidence. The control plane validates the PR URL's expected repository and the
+field shapes, then records the branch and SHA as trusted operator evidence. It
+does not need GitHub credentials. Agent-owned Work uses the stricter Worker
+validation below.
 
-IDs are random UUIDs. A Worker ID persists on its host. A manual or API Run uses
-a caller request key. A scheduled Run uses `(Trigger ID, scheduled UTC instant)`.
-A later webhook Run uses `(Trigger ID, delivery ID)`.
+### Agent update contract
 
-Existing Workflow current content maps to Definition prompt. A Workflow revision
-maps to the snapshot already stored on historical work. Automation schedule
-configuration maps to a Trigger. The Task execution contract informs the new Job
-contract, and worker maps to Worker.
+The Worker injects:
 
-Historical Tasks, Executions, Attempts, events, and linked Occurrences remain in
-a clearly labelled read-only **Legacy history** view. Their existing URLs and
-identities remain valid. Factory does not create synthetic Runs for them or
-project them as Jobs because they never belonged to a Run.
+```text
+FACTORY_WORK_ID
+FACTORY_ATTEMPT_ID
+FACTORY_UPDATE_SOCKET
+FACTORY_UPDATE_TOKEN
+```
+
+The socket is created below the Worker data directory with mode `0600`. The
+random update token is valid only while the Attempt owns its active lease. The
+Worker stores only its digest and never forwards the token to the control
+plane. For each invocation, the helper creates a random request ID and reuses it
+for bounded transport retries. The Worker validates the token, Work and Attempt
+identity, request ID, current lifecycle, status, message, and optional PR URL
+before forwarding a typed update under the Worker lease.
+
+The token is a scope and accidental-misuse guard, not a sandbox boundary. V1
+trusts processes running as the Worker operating-system user with the same host
+authority as that user. A local agent can reach the unauthenticated loopback
+operator API, and a remote agent may be able to read the Worker credential.
+Operators who need hostile-code isolation must use separate OS identities and
+an authenticated operator endpoint, which are outside V1.
+
+An accepted outcome update sets `terminal_reported_at` and asks the agent to
+stop. The supervisor allows ten seconds for normal exit, then stops the process
+group. The Worker reports terminal Attempt completion only after it proves the
+process group stopped. Cancellation received before completion wins.
+
+On completion, a valid outcome report maps to a `succeeded` Attempt and its
+reported Work outcome. No report or an infrastructure error maps to a `failed`
+Attempt and failed Work. This keeps process execution evidence separate from
+the agent's semantic judgment.
+
+### Stored resources
+
+| Resource | New or changed ownership |
+| --- | --- |
+| Procedure | trusted instructions, runtime, timeout, concurrency, outcome contract, generation |
+| Run | Procedure snapshot including outcome contract, resolved runtime, source, ordered frozen targets, aggregate state |
+| Work | target identity, repository, source context, publish branch, user state, execution owner, waiting reason, question, result |
+| Work update | Work, optional Attempt, request ID, sequence, status, message, PR URL, accepted time, actor |
+| Attempt | Worker lease, process identity, local branch, lifecycle and events |
+| Worker | capacity, runtime capabilities, repository access and retained worktrees |
+
+A Work target stores:
+
+```text
+id
+run_id
+target_key
+target_kind: work_item | repository
+repository_id
+repository_identity
+source_kind: github_issue | opaque | manual | repository
+source_key
+source_reference
+context_snapshot
+publish_branch
+state
+execution_owner: none | worker_attempt | operator
+waiting_reason
+latest_progress
+question
+pull_request_url
+pull_request_head_branch
+pull_request_head_sha
+terminal_message
+timestamps
+```
+
+The existing Execution and Attempt records remain internal. Existing Run and
+Session history stays readable. An implementation may initially add the new
+target and update fields to current records rather than renaming every table.
+
+Run state is a derived summary, not a second workflow engine. A Run is active
+while any Work is queued or running, needs attention when no Work can advance
+and at least one needs input, and finished when every Work is terminal. Mixed
+success and failure are shown as counts rather than collapsed into one success
+label. The control plane may cache this projection, but Work remains its source
+of truth.
+
+### Naming and identity
+
+Run, Work, Attempt, and Worker IDs are random UUIDs. A Work publish branch is
+derived from its immutable Work ID and is bounded to a Git-safe value such as
+`factory/work-<uuid-prefix>`.
+
+A GitHub issue URL normalizes to
+`github:<lowercase-owner>/<lowercase-repository>:issue:<number>`. An opaque
+reference normalizes Unicode whitespace but otherwise preserves case and is
+scoped to its managed repository. Manual text uses a random source key. A
+repository target uses the managed repository ID.
+
+`target_key` is the source key plus repository ID for a work item and the
+repository ID for a fleet target. It is unique inside one Run. The admission
+request key and normalized request digest make uncertain client replay return
+the original Run. A second active Build for the same work-item target conflicts.
+After terminal Work, `factory build` requires `--rebuild` to admit the same
+target again.
+
+An agent update request is unique by `(attempt_id, request_id)`. An operator
+update request is unique by `(work_id, request_id)`. The CLI generates the
+request ID once per invocation and reuses it for its internal retry. A repeated
+outcome report with identical fields returns the accepted result even when it
+arrives in a later invocation; a different outcome report conflicts.
 
 ## 7. Failure behavior and lifecycle
 
-Run admission stores the Definition snapshot, complete target set, and Jobs in
-one transaction. A selector failure stores nothing.
+Admission validates the complete target set before writing anything. Unknown,
+disabled, duplicate, empty, or oversized targets create no Run. An opaque
+reference without an explicit repository creates no Run.
 
-If no compatible Worker is online, the Job remains blocked with a reason. If a
-Worker disappears before its agent process starts, its lease expires and the
-Job may follow its bounded infrastructure retry policy. Loss after process
-start fails the Attempt and requires an explicit warned retry because the agent
-may already have changed GitHub. Cancelling a Run cancels undispatched Jobs and
-requests cancellation of active agents without rewriting terminal outcomes.
+Work waits visibly when no compatible Worker has capacity. A Worker that loses
+its lease stops the agent process group. Infrastructure failure before or after
+process start fails the Attempt and Work. V1 never retries execution
+automatically. An explicit retry warns about duplicate effects when a process
+previously started because the agent may already have pushed, commented, or
+opened a pull request.
 
-An agent may complete a GitHub write and then crash before reporting success.
-Factory records the Job failure and retained events but does not repeat or undo
-the write. A manual retry displays the duplicate-effect warning and gives the
-new agent the stable Run and Job identities.
+Each retry creates a fresh local worktree. If the stable remote publish branch
+exists, preparation starts from its current fetched head. Otherwise it starts
+from the repository base only when no PR is recorded. A missing publish branch
+for known PR Work moves the Work to `needs-input` instead of guessing. The retry
+prompt identifies prior updates, known PR, publish ref, and duplicate-effect
+risk. Factory never force-pushes or deletes the ref. If the ref moves while an
+Attempt is active, the agent must reconcile a normal push or report
+`needs-input`.
 
-Migration starts with a preview of every Workflow and Automation. Factory stops
-new legacy Automation evaluation and lets already admitted Tasks and Executions
-finish or be cancelled. It then imports current Workflow content as Definitions.
+An agent update request with an expired or wrong token is rejected. An exact
+transport retry returns the stored update. A second identical Attempt-ending
+report returns the stored outcome, while a different outcome report conflicts.
+Progress after an outcome report conflicts.
 
-Schedule Automations migrate losslessly. Their repository, context, timeout,
-enabled state, schedule, and next due instant become Definition or Trigger
-fields as appropriate. Current GitHub issue and pull-request polling Automations
-have no V1 equivalent. The preview marks them unsupported, keeps their history
-readable, and requires explicit operator confirmation before retiring them. It
-recommends either a scheduled Definition whose agent queries GitHub with `gh`,
-or the later webhook Trigger.
+For `ready`, the Worker performs a bounded GitHub and remote-ref check before
+accepting the report. A timeout or provider outage returns a retriable validation
+error and leaves the Attempt running. Factory validates delivery identity, not
+CI success or semantic correctness; the agent remains responsible for both.
 
-After every supported item imports or receives an explicit retirement decision,
-Factory writes a cutover marker and enables new admission. No in-flight work is
-translated between execution models. After cutover, completed standalone Tasks
-and Occurrence-linked Tasks remain available only through Legacy history.
+If the agent process exits without an outcome report, the Worker fails the
+Attempt with the fixed missing-report reason. If it reports an outcome but does
+not exit, the supervisor stops it after ten seconds. If the Worker dies after
+forwarding the report, normal lease expiry stops or reconciles the process
+before the report may become final. Factory never presents Work as ready while
+process ownership is uncertain.
+
+A valid `failed` report still completes the Attempt successfully because the
+agent fulfilled the reporting contract; the Work outcome is failed. This
+distinction lets operators tell an engineering blocker from a broken runtime.
+
+Cancellation of queued Work is immediate. Active cancellation is returned by
+the Worker heartbeat, stops the process group, and overrides any terminal
+report not already finalized. Cancelling a Run cancels each nonterminal Work
+target without changing terminal siblings.
+
+An operator answer to `needs-input` appends trusted context and requeues the
+same Work. The next Worker claim creates a new Attempt. The agent receives the
+original frozen Procedure, original context, prior question, answer, updates,
+known branch, and PR metadata. Archiving a Procedure prevents new Runs but does
+not cancel admitted Work.
+
+Control-plane shutdown stops admission before HTTP shutdown. Workers continue
+until lease renewal fails, then stop active processes. Restart sweeps expired
+leases and reconstructs queue and update state from SQLite. Worker restart uses
+the existing manifest reconciliation before it claims more Work.
 
 ## 8. Security, privacy, and operations
 
-V1 keeps the current trusted-host boundary. The operator API remains loopback
-only. A local agent has the operating-system user's filesystem, network, Git,
-and `gh` permissions. Factory must state this clearly and must not present a
-prompt as a security boundary.
+V1 remains a trusted single-operator system. The operator API accepts loopback
+clients only and has no user authentication. It must not be exposed to a
+network. Remote Workers use the existing TLS enrollment and credential model.
 
-“Shared Definition” in V1 means shared by people using the same trusted local
-Factory instance. V1 has no user identity, remote browser access, or per-user
-authorization. Authenticated team access requires a later design.
+The agent has the Worker operating-system user's filesystem, network, Git, and
+provider CLI permissions. Worktrees isolate Git state but are not a security
+sandbox. Operators must register only repositories and Worker hosts that the
+agent may modify.
 
-Remote VM Workers use a separate TLS listener containing only enrollment and
-the Worker lifecycle. A ten-minute, one-time token bound to the stable Worker
-identity creates a per-Worker credential. Agent and provider credentials remain
-host-managed trusted inputs. Future Worker targets must preserve these
-boundaries.
+Procedure instructions are trusted operator policy. Work-item titles, bodies,
+comments, repository files, CI output, and review content are untrusted agent
+context. Prompt assembly labels those boundaries, and admission prevents that
+content from selecting a clone URL or changing the Procedure snapshot. This is
+a prompt-integrity boundary, not hostile-code isolation. Factory does not place
+credentials in the prompt or update protocol, but the agent may access anything
+available to its shared Worker OS identity, including local operator or Worker
+credentials.
 
-A later public webhook listener exposes only signed, bounded delivery routes.
-Webhook payloads and repository content are untrusted agent context and cannot
-choose clone URLs, Worker credentials, or Definition instructions.
+The Attempt update token is separate from the Worker credential and lease. It
+is random, short-lived, stored only as a digest, scoped to one Attempt, removed
+from stale inherited environments, and invalid after process stop, cancellation,
+or lease loss. It prevents accidental cross-Work updates through the injected
+tool; it does not constrain a malicious process with the Worker user's broader
+authority. Update events and messages may contain source code or private ticket
+context and receive the same local-data protection as current prompts and agent
+events.
 
-Each Worker advertises hard capacity. Runs have target, concurrency, timeout,
-event, output, and retained-work limits. Reaching a limit produces a visible
-blocked or failed Job rather than silently dropping work.
+Existing Worker capacity, repository-cache, event, prompt, result, timeout, and
+retained-worktree limits continue to apply. A Run may add at most 100 Work
+targets. Update history adds at most 200 records per Attempt and at most 8 KiB
+per outcome message. Limit failure remains visible and never silently drops an
+outcome.
 
 ## 9. Acceptance criteria
 
-- A new user can configure a local Pi, Codex, or Claude Code Worker and run a
-  prompt against one repository.
-- One launcher command starts the local instance, reuses its Worker identity,
-  and reports Git, `gh`, and each configured agent runtime separately.
-- A team can save and reuse one Definition without selecting revisions.
-- One manual Run can execute the same Definition against five repositories and
-  show independent Job outcomes.
-- The dashboard reports failures, success rate, queue time, cycle time,
-  throughput, active Jobs, and Worker health.
-- A schedule creates the same Run and Jobs as manual **Run once**.
-- An agent can use authenticated `gh` to comment, create an issue, push a branch,
-  or open a pull request without Factory publishing the action.
-- Retrying a Job after its agent started shows the duplicate-effect warning.
-- Current Workflow, Automation, Task, Execution, Attempt, and Occurrence history
-  remains readable after cutover.
-- Standalone and Occurrence-linked Tasks keep their existing URLs and appear in
-  Legacy history without synthetic Runs or Jobs.
-- Migration preserves every schedule Automation field and requires an explicit
-  retirement decision for each unsupported GitHub polling Automation.
-- Definitions run unchanged on local and remote VM Workers and when webhook
-  support is added later.
+- `AC-1`: One `factory build` command with five valid references creates one
+  Run and five independently visible Work targets without opening agent
+  processes in the CLI.
+- `AC-2`: Two work-item targets for the same repository run in separate
+  worktrees and retain separate state, updates, branches, and outcomes.
+- `AC-3`: `factory run bug-fix --repos all` freezes the current enabled
+  repository set and produces one independently retryable Work target per
+  repository.
+- `AC-4`: Every new Build uses the exact recorded `standard-build` Procedure
+  generation and resolved runtime, and labels work-item content as untrusted
+  context.
+- `AC-5`: An active agent can report progress and exactly one Attempt-ending
+  outcome for only its current Work through the injected `factory update`
+  capability.
+- `AC-6`: The Work board shows queued, running, needs-input, ready, failed,
+  no-change, and cancelled Work with latest progress, repository, Worker, and
+  PR link where present.
+- `AC-7`: An agent that exits without a terminal update produces the fixed
+  visible failure reason and no inferred success.
+- `AC-8`: A ready update cannot make Work ready until the Worker proves the
+  agent process stopped and verifies the immutable branch and head SHA;
+  cancellation wins over a late report.
+- `AC-9`: Answering a needs-input question requeues Work with the answer and
+  prior history while preserving the original Procedure and context; only the
+  next Worker claim creates an Attempt.
+- `AC-10`: A warned retry after process start continues from the stable remote
+  publish branch when one exists and does not create a second Work record.
+- `AC-11`: Replaying an admission or update after a lost response returns the
+  original stored result without duplication.
+- `AC-12`: Local and enrolled VM Workers use the same scoped update protocol
+  without transmitting the operator credential, Worker credential, or Attempt
+  lease token in that protocol.
+- `AC-13`: Restarting the control plane or Worker preserves Work, updates,
+  questions, results, and retained recovery state.
+- `AC-14`: Existing Task, Run, Session, Attempt, event, schedule, and repository
+  history remains readable through the transition.
+- `AC-15`: A configured default Build runtime and an explicit `--runtime`
+  override both resolve before admission and remain frozen in historical Work.
+- `AC-16`: An unconverted legacy Task's next manual and scheduled Runs retain
+  their existing repository selection and exit-based success behavior without
+  requiring `factory update`.
+- `AC-17`: Every Run freezes `outcome_contract`; converting a legacy Procedure
+  increments its generation and cannot change admitted Runs.
+- `AC-18`: A manual ready update resolves or accepts operator PR head evidence,
+  succeeds without control-plane GitHub credentials, and replays idempotently
+  by Work and request ID.
 
 ## 10. Test approach
 
-Store and API tests prove Definition snapshots, atomic target creation,
-idempotent admission, aggregate state, cancellation, retry, and bounded
-pagination. State tests prove every Job transition, derived Run state, timestamp,
-metric denominator, and 30-second Worker health boundary. Scheduler tests prove
-capacity, blocked routing, per-Run concurrency, and fair progress.
+Store tests prove `INV-1` through `INV-4`, `INV-9`, `INV-12`, `INV-14`, and
+`INV-16` with transaction rollback, duplicate target, replay, partial outcome,
+queued, running, and needs-input cancellation, retry, manual-claim races, and
+legacy completion cases. HTTP tests prove CLI admission validation, source
+normalization, message limits, cursor bounds, and operator updates for `AC-1`,
+`AC-3`, `AC-11`, `AC-15`, `AC-17`, and `AC-18`.
 
-Worker integration tests use fake Pi, Codex, Claude Code, and `gh` executables
-to prove first-run identity creation, restart reuse, discovery, authentication
-health, process cleanup, result capture, and stable Factory environment IDs. No
-test uses live provider credentials.
+Worker and supervisor tests prove `INV-5` through `INV-8` and `INV-11` with
+wrong tokens, expired leases, terminal-report races, cancellation, forced exit,
+parent loss, stable publish continuation, PR identity validation, and cleanup.
+They verify `AC-5`, `AC-7`, `AC-8`, `AC-10`, `AC-12`, and `AC-13`, including
+the race detector.
+They also prove that every valid semantic outcome completes the Attempt while
+only `ready` makes the Work ready.
 
-Browser tests cover the complete V1 journey: configure a Worker, add
-repositories, save a Definition, run one repository, run five repositories,
-inspect mixed outcomes and metrics, retry one Job, and create a schedule.
+Prompt boundary tests prove `INV-10` and `INV-13`, the exact Procedure snapshot,
+trusted and untrusted sections, injected update instructions, and maximum final
+prompt size for `AC-4`.
 
-Migration tests prove legacy admission stops before cutover, active work drains,
-every schedule field imports once, unsupported GitHub polling Automations require
-an explicit decision, history remains readable, and new admission starts only
-after the cutover marker. Browser tests cover both a standalone historical Task
-and an Occurrence-linked Task through their preserved URLs and Legacy history.
+CLI tests use a real loopback server to prove multi-reference admission,
+request replay, human and JSON output, `--wait`, opaque-reference repository
+requirements, runtime default and override, and agent-context routing. Browser
+component tests and a real browser flow prove `AC-2`, `AC-6`, `AC-9`, and
+accessibility at desktop and 390-pixel widths.
+
+Migration tests open supported historical databases and prove `AC-14` and
+`AC-16` without dropping, relabelling, or changing the next scheduled outcome.
+They prove that existing Procedures default to `process_exit` and conversion
+increments generation for `AC-17`. One end-to-end smoke test runs a fake agent
+executable that reports progress and each Attempt-ending outcome through the
+real Worker-local update endpoint.
 
 ## 11. Risks and tradeoffs
 
-- Agent-owned GitHub writes can be duplicated after a crash or retry. Stable
-  identifiers, explicit Definition instructions, and a retry warning make the
-  risk visible without building a second execution engine.
-- A 500-repository Run can consume the fleet. Per-Run concurrency and fair
-  scheduling bound its effect.
-- Shared host credentials are broad. V1 labels local Workers as trusted, while
-  later managed Workers use narrower temporary credentials.
-- The compatibility window exposes old and new names. Keep it short and make
-  all new creation use the target model.
+- An agent may report `ready` incorrectly. Factory stores the exact report,
+  Procedure, PR, and events so the error is visible. Repository, branch, and
+  head-SHA checks reject obvious delivery mismatch, but semantic correctness
+  remains the agent's job.
+- An agent may forget to call `factory update`. The standard wrapper makes the
+  requirement short and explicit. Missing reports fail visibly instead of
+  being inferred from prose.
+- Waiting for CI consumes a Worker slot. V1 measures wait duration and timeout
+  frequency before adding durable external waiting and continuation.
+- Stable publish branches reduce duplicate PRs but cannot make comments,
+  labels, or provider writes exactly once. Warned retry remains required after
+  process start.
+- Multiple Work targets in one repository may produce conflicting pull
+  requests. V1 isolates worktrees and leaves integration ordering to human
+  review. Automatic merge and conflict sequencing require later evidence.
+- Product names and internal table names temporarily differ. This keeps the
+  first vertical slice smaller but requires clear API adapters and contributor
+  documentation.
 
 ## 12. Open questions
 
-No question blocks V1. Remote credentials and public webhook deployment require
-focused designs before those later milestones start. Any future Worker target,
-including Kubernetes, requires its own accepted design before implementation.
-The optional production orchestration backend is deliberately unresolved until
-[#259](https://github.com/owainlewis/factory/issues/259) defines ownership,
-deployment, migration, rollback, and failure behavior and proves the boundary
-with a small prototype.
+No question blocks the first implementation plan. These defaults should be
+validated through use:
+
+- Should Factory add a bounded final reminder turn when an agent exits without
+  an update? Default: fail visibly first and measure frequency because runtime
+  support for another turn differs.
+- Should a ready update require Factory to query GitHub checks? Default: no.
+  The agent owns semantic completion; Factory validates only URL shape and
+  repository identity in V1.
+- Should one Run limit parallel Work per repository? Default: no separate
+  per-repository limit. Worker capacity and Run concurrency bound execution,
+  while isolated pull requests expose conflicts for human review.
+- When should bare Linear references resolve without `--repo`? Default: after
+  a separate design defines workspace identity, credentials, and repository
+  mapping.
 
 ## 13. Out of scope
 
-- Deterministic GitHub action publishing or exactly-once external side effects.
-- General business automation and non-engineering providers.
-- Human project management, chat, inboxes, personas, or squads.
-- DAGs, workflow chaining, visual pipelines, or synthesis Jobs.
-- One agent process changing several repositories atomically.
-- Remote operator access, automatic merge, approval, deployment, or release.
+- A Factory coding agent, model loop, context manager, or subagent framework.
+- Ordered Stage graphs, arbitrary DAGs, visual pipeline editing, or workflow
+  chaining.
+- Central CI polling, webhook-driven continuation, or long-lived wait state.
+- Automatic merge, release, deployment, or production monitoring.
+- Linear, Jira, or generic provider clients and plugin interfaces.
+- Public operator access, team accounts, roles, or multi-tenancy.
+- Cloud Run implementation or another execution backend change.
+- Deterministic proof that an agent's implementation is correct.
+- Exactly-once external provider side effects.

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -527,7 +527,7 @@ claims cancelled Work, so a Worker cannot win an intermediate queued state.
 
 ```text
 factory build [--repo REPOSITORY] [--runtime RUNTIME] [--request-key KEY] [--rebuild] [--wait] REFERENCE...
-factory run PROCEDURE --repos REPOSITORY...|all [--request-key KEY] [--wait]
+factory run PROCEDURE --repos REPOSITORY...|all [--request-key KEY] [--rebuild] [--wait]
 factory status [--run RUN_ID]
 factory show WORK_ID
 factory answer WORK_ID MESSAGE
@@ -705,6 +705,9 @@ a different fingerprint conflicts. Any existing nonterminal Work for the same
 work-item target, including `needs-input`, blocks duplicate Build admission.
 After terminal Work,
 `factory build` requires `--rebuild` to admit the same target again.
+For repository-target Work, rebuild identity is the exact
+`(procedure_id, repository_id)` tuple; independent Procedures for one repository
+remain independent.
 
 A caller fingerprint contains the operation, ordered syntactically normalized
 references or repository selectors, explicit repository selector presence and
@@ -713,7 +716,8 @@ option or context value that changes admitted Work. It excludes the request key
 itself and client-only `--wait`. It is computed and compared before repository,
 Procedure, configured-default, or current-Work reads.
 
-A new rebuild request must not reuse the original Build's stored request key.
+A new Build or Procedure Run rebuild request must not reuse the original stored
+request key.
 After proving the new key is unused, one transaction requires every target to
 have no nonterminal Work and selects its most recently created terminal Work,
 ordered by `created_at DESC, id DESC`. It stores that target's
@@ -754,7 +758,10 @@ is recorded.
 A missing publish branch for known PR Work fails preparation with a fixed
 recovery message that identifies the PR, ref, and recorded trusted PR head SHA.
 It tells the operator to restore the ref to exactly that SHA or admit warned
-replacement Work with `--rebuild`; a missing trusted SHA permits only the latter.
+replacement Work with the matching command's `--rebuild`; a missing trusted SHA
+permits only the latter. Work-item recovery uses `factory build --rebuild`.
+Repository-target recovery uses `factory run PROCEDURE --repos REPOSITORY
+--rebuild`, whose predecessor lookup is scoped to that Procedure identity.
 Preparation re-fetches and proves the restored ref equals the recorded SHA. It
 does not create a resumable question without a checkpoint. The retry prompt
 identifies prior updates, known PR, publish ref, and duplicate-effect risk.
@@ -808,14 +815,28 @@ nonterminal Work target without changing terminal siblings.
 An operator answer to `needs-input` appends trusted context and requeues the
 same Work while retaining its authoritative `pending_resume_sha`.
 The next Worker claim creates a new Attempt. The agent receives the original
-frozen Procedure, original context, prior question, answer, updates, known
-branch, checkpoint SHA, and PR metadata. Worktree preparation starts from that
+frozen Procedure, original context, prior question, answer, bounded newest
+updates, known branch, checkpoint SHA, and PR metadata. Worktree preparation starts from that
 exact checkpoint. A missing or unreachable checkpoint fails preparation visibly
 instead of falling back to the publish ref or repository base. Cancellation,
 failed preparation, and explicit retry retain `pending_resume_sha`. It is cleared
 only after an Attempt successfully starts from that commit; the historical
 `checkpoint_sha` and update remain stored. Archiving a Procedure prevents new
 Runs but does not cancel admitted Work.
+
+Every assembled agent prompt remains within the existing 72 KiB byte limit.
+Admission requires the frozen Procedure, original context, fixed wrapper, and
+bounded recovery metadata to fit while reserving the maximum 8 KiB question and
+8 KiB answer. Before accepting `needs-input` or an answer, Factory also proves
+the actual mandatory continuation sections fit; rejection leaves the current
+state unchanged. The continuation always includes the Procedure, original
+context, current question and answer, checkpoint and branch identity, PR
+metadata, and an omission marker. It fills remaining bytes with the newest
+prior updates, prioritizing Attempt outcomes over progress and displaying the
+selected records chronologically. If history is omitted or one message must be
+UTF-8-boundary truncated, the marker includes stored and inserted counts and a
+SHA-256 digest of the complete omitted serialized history. All full updates
+remain stored and visible outside the prompt.
 
 Control-plane shutdown stops admission before HTTP shutdown. Workers continue
 until lease renewal fails, then stop active processes. Restart sweeps expired
@@ -889,7 +910,8 @@ remains visible and never silently drops an outcome.
   prior history while preserving the original Procedure and context; only the
   next Worker claim creates an Attempt, starting from the revalidated
   checkpoint SHA. Cancellation, failed preparation, and retry keep that SHA
-  authoritative until an Attempt successfully starts from it.
+  authoritative until an Attempt successfully starts from it. The continuation
+  prompt remains within 72 KiB and visibly identifies omitted stored history.
 - `AC-10`: A warned retry after process start continues from the stable remote
   publish branch when one exists and does not create a second Work record. It is
   rejected without state change when replacement or matching nonterminal Work
@@ -916,8 +938,8 @@ remains visible and never silently drops an outcome.
   succeeds without control-plane GitHub credentials, and replays idempotently
   by Work and request ID.
 - `AC-19`: Duplicate admission while matching Work needs input conflicts, and
-  a rebuild atomically binds every replacement to its deterministic terminal
-  predecessor Work with a new idempotency key.
+  a Build or Procedure Run rebuild atomically binds every replacement to its
+  deterministic terminal predecessor Work with a new idempotency key.
 - `AC-20`: `--wait` returns 2 on needs-input, 0 when all Work finishes ready,
   no-change, or legacy succeeded, and 1 when finished Work includes failed or
   cancelled.
@@ -930,6 +952,9 @@ remains visible and never silently drops an outcome.
   Work with retry guards and no intermediate queued race.
 - `AC-23`: Cancelling queued, needs-input, or operator-owned Work with no active
   Worker Attempt completes synchronously and cannot wait for a heartbeat.
+- `AC-24`: Initial and continuation prompts cannot exceed 72 KiB; mandatory
+  recovery context is preserved while omitted update history is counted and
+  digested without deleting the stored events.
 
 ## 10. Test approach
 
@@ -951,7 +976,9 @@ parent loss, stable publish continuation, preflight and post-stop PR identity
 validation, provider outage, branch movement after report, the 199-progress
 limit with a reserved outcome slot, dirty needs-input rejection, pushed and
 unchanged checkpoints, answer continuation, answer then cancellation or failed
-preparation then retry with moved and missing refs, and cleanup.
+preparation then retry with moved and missing refs, maximum question and answer
+sizes, bounded multi-Attempt history with UTF-8 truncation and omission digests,
+and cleanup.
 They verify `AC-5`, `AC-7`, `AC-8`, `AC-10`, `AC-12`, and `AC-13`, including
 the race detector.
 They also prove that every valid semantic outcome completes the Attempt while
@@ -972,7 +999,8 @@ explicit and generated-key replay across separate CLI processes, pending-journal
 locking, typed-response cleanup, uncertain-response retention, human and JSON
 output, `--wait`, opaque-reference repository
 requirements, runtime default and override, rebuild key conflicts,
-needs-input duplicate rejection, replay after a rebuild becomes terminal, wait
+Build and Procedure Run rebuild identity, needs-input duplicate rejection,
+replay after a rebuild becomes terminal, wait
 exit codes, missing-PR-ref recovery, and agent-context routing. Replay tests also
 disable or delete the repository and change configured defaults before retrying
 the stored key. Browser

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -797,10 +797,13 @@ A valid `failed` report still completes the Attempt successfully because the
 agent fulfilled the reporting contract; the Work outcome is failed. This
 distinction lets operators tell an engineering blocker from a broken runtime.
 
-Cancellation of queued Work is immediate. Active cancellation is returned by
-the Worker heartbeat, stops the process group, and overrides any terminal
-report not already finalized. Cancelling a Run cancels each nonterminal Work
-target without changing terminal siblings.
+Cancellation of Work with no active Worker Attempt is immediate and
+transactional. This includes queued, needs-input, and operator-owned running
+Work; Factory clears operator ownership and records cancelled without waiting
+for a heartbeat. Cancellation with an active Worker Attempt is returned by the
+Worker heartbeat, stops the process group, and overrides any terminal report
+not already finalized. Cancelling a Run applies the appropriate path to each
+nonterminal Work target without changing terminal siblings.
 
 An operator answer to `needs-input` appends trusted context and requeues the
 same Work while retaining its authoritative `pending_resume_sha`.
@@ -925,6 +928,8 @@ remains visible and never silently drops an outcome.
 - `AC-22`: An operator can atomically finish queued `agent_update` Work, or take
   over active agent Work by cancelling it and atomically claiming the cancelled
   Work with retry guards and no intermediate queued race.
+- `AC-23`: Cancelling queued, needs-input, or operator-owned Work with no active
+  Worker Attempt completes synchronously and cannot wait for a heartbeat.
 
 ## 10. Test approach
 
@@ -933,7 +938,8 @@ Store tests prove `INV-1` through `INV-4`, `INV-9`, `INV-12`, `INV-14`,
 partial outcome, queued, running, and needs-input cancellation, retry of
 replaced Work, matching-nonterminal retry races, manual-claim races, and legacy
 completion cases. Manual-claim tests include queued direct completion and
-cancel-wait-takeover from cancelled Work. HTTP tests prove CLI admission validation, source
+cancel-wait-takeover from cancelled Work. Cancellation tests include every
+no-Attempt state and active Worker delivery. HTTP tests prove CLI admission validation, source
 normalization, message limits, cursor bounds, and operator updates for `AC-1`,
 `AC-3`, `AC-11`, `AC-15`, `AC-17`, and `AC-18`.
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -138,9 +138,11 @@ factory update --status=failed --message="The required service is unavailable"
 The local helper validates the Attempt-scoped capability and forwards the
 typed update through the Worker. An Attempt-ending update becomes final only after the
 agent process stops and the Worker completes the Attempt under its existing
-lease. A process that exits without an outcome update fails with the visible
-reason `Agent exited without reporting an outcome.` Factory never parses the
-agent's final prose to infer status.
+lease. Under `outcome_contract=agent_update`, a process that exits without an
+outcome update fails with the visible reason
+`Agent exited without reporting an outcome.` A legacy `process_exit` Run keeps
+its existing exit-based completion. Factory never parses the agent's final
+prose to infer agent-update status.
 
 Attempt lifecycle and Work outcome are deliberately separate. When an agent
 reports any valid Attempt-ending outcome and then stops, the Attempt is `succeeded`
@@ -396,6 +398,8 @@ Progress is an event, not a durable workflow state change. `running` means an
 execution owner exists. `needs-input` ends the current Attempt but pauses the
 Work, so it is not terminal. Capacity and routing waits remain `queued` with a
 visible `waiting_reason`; V1 does not add a separate blocked state.
+Compatibility-only `succeeded` represents exit-zero `process_exit` Work. It is
+not an agent update status and does not imply a pull request.
 
 | Current state | Owner | Allowed transition | Cause |
 | --- | --- | --- | --- |
@@ -403,6 +407,7 @@ visible `waiting_reason`; V1 does not add a separate blocked state.
 | `queued` | none | `cancelled` | operator cancellation |
 | `running` | Worker Attempt | unchanged | agent `running` progress update |
 | `running` | Worker Attempt | `ready`, `needs-input`, `failed`, `no-change` | accepted outcome followed by stopped process |
+| `running` | Worker Attempt | `succeeded` or `failed` | legacy `process_exit` completion |
 | `running` | operator | `ready`, `needs-input`, `failed`, `no-change` | trusted operator update |
 | `running` | either | `cancelled` | operator cancellation |
 | `needs-input` | none | `queued` | operator answer appends context; the next Worker claim creates the Attempt |
@@ -410,12 +415,12 @@ visible `waiting_reason`; V1 does not add a separate blocked state.
 | `needs-input` | none | `cancelled` | operator cancellation |
 | `failed` or `cancelled` | none | `queued` | explicit warned retry |
 
-`ready`, `failed`, `no-change`, and `cancelled` are terminal outcomes unless an
-explicit retry rule above applies. A manual `running` update atomically records
-operator ownership and removes the Work from Worker eligibility. A direct
-manual terminal update from queued Work performs that claim and completion in
-one transaction. An operator must cancel an active Worker Attempt before taking
-manual ownership.
+`ready`, `succeeded`, `failed`, `no-change`, and `cancelled` are terminal
+outcomes unless an explicit retry rule above applies. A manual `running` update
+atomically records operator ownership and removes the Work from Worker
+eligibility. A direct manual terminal update from queued Work performs that
+claim and completion in one transaction. An operator must cancel an active
+Worker Attempt before taking manual ownership.
 
 ### Requirements
 
@@ -448,7 +453,8 @@ manual ownership.
   Reusing it for `--rebuild` or any different request conflicts.
 - Duplicate Build admission conflicts while matching Work is queued, running,
   or needs-input.
-- A process exit without an outcome report fails with a fixed reason.
+- Under `outcome_contract=agent_update`, a process exit without an outcome
+  report fails with a fixed reason. `process_exit` Runs retain legacy behavior.
 - An operator answer is non-empty UTF-8 text of at most 8 KiB and requeues Work
   without changing the frozen Procedure or original context. The next Worker
   claim creates the Attempt.
@@ -493,8 +499,8 @@ and requires `--id`.
 
 `--wait` streams status and returns as soon as any Work needs input, using exit
 code 2, even while independent siblings continue. Otherwise it returns when the
-Run finishes: exit 0 when every Work is ready or no-change, and exit 1 when any
-Work is failed or cancelled. The CLI always prints the Work counts and IDs
+Run finishes: exit 0 when every Work is ready, no-change, or compatibility
+succeeded, and exit 1 when any Work is failed or cancelled. The CLI always prints the Work counts and IDs
 before returning so the operator can answer or inspect the result.
 
 An operator `running` update atomically claims manual ownership when the Work
@@ -680,12 +686,14 @@ Attempt and Work with stored delivery evidence and a fixed postflight reason;
 it never marks stale evidence ready. Factory validates delivery identity, not
 CI success or semantic correctness; the agent remains responsible for both.
 
-If the agent process exits without an outcome report, the Worker fails the
-Attempt with the fixed missing-report reason. If it reports an outcome but does
-not exit, the supervisor stops it after ten seconds. If the Worker dies after
-forwarding the report, normal lease expiry stops or reconciles the process
-before the report may become final. Factory never presents Work as ready while
-process ownership is uncertain.
+For `outcome_contract=agent_update`, if the agent process exits without an
+outcome report, the Worker fails the Attempt with the fixed missing-report
+reason. A `process_exit` Run completes through its legacy exit and result rules.
+If an agent-update Run reports an outcome but does not exit, the supervisor
+stops it after ten seconds. If the Worker dies after forwarding the report,
+normal lease expiry stops or reconciles the process before the report may
+become final. Factory never presents Work as ready while process ownership is
+uncertain.
 
 A valid `failed` report still completes the Attempt successfully because the
 agent fulfilled the reporting contract; the Work outcome is failed. This
@@ -758,11 +766,13 @@ outcome.
 - `AC-5`: An active agent can report progress and exactly one Attempt-ending
   outcome for only its current Work through the injected `factory update`
   capability.
-- `AC-6`: The Work board shows queued, running, needs-input, ready, failed,
-  no-change, and cancelled Work with latest progress, repository, Worker, and
-  PR link where present.
-- `AC-7`: An agent that exits without a terminal update produces the fixed
-  visible failure reason and no inferred success.
+- `AC-6`: The Work board shows queued, running, needs-input, ready, succeeded,
+  failed, no-change, and cancelled Work with latest progress, repository,
+  Worker, and PR link where present. `succeeded` is labelled as legacy
+  process-exit completion and never implies a PR.
+- `AC-7`: An `agent_update` agent that exits without an outcome update produces
+  the fixed visible failure reason and no inferred success; a `process_exit`
+  Run retains its legacy completion behavior.
 - `AC-8`: A ready update cannot make Work ready until the Worker proves the
   agent process stopped and then revalidates the repository, immutable branch,
   remote ref, local HEAD, and PR head SHA;
@@ -794,8 +804,9 @@ outcome.
 - `AC-19`: Duplicate admission while matching Work needs input conflicts, and
   a rebuild atomically binds every replacement to its deterministic terminal
   predecessor Work with a new idempotency key.
-- `AC-20`: `--wait` returns 2 on needs-input, 0 when all Work finishes ready or
-  no-change, and 1 when finished Work includes failed or cancelled.
+- `AC-20`: `--wait` returns 2 on needs-input, 0 when all Work finishes ready,
+  no-change, or legacy succeeded, and 1 when finished Work includes failed or
+  cancelled.
 
 ## 10. Test approach
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -94,6 +94,8 @@ factory build LINEAR-123 LINEAR-124 --repo github.com/acme/api
 
 The CLI performs only pure syntax normalization and sends one idempotent
 admission request containing the ordered references and unresolved selectors.
+It always sends a request key, using the durable generated-key behavior in the
+CLI contract when the operator does not provide one.
 The control plane checks an existing request key before reading repositories,
 Procedures, or defaults. For a new key, it resolves the managed repository,
 selects the built-in `standard-build` Procedure, freezes its current generation,
@@ -403,6 +405,8 @@ model.
   revalidated after its process group has stopped.
 - `INV-18`: An answered Work starts from the exact checkpoint revalidated after
   the needs-input process group stopped.
+- `INV-19`: A Work that has been replaced cannot be retried, and retry admission
+  cannot create a second nonterminal Work target for the same retry identity.
 
 ### Work state transitions
 
@@ -425,7 +429,7 @@ not an agent update status and does not imply a pull request.
 | `needs-input` | none | `queued` | operator answer appends context; the next Worker claim creates the Attempt |
 | `needs-input` | none | `running` | trusted operator claims manual ownership |
 | `needs-input` | none | `cancelled` | operator cancellation |
-| `failed` or `cancelled` | none | `queued` | explicit warned retry |
+| `failed` or `cancelled` | none | `queued` | explicit warned retry, only when no replacement or matching nonterminal Work exists |
 
 `ready`, `succeeded`, `failed`, `no-change`, and `cancelled` are terminal
 outcomes unless an explicit retry rule above applies. A manual `running` update
@@ -477,6 +481,12 @@ Worker Attempt before taking manual ownership.
 - V1 performs no automatic execution retry. Every failed or cancelled Work
   retry is explicit and warns about duplicate external effects if an agent
   process previously started.
+- Retrying Work is one transaction that rejects the request when any Work names
+  it as `predecessor_work_id` or when another nonterminal Work with the same
+  retry identity exists. For work-item Work, retry identity is the exact
+  `(repository_id, source_kind, source_key)` tuple. For repository Work, only
+  Work in the same predecessor lineage matches; an independent Procedure Run
+  against that repository does not. A rejected retry does not change Work state.
 - Setup requires one valid default Build runtime. `factory build --runtime`
   accepts only a configured runtime and admission freezes the resolved choice.
 - An opaque work-item reference is 1 to 64 ASCII characters matching
@@ -514,6 +524,23 @@ Finite operator commands call the loopback API and never open SQLite or Worker
 directories. `factory update` detects an injected Attempt context and uses the
 Worker-local capability. Without that context it is a trusted operator command
 and requires `--id`.
+
+`--request-key` is optional for the operator, not for admission. When it is
+omitted, the CLI creates a random key and durably records it with the server
+endpoint and canonical caller-input fingerprint in its private operator state
+directory before the first request. A later invocation with the same pending
+fingerprint reuses that key. The CLI removes the pending record only after it
+receives a typed admission response that says `admitted`, `replayed`, or
+`rejected_before_commit`, and prints the key with every result. A timeout,
+connection loss, interruption, malformed response, or server error remains
+pending because it may have happened after commit. The control plane returns
+`rejected_before_commit` only when the transaction created no Run.
+This lets a new CLI process replay a request whose response was lost without
+turning all future identical commands into replays. Journal access is locked,
+it retains at most 100 pending entries, and its directory and file use `0700`
+and `0600` modes. At the limit, implicit key creation fails with the journal path
+and asks the operator to recover pending requests or supply an explicit key; it
+never silently evicts an uncertain request.
 
 `--wait` streams status and returns as soon as any Work needs input, using exit
 code 2, even while independent siblings continue. Otherwise it returns when the
@@ -657,7 +684,7 @@ option or context value that changes admitted Work. It excludes the request key
 itself and client-only `--wait`. It is computed and compared before repository,
 Procedure, configured-default, or current-Work reads.
 
-A new rebuild request must not reuse the original Build's explicit request key.
+A new rebuild request must not reuse the original Build's stored request key.
 After proving the new key is unused, one transaction requires every target to
 have no nonterminal Work and selects its most recently created terminal Work,
 ordered by `created_at DESC, id DESC`. It stores that target's
@@ -686,14 +713,20 @@ automatically. An explicit retry warns about duplicate effects when a process
 previously started because the agent may already have pushed, commented, or
 opened a pull request.
 
-Each retry creates a fresh local worktree. If the stable remote publish branch
-exists, preparation starts from its current fetched head. Otherwise it starts
-from the repository base only when no PR is recorded. A missing publish branch
-for known PR Work moves the Work to `needs-input` instead of guessing. The retry
-prompt identifies prior updates, known PR, publish ref, and duplicate-effect
-risk. Factory never force-pushes or deletes the ref. If the ref moves while an
-Attempt is active, the agent must reconcile a normal push or report
-`needs-input`.
+Retry first transactionally proves that no replacement names this Work as its
+predecessor and that no other nonterminal Work with the retry identity defined
+above exists. Each accepted retry then creates a fresh local worktree. If the
+stable remote publish branch exists, preparation starts from its current fetched
+head. Otherwise it starts from the repository base only when no PR is recorded.
+A missing publish branch for known PR Work fails preparation with a fixed
+recovery message that identifies the PR, ref, and recorded trusted PR head SHA.
+It tells the operator to restore the ref to exactly that SHA or admit warned
+replacement Work with `--rebuild`; a missing trusted SHA permits only the latter.
+Preparation re-fetches and proves the restored ref equals the recorded SHA. It
+does not create a resumable question without a checkpoint. The retry prompt
+identifies prior updates, known PR, publish ref, and duplicate-effect risk.
+Factory never force-pushes or deletes the ref. If the ref moves while an Attempt
+is active, the agent must reconcile a normal push or report `needs-input`.
 
 An agent update request with an expired or wrong token is rejected. An exact
 transport retry returns the stored update. A second identical Attempt-ending
@@ -814,9 +847,12 @@ remains visible and never silently drops an outcome.
   next Worker claim creates an Attempt, starting from the revalidated
   checkpoint SHA.
 - `AC-10`: A warned retry after process start continues from the stable remote
-  publish branch when one exists and does not create a second Work record.
+  publish branch when one exists and does not create a second Work record. It is
+  rejected without state change when replacement or matching nonterminal Work
+  exists.
 - `AC-11`: Replaying an admission or update after a lost response returns the
-  original stored result without duplication.
+  original stored result without duplication, including when a new CLI process
+  reuses a generated key from its pending-admission journal.
 - `AC-12`: Local and enrolled VM Workers use the same scoped update protocol
   without transmitting the operator credential, Worker credential, or Attempt
   lease token in that protocol.
@@ -840,13 +876,18 @@ remains visible and never silently drops an outcome.
 - `AC-20`: `--wait` returns 2 on needs-input, 0 when all Work finishes ready,
   no-change, or legacy succeeded, and 1 when finished Work includes failed or
   cancelled.
+- `AC-21`: Retry preparation for known PR Work with a missing publish ref fails
+  with the trusted recovery SHA and explicit recovery instructions, accepts only
+  a restored ref at that SHA, and never creates `needs-input` without a verified
+  checkpoint.
 
 ## 10. Test approach
 
-Store tests prove `INV-1` through `INV-4`, `INV-9`, `INV-12`, `INV-14`, and
-`INV-16` with transaction rollback, duplicate target, replay, partial outcome,
-queued, running, and needs-input cancellation, retry, manual-claim races, and
-legacy completion cases. HTTP tests prove CLI admission validation, source
+Store tests prove `INV-1` through `INV-4`, `INV-9`, `INV-12`, `INV-14`,
+`INV-16`, and `INV-19` with transaction rollback, duplicate target, replay,
+partial outcome, queued, running, and needs-input cancellation, retry of
+replaced Work, matching-nonterminal retry races, manual-claim races, and legacy
+completion cases. HTTP tests prove CLI admission validation, source
 normalization, message limits, cursor bounds, and operator updates for `AC-1`,
 `AC-3`, `AC-11`, `AC-15`, `AC-17`, and `AC-18`.
 
@@ -870,11 +911,14 @@ Admission tests prove the exact opaque-reference grammar and reject whitespace,
 prose, Unicode, empty, and overlength values without creating partial Work.
 
 CLI tests use a real loopback server to prove multi-reference admission,
-request replay, human and JSON output, `--wait`, opaque-reference repository
+explicit and generated-key replay across separate CLI processes, pending-journal
+locking, typed-response cleanup, uncertain-response retention, human and JSON
+output, `--wait`, opaque-reference repository
 requirements, runtime default and override, rebuild key conflicts,
 needs-input duplicate rejection, replay after a rebuild becomes terminal, wait
-exit codes, and agent-context routing. Replay tests also disable or delete the
-repository and change configured defaults before retrying the stored key. Browser
+exit codes, missing-PR-ref recovery, and agent-context routing. Replay tests also
+disable or delete the repository and change configured defaults before retrying
+the stored key. Browser
 component tests and a real browser flow prove `AC-2`, `AC-6`, `AC-9`, and
 accessibility at desktop and 390-pixel widths.
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -92,10 +92,12 @@ A developer runs:
 factory build LINEAR-123 LINEAR-124 --repo github.com/acme/api
 ```
 
-The CLI resolves the managed repository and sends one idempotent admission
-request containing the ordered references. The control plane selects the
-built-in `standard-build` Procedure, freezes its current generation, and
-creates one Run with two Work targets. Each Work has its own identity,
+The CLI performs only pure syntax normalization and sends one idempotent
+admission request containing the ordered references and unresolved selectors.
+The control plane checks an existing request key before reading repositories,
+Procedures, or defaults. For a new key, it resolves the managed repository,
+selects the built-in `standard-build` Procedure, freezes its current generation,
+and creates one Run with two Work targets. Each Work has its own identity,
 repository, context, state, progress history, result, and Attempts. Two targets
 may use the same repository.
 
@@ -440,6 +442,12 @@ manual ownership.
 - Every update invocation has a random request ID. A transport retry with the
   same Attempt and request ID, or the same operator Work and request ID, returns
   the stored response.
+- An admission request key returns the original Run only when its canonical
+  caller-input fingerprint matches. This lookup occurs before repository,
+  Procedure, default, state-dependent validation, or predecessor selection.
+  Reusing it for `--rebuild` or any different request conflicts.
+- Duplicate Build admission conflicts while matching Work is queued, running,
+  or needs-input.
 - A process exit without an outcome report fails with a fixed reason.
 - An operator answer is non-empty UTF-8 text of at most 8 KiB and requeues Work
   without changing the frozen Procedure or original context. The next Worker
@@ -482,6 +490,12 @@ Finite operator commands call the loopback API and never open SQLite or Worker
 directories. `factory update` detects an injected Attempt context and uses the
 Worker-local capability. Without that context it is a trusted operator command
 and requires `--id`.
+
+`--wait` streams status and returns as soon as any Work needs input, using exit
+code 2, even while independent siblings continue. Otherwise it returns when the
+Run finishes: exit 0 when every Work is ready or no-change, and exit 1 when any
+Work is failed or cancelled. The CLI always prints the Work counts and IDs
+before returning so the operator can answer or inspect the result.
 
 An operator `running` update atomically claims manual ownership when the Work
 has no active Attempt. Later operator updates require that ownership. A direct
@@ -560,6 +574,7 @@ source_key
 source_reference
 context_snapshot
 publish_branch
+predecessor_work_id
 state
 execution_owner: none | worker_attempt | operator
 waiting_reason
@@ -597,10 +612,31 @@ repository ID.
 
 `target_key` is the source key plus repository ID for a work item and the
 repository ID for a fleet target. It is unique inside one Run. The admission
-request key and normalized request digest make uncertain client replay return
-the original Run. A second active Build for the same work-item target conflicts.
-After terminal Work, `factory build` requires `--rebuild` to admit the same
-target again.
+request key and canonical caller-input fingerprint make uncertain client
+replay return the original Run. Admission looks up the request key before
+target validation, duplicate checks, or rebuild predecessor selection. A
+matching stored fingerprint returns its Run without consulting current Work;
+a different fingerprint conflicts. Any existing nonterminal Work for the same
+work-item target, including `needs-input`, blocks duplicate Build admission.
+After terminal Work,
+`factory build` requires `--rebuild` to admit the same target again.
+
+A caller fingerprint contains the operation, ordered syntactically normalized
+references or repository selectors, explicit repository selector presence and
+value, explicit runtime presence and value, rebuild flag, and every submitted
+option or context value that changes admitted Work. It excludes the request key
+itself and client-only `--wait`. It is computed and compared before repository,
+Procedure, configured-default, or current-Work reads.
+
+A new rebuild request must not reuse the original Build's explicit request key.
+After proving the new key is unused, one transaction requires every target to
+have no nonterminal Work and selects its most recently created terminal Work,
+ordered by `created_at DESC, id DESC`. It stores that target's
+`predecessor_work_id` on the replacement Work and admits the complete batch.
+If any target lacks a terminal predecessor, nothing is admitted. A lost-response
+retry with the same new key and caller fingerprint returns that stored rebuild
+Run even when a repository is disabled or deleted, configuration changes, or
+newer terminal Work now exists.
 
 An agent update request is unique by `(attempt_id, request_id)`. An operator
 update request is unique by `(work_id, request_id)`. The CLI generates the
@@ -755,6 +791,11 @@ outcome.
 - `AC-18`: A manual ready update resolves or accepts operator PR head evidence,
   succeeds without control-plane GitHub credentials, and replays idempotently
   by Work and request ID.
+- `AC-19`: Duplicate admission while matching Work needs input conflicts, and
+  a rebuild atomically binds every replacement to its deterministic terminal
+  predecessor Work with a new idempotency key.
+- `AC-20`: `--wait` returns 2 on needs-input, 0 when all Work finishes ready or
+  no-change, and 1 when finished Work includes failed or cancelled.
 
 ## 10. Test approach
 
@@ -784,7 +825,10 @@ prose, Unicode, empty, and overlength values without creating partial Work.
 
 CLI tests use a real loopback server to prove multi-reference admission,
 request replay, human and JSON output, `--wait`, opaque-reference repository
-requirements, runtime default and override, and agent-context routing. Browser
+requirements, runtime default and override, rebuild key conflicts,
+needs-input duplicate rejection, replay after a rebuild becomes terminal, wait
+exit codes, and agent-context routing. Replay tests also disable or delete the
+repository and change configured defaults before retrying the stored key. Browser
 component tests and a real browser flow prove `AC-2`, `AC-6`, `AC-9`, and
 accessibility at desktop and 390-pixel widths.
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -178,9 +178,18 @@ Retry, cancel, events, timeouts, and retained worktrees remain per Work target.
 
 When an agent reports `needs-input`, Factory stores the exact question and
 makes the Work visible in the attention column. The developer answers through
-the CLI or browser. The answer is stored as trusted operator context and a new
-Attempt starts in the same Work history. Factory does not keep an idle agent
-process alive while waiting for a person.
+the CLI or browser. The answer is stored as trusted operator context and
+requeues the same Work. The next Worker claim creates an Attempt when capacity
+is available. Factory does not keep an idle agent process alive while waiting
+for a person.
+
+Before accepting `needs-input`, the Worker requires a clean worktree and a
+durable checkpoint. If the agent changed the repository, local `HEAD` must be
+committed and pushed to the immutable publish ref; if it made no change, the
+checkpoint is the exact base SHA. A failed check returns actionable feedback
+and leaves the Attempt running. The Worker repeats the check after the process
+group stops and stores `checkpoint_sha`. The answered Attempt starts from that
+exact checkpoint, so partial work cannot silently disappear.
 
 ### Components and responsibilities
 
@@ -319,9 +328,10 @@ Procedure text and generation are frozen for audit.
 
 The prompt must also state that the Work is unfinished until the agent has
 called `factory update`, list every allowed status, require a PR URL for
-`ready`, explain that `needs-input` ends the current Attempt, and tell the agent
-to use progress updates only when they help an operator. These are Procedure
-requirements, not a transcript parser or a Factory-owned reasoning loop.
+`ready`, explain that `needs-input` ends the current Attempt, require committed
+and pushed partial work before `needs-input`, and tell the agent to use progress
+updates only when they help an operator. These are Procedure requirements, not
+a transcript parser or a Factory-owned reasoning loop.
 
 #### GitHub URLs and explicit repositories first
 
@@ -391,6 +401,8 @@ model.
   operator explicitly converts its outcome contract.
 - `INV-17`: Agent-owned Work becomes ready only from delivery evidence
   revalidated after its process group has stopped.
+- `INV-18`: An answered Work starts from the exact checkpoint revalidated after
+  the needs-input process group stopped.
 
 ### Work state transitions
 
@@ -408,7 +420,7 @@ not an agent update status and does not imply a pull request.
 | `running` | Worker Attempt | unchanged | agent `running` progress update |
 | `running` | Worker Attempt | `ready`, `needs-input`, `failed`, `no-change` | accepted outcome followed by stopped process |
 | `running` | Worker Attempt | `succeeded` or `failed` | legacy `process_exit` completion |
-| `running` | operator | `ready`, `needs-input`, `failed`, `no-change` | trusted operator update |
+| `running` | operator | `ready`, `failed`, `no-change` | trusted operator update |
 | `running` | either | `cancelled` | operator cancellation |
 | `needs-input` | none | `queued` | operator answer appends context; the next Worker claim creates the Attempt |
 | `needs-input` | none | `running` | trusted operator claims manual ownership |
@@ -441,6 +453,9 @@ Worker Attempt before taking manual ownership.
   repository, head branch, and head SHA match the Work repository, immutable
   publish ref, remote ref, and local `HEAD`. Manual `ready` requires the
   expected repository and records the provider-reported branch and SHA.
+- Agent-owned `needs-input` requires a clean worktree and a checkpoint SHA. A
+  changed HEAD must equal the fetched publish ref; an unchanged Work uses its
+  exact base SHA. The Worker revalidates after process stop.
 - `needs-input`, `failed`, and `no-change` require a message. `needs-input`
   exposes the message as the current operator question.
 - Exactly one Attempt-ending agent report can win. Repeating the same report is
@@ -468,6 +483,8 @@ Worker Attempt before taking manual ownership.
   `[A-Za-z0-9][A-Za-z0-9._-]*`. Whitespace, prose, and other characters are
   rejected before admission.
 - A trusted operator may update Work only when it has no active Attempt.
+- A trusted operator cannot report `needs-input`; that outcome requires a
+  Worker-owned checkpoint.
 - Queue, Work, update, Attempt, and Worker list APIs remain bounded and cursor
   paginated.
 - The local operator API remains loopback-only. Remote Workers continue to use
@@ -510,6 +527,10 @@ terminal update from queued Work claims and completes it in one transaction.
 An operator who wants to take over active agent Work must cancel its Attempt
 first. This makes manual and agent-driven Work share one history without
 creating a second completion model or a claim race.
+
+Operator-owned Work may finish as `ready`, `failed`, or `no-change` but cannot
+enter `needs-input`. Only a Worker Attempt with a verified checkpoint may create
+a resumable question. An operator can still answer that agent-created question.
 
 A manual `ready` update is not required to have a Factory worktree or publish
 branch. The CLI uses the operator's local GitHub credentials to resolve the PR
@@ -582,6 +603,7 @@ source_reference
 context_snapshot
 publish_branch
 predecessor_work_id
+checkpoint_sha
 state
 execution_owner: none | worker_attempt | operator
 waiting_reason
@@ -687,6 +709,13 @@ Attempt and Work with stored delivery evidence and a fixed postflight reason;
 it never marks stale evidence ready. Factory validates delivery identity, not
 CI success or semantic correctness; the agent remains responsible for both.
 
+For agent-owned `needs-input`, the Worker similarly validates a clean worktree
+and durable checkpoint before accepting the report and after process stop. A
+dirty tree, moved ref, missing commit, or post-stop mismatch fails validation.
+If the post-stop check fails, the Attempt and Work fail with the retained
+worktree and a fixed checkpoint reason; Factory does not present a question
+whose continuation would lose local work.
+
 For `outcome_contract=agent_update`, if the agent process exits without an
 outcome report, the Worker fails the Attempt with the fixed missing-report
 reason. A `process_exit` Run completes through its legacy exit and result rules.
@@ -708,8 +737,10 @@ target without changing terminal siblings.
 An operator answer to `needs-input` appends trusted context and requeues the
 same Work. The next Worker claim creates a new Attempt. The agent receives the
 original frozen Procedure, original context, prior question, answer, updates,
-known branch, and PR metadata. Archiving a Procedure prevents new Runs but does
-not cancel admitted Work.
+known branch, checkpoint SHA, and PR metadata. Worktree preparation starts from
+that exact checkpoint. A missing or unreachable checkpoint fails preparation
+visibly instead of falling back to repository base. Archiving a Procedure
+prevents new Runs but does not cancel admitted Work.
 
 Control-plane shutdown stops admission before HTTP shutdown. Workers continue
 until lease renewal fails, then stop active processes. Restart sweeps expired
@@ -780,7 +811,8 @@ remains visible and never silently drops an outcome.
   cancellation wins over a late report.
 - `AC-9`: Answering a needs-input question requeues Work with the answer and
   prior history while preserving the original Procedure and context; only the
-  next Worker claim creates an Attempt.
+  next Worker claim creates an Attempt, starting from the revalidated
+  checkpoint SHA.
 - `AC-10`: A warned retry after process start continues from the stable remote
   publish branch when one exists and does not create a second Work record.
 - `AC-11`: Replaying an admission or update after a lost response returns the
@@ -818,12 +850,13 @@ legacy completion cases. HTTP tests prove CLI admission validation, source
 normalization, message limits, cursor bounds, and operator updates for `AC-1`,
 `AC-3`, `AC-11`, `AC-15`, `AC-17`, and `AC-18`.
 
-Worker and supervisor tests prove `INV-5` through `INV-8`, `INV-11`, and
-`INV-17` with
+Worker and supervisor tests prove `INV-5` through `INV-8`, `INV-11`, `INV-17`,
+and `INV-18` with
 wrong tokens, expired leases, terminal-report races, cancellation, forced exit,
 parent loss, stable publish continuation, preflight and post-stop PR identity
 validation, provider outage, branch movement after report, the 199-progress
-limit with a reserved outcome slot, and cleanup.
+limit with a reserved outcome slot, dirty needs-input rejection, pushed and
+unchanged checkpoints, answer continuation, and cleanup.
 They verify `AC-5`, `AC-7`, `AC-8`, `AC-10`, `AC-12`, and `AC-13`, including
 the race detector.
 They also prove that every valid semantic outcome completes the Attempt while

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -427,6 +427,7 @@ not an agent update status and does not imply a pull request.
 | Current state | Owner | Allowed transition | Cause |
 | --- | --- | --- | --- |
 | `queued` | none | `running` | Worker claim creates an Attempt, or trusted operator claims manual ownership |
+| `queued` | none | `ready`, `failed`, `no-change` | trusted operator claims and completes `agent_update` Work in one transaction |
 | `queued` | none | `cancelled` | operator cancellation |
 | `running` | Worker Attempt | unchanged | agent `running` progress update |
 | `running` | Worker Attempt | `ready`, `needs-input`, `failed`, `no-change` | accepted outcome followed by stopped process |
@@ -437,13 +438,16 @@ not an agent update status and does not imply a pull request.
 | `needs-input` | none | `running` | trusted operator claims manual ownership |
 | `needs-input` | none | `cancelled` | operator cancellation |
 | `failed` or `cancelled` | none | `queued` | explicit warned retry, only when no replacement or matching nonterminal Work exists |
+| `cancelled` | none | `running` | explicit warned operator takeover after active cancellation, with the same retry guards |
 
 `ready`, `succeeded`, `failed`, `no-change`, and `cancelled` are terminal
 outcomes unless an explicit retry rule above applies. A manual `running` update
 atomically records operator ownership and removes the Work from Worker
 eligibility. A direct manual terminal update from queued Work performs that
 claim and completion in one transaction. An operator must cancel an active
-Worker Attempt before taking manual ownership.
+Worker Attempt and wait until Work is cancelled before taking manual ownership.
+The subsequent operator `running` update atomically applies the retry guards and
+claims cancelled Work, so a Worker cannot win an intermediate queued state.
 
 ### Requirements
 
@@ -569,9 +573,12 @@ before returning so the operator can answer or inspect the result.
 An operator `running` update atomically claims manual ownership when the Work
 has no active Attempt. Later operator updates require that ownership. A direct
 terminal update from queued Work claims and completes it in one transaction.
-An operator who wants to take over active agent Work must cancel its Attempt
-first. This makes manual and agent-driven Work share one history without
-creating a second completion model or a claim race.
+An operator who wants to take over active agent Work must cancel it, wait until
+Work is cancelled, then send one `running` update. That update performs the same
+replacement and matching-nonterminal checks as retry, records the duplicate-
+effect warning, and claims operator ownership without exposing a queued race.
+This makes manual and agent-driven Work share one history without creating a
+second completion model or a claim race.
 
 Operator-owned Work may finish as `ready`, `failed`, or `no-change` but cannot
 enter `needs-input`. Only a Worker Attempt with a verified checkpoint may create
@@ -915,6 +922,9 @@ remains visible and never silently drops an outcome.
   with the trusted recovery SHA and explicit recovery instructions, accepts only
   a restored ref at that SHA, and never creates `needs-input` without a verified
   checkpoint.
+- `AC-22`: An operator can atomically finish queued `agent_update` Work, or take
+  over active agent Work by cancelling it and atomically claiming the cancelled
+  Work with retry guards and no intermediate queued race.
 
 ## 10. Test approach
 
@@ -922,7 +932,8 @@ Store tests prove `INV-1` through `INV-4`, `INV-9`, `INV-12`, `INV-14`,
 `INV-16`, and `INV-19` with transaction rollback, duplicate target, replay,
 partial outcome, queued, running, and needs-input cancellation, retry of
 replaced Work, matching-nonterminal retry races, manual-claim races, and legacy
-completion cases. HTTP tests prove CLI admission validation, source
+completion cases. Manual-claim tests include queued direct completion and
+cancel-wait-takeover from cancelled Work. HTTP tests prove CLI admission validation, source
 normalization, message limits, cursor bounds, and operator updates for `AC-1`,
 `AC-3`, `AC-11`, `AC-15`, `AC-17`, and `AC-18`.
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -448,7 +448,7 @@ manual ownership.
 ### CLI
 
 ```text
-factory build [--repo REPOSITORY] [--runtime RUNTIME] [--request-key KEY] [--wait] REFERENCE...
+factory build [--repo REPOSITORY] [--runtime RUNTIME] [--request-key KEY] [--rebuild] [--wait] REFERENCE...
 factory run PROCEDURE --repos REPOSITORY...|all [--request-key KEY] [--wait]
 factory status [--run RUN_ID]
 factory show WORK_ID
@@ -799,8 +799,9 @@ validated through use:
   an update? Default: fail visibly first and measure frequency because runtime
   support for another turn differs.
 - Should a ready update require Factory to query GitHub checks? Default: no.
-  The agent owns semantic completion; Factory validates only URL shape and
-  repository identity in V1.
+  The agent owns semantic completion. Factory still validates the URL,
+  repository, immutable branch, remote ref, and head SHA as required above,
+  but does not require passing GitHub checks in V1.
 - Should one Run limit parallel Work per repository? Default: no separate
   per-repository limit. Worker capacity and Run concurrency bound execution,
   while isolated pull requests expose conflicts for human review.

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -572,11 +572,19 @@ connection loss, malformed response, or server error remains
 pending because it may have happened after commit. The control plane returns
 `rejected_before_commit` only when the transaction created no Run.
 This lets a new CLI process replay a request whose response was lost without
-turning all future identical commands into replays. Journal access is locked,
-it retains at most 100 pending entries, and its directory and file use `0700`
-and `0600` modes. At the limit, implicit key creation fails with the journal path
-and asks the operator to recover pending requests or supply an explicit key; it
-never silently evicts an uncertain request.
+turning all future identical commands into replays. Before journal lookup, the
+CLI acquires a nonblocking exclusive OS lock scoped to the endpoint and caller
+fingerprint and holds it through the final output flush and journal cleanup.
+A concurrent command with that same scope exits before sending any request,
+prints that the admission is already in progress, and may be retried after the
+owner finishes. Unrelated fingerprints use independent locks. If the owner
+process exits, the OS releases its lock and the still-pending record lets the
+next process reuse the same key. Journal mutations also use a short global lock;
+the journal retains at most 100 pending entries. Its directory uses mode `0700`;
+its data and lock files use mode `0600`. At the limit, implicit
+key creation fails with the journal path and asks the operator to recover
+pending requests or supply an explicit key; it never silently evicts an
+uncertain request.
 
 `--wait` streams status and returns as soon as any Work needs input, using exit
 code 2, even while independent siblings continue. Otherwise it returns when the
@@ -1038,9 +1046,11 @@ admission works when `--repo` is absent.
 
 CLI tests use a real loopback server to prove multi-reference admission,
 explicit and generated-key replay across separate CLI processes, pending-journal
-locking, cleanup only after flushed authoritative output, interruption after an
-admission response and during `--wait`, uncertain-response retention, human and
-JSON output, `--wait`, opaque-reference repository
+locking, fail-fast concurrent invocation for the same endpoint and fingerprint,
+independent concurrent fingerprints, owner-process exit and key recovery,
+cleanup only after flushed authoritative output, interruption after an admission
+response and during `--wait`, uncertain-response retention, human and JSON
+output, `--wait`, opaque-reference repository
 requirements, runtime default and override, rebuild key conflicts,
 Build and Procedure Run rebuild identity, needs-input duplicate rejection,
 exact older-Work replacement, replay after a rebuild becomes terminal, wait

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -653,6 +653,9 @@ and its reported Work outcome. A ready report maps to succeeded and ready only
 after post-stop delivery revalidation. No report, an infrastructure error, or
 failed post-stop validation maps to a `failed` Attempt and failed Work. This
 keeps process execution evidence separate from the agent's semantic judgment.
+Worktree cleanup uses the final Work outcome as well as Attempt execution state:
+a `succeeded` Attempt whose reported Work outcome is `failed` retains its
+worktree under the existing failure-retention limits.
 
 ### Stored resources
 
@@ -840,6 +843,11 @@ uncertain.
 A valid `failed` report still completes the Attempt successfully because the
 agent fulfilled the reporting contract; the Work outcome is failed. This
 distinction lets operators tell an engineering blocker from a broken runtime.
+The Worker retains that Attempt worktree even though the Attempt succeeded and
+records its Worker and local path for operator inspection. Retry still creates
+a fresh worktree from `pending_resume_sha`, the publish ref, or repository base
+under the normal rules; it never silently treats unpushed files as durable or
+deletes them through successful-Attempt cleanup.
 
 Cancellation of Work with no active Worker Attempt is immediate and
 transactional. This includes queued, needs-input, and operator-owned running
@@ -1004,6 +1012,9 @@ remains visible and never silently drops an outcome.
   frozen Procedure and target as a new one-Work Run, records that predecessor,
   requires its current Procedure and repository to be eligible on first
   admission, and replays without consulting later Work or configuration.
+- `AC-26`: An agent-reported `failed` outcome completes the Attempt as succeeded
+  but retains its worktree under failure-retention limits and exposes its Worker
+  and local path; successful-Attempt cleanup cannot delete it.
 
 ## 10. Test approach
 
@@ -1028,7 +1039,7 @@ unchanged checkpoints, answer continuation, answer then cancellation or failed
 preparation then retry with moved and missing refs, maximum question and answer
 sizes, bounded multi-Attempt history with UTF-8 truncation and omission digests,
 claim protocol version 3 acceptance, older-Worker rejection before any Work
-claim, and cleanup.
+claim, outcome-aware worktree retention and cleanup.
 They verify `AC-5`, `AC-7`, `AC-8`, `AC-10`, `AC-12`, and `AC-13`, including
 the race detector.
 They also prove that every valid semantic outcome completes the Attempt while

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -252,6 +252,15 @@ protocol. V1 does not treat the agent process as isolated from other files and
 services available to the Worker operating-system user. The Worker does not
 decide whether the engineering task is semantically complete.
 
+The implementation increments `ClaimProtocolVersion` from 2 to 3 because the
+claim and completion contract now includes frozen outcome behavior, scoped
+updates, checkpoints, and post-stop validation. The control plane rejects an
+older registration or claim with `worker_upgrade_required`; an old Worker can
+never claim `agent_update` Work. V1 requires the server and all Workers to be
+upgraded together. A server-first upgrade pauses claims from older Workers,
+including legacy `process_exit` Work, until those Workers are upgraded. Rolling
+mixed-version operation is not supported.
+
 #### Agent runtime
 
 The agent runtime owns model interaction, repository exploration, planning,
@@ -845,18 +854,23 @@ only after an Attempt successfully starts from that commit; the historical
 Runs but does not cancel admitted Work.
 
 Every assembled agent prompt remains within the existing 72 KiB byte limit.
-Admission requires the frozen Procedure, original context, fixed wrapper, and
-bounded recovery metadata to fit while reserving the maximum 8 KiB question and
-8 KiB answer. Before accepting `needs-input` or an answer, Factory also proves
-the actual mandatory continuation sections fit; rejection leaves the current
-state unchanged. The continuation always includes the Procedure, original
-context, current question and answer, checkpoint and branch identity, PR
-metadata, and an omission marker. It fills remaining bytes with the newest
-prior updates, prioritizing Attempt outcomes over progress and displaying the
-selected records chronologically. If history is omitted or one message must be
-UTF-8-boundary truncated, the marker includes stored and inserted counts and a
-SHA-256 digest of the complete omitted serialized history. All full updates
-remain stored and visible outside the prompt.
+For `agent_update` Work, admission requires the frozen Procedure, original
+context, fixed wrapper, and bounded recovery metadata to fit while reserving
+the maximum 8 KiB question and 8 KiB answer. Before accepting `needs-input` or
+an answer, Factory also proves the actual mandatory continuation sections fit;
+rejection leaves the current state unchanged. The continuation always includes
+the Procedure, original context, current question and answer, checkpoint and
+branch identity, PR metadata, and an omission marker. It fills remaining bytes
+with the newest prior updates, prioritizing Attempt outcomes over progress and
+displaying the selected records chronologically. If history is omitted or one
+message must be UTF-8-boundary truncated, the marker includes stored and
+inserted counts and a SHA-256 digest of the complete omitted serialized history.
+All full updates remain stored and visible outside the prompt.
+
+`process_exit` Work has no question or answer reserve and keeps the current
+prompt-fit rules: its resolved prompt may use the existing 64 KiB limit as long
+as the final assembled prompt fits within 72 KiB. Migration and the protocol
+upgrade do not make a previously valid legacy prompt inadmissible.
 
 Control-plane shutdown stops admission before HTTP shutdown. Workers continue
 until lease renewal fails, then stop active processes. Restart sweeps expired
@@ -942,7 +956,8 @@ remains visible and never silently drops an outcome.
   stored agent update is retried after its lease expires.
 - `AC-12`: Local and enrolled VM Workers use the same scoped update protocol
   without transmitting the operator credential, Worker credential, or Attempt
-  lease token in that protocol.
+  lease token in that protocol. Claim protocol version 3 is required; older
+  Workers receive `worker_upgrade_required` and cannot claim Work.
 - `AC-13`: Restarting the control plane or Worker preserves Work, updates,
   questions, results, and retained recovery state.
 - `AC-14`: Existing Task, Run, Session, Attempt, event, schedule, and repository
@@ -972,9 +987,11 @@ remains visible and never silently drops an outcome.
   Work with retry guards and no intermediate queued race.
 - `AC-23`: Cancelling queued, needs-input, or operator-owned Work with no active
   Worker Attempt completes synchronously and cannot wait for a heartbeat.
-- `AC-24`: Initial and continuation prompts cannot exceed 72 KiB; mandatory
-  recovery context is preserved while omitted update history is counted and
-  digested without deleting the stored events.
+- `AC-24`: Initial and continuation `agent_update` prompts cannot exceed 72 KiB;
+  mandatory recovery context is preserved while omitted update history is
+  counted and digested without deleting the stored events. `process_exit`
+  prompts keep their existing 64 KiB resolved and 72 KiB assembled limits with
+  no continuation reserve.
 - `AC-25`: `factory replace WORK_ID` admits exactly the named terminal Work's
   frozen Procedure and target as a new one-Work Run, records that predecessor,
   requires its current Procedure and repository to be eligible on first
@@ -1002,7 +1019,8 @@ limit with a reserved outcome slot, dirty needs-input rejection, pushed and
 unchanged checkpoints, answer continuation, answer then cancellation or failed
 preparation then retry with moved and missing refs, maximum question and answer
 sizes, bounded multi-Attempt history with UTF-8 truncation and omission digests,
-and cleanup.
+claim protocol version 3 acceptance, older-Worker rejection before any Work
+claim, and cleanup.
 They verify `AC-5`, `AC-7`, `AC-8`, `AC-10`, `AC-12`, and `AC-13`, including
 the race detector.
 They also prove that every valid semantic outcome completes the Attempt while
@@ -1036,10 +1054,11 @@ accessibility at desktop and 390-pixel widths.
 
 Migration tests open supported historical databases and prove `AC-14` and
 `AC-16` without dropping, relabelling, or changing the next scheduled outcome.
-They prove that existing Procedures default to `process_exit` and conversion
-increments generation for `AC-17`. One end-to-end smoke test runs a fake agent
-executable that reports progress and each Attempt-ending outcome through the
-real Worker-local update endpoint.
+They prove that an existing maximum-size valid prompt remains admissible without
+question or answer reserves, existing Procedures default to `process_exit`, and
+conversion increments generation for `AC-17`. One end-to-end smoke test runs a
+fake agent executable that reports progress and each Attempt-ending outcome
+through the real Worker-local update endpoint.
 
 ## 11. Risks and tradeoffs
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -554,8 +554,12 @@ endpoint and canonical caller-input fingerprint in its private operator state
 directory before the first request. A later invocation with the same pending
 fingerprint reuses that key. The CLI removes the pending record only after it
 receives a typed admission response that says `admitted`, `replayed`, or
-`rejected_before_commit`, and prints the key with every result. A timeout,
-connection loss, interruption, malformed response, or server error remains
+`rejected_before_commit`, renders the command's authoritative result, writes it
+to the selected human or JSON output, and successfully flushes that output.
+For `--wait`, the authoritative result is the terminal or needs-input result,
+not the initial admission response. The CLI prints the key with every result.
+A process exit or interruption before the final output is flushed, timeout,
+connection loss, malformed response, or server error remains
 pending because it may have happened after commit. The control plane returns
 `rejected_before_commit` only when the transaction created no Run.
 This lets a new CLI process replay a request whose response was lost without
@@ -733,9 +737,13 @@ new admission key and creates one new Run and one replacement Work by copying
 the named terminal Work's frozen Procedure snapshot, runtime, target, source
 reference, repository identity, and original context. The transaction stores
 that exact `predecessor_work_id` and rejects a nonterminal predecessor, an
-existing replacement, or matching nonterminal Work. Its fingerprint contains
-the operation and Work ID, and exact replay is checked before reading the named
-Work or current configuration. It never selects the newest Work by target.
+existing replacement, matching nonterminal Work, an archived current Procedure,
+or a disabled or deleted current repository. Current eligibility is checked
+only on first admission; it does not replace any frozen field copied from the
+predecessor. Its fingerprint contains the operation and Work ID. Exact replay
+is checked before reading the named Work or current configuration and returns
+the stored replacement even if later configuration becomes ineligible. It
+never selects the newest Work by target.
 
 An agent update request is unique by `(attempt_id, request_id)`. An operator
 update request is unique by `(work_id, request_id)`. The CLI generates the
@@ -969,7 +977,8 @@ remains visible and never silently drops an outcome.
   digested without deleting the stored events.
 - `AC-25`: `factory replace WORK_ID` admits exactly the named terminal Work's
   frozen Procedure and target as a new one-Work Run, records that predecessor,
-  and replays without consulting later Work or configuration.
+  requires its current Procedure and repository to be eligible on first
+  admission, and replays without consulting later Work or configuration.
 
 ## 10. Test approach
 
@@ -1011,14 +1020,17 @@ admission works when `--repo` is absent.
 
 CLI tests use a real loopback server to prove multi-reference admission,
 explicit and generated-key replay across separate CLI processes, pending-journal
-locking, typed-response cleanup, uncertain-response retention, human and JSON
-output, `--wait`, opaque-reference repository
+locking, cleanup only after flushed authoritative output, interruption after an
+admission response and during `--wait`, uncertain-response retention, human and
+JSON output, `--wait`, opaque-reference repository
 requirements, runtime default and override, rebuild key conflicts,
 Build and Procedure Run rebuild identity, needs-input duplicate rejection,
 exact older-Work replacement, replay after a rebuild becomes terminal, wait
 exit codes, missing-PR-ref recovery, and agent-context routing. Replay tests also
 disable or delete the repository and change configured defaults before retrying
-the stored key. Browser
+the stored key. Exact-replacement tests reject first admission after Procedure
+archive or repository disablement or deletion, then prove a previously admitted
+replacement still replays after those changes. Browser
 component tests and a real browser flow prove `AC-2`, `AC-6`, `AC-9`, and
 accessibility at desktop and 390-pixel widths.
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -222,12 +222,17 @@ keep the same IDs, generations, repository selection, and schedules. They may
 appear as legacy Procedures in operator surfaces, but do not require
 `factory update` until an operator explicitly converts them to the new outcome
 contract. `outcome_contract` is `process_exit` or `agent_update`; conversion
-increments the Procedure generation. Their next scheduled occurrence behaves
-exactly as it does today.
+increments the Procedure generation. Conversion requires the persistent
+execution backend. A Task configured with `fake_cloud_run` is rejected with
+`agent_update_backend_unsupported` without changing its generation or contract;
+the synthetic dispatcher does not launch an agent or implement scoped updates.
+Its next scheduled occurrence behaves exactly as it does today.
 
 New Procedures default to `agent_update`. `process_exit` exists only to retain
 unconverted legacy behavior. Every Run snapshot stores the selected contract,
-so later conversion cannot change admitted or historical Work.
+so later conversion cannot change admitted or historical Work. Admission of
+new `agent_update` Work likewise requires a frozen persistent execution snapshot
+and rejects any other backend with `agent_update_backend_unsupported`.
 
 #### Admission service
 
@@ -662,7 +667,7 @@ worktree under the existing failure-retention limits.
 | Resource | New or changed ownership |
 | --- | --- |
 | Procedure | trusted instructions, runtime, timeout, concurrency, outcome contract, generation |
-| Run | Procedure snapshot including outcome contract, resolved runtime, source, ordered frozen targets, aggregate state |
+| Run | Procedure snapshot including outcome contract, complete execution snapshot, source, ordered frozen targets, aggregate state |
 | Work | target identity, repository, source context, publish branch, user state, execution owner, waiting reason, question, result |
 | Work update | Work, optional Attempt, request ID, sequence, status, message, PR URL, accepted time, actor |
 | Attempt | Worker lease, process identity, local branch, lifecycle and events |
@@ -754,11 +759,15 @@ newer terminal Work now exists.
 
 `factory replace WORK_ID` is the exact-predecessor recovery path. It requires a
 new admission key and creates one new Run and one replacement Work by copying
-the named terminal Work's frozen Procedure snapshot, runtime, target, source
-reference, repository identity, and original context. The transaction stores
-that exact `predecessor_work_id` and rejects a nonterminal predecessor, an
-existing replacement, matching nonterminal Work, an archived current Procedure,
-or a disabled or deleted current repository. Current eligibility is checked
+the named terminal Work's frozen Procedure snapshot, complete execution
+snapshot, target, source reference, repository identity, and original context.
+The execution snapshot includes profile ID and version, backend, runtime,
+provider, model, timeout, resource class, and commit-resolution policy; exact
+replacement never re-resolves a current or default profile. The transaction
+stores that exact `predecessor_work_id` and rejects a nonterminal predecessor,
+an existing replacement, matching nonterminal Work, an archived current
+Procedure, a disabled or deleted current repository, or an execution snapshot
+incompatible with its frozen outcome contract. Current eligibility is checked
 only on first admission; it does not replace any frozen field copied from the
 predecessor. Its fingerprint contains the operation and Work ID. Exact replay
 is checked before reading the named Work or current configuration and returns
@@ -984,7 +993,9 @@ remains visible and never silently drops an outcome.
   their existing repository selection and exit-based success behavior without
   receiving or accepting agent or operator semantic `factory update` calls.
 - `AC-17`: Every Run freezes `outcome_contract`; converting a legacy Procedure
-  increments its generation and cannot change admitted Runs.
+  increments its generation and cannot change admitted Runs. Conversion or new
+  admission rejects a non-persistent backend for `agent_update` without state
+  change, while legacy `fake_cloud_run` process-exit schedules remain unchanged.
 - `AC-18`: A manual ready update resolves or accepts operator PR head evidence,
   succeeds without control-plane GitHub credentials, and replays idempotently
   by Work and request ID.
@@ -1009,9 +1020,10 @@ remains visible and never silently drops an outcome.
   prompts keep their existing 64 KiB resolved and 72 KiB assembled limits with
   no continuation reserve.
 - `AC-25`: `factory replace WORK_ID` admits exactly the named terminal Work's
-  frozen Procedure and target as a new one-Work Run, records that predecessor,
-  requires its current Procedure and repository to be eligible on first
-  admission, and replays without consulting later Work or configuration.
+  frozen Procedure, complete execution snapshot, and target as a new one-Work
+  Run, records that predecessor, requires its current Procedure and repository
+  to be eligible on first admission, and replays without consulting later Work
+  or configuration.
 - `AC-26`: An agent-reported `failed` outcome completes the Attempt as succeeded
   but retains its worktree under failure-retention limits and exposes its Worker
   and local path; successful-Attempt cleanup cannot delete it.
@@ -1077,9 +1089,13 @@ Migration tests open supported historical databases and prove `AC-14` and
 `AC-16` without dropping, relabelling, or changing the next scheduled outcome.
 They prove that an existing maximum-size valid prompt remains admissible without
 question or answer reserves, existing Procedures default to `process_exit`, and
-conversion increments generation for `AC-17`. One end-to-end smoke test runs a
-fake agent executable that reports progress and each Attempt-ending outcome
-through the real Worker-local update endpoint.
+conversion increments generation for `AC-17`. Conversion tests reject
+`fake_cloud_run` with no state change and prove its next legacy schedule still
+uses synthetic exit completion. Exact-replacement tests preserve every field of
+a predecessor's manually overridden execution snapshot and never resolve the
+current profile. One end-to-end smoke test runs a fake agent executable that
+reports progress and each Attempt-ending outcome through the real Worker-local
+update endpoint.
 
 ## 11. Risks and tradeoffs
 

--- a/docs/software-factory/design.md
+++ b/docs/software-factory/design.md
@@ -532,6 +532,7 @@ factory status [--run RUN_ID]
 factory show WORK_ID
 factory answer WORK_ID MESSAGE
 factory retry WORK_ID
+factory replace WORK_ID [--request-key KEY] [--wait]
 factory cancel WORK_ID
 factory update [--id WORK_ID] --status STATUS --message MESSAGE [--pr URL] [--head-branch BRANCH] [--head-sha SHA]
 
@@ -727,6 +728,15 @@ retry with the same new key and caller fingerprint returns that stored rebuild
 Run even when a repository is disabled or deleted, configuration changes, or
 newer terminal Work now exists.
 
+`factory replace WORK_ID` is the exact-predecessor recovery path. It requires a
+new admission key and creates one new Run and one replacement Work by copying
+the named terminal Work's frozen Procedure snapshot, runtime, target, source
+reference, repository identity, and original context. The transaction stores
+that exact `predecessor_work_id` and rejects a nonterminal predecessor, an
+existing replacement, or matching nonterminal Work. Its fingerprint contains
+the operation and Work ID, and exact replay is checked before reading the named
+Work or current configuration. It never selects the newest Work by target.
+
 An agent update request is unique by `(attempt_id, request_id)`. An operator
 update request is unique by `(work_id, request_id)`. The CLI generates the
 request ID once per invocation and reuses it for its internal retry. A repeated
@@ -759,9 +769,11 @@ A missing publish branch for known PR Work fails preparation with a fixed
 recovery message that identifies the PR, ref, and recorded trusted PR head SHA.
 It tells the operator to restore the ref to exactly that SHA or admit warned
 replacement Work with the matching command's `--rebuild`; a missing trusted SHA
-permits only the latter. Work-item recovery uses `factory build --rebuild`.
-Repository-target recovery uses `factory run PROCEDURE --repos REPOSITORY
---rebuild`, whose predecessor lookup is scoped to that Procedure identity.
+permits only an exact `factory replace WORK_ID`. An operator may also choose
+exact replacement instead of restoring a known SHA. Common target rebuilds use
+`factory build --rebuild` or `factory run PROCEDURE --repos REPOSITORY
+--rebuild`; only `factory replace` guarantees a particular older Work is the
+predecessor.
 Preparation re-fetches and proves the restored ref equals the recorded SHA. It
 does not create a resumable question without a checkpoint. The retry prompt
 identifies prior updates, known PR, publish ref, and duplicate-effect risk.
@@ -955,6 +967,9 @@ remains visible and never silently drops an outcome.
 - `AC-24`: Initial and continuation prompts cannot exceed 72 KiB; mandatory
   recovery context is preserved while omitted update history is counted and
   digested without deleting the stored events.
+- `AC-25`: `factory replace WORK_ID` admits exactly the named terminal Work's
+  frozen Procedure and target as a new one-Work Run, records that predecessor,
+  and replays without consulting later Work or configuration.
 
 ## 10. Test approach
 
@@ -1000,7 +1015,7 @@ locking, typed-response cleanup, uncertain-response retention, human and JSON
 output, `--wait`, opaque-reference repository
 requirements, runtime default and override, rebuild key conflicts,
 Build and Procedure Run rebuild identity, needs-input duplicate rejection,
-replay after a rebuild becomes terminal, wait
+exact older-Work replacement, replay after a rebuild becomes terminal, wait
 exit codes, missing-PR-ref recovery, and agent-context routing. Replay tests also
 disable or delete the repository and change configured defaults before retrying
 the stored key. Browser

--- a/docs/software-factory/vision.md
+++ b/docs/software-factory/vision.md
@@ -150,8 +150,8 @@ Factory is moving toward this vision when a developer can:
 - run one Procedure across at least 100 frozen repository targets;
 - retry one failed target without replaying successful siblings;
 - add or remove Worker capacity without changing a Procedure;
-- identify the exact Procedure, context, runtime, Worker, updates, and outcome
-  used for historical Work;
+- identify the exact Procedure, Factory-supplied context, source reference,
+  runtime, Worker, updates, and outcome used for historical Work;
 - measure ready pull requests and developer interventions rather than only
   process exits.
 

--- a/docs/software-factory/vision.md
+++ b/docs/software-factory/vision.md
@@ -9,7 +9,8 @@
 Factory is the control plane for software work performed by coding agents. A
 developer gives Factory one work item or a repository fleet. Factory queues the
 work, assigns it to available machines, supplies a consistent procedure, and
-shows what is running, ready, blocked, or failed.
+shows what is queued for capacity, running, ready, needs input, failed, or
+completed under a legacy exit-based contract.
 
 Factory does not try to become a better coding agent. Pi, Codex, Claude Code,
 and future runtimes already reason about repositories, use tools, create
@@ -134,10 +135,13 @@ It includes local and VM Workers, bounded concurrency, isolated worktrees,
 versioned Procedure snapshots, agent progress and terminal updates, central
 status, cancellation, and warned retries.
 
-It stops when Work is ready for human review, needs input, has no change, or
-fails. Human merge remains in GitHub. Central CI monitoring, automatic merge,
-general pipeline graphs, and a new Factory coding agent are not required to
-test the product thesis.
+It pauses Work when an agent needs input and requeues it after an answer.
+Agent-update Work finishes when it is ready for human review, has no change,
+fails, or is cancelled. Unconverted legacy Work may finish as `succeeded` from
+its existing exit-based contract without implying a pull request. Human merge
+remains in GitHub. Central CI monitoring, automatic merge, general pipeline
+graphs, and a new Factory coding agent are not required to test the product
+thesis.
 
 ## Measures of progress
 

--- a/docs/software-factory/vision.md
+++ b/docs/software-factory/vision.md
@@ -2,169 +2,166 @@
 
 > **Status:** Product direction
 >
-> **Superseded vocabulary:** This document uses Job Definition, Run, and Job.
-> The implemented operator model is Task, Run, and Session; see
-> [Tasks and Runs](../tasks/design.md) and [ARCHITECTURE.md](../../ARCHITECTURE.md).
-> The thesis, scope, principles, and measures below still apply.
+> The [target design](design.md) proposes this direction. The root
+> [architecture](../../ARCHITECTURE.md) continues to describe only code that
+> exists today.
 
-Factory is infrastructure for building a software factory. It turns
-software-engineering intent and events into reliable agent jobs across Git
-repositories and compute.
+Factory is the control plane for software work performed by coding agents. A
+developer gives Factory one work item or a repository fleet. Factory queues the
+work, assigns it to available machines, supplies a consistent procedure, and
+shows what is running, ready, blocked, or failed.
 
-The primary user is a software team that owns many repositories and wants to
-apply repeatable engineering procedures with coding agents. Factory is not a
-general automation product or another issue tracker. It is the execution and
-control layer between engineering work, repository fleets, agent runtimes, and
-the compute that runs them.
+Factory does not try to become a better coding agent. Pi, Codex, Claude Code,
+and future runtimes already reason about repositories, use tools, create
+subagents, test changes, and open pull requests. Factory makes those agents
+repeatable and operable across more work than a developer can coordinate in
+terminal windows.
 
 ## Product promise
 
-A team can define a standard engineering procedure once, run it once or many
-times, target one work item or hundreds of repositories, and understand what
-happened at every target.
+A developer can submit several software tasks, close the terminal, and return
+to ready pull requests or precise questions:
 
-Examples include:
+```sh
+factory build LINEAR-123 LINEAR-124 --repo github.com/acme/api
+factory status
+```
 
-- triage and refine issue backlogs;
-- review a ticket, implementation plan, patch, or pull request;
-- inspect a codebase for bugs, security concerns, or policy drift;
-- apply dependency, configuration, or CI changes across a repository fleet;
-- let agents create issues, comments, branches, and pull requests with the tools
-  available on their Worker;
-- run scheduled maintenance and react to GitHub events.
+The same system can apply one reusable engineering procedure across a managed
+repository fleet:
 
-Every use case becomes the same execution primitive. A **Job** runs one agent
-against one repository and optional work item. A **Run** invokes one saved
-**Job Definition** and may fan out into many independent Jobs.
+```sh
+factory run bug-fix --repos all
+```
+
+Each target proceeds independently. One failure does not replay successful
+siblings. Worker capacity bounds parallelism. Every agent reports progress and
+its outcome through a small Factory capability instead of leaving Factory to
+interpret arbitrary text.
 
 ## Core experience
 
-An operator starts with a Job Definition such as `Review pull request`, `Triage
-issue`, or `Find dependency risks`. The definition contains the shared prompt,
-runtime needs, and execution defaults.
+Factory has four operator concepts:
 
-The operator can run it manually, call it through the API, attach a schedule,
-or attach a GitHub event trigger. The invocation freezes the definition,
-parameters, and concrete targets into one Run. Each target becomes one Job and
-uses the same attempt, lease, log, result, retry, and cancellation machinery.
+- A **Procedure** is trusted, reusable engineering instruction such as the
+  built-in standard Build procedure or a saved `bug-fix` procedure.
+- A **Run** is one immutable invocation of a Procedure against frozen targets.
+- **Work** is one independently scheduled target inside a Run. It owns one
+  repository and may also own one work-item reference.
+- A **Worker** is a local or remote machine that runs coding agents in isolated
+  Git worktrees.
 
-The operator sees the aggregate Run and every Job. A failure in one repository
-does not erase successful siblings. Retrying one Job does not replay the whole
-Run.
-
-## Product model
+An Attempt remains internal history for one agent process. A queue is not a
+separate product object. It is the set of Work waiting for Worker capacity.
 
 ```text
-Job Definition
-  reusable software-engineering procedure
-        |
-        +-- manual invocation
-        +-- schedule trigger
-        +-- GitHub webhook trigger
-        `-- API invocation
-                 |
-                 v
-                Run
-       frozen definition and target set
-                 |
-       +---------+---------+
-       v         v         v
-      Job       Job       Job
-   repo/item  repo/item  repo/item
-       +---------+---------+
-                 |
-                 v
- Worker on a local host or VM
-       |
-       v
- Pi, Codex, Claude Code, or another coding agent
- using Git and GitHub CLI
+Work item references or repository selector
+                    |
+                    v
+                  Run
+        frozen Procedure and targets
+                    |
+           +--------+--------+
+           v        v        v
+          Work     Work     Work
+        repo/item  repo     repo/item
+           |        |        |
+           +--------+--------+
+                    v
+          local and VM Workers
+                    |
+                    v
+       Pi, Codex, Claude Code, or another agent
 ```
 
-The Job Definition is the saved procedure. Its instructions are not a separate
-Runbook resource. A Trigger is an admission rule attached to a definition, not
-a second kind of job. A Run records one invocation, so Factory does not need a
-separate Occurrence concept.
+## Agent-directed work
+
+The agent owns the meaning of the work. It decides how to refine the task,
+explore the repository, plan, use subagents, implement, test, review, open a
+pull request, and fix CI. Factory does not encode those activities as a
+pipeline graph.
+
+Factory injects a short procedure wrapper and an Attempt-scoped update tool:
+
+```sh
+factory update --status=running --message="Running integration tests"
+factory update --status=ready --pr=<url> --message="Change ready for review"
+factory update --status=needs-input --message="Which behavior is correct?"
+factory update --status=failed --message="The required service is unavailable"
+factory update --status=no-change --message="No concrete bug was found"
+```
+
+The agent supplies semantic judgment. Factory supplies durable state,
+authorization, validation, idempotency, capacity, process supervision, and
+visibility. Deterministic checks may return useful feedback to the agent, but
+they do not replace its judgment about whether the software task is complete.
+
+## Where Factory is better
+
+An interactive coding-agent terminal remains better for exploration, difficult
+product choices, and one high-touch task. Factory is better when a developer
+has several buildable tasks, wants work to continue without open terminals, or
+needs the same procedure applied across many repositories.
+
+Factory succeeds when it reduces developer attention per ready pull request.
+It fails when a developer still has to open, prompt, and monitor every agent
+session individually.
 
 ## Product principles
 
-1. Everything admitted becomes a Run and one or more Jobs.
-2. One Job touches one repository by default.
-3. A Run freezes its complete definition, parameters, and target set.
-4. Saved definitions edit in place. Historical Runs retain their snapshots.
-5. Triggers admit work but never execute agents.
-6. Workers supply compute. Runtimes such as Pi, Codex, and Claude Code supply
-   agent behavior.
-7. Provider payloads and repository content are untrusted inputs. Definition
-   instructions are trusted operator configuration.
-8. Agents use the tools and credentials available on their Worker. Factory does
-   not intermediate GitHub comments, branches, issues, or pull requests.
-9. Fleet-wide work is bounded, fair, observable, and retryable per target.
-10. Product concepts must earn their place through operator behavior, not
-    speculative reuse.
+1. Factory owns coordination; coding agents own engineering judgment.
+2. Every invocation becomes one Run and one or more independent Work targets.
+3. One Work target changes one repository by default.
+4. Every Run freezes its Procedure and complete target set.
+5. Agents update semantic Work state through bounded, scoped capabilities.
+6. Workers retain exclusive ownership of leases, processes, and worktree
+   cleanup.
+7. Work-item bodies and repository content are untrusted agent context.
+   Procedures are trusted operator instructions.
+8. Agents use the tools and credentials available on their Worker.
+9. Fleet work is bounded, observable, and retryable per target.
+10. Factory adds a durable outer loop, not another model conversation loop.
 
-## Differentiation
+## First useful version
 
-Factory focuses on software delivery execution:
+The first version proves two paths through the same engine:
 
-- Git repository fleets and work-item targets;
-- isolated worktrees, branches, commits, and pull requests;
-- reliable agent scheduling, leases, attempts, and recovery;
-- local and VM capacity, with more Worker targets added when needed;
-- reusable engineering procedures;
-- manual, scheduled, event, and API admission;
-- throughput, reliability, cost, and outcome visibility.
+1. `factory build` admits one or more work-item references and runs the
+   built-in standard Build procedure.
+2. `factory run` applies a saved Procedure to one or more managed repositories.
 
-Factory does not aim to own human project management, chat, inboxes, agent
-personas, squads, a generic workflow builder, or business-process automation.
-GitHub and other engineering systems remain the source of issues, pull
-requests, reviews, and repository state.
+It includes local and VM Workers, bounded concurrency, isolated worktrees,
+versioned Procedure snapshots, agent progress and terminal updates, central
+status, cancellation, and warned retries.
 
-## V1 experience
-
-V1 is a local software factory. An operator can:
-
-- configure a local agent Worker using Pi, Codex, or Claude Code;
-- add the team's Git repositories;
-- save a shared prompt as a Definition;
-- press **Run once** for one repository or a selected repository fleet;
-- see every Job, failure, cycle time, throughput, and Worker health;
-- attach a schedule to repeat the same Run automatically.
-
-Remote VM Workers are the next scaling step after this local manual and
-scheduled path works end to end. GitHub webhook Triggers follow later.
-Kubernetes and other execution targets remain possible future Worker types,
-but they are not on the active roadmap.
-
-The built-in SQLite control plane remains a first-class deployment for local
-use and small teams. For larger production installations, the intended
-direction is an optional durable orchestration backend such as Temporal. That
-backend may own timers, retries, cancellation, fan-out, and recovery, but it
-must not change the Definition, Trigger, Run, Job, or Worker experience. The
-full boundary and migration design is tracked in
-[#259](https://github.com/owainlewis/factory/issues/259) and follows the stable
-local and VM Worker experience.
+It stops when Work is ready for human review, needs input, has no change, or
+fails. Human merge remains in GitHub. Central CI monitoring, automatic merge,
+general pipeline graphs, and a new Factory coding agent are not required to
+test the product thesis.
 
 ## Measures of progress
 
-The product is moving toward this vision when a team can:
+Factory is moving toward this vision when a developer can:
 
-- connect a repository fleet without configuring each worker per repository;
-- run one procedure across at least hundreds of frozen targets;
-- react to a GitHub delivery without duplicate Jobs;
-- add or remove local and VM capacity without changing a Job Definition;
-- identify the exact instructions, input, runtime, worker, and outcome for every
-  Job;
-- recover or retry one failed target without replaying successful work;
-- measure useful engineering outcomes rather than only process completion.
+- submit at least five independent work items in one command;
+- stop managing separate coding-agent conversations;
+- identify every active agent, repository, branch, and latest progress update;
+- receive a precise question when an agent cannot continue;
+- run one Procedure across at least 100 frozen repository targets;
+- retry one failed target without replaying successful siblings;
+- add or remove Worker capacity without changing a Procedure;
+- identify the exact Procedure, context, runtime, Worker, updates, and outcome
+  used for historical Work;
+- measure ready pull requests and developer interventions rather than only
+  process exits.
 
 ## Explicit non-goals
 
-- General-purpose automation outside software engineering.
-- A replacement for GitHub Issues, Jira, Linear, or team chat.
-- Multi-step DAGs, workflow chaining, or a visual pipeline builder.
-- One agent process changing several repositories atomically.
-- Autonomous merge, approval, or unbounded recursive Job creation in the first
-  target architecture.
-- A deterministic gateway for agent GitHub actions or exactly-once external
-  side effects.
+- A replacement for an interactive coding-agent terminal.
+- A new coding agent, model loop, planner, or subagent framework.
+- A replacement for GitHub, Linear, Jira, or team chat.
+- A generic workflow builder, DAG, or visual pipeline editor.
+- Deterministically deciding whether an agent's software work is correct.
+- Exactly-once GitHub or other external side effects.
+- Automatic merge in the first version.
+- Public multi-user control-plane access in the first version.


### PR DESCRIPTION
## Summary

- replace the pipeline proposal with a durable Work queue and Worker fleet model
- add build-item and repository-fleet admission through one Run and Work primitive
- define agent-directed progress and outcomes, manual updates, retries, branch continuity, and legacy Task compatibility
- keep current implementation architecture separate from proposed behavior

## Verification

- git diff --check
- just format-check
- just boundary
- independent architecture review: Approve

## Context

This supersedes the direction proposed in #333. It does not implement the design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated architecture and roadmap guidance for an agent-directed software factory.
  * Added design details for work-item admission, repository runs, retries, durable checkpoints, cancellation, recovery, and operator takeover.
  * Documented Claim Protocol version 3 requirements, worker upgrades, eligibility validation, and reliable admission output handling.
  * Clarified CLI workflows for building, running, monitoring, and submitting updates.
  * Reframed the product vision around procedures, runs, work items, workers, and controlled agent operations.
  * Refreshed documentation navigation and Browser UI descriptions, including the Work view for run history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->