### PR TITLE
feat: add unified Factory CLI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,17 +1,6 @@
 # Factory architecture
 
-> **Status:** Current implementation
->
-> **Verification basis:** `origin/main` at commit `e767947`
->
-> **Future direction:** The proposed
-> [agent-directed software factory](docs/software-factory/design.md) adds
-> work-item admission and agent-owned semantic status while preserving the
-> current Worker lifecycle. The proposed
-> [Cloud Run agent backend](docs/cloud-run-agents/design.md) adds elastic
-> execution. This document describes only code that exists today.
-
-## 1. Executive summary
+## Executive summary
 
 Factory is a local-first control plane for repeatable software-engineering
 agents. An operator saves a prompt and execution settings as a Task. Running
@@ -19,8 +8,11 @@ or scheduling that Task creates a Run with one Session per repository. A
 persistent Worker claims each Session, prepares an isolated Git worktree, runs
 Pi, Codex, or Claude Code, streams events, and reports one terminal result.
 
-The implementation has three main parts:
+The implementation has four main parts:
 
+- `factory` is the operator CLI. Long-running commands replace themselves with
+  the compatible server or Worker executable, while finite commands read the
+  loopback HTTP API and never open SQLite or Worker directories.
 - `factory-server` owns durable state, scheduling, routing, the HTTP API, and
   the embedded browser UI.
 - `factory-worker` owns runtime health, repository caches, worktrees, agent
@@ -38,10 +30,10 @@ artifacts, and credentials are not implemented yet. The contract keeps Factory
 as the source of truth and preserves the persistent Worker path as the built-in
 `persistent-auto` default.
 
-## 2. System context
+### System architecture
 
 ```text
-Operator browser
+Operator browser or `factory` CLI
       |
       | loopback HTTP and JSON
       v
@@ -66,7 +58,21 @@ The control plane decides what should run and records what happened. A Worker
 decides how to execute one claim safely on its machine. The agent runtime is a
 child process and does not receive a control-plane operator credential.
 
-## 3. Current product model
+### Dependency hierarchy
+
+```text
+cmd/factory         -> internal/factorycli   -> internal/protocol
+cmd/factory-server  -> internal/controlplane -> internal/protocol
+                    -> web
+cmd/factory-worker  -> internal/worker       -> internal/protocol
+```
+
+Entry points depend on their runtime package, and both long-running runtime
+packages share only protocol types. Worker code must never import control-plane
+implementation code. Finite CLI commands depend on the HTTP protocol and cannot
+read control-plane or Worker state directly.
+
+## Current product model
 
 ### Task
 
@@ -135,7 +141,7 @@ Workers clone them on demand with `gh`, keep at most 100 cache entries, fetch
 before an Attempt, and resolve the current base branch and commit. Legacy
 static repository paths remain readable through Worker configuration.
 
-## 4. Architectural invariants
+## Architectural invariants
 
 1. SQLite and the control plane are the authority for Run and Attempt state.
 2. A claim is assigned only to its selected, healthy, online Worker with a ready
@@ -159,8 +165,23 @@ static repository paths remain readable through Worker configuration.
    concurrency, generation, and schedule context.
 10. Operator builds embed committed `web/dist` assets and do not require Node.js
     at runtime.
+11. Finite `factory` commands accept only an explicit-port plain HTTP loopback
+    endpoint and read current state through bounded API routes.
 
-## 5. Components
+## Components
+
+### Operator CLI
+
+`cmd/factory` delegates parsing and finite HTTP work to `internal/factorycli`.
+The `status`, `show`, and `workers` commands decode protocol resources and write
+either stable tabular output or one JSON value. They do not import SQLite or
+Worker packages.
+
+The `server start` and `worker start` commands replace the CLI process with the
+matching compatibility executable beside it or on `PATH`. An explicit config
+path is passed through the existing `FACTORY_SERVER_CONFIG` or
+`FACTORY_WORKER_CONFIG` environment contract. Process replacement preserves the
+existing role's signal and shutdown behavior.
 
 ### Control plane
 
@@ -223,7 +244,7 @@ the same-origin API.
 uses an SPA fallback, immutable caching for versioned assets, and restrictive
 security headers. Node.js is needed only when UI source changes.
 
-## 6. Critical flows
+## Critical flows
 
 ### Task admission
 
@@ -265,7 +286,7 @@ Only failed or cancelled Sessions can be retried. Retry preserves the Session
 and Attempt history, selects a currently eligible Worker, and creates the next
 Attempt when claimed.
 
-## 7. API and security boundaries
+## API and security boundaries
 
 The local listener exposes health plus operator and Worker routes under
 `/api/v1`: Workers, repositories, Tasks, Runs, overview, Attempts, and event
@@ -282,7 +303,7 @@ Agents may execute repository code using credentials already available on the
 Worker host. Worktrees isolate Git state, not hostile code. The product must not
 describe a Worker as a security sandbox.
 
-## 8. Persistence and migration
+## Persistence and migration
 
 Migrations are embedded from `migrations/` and applied in order. Migration 27
 introduces the current lifecycle model. Migration 28 adds the current
@@ -302,33 +323,9 @@ Worker enrollment or credentials. Older migration tables may remain for
 history and upgrade compatibility but are not part of the current UI or
 admission path.
 
-## 9. Future execution backend boundary
-
-The product direction separates three choices:
-
-| Choice | Current | Proposed |
-| --- | --- | --- |
-| Execution backend | Persistent local or VM Worker | Cloud Run Job |
-| Agent runtime | Pi, Codex, Claude Code | Same runtime contract |
-| Provider and model | Local subscription or API access | API-backed access |
-
-Persistent Workers remain the best path for subscription sessions, warm
-caches, and inspectable worktrees. Cloud Run is intended for bursty parallel
-Runs where a disposable container and API-backed model are acceptable.
-
-The proposed adapter does not make Cloud Run the scheduler or database.
-Factory still owns frozen input, Attempt identity, retry, cancellation, events,
-cost history, and the terminal result. Cloud Run owns disposable compute. A
-verified patch or Git recovery artifact replaces the retained-worktree
-guarantee for ephemeral execution. See the
-[Cloud Run design](docs/cloud-run-agents/design.md) for dispatch fencing,
-outbound control, least-privilege identity, failure recovery, and rollout.
-
-## 10. Known limitations
+## Known limitations
 
 - Only the embedded SQLite orchestration path exists.
-- Cloud Run execution profiles and elastic dispatch are designed but not
-  implemented.
 - Managed repository acquisition supports GitHub through `gh`.
 - The current Worker resolves a repository's base commit during Attempt
   preparation, so a later retry can observe a newer default branch commit.
@@ -337,10 +334,11 @@ outbound control, least-privilege identity, failure recovery, and rollout.
 - Execution isolates worktrees and process groups but does not sandbox hostile
   repository code or network egress.
 
-## 11. Source map
+## Source map
 
 | Area | Primary files |
 | --- | --- |
+| Operator CLI | `cmd/factory/main.go`, `internal/factorycli/command.go`, `internal/factorycli/client.go` |
 | Server startup and config | `cmd/factory-server/main.go`, `cmd/factory-server/config.go` |
 | HTTP routes and auth | `internal/controlplane/http.go`, `internal/controlplane/worker_auth.go` |
 | Task and Run model | `internal/controlplane/tasks.go`, `internal/protocol/tasks.go` |
@@ -353,3 +351,14 @@ outbound control, least-privilege identity, failure recovery, and rollout.
 | Protocol limits and types | `internal/protocol/types.go`, `internal/protocol/prompt.go` |
 | Schema | `migrations/027_routines_work.sql`, `migrations/028_work_claim_protocol.sql`, `migrations/030_task_run_session.sql` |
 | Browser UI | `web/src/App.tsx`, `web/src/Tasks.tsx`, `web/src/Runs.tsx`, `web/src/Workers.tsx`, `web/src/Repositories.tsx` |
+
+## Verification
+
+- `go test ./cmd/... ./internal/...` covers entry points, CLI routing and output,
+  API contracts, storage, Worker lifecycle, and release construction.
+- `just boundary` proves Worker code does not import control-plane code.
+- `just test-tooling` proves the Node-free build produces the complete operator
+  binary set.
+- `just test-launcher` proves server and Worker readiness and signal handling.
+- `just test-release` proves archive contents, metadata, reproducibility, and
+  native execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ recorded here. This project follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- One `factory` command for starting the existing server or Worker and reading
+  current Runs, Run details, and Workers through the loopback API. The
+  `factory-server` and `factory-worker` commands remain available for
+  compatibility.
 - Reproducible Linux and macOS release archives for amd64 and arm64.
-- Embedded version and source commit reporting in both Factory binaries.
+- Embedded version and source commit reporting in all Factory binaries.
 - SPDX SBOMs, SHA-256 checksums, and generated third-party license notices.
 
 ### Changed

--- a/Justfile
+++ b/Justfile
@@ -10,6 +10,7 @@ build:
     data_home="${FACTORY_DATA_HOME:-${FACTORY_V2_DATA_HOME:-${HOME:?HOME or FACTORY_DATA_HOME is required}/.factory}}"
     build_directory="${FACTORY_BUILD_DIR:-${FACTORY_V2_BUILD_DIR:-$data_home/bin}}"
     mkdir -p "$build_directory"
+    go build -o "$build_directory/factory" ./cmd/factory
     go build -o "$build_directory/factory-server" ./cmd/factory-server
     go build -o "$build_directory/factory-worker" ./cmd/factory-worker
     printf 'Factory binaries built in %s\n' "$build_directory"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ just run
 
 Open [http://127.0.0.1:7337](http://127.0.0.1:7337). Edit
 `~/.factory/worker.toml` to enable the agent runtimes installed on your machine.
+Use `~/.factory/bin/factory status` to read current Runs or
+`~/.factory/bin/factory workers` to check the Worker pool from the terminal.
 The [local guide](docs/local.md) covers authentication, repository setup, and
 the complete first Run.
 

--- a/cmd/factory/main.go
+++ b/cmd/factory/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+
+	"github.com/owainlewis/factory/internal/factorycli"
+)
+
+func main() {
+	os.Exit(factorycli.Run(factorycli.Options{
+		Arguments: os.Args[1:],
+		Stdout:    os.Stdout,
+		Stderr:    os.Stderr,
+	}))
+}

--- a/docs/local.md
+++ b/docs/local.md
@@ -139,6 +139,7 @@ loopback API:
 
 ```sh
 ~/.factory/bin/factory status
+~/.factory/bin/factory status --cursor CURSOR
 ~/.factory/bin/factory show RUN_ID
 ~/.factory/bin/factory workers
 ```

--- a/docs/local.md
+++ b/docs/local.md
@@ -124,6 +124,30 @@ Open [http://127.0.0.1:7337](http://127.0.0.1:7337).
 
 Stop both processes with Ctrl+C.
 
+The build also installs a unified command beside the compatibility binaries.
+It can start either existing process without changing its configuration or
+signal behavior:
+
+```sh
+~/.factory/bin/factory server start
+~/.factory/bin/factory worker start
+```
+
+Use `--config PATH` with either `start` command to select the corresponding
+server or Worker TOML file. In another terminal, finite commands read only the
+loopback API:
+
+```sh
+~/.factory/bin/factory status
+~/.factory/bin/factory show RUN_ID
+~/.factory/bin/factory workers
+```
+
+Add the global `--json` option for one JSON value on stdout. Set
+`FACTORY_SERVER=http://127.0.0.1:PORT` or pass `--server URL` when the operator
+API does not use the default port. These commands never open SQLite or Worker
+directories.
+
 Add a GitHub repository to the central fleet once:
 
 ```sh

--- a/docs/release.md
+++ b/docs/release.md
@@ -5,10 +5,10 @@ Factory publishes one archive for each supported operating system and CPU:
 - Linux amd64 and arm64
 - macOS amd64 and arm64
 
-Each archive contains `factory-server`, `factory-worker`, the project license,
-this guide, the changelog, and generated third-party notices. The release also
-publishes one SPDX 2.3 SBOM per archive, `SHA256SUMS`, a release manifest, and a
-standalone copy of the third-party notices.
+Each archive contains `factory`, `factory-server`, `factory-worker`, the project
+license, this guide, the changelog, and generated third-party notices. The
+release also publishes one SPDX 2.3 SBOM per archive, `SHA256SUMS`, a release
+manifest, and a standalone copy of the third-party notices.
 
 ## Install a release
 
@@ -29,17 +29,19 @@ awk -v file="$archive" '$2 == file' SHA256SUMS | sha256sum -c -
 ```
 
 The checksum file covers every published file except itself. Extract the
-verified archive for your platform and install both binaries:
+verified archive for your platform and install all three binaries:
 
 ```sh
 tar -xzf factory_1.2.3_linux_amd64.tar.gz
+install -m 0755 factory_1.2.3_linux_amd64/factory ~/.local/bin/factory
 install -m 0755 factory_1.2.3_linux_amd64/factory-server ~/.local/bin/factory-server
 install -m 0755 factory_1.2.3_linux_amd64/factory-worker ~/.local/bin/factory-worker
+factory version
 factory-server version
 factory-worker version
 ```
 
-Both commands must report the release tag and the same full source commit shown
+All three commands must report the release tag and the same full source commit shown
 by the GitHub release. Factory stores configuration and state outside the
 archive, under `~/.factory` by default.
 
@@ -60,8 +62,8 @@ server and workers. Upgrade them as one unit:
    done
    ```
 
-3. Replace both binaries from the verified new archive.
-4. Confirm both `version` commands show the same tag and commit.
+3. Replace all three binaries from the verified new archive.
+4. Confirm all three `version` commands show the same tag and commit.
 5. Start the server, check `/healthz`, then start the workers and confirm they
    are healthy in the UI.
 
@@ -72,7 +74,8 @@ rollback is compatible.
 ## Roll back
 
 Stop the workers and server first. If the failed version did not migrate the
-database, reinstall both binaries from the prior verified archive and restart.
+database, reinstall all three binaries from the prior verified archive and
+restart.
 If it did migrate the database, move the failed database aside and restore the
 closed pre-upgrade copy before reinstalling the prior binaries:
 
@@ -111,7 +114,7 @@ identical. Verify a target without executing it:
 ```
 
 Pass `execute` as the final argument on a matching host to install-extract and
-run both version commands.
+run all three version commands.
 
 ## Publish a release
 

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -365,7 +365,26 @@ func (a *API) listWorkers(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"workers": workers})
+	switch r.URL.Query().Get("view") {
+	case "":
+		writeJSON(w, http.StatusOK, map[string]any{"workers": workers})
+	case "summary":
+		writeJSON(w, http.StatusOK, summarizeWorkers(workers))
+	default:
+		writeError(w, invalid("invalid_view", "view must be summary when provided"))
+	}
+}
+
+func summarizeWorkers(workers []protocol.Worker) protocol.WorkerSummaryPage {
+	page := protocol.WorkerSummaryPage{Workers: make([]protocol.WorkerSummary, 0, len(workers))}
+	for _, worker := range workers {
+		page.Workers = append(page.Workers, protocol.WorkerSummary{
+			ID: worker.ID, Name: worker.Name, Runtime: worker.Runtime, Capacity: worker.Capacity,
+			ActiveCount: worker.ActiveCount, Health: worker.Health, Online: worker.Online,
+			LastHeartbeat: worker.LastHeartbeat,
+		})
+	}
+	return page
 }
 
 func (a *API) getWorker(w http.ResponseWriter, r *http.Request) {

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -360,31 +360,24 @@ func (a *API) claim(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) listWorkers(w http.ResponseWriter, r *http.Request) {
-	workers, err := a.store.Workers(r.Context())
-	if err != nil {
-		writeError(w, err)
-		return
-	}
 	switch r.URL.Query().Get("view") {
 	case "":
+		workers, err := a.store.Workers(r.Context())
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"workers": workers})
 	case "summary":
-		writeJSON(w, http.StatusOK, summarizeWorkers(workers))
+		page, err := a.store.WorkerSummaries(r.Context())
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, page)
 	default:
 		writeError(w, invalid("invalid_view", "view must be summary when provided"))
 	}
-}
-
-func summarizeWorkers(workers []protocol.Worker) protocol.WorkerSummaryPage {
-	page := protocol.WorkerSummaryPage{Workers: make([]protocol.WorkerSummary, 0, len(workers))}
-	for _, worker := range workers {
-		page.Workers = append(page.Workers, protocol.WorkerSummary{
-			ID: worker.ID, Name: worker.Name, Runtime: worker.Runtime, Capacity: worker.Capacity,
-			ActiveCount: worker.ActiveCount, Health: worker.Health, Online: worker.Online,
-			LastHeartbeat: worker.LastHeartbeat,
-		})
-	}
-	return page
 }
 
 func (a *API) getWorker(w http.ResponseWriter, r *http.Request) {

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -1861,6 +1861,35 @@ func (s *Store) Workers(ctx context.Context) ([]protocol.Worker, error) {
 	return workers, nil
 }
 
+func (s *Store) WorkerSummaries(ctx context.Context) (protocol.WorkerSummaryPage, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, name, runtime, capacity, active_count, health, synthetic, last_heartbeat
+		FROM workers ORDER BY registered_at, id
+	`)
+	if err != nil {
+		return protocol.WorkerSummaryPage{}, unavailable(err)
+	}
+	defer rows.Close()
+	page := protocol.WorkerSummaryPage{Workers: make([]protocol.WorkerSummary, 0)}
+	for rows.Next() {
+		var worker protocol.WorkerSummary
+		var synthetic int
+		var heartbeat int64
+		if err := rows.Scan(&worker.ID, &worker.Name, &worker.Runtime, &worker.Capacity,
+			&worker.ActiveCount, &worker.Health, &synthetic, &heartbeat); err != nil {
+			return protocol.WorkerSummaryPage{}, unavailable(err)
+		}
+		worker.LastHeartbeat = fromMillis(heartbeat)
+		worker.Online = synthetic != 0 && worker.Health == "healthy" ||
+			synthetic == 0 && s.now().Sub(worker.LastHeartbeat) <= protocol.WorkerOnlineWindow
+		page.Workers = append(page.Workers, worker)
+	}
+	if err := rows.Err(); err != nil {
+		return protocol.WorkerSummaryPage{}, unavailable(err)
+	}
+	return page, nil
+}
+
 func (s *Store) Worker(ctx context.Context, id string) (protocol.Worker, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT w.id, w.name, w.labels_json, w.worker_version, w.runtime, w.runtime_version,

--- a/internal/controlplane/tasks.go
+++ b/internal/controlplane/tasks.go
@@ -1106,6 +1106,102 @@ func (s *Store) RunPage(ctx context.Context, limit int, cursor string) (protocol
 	return page, nil
 }
 
+func (s *Store) RunSummaryPage(ctx context.Context, limit int, cursor string) (protocol.RunListPage, error) {
+	if limit == 0 {
+		limit = defaultTaskPageSize
+	}
+	if limit < 1 || limit > maxTaskPageSize {
+		return protocol.RunListPage{}, invalid("invalid_limit", "limit must be between 1 and 200")
+	}
+	admitted, cursorID, err := decodeRunCursor(cursor)
+	if err != nil {
+		return protocol.RunListPage{}, err
+	}
+	query := `
+		SELECT id, json_extract(task_snapshot, '$.name'), source, admitted_at, updated_at, terminal_at
+		FROM runs WHERE 1 = 1
+	`
+	args := make([]any, 0, 5)
+	if admitted != 0 {
+		query += ` AND (admitted_at < ? OR (admitted_at = ? AND id < ?))`
+		args = append(args, admitted, admitted, cursorID)
+	}
+	query += ` ORDER BY admitted_at DESC, id DESC LIMIT ?`
+	args = append(args, limit+1)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return protocol.RunListPage{}, unavailable(err)
+	}
+	page := protocol.RunListPage{Runs: make([]protocol.RunListSummary, 0, limit)}
+	var admittedMillis []int64
+	for rows.Next() {
+		var summary protocol.RunListSummary
+		var admittedAt, updatedAt int64
+		var terminalAt sql.NullInt64
+		if err := rows.Scan(&summary.ID, &summary.TaskName, &summary.Source, &admittedAt, &updatedAt, &terminalAt); err != nil {
+			rows.Close()
+			return protocol.RunListPage{}, unavailable(err)
+		}
+		summary.AdmittedAt, summary.UpdatedAt = fromMillis(admittedAt), fromMillis(updatedAt)
+		if terminalAt.Valid {
+			value := fromMillis(terminalAt.Int64)
+			summary.TerminalAt = &value
+		}
+		page.Runs = append(page.Runs, summary)
+		admittedMillis = append(admittedMillis, admittedAt)
+	}
+	if err := rows.Close(); err != nil {
+		return protocol.RunListPage{}, unavailable(err)
+	}
+	hasMore := len(page.Runs) > limit
+	if hasMore {
+		page.Runs = page.Runs[:limit]
+		admittedMillis = admittedMillis[:limit]
+	}
+	for index := range page.Runs {
+		if err := s.applyRunListSummary(ctx, &page.Runs[index]); err != nil {
+			return protocol.RunListPage{}, err
+		}
+	}
+	if hasMore {
+		last := page.Runs[len(page.Runs)-1]
+		page.NextCursor = encodeRunCursor(admittedMillis[len(admittedMillis)-1], last.ID)
+	}
+	return page, nil
+}
+
+func (s *Store) applyRunListSummary(ctx context.Context, summary *protocol.RunListSummary) error {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT state, blocked_reason
+		FROM sessions WHERE run_id = ? ORDER BY target_position, id
+	`, summary.ID)
+	if err != nil {
+		return unavailable(err)
+	}
+	defer rows.Close()
+	sessions := make([]protocol.Session, 0)
+	for rows.Next() {
+		var session protocol.Session
+		var blockedReason sql.NullString
+		if err := rows.Scan(&session.State, &blockedReason); err != nil {
+			return unavailable(err)
+		}
+		session.BlockedReason = blockedReason.String
+		sessions = append(sessions, session)
+	}
+	if err := rows.Err(); err != nil {
+		return unavailable(err)
+	}
+	run := protocol.Run{TerminalAt: summary.TerminalAt}
+	applyRunAggregate(&run, sessions, s.now())
+	summary.State, summary.NeedsAttention = run.State, run.NeedsAttention
+	summary.SessionCount, summary.SucceededCount = run.SessionCount, run.SucceededCount
+	summary.ReadyCount, summary.NeedsInputCount = run.ReadyCount, run.NeedsInputCount
+	summary.NoChangeCount, summary.FailedCount = run.NoChangeCount, run.FailedCount
+	summary.CancelledCount, summary.ActiveCount = run.CancelledCount, run.ActiveCount
+	return nil
+}
+
 func (s *Store) runListEntry(ctx context.Context, id string) (protocol.Run, error) {
 	var run protocol.Run
 	var snapshot, executionSnapshot, targetsSnapshot []byte

--- a/internal/controlplane/tasks.go
+++ b/internal/controlplane/tasks.go
@@ -1063,6 +1063,56 @@ func (s *Store) Run(ctx context.Context, id string) (protocol.RunDetail, error) 
 	return detail, nil
 }
 
+func (s *Store) RunSummary(ctx context.Context, id string) (protocol.RunSummary, error) {
+	var summary protocol.RunSummary
+	var admittedAt, updatedAt int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT run.id, json_extract(run.task_snapshot, '$.name'), run.source,
+		       run.admitted_at, run.updated_at
+		FROM runs run WHERE run.id = ?
+	`, id).Scan(&summary.ID, &summary.TaskName, &summary.Source, &admittedAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return summary, ErrNotFound
+	}
+	if err != nil {
+		return summary, unavailable(err)
+	}
+	summary.AdmittedAt, summary.UpdatedAt = fromMillis(admittedAt), fromMillis(updatedAt)
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT session.id, session.repository_identity, session.state,
+		       session.assigned_worker_id, session.result, session.failure_reason,
+		       (SELECT COUNT(*) FROM attempts attempt
+		        JOIN executions execution ON execution.id = attempt.execution_id
+		        WHERE execution.session_id = session.id)
+		FROM sessions session
+		WHERE session.run_id = ?
+		ORDER BY session.admitted_at, session.id
+	`, id)
+	if err != nil {
+		return summary, unavailable(err)
+	}
+	defer rows.Close()
+	sessions := make([]protocol.Session, 0)
+	for rows.Next() {
+		var session protocol.RunSessionSummary
+		var workerID, result, failure sql.NullString
+		if err := rows.Scan(&session.ID, &session.RepositoryIdentity, &session.State,
+			&workerID, &result, &failure, &session.AttemptCount); err != nil {
+			return summary, unavailable(err)
+		}
+		session.AssignedWorkerID, session.Result, session.FailureReason = workerID.String, result.String, failure.String
+		summary.Sessions = append(summary.Sessions, session)
+		sessions = append(sessions, protocol.Session{State: session.State})
+	}
+	if err := rows.Err(); err != nil {
+		return summary, unavailable(err)
+	}
+	run := protocol.Run{}
+	applyRunAggregate(&run, sessions, s.now())
+	summary.State = run.State
+	return summary, nil
+}
+
 func applyRunAggregate(run *protocol.Run, sessions []protocol.Session, now time.Time) {
 	run.SessionCount = len(sessions)
 	run.SucceededCount, run.FailedCount, run.CancelledCount, run.ActiveCount = 0, 0, 0, 0

--- a/internal/controlplane/tasks.go
+++ b/internal/controlplane/tasks.go
@@ -918,20 +918,83 @@ func (s *Store) RunPage(ctx context.Context, limit int, cursor string) (protocol
 	}
 	page := protocol.RunPage{Runs: make([]protocol.Run, 0, len(keys))}
 	for _, key := range keys {
-		detail, err := s.Run(ctx, key.id)
+		run, err := s.runListEntry(ctx, key.id)
 		if err != nil {
 			return protocol.RunPage{}, err
 		}
-		detail.Run.Task.Prompt = ""
-		detail.Run.Task.TimeoutSeconds = 0
-		detail.Run.Task.ConcurrencyLimit = 0
-		page.Runs = append(page.Runs, detail.Run)
+		page.Runs = append(page.Runs, run)
 	}
 	if hasMore {
 		last := keys[len(keys)-1]
 		page.NextCursor = encodeRunCursor(last.admitted, last.id)
 	}
 	return page, nil
+}
+
+func (s *Store) runListEntry(ctx context.Context, id string) (protocol.Run, error) {
+	var run protocol.Run
+	var snapshot, executionSnapshot []byte
+	var scheduledAt, terminalAt sql.NullInt64
+	var admittedAt, updatedAt int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, task_id, task_snapshot, execution_snapshot, source, scheduled_at,
+		       admitted_at, updated_at, terminal_at
+		FROM runs WHERE id = ?
+	`, id).Scan(&run.ID, &run.TaskID, &snapshot, &executionSnapshot, &run.Source,
+		&scheduledAt, &admittedAt, &updatedAt, &terminalAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return run, ErrNotFound
+	}
+	if err != nil {
+		return run, unavailable(err)
+	}
+	if err := json.Unmarshal(snapshot, &run.Task); err != nil {
+		return run, unavailable(err)
+	}
+	if err := json.Unmarshal(executionSnapshot, &run.Execution); err != nil {
+		return run, unavailable(err)
+	}
+	run.Task.Prompt, run.Task.TimeoutSeconds, run.Task.ConcurrencyLimit = "", 0, 0
+	run.AdmittedAt, run.UpdatedAt = fromMillis(admittedAt), fromMillis(updatedAt)
+	if scheduledAt.Valid {
+		value := fromMillis(scheduledAt.Int64)
+		run.ScheduledAt = &value
+	}
+	if terminalAt.Valid {
+		value := fromMillis(terminalAt.Int64)
+		run.TerminalAt = &value
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT repository_id, repository_identity, state, blocked_reason
+		FROM sessions WHERE run_id = ? ORDER BY admitted_at, id
+	`, id)
+	if err != nil {
+		return run, unavailable(err)
+	}
+	defer rows.Close()
+	var sessions []protocol.Session
+	seenRepositories := make(map[string]bool)
+	rebuildRepositories := len(run.Task.Repositories) == 0
+	for rows.Next() {
+		var session protocol.Session
+		var blockedReason sql.NullString
+		if err := rows.Scan(&session.RepositoryID, &session.RepositoryIdentity, &session.State, &blockedReason); err != nil {
+			return run, unavailable(err)
+		}
+		session.BlockedReason = blockedReason.String
+		sessions = append(sessions, session)
+		if rebuildRepositories && session.RepositoryID != "" && session.RepositoryIdentity != "" && !seenRepositories[session.RepositoryID] {
+			seenRepositories[session.RepositoryID] = true
+			run.Task.Repositories = append(run.Task.Repositories, protocol.TaskRepository{
+				ID: session.RepositoryID, RemoteIdentity: session.RepositoryIdentity,
+			})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return run, unavailable(err)
+	}
+	applyRunAggregate(&run, sessions, s.now())
+	return run, nil
 }
 
 func (s *Store) Run(ctx context.Context, id string) (protocol.RunDetail, error) {
@@ -1079,7 +1142,7 @@ func (s *Store) RunSummary(ctx context.Context, id string) (protocol.RunSummary,
 	}
 	summary.AdmittedAt, summary.UpdatedAt = fromMillis(admittedAt), fromMillis(updatedAt)
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT session.id, session.repository_identity, session.state,
+		SELECT session.id, session.repository_identity, session.state, session.blocked_reason,
 		       session.assigned_worker_id, session.result, session.failure_reason,
 		       (SELECT COUNT(*) FROM attempts attempt
 		        JOIN executions execution ON execution.id = attempt.execution_id
@@ -1095,14 +1158,15 @@ func (s *Store) RunSummary(ctx context.Context, id string) (protocol.RunSummary,
 	sessions := make([]protocol.Session, 0)
 	for rows.Next() {
 		var session protocol.RunSessionSummary
-		var workerID, result, failure sql.NullString
+		var blockedReason, workerID, result, failure sql.NullString
 		if err := rows.Scan(&session.ID, &session.RepositoryIdentity, &session.State,
-			&workerID, &result, &failure, &session.AttemptCount); err != nil {
+			&blockedReason, &workerID, &result, &failure, &session.AttemptCount); err != nil {
 			return summary, unavailable(err)
 		}
-		session.AssignedWorkerID, session.Result, session.FailureReason = workerID.String, result.String, failure.String
+		session.BlockedReason, session.AssignedWorkerID = blockedReason.String, workerID.String
+		session.Result, session.FailureReason = result.String, failure.String
 		summary.Sessions = append(summary.Sessions, session)
-		sessions = append(sessions, protocol.Session{State: session.State})
+		sessions = append(sessions, protocol.Session{State: session.State, BlockedReason: session.BlockedReason})
 	}
 	if err := rows.Err(); err != nil {
 		return summary, unavailable(err)

--- a/internal/controlplane/tasks_http.go
+++ b/internal/controlplane/tasks_http.go
@@ -133,12 +133,24 @@ func (a *API) listRuns(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	page, err := a.store.RunPage(r.Context(), limit, r.URL.Query().Get("cursor"))
-	if err != nil {
-		writeError(w, err)
-		return
+	switch r.URL.Query().Get("view") {
+	case "":
+		page, err := a.store.RunPage(r.Context(), limit, r.URL.Query().Get("cursor"))
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, page)
+	case "summary":
+		page, err := a.store.RunSummaryPage(r.Context(), limit, r.URL.Query().Get("cursor"))
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, page)
+	default:
+		writeError(w, invalid("invalid_view", "view must be summary when provided"))
 	}
-	writeJSON(w, http.StatusOK, page)
 }
 
 func (a *API) getRun(w http.ResponseWriter, r *http.Request) {

--- a/internal/controlplane/tasks_http.go
+++ b/internal/controlplane/tasks_http.go
@@ -147,7 +147,30 @@ func (a *API) getRun(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, detail)
+	switch r.URL.Query().Get("view") {
+	case "":
+		writeJSON(w, http.StatusOK, detail)
+	case "summary":
+		writeJSON(w, http.StatusOK, summarizeRun(detail))
+	default:
+		writeError(w, invalid("invalid_view", "view must be summary when provided"))
+	}
+}
+
+func summarizeRun(detail protocol.RunDetail) protocol.RunSummary {
+	summary := protocol.RunSummary{
+		ID: detail.Run.ID, TaskName: detail.Run.Task.Name, State: detail.Run.State,
+		Source: detail.Run.Source, AdmittedAt: detail.Run.AdmittedAt, UpdatedAt: detail.Run.UpdatedAt,
+		Sessions: make([]protocol.RunSessionSummary, 0, len(detail.Sessions)),
+	}
+	for _, session := range detail.Sessions {
+		summary.Sessions = append(summary.Sessions, protocol.RunSessionSummary{
+			ID: session.ID, RepositoryIdentity: session.RepositoryIdentity, State: session.State,
+			AssignedWorkerID: session.AssignedWorkerID, AttemptCount: len(session.Attempts),
+			Result: session.Result, FailureReason: session.FailureReason,
+		})
+	}
+	return summary
 }
 
 func (a *API) cancelRun(w http.ResponseWriter, r *http.Request) {

--- a/internal/controlplane/tasks_http.go
+++ b/internal/controlplane/tasks_http.go
@@ -142,35 +142,24 @@ func (a *API) listRuns(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) getRun(w http.ResponseWriter, r *http.Request) {
-	detail, err := a.store.Run(r.Context(), r.PathValue("run_id"))
-	if err != nil {
-		writeError(w, err)
-		return
-	}
 	switch r.URL.Query().Get("view") {
 	case "":
+		detail, err := a.store.Run(r.Context(), r.PathValue("run_id"))
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 		writeJSON(w, http.StatusOK, detail)
 	case "summary":
-		writeJSON(w, http.StatusOK, summarizeRun(detail))
+		summary, err := a.store.RunSummary(r.Context(), r.PathValue("run_id"))
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, summary)
 	default:
 		writeError(w, invalid("invalid_view", "view must be summary when provided"))
 	}
-}
-
-func summarizeRun(detail protocol.RunDetail) protocol.RunSummary {
-	summary := protocol.RunSummary{
-		ID: detail.Run.ID, TaskName: detail.Run.Task.Name, State: detail.Run.State,
-		Source: detail.Run.Source, AdmittedAt: detail.Run.AdmittedAt, UpdatedAt: detail.Run.UpdatedAt,
-		Sessions: make([]protocol.RunSessionSummary, 0, len(detail.Sessions)),
-	}
-	for _, session := range detail.Sessions {
-		summary.Sessions = append(summary.Sessions, protocol.RunSessionSummary{
-			ID: session.ID, RepositoryIdentity: session.RepositoryIdentity, State: session.State,
-			AssignedWorkerID: session.AssignedWorkerID, AttemptCount: len(session.Attempts),
-			Result: session.Result, FailureReason: session.FailureReason,
-		})
-	}
-	return summary
 }
 
 func (a *API) cancelRun(w http.ResponseWriter, r *http.Request) {

--- a/internal/controlplane/tasks_http_test.go
+++ b/internal/controlplane/tasks_http_test.go
@@ -30,3 +30,22 @@ func TestSummarizeRunOmitsUnboundedAttemptHistory(t *testing.T) {
 		t.Fatalf("Session summary = %#v", session)
 	}
 }
+
+func TestSummarizeWorkersOmitsLargeOperationalState(t *testing.T) {
+	now := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
+	workers := []protocol.Worker{{
+		ID: "worker-1", Name: "local", Runtime: "codex", Capacity: 10, ActiveCount: 2,
+		Health: "healthy", Online: true, LastHeartbeat: now,
+		Repositories:      []protocol.Repository{{ID: "repository-1", RemoteIdentity: "github.com/owainlewis/factory"}},
+		RetainedWorktrees: []protocol.RetainedWorktree{{AttemptID: "attempt-1"}},
+	}}
+
+	page := summarizeWorkers(workers)
+	if len(page.Workers) != 1 {
+		t.Fatalf("Worker summary page = %#v", page)
+	}
+	summary := page.Workers[0]
+	if summary.ID != workers[0].ID || summary.ActiveCount != 2 || summary.LastHeartbeat != now {
+		t.Fatalf("Worker summary = %#v", summary)
+	}
+}

--- a/internal/controlplane/tasks_http_test.go
+++ b/internal/controlplane/tasks_http_test.go
@@ -11,28 +11,29 @@ import (
 
 func TestRunSummaryCountsAttemptsWithoutReturningTheirBodies(t *testing.T) {
 	store := newTestStore(t)
+	ctx := context.Background()
 	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
 		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
 	})
-	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+	task, err := store.CreateTask(ctx, protocol.SaveTaskRequest{
 		Name: "Review Factory", Prompt: "Review the repository.", Runtime: protocol.RuntimeCodex,
 		RepositoryIDs: []string{worker.Repositories[0].ID},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	detail, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "summary-run"})
+	detail, _, err := store.RunTask(ctx, task.ID, protocol.RunTaskRequest{RequestKey: "summary-run"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	sessionID := detail.Sessions[0].ID
 	var executionID string
-	if err := store.db.QueryRow(`SELECT id FROM executions WHERE session_id = ?`, sessionID).Scan(&executionID); err != nil {
+	if err := store.db.QueryRowContext(ctx, `SELECT id FROM executions WHERE session_id = ?`, sessionID).Scan(&executionID); err != nil {
 		t.Fatal(err)
 	}
 	largeResult := strings.Repeat("x", protocol.MaxResultBytes)
 	for number := 1; number <= 2; number++ {
-		if _, err := store.db.Exec(`
+		if _, err := store.db.ExecContext(ctx, `
 			INSERT INTO attempts(id, execution_id, worker_id, attempt_number, state,
 			                     lease_digest, lease_expires_at, result, created_at)
 			VALUES (?, ?, ?, ?, 'succeeded', X'01', 0, ?, ?)
@@ -40,11 +41,11 @@ func TestRunSummaryCountsAttemptsWithoutReturningTheirBodies(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if _, err := store.db.Exec(`UPDATE sessions SET state = 'succeeded', result = 'done', terminal_at = 2 WHERE id = ?`, sessionID); err != nil {
+	if _, err := store.db.ExecContext(ctx, `UPDATE sessions SET state = 'succeeded', result = 'done', terminal_at = 2 WHERE id = ?`, sessionID); err != nil {
 		t.Fatal(err)
 	}
 
-	summary, err := store.RunSummary(context.Background(), detail.Run.ID)
+	summary, err := store.RunSummary(ctx, detail.Run.ID)
 	if err != nil || summary.ID != detail.Run.ID || summary.TaskName != task.Name || len(summary.Sessions) != 1 {
 		t.Fatalf("Run summary = %#v, error %v", summary, err)
 	}
@@ -52,14 +53,29 @@ func TestRunSummaryCountsAttemptsWithoutReturningTheirBodies(t *testing.T) {
 	if summary.State != protocol.RunSucceeded || session.AttemptCount != 2 || session.Result != "done" || session.ID != sessionID {
 		t.Fatalf("Run summary state = %#v", summary)
 	}
+	page, err := store.RunPage(ctx, 50, "")
+	if err != nil || len(page.Runs) != 1 || page.Runs[0].State != protocol.RunSucceeded {
+		t.Fatalf("Run page = %#v, error %v", page, err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		UPDATE sessions SET state = 'blocked', result = NULL, blocked_reason = 'Repository is disabled.'
+		WHERE id = ?
+	`, sessionID); err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := store.RunSummary(ctx, detail.Run.ID)
+	if err != nil || blocked.Sessions[0].BlockedReason != "Repository is disabled." || blocked.State != protocol.RunBlocked {
+		t.Fatalf("Blocked Run summary = %#v, error %v", blocked, err)
+	}
 }
 
 func TestWorkerSummariesDoNotReadOperationalJSON(t *testing.T) {
 	store := newTestStore(t)
+	ctx := context.Background()
 	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
 		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
 	})
-	if _, err := store.db.Exec(`
+	if _, err := store.db.ExecContext(ctx, `
 		UPDATE workers
 		SET capabilities_json = 'not-json', retained_worktrees_json = 'not-json'
 		WHERE id = ?
@@ -67,7 +83,7 @@ func TestWorkerSummariesDoNotReadOperationalJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	page, err := store.WorkerSummaries(context.Background())
+	page, err := store.WorkerSummaries(ctx)
 	if err != nil || len(page.Workers) != 1 {
 		t.Fatalf("Worker summaries = %#v, error %v", page, err)
 	}

--- a/internal/controlplane/tasks_http_test.go
+++ b/internal/controlplane/tasks_http_test.go
@@ -1,0 +1,32 @@
+package controlplane
+
+import (
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestSummarizeRunOmitsUnboundedAttemptHistory(t *testing.T) {
+	now := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
+	detail := protocol.RunDetail{
+		Run: protocol.Run{
+			ID: "run-1", Task: protocol.TaskSnapshot{Name: "Review Factory", Prompt: "private"},
+			State: protocol.RunRunning, Source: "manual", AdmittedAt: now, UpdatedAt: now,
+		},
+		Sessions: []protocol.Session{{
+			ID: "session-1", RepositoryIdentity: "github.com/owainlewis/factory",
+			State: protocol.SessionSucceeded, AssignedWorkerID: "worker-1", Result: "done",
+			Attempts: []protocol.Attempt{{ID: "attempt-1", Result: "large"}, {ID: "attempt-2", Result: "large"}},
+		}},
+	}
+
+	summary := summarizeRun(detail)
+	if summary.ID != detail.Run.ID || summary.TaskName != detail.Run.Task.Name || len(summary.Sessions) != 1 {
+		t.Fatalf("Run summary = %#v", summary)
+	}
+	session := summary.Sessions[0]
+	if session.AttemptCount != 2 || session.Result != "done" || session.ID != "session-1" {
+		t.Fatalf("Session summary = %#v", session)
+	}
+}

--- a/internal/controlplane/tasks_http_test.go
+++ b/internal/controlplane/tasks_http_test.go
@@ -1,51 +1,78 @@
 package controlplane
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/owainlewis/factory/internal/protocol"
 )
 
-func TestSummarizeRunOmitsUnboundedAttemptHistory(t *testing.T) {
-	now := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
-	detail := protocol.RunDetail{
-		Run: protocol.Run{
-			ID: "run-1", Task: protocol.TaskSnapshot{Name: "Review Factory", Prompt: "private"},
-			State: protocol.RunRunning, Source: "manual", AdmittedAt: now, UpdatedAt: now,
-		},
-		Sessions: []protocol.Session{{
-			ID: "session-1", RepositoryIdentity: "github.com/owainlewis/factory",
-			State: protocol.SessionSucceeded, AssignedWorkerID: "worker-1", Result: "done",
-			Attempts: []protocol.Attempt{{ID: "attempt-1", Result: "large"}, {ID: "attempt-2", Result: "large"}},
-		}},
+func TestRunSummaryCountsAttemptsWithoutReturningTheirBodies(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Review Factory", Prompt: "Review the repository.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	detail, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "summary-run"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionID := detail.Sessions[0].ID
+	var executionID string
+	if err := store.db.QueryRow(`SELECT id FROM executions WHERE session_id = ?`, sessionID).Scan(&executionID); err != nil {
+		t.Fatal(err)
+	}
+	largeResult := strings.Repeat("x", protocol.MaxResultBytes)
+	for number := 1; number <= 2; number++ {
+		if _, err := store.db.Exec(`
+			INSERT INTO attempts(id, execution_id, worker_id, attempt_number, state,
+			                     lease_digest, lease_expires_at, result, created_at)
+			VALUES (?, ?, ?, ?, 'succeeded', X'01', 0, ?, ?)
+		`, fmt.Sprintf("summary-attempt-%d", number), executionID, worker.ID, number, largeResult, number); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.db.Exec(`UPDATE sessions SET state = 'succeeded', result = 'done', terminal_at = 2 WHERE id = ?`, sessionID); err != nil {
+		t.Fatal(err)
 	}
 
-	summary := summarizeRun(detail)
-	if summary.ID != detail.Run.ID || summary.TaskName != detail.Run.Task.Name || len(summary.Sessions) != 1 {
-		t.Fatalf("Run summary = %#v", summary)
+	summary, err := store.RunSummary(context.Background(), detail.Run.ID)
+	if err != nil || summary.ID != detail.Run.ID || summary.TaskName != task.Name || len(summary.Sessions) != 1 {
+		t.Fatalf("Run summary = %#v, error %v", summary, err)
 	}
 	session := summary.Sessions[0]
-	if session.AttemptCount != 2 || session.Result != "done" || session.ID != "session-1" {
-		t.Fatalf("Session summary = %#v", session)
+	if summary.State != protocol.RunSucceeded || session.AttemptCount != 2 || session.Result != "done" || session.ID != sessionID {
+		t.Fatalf("Run summary state = %#v", summary)
 	}
 }
 
-func TestSummarizeWorkersOmitsLargeOperationalState(t *testing.T) {
-	now := time.Date(2026, time.August, 23, 12, 0, 0, 0, time.UTC)
-	workers := []protocol.Worker{{
-		ID: "worker-1", Name: "local", Runtime: "codex", Capacity: 10, ActiveCount: 2,
-		Health: "healthy", Online: true, LastHeartbeat: now,
-		Repositories:      []protocol.Repository{{ID: "repository-1", RemoteIdentity: "github.com/owainlewis/factory"}},
-		RetainedWorktrees: []protocol.RetainedWorktree{{AttemptID: "attempt-1"}},
-	}}
+func TestWorkerSummariesDoNotReadOperationalJSON(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	if _, err := store.db.Exec(`
+		UPDATE workers
+		SET capabilities_json = 'not-json', retained_worktrees_json = 'not-json'
+		WHERE id = ?
+	`, worker.ID); err != nil {
+		t.Fatal(err)
+	}
 
-	page := summarizeWorkers(workers)
-	if len(page.Workers) != 1 {
-		t.Fatalf("Worker summary page = %#v", page)
+	page, err := store.WorkerSummaries(context.Background())
+	if err != nil || len(page.Workers) != 1 {
+		t.Fatalf("Worker summaries = %#v, error %v", page, err)
 	}
 	summary := page.Workers[0]
-	if summary.ID != workers[0].ID || summary.ActiveCount != 2 || summary.LastHeartbeat != now {
+	if summary.ID != worker.ID || summary.Name != worker.Name || summary.Capacity != worker.Capacity {
 		t.Fatalf("Worker summary = %#v", summary)
 	}
 }

--- a/internal/controlplane/tasks_http_test.go
+++ b/internal/controlplane/tasks_http_test.go
@@ -2,7 +2,12 @@ package controlplane
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -56,6 +61,55 @@ func TestRunSummaryCountsAttemptsWithoutReturningTheirBodies(t *testing.T) {
 	page, err := store.RunPage(ctx, 50, "")
 	if err != nil || len(page.Runs) != 1 || page.Runs[0].State != protocol.RunSucceeded {
 		t.Fatalf("Run page = %#v, error %v", page, err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+		UPDATE runs SET
+			task_snapshot = json_set(task_snapshot, '$.prompt', ?),
+			targets_snapshot = json_array(json_object('context_snapshot', ?))
+		WHERE id = ?
+	`, strings.Repeat("p", protocol.MaxTaskPromptBytes), strings.Repeat("c", protocol.MaxResolvedPromptBytes), detail.Run.ID); err != nil {
+		t.Fatal(err)
+	}
+	list, err := store.RunSummaryPage(ctx, 50, "")
+	if err != nil || len(list.Runs) != 1 || list.Runs[0].ID != detail.Run.ID || list.Runs[0].TaskName != task.Name {
+		t.Fatalf("Run summary page = %#v, error %v", list, err)
+	}
+	encoded, err := json.Marshal(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(encoded) > 4096 || strings.Contains(string(encoded), strings.Repeat("c", 100)) {
+		t.Fatalf("Run summary page includes frozen payloads: %d bytes", len(encoded))
+	}
+	handler := NewHandler(store, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	request := httptest.NewRequestWithContext(ctx, http.MethodGet, "http://localhost/api/v1/runs?limit=50&view=summary", nil)
+	request.Host = "localhost"
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	var apiList protocol.RunListPage
+	if response.Code != http.StatusOK {
+		t.Fatalf("Run summary API status = %d: %s", response.Code, response.Body.String())
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &apiList); err != nil || len(apiList.Runs) != 1 || apiList.Runs[0].ID != detail.Run.ID {
+		t.Fatalf("Run summary API = %#v, error %v", apiList, err)
+	}
+	terminalAt := store.now().UnixMilli()
+	if _, err := store.db.ExecContext(ctx, `UPDATE sessions SET state = 'failed', terminal_at = ? WHERE id = ?`, terminalAt, sessionID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE runs SET terminal_at = ?, updated_at = ? WHERE id = ?`, terminalAt, terminalAt, detail.Run.ID); err != nil {
+		t.Fatal(err)
+	}
+	fullFailed, err := store.RunPage(ctx, 50, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	compactFailed, err := store.RunSummaryPage(ctx, 50, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fullFailed.Runs[0].NeedsAttention || compactFailed.Runs[0].NeedsAttention != fullFailed.Runs[0].NeedsAttention {
+		t.Fatalf("Run summary attention parity: full=%t compact=%t", fullFailed.Runs[0].NeedsAttention, compactFailed.Runs[0].NeedsAttention)
 	}
 	if _, err := store.db.ExecContext(ctx, `
 		UPDATE sessions SET state = 'blocked', result = NULL, blocked_reason = 'Repository is disabled.'

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -19,7 +19,11 @@ import (
 	"github.com/owainlewis/factory/internal/protocol"
 )
 
-const maxResponseBytes = 16 << 20
+const (
+	maxResponseBytes           = 16 << 20
+	maxRunSummaryResponseBytes = 64 << 20
+	maxRunDetailResponseBytes  = 256 << 20
+)
 
 type apiClient struct {
 	endpoint *url.URL
@@ -46,13 +50,13 @@ func newAPIClient(ctx context.Context, value string, client *http.Client) (apiCl
 	if host == "" || err != nil || port == 0 {
 		return apiClient{}, errors.New("server URL must include a loopback host and nonzero port")
 	}
-	if err := validateLoopbackHost(ctx, host); err != nil {
+	pinnedHost, err := validateLoopbackHost(ctx, host)
+	if err != nil {
 		return apiClient{}, err
 	}
-	if strings.EqualFold(host, "localhost") {
-		// ProxyFromEnvironment exempts exact lowercase localhost only.
-		parsed.Host = net.JoinHostPort("localhost", parsed.Port())
-	}
+	// Use the validated literal address so proxies and a second DNS lookup
+	// cannot move a loopback-only command away from the local machine.
+	parsed.Host = net.JoinHostPort(pinnedHost, parsed.Port())
 	parsed.Path = ""
 	clientCopy := *client
 	clientCopy.CheckRedirect = func(*http.Request, []*http.Request) error {
@@ -61,29 +65,33 @@ func newAPIClient(ctx context.Context, value string, client *http.Client) (apiCl
 	return apiClient{endpoint: parsed, client: &clientCopy}, nil
 }
 
-func validateLoopbackHost(ctx context.Context, host string) error {
+func validateLoopbackHost(ctx context.Context, host string) (string, error) {
 	if address := net.ParseIP(host); address != nil {
 		if address.IsLoopback() {
-			return nil
+			return address.String(), nil
 		}
-		return errors.New("server URL host must be loopback")
+		return "", errors.New("server URL host must be loopback")
 	}
 	if !strings.EqualFold(host, "localhost") {
-		return errors.New("server URL host must be a loopback IP or localhost")
+		return "", errors.New("server URL host must be a loopback IP or localhost")
 	}
 	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if err != nil {
-		return fmt.Errorf("resolve server URL host: %w", err)
+		return "", fmt.Errorf("resolve server URL host: %w", err)
 	}
 	if len(addresses) == 0 {
-		return errors.New("server URL host resolved to no addresses")
+		return "", errors.New("server URL host resolved to no addresses")
 	}
+	var pinned net.IP
 	for _, address := range addresses {
 		if !address.IP.IsLoopback() {
-			return errors.New("server URL host must resolve only to loopback")
+			return "", errors.New("server URL host must resolve only to loopback")
+		}
+		if pinned == nil || pinned.To4() == nil && address.IP.To4() != nil {
+			pinned = address.IP
 		}
 	}
-	return nil
+	return pinned.String(), nil
 }
 
 func (c apiClient) get(ctx context.Context, path string, target any, responseLimit int64) error {
@@ -167,33 +175,35 @@ func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) 
 }
 
 func (c command) show(ctx context.Context, client apiClient, runID string, jsonOutput bool) error {
-	var detail protocol.RunDetail
-	// Run details include an unbounded retry history, so no finite byte cap can
-	// cover every valid response. The command deadline still bounds the read.
-	if err := client.get(ctx, "/api/v1/runs/"+url.PathEscape(runID), &detail, 0); err != nil {
-		return err
-	}
 	if jsonOutput {
+		var detail protocol.RunDetail
+		if err := client.get(ctx, "/api/v1/runs/"+url.PathEscape(runID), &detail, maxRunDetailResponseBytes); err != nil {
+			return err
+		}
 		return writeJSON(c.stdout, detail)
 	}
-	run := detail.Run
+	var summary protocol.RunSummary
+	path := "/api/v1/runs/" + url.PathEscape(runID) + "?view=summary"
+	if err := client.get(ctx, path, &summary, maxRunSummaryResponseBytes); err != nil {
+		return err
+	}
 	fmt.Fprintf(c.stdout, "Run: %s\nTask: %s\nState: %s\nSource: %s\nAdmitted: %s\nUpdated: %s\n",
-		oneLine(run.ID), oneLine(run.Task.Name), oneLine(string(run.State)), oneLine(run.Source), formatTime(run.AdmittedAt), formatTime(run.UpdatedAt))
-	if len(detail.Sessions) == 0 {
+		oneLine(summary.ID), oneLine(summary.TaskName), oneLine(string(summary.State)), oneLine(summary.Source), formatTime(summary.AdmittedAt), formatTime(summary.UpdatedAt))
+	if len(summary.Sessions) == 0 {
 		fmt.Fprintln(c.stdout, "\nNo Sessions.")
 		return nil
 	}
 	fmt.Fprintln(c.stdout)
 	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
 	fmt.Fprintln(writer, "SESSION ID\tREPOSITORY\tSTATE\tWORKER\tATTEMPTS\tRESULT")
-	for _, session := range detail.Sessions {
+	for _, session := range summary.Sessions {
 		result := session.Result
 		if result == "" {
 			result = session.FailureReason
 		}
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%d\t%s\n",
 			oneLine(session.ID), oneLine(session.RepositoryIdentity), oneLine(string(session.State)),
-			oneLine(session.AssignedWorkerID), len(session.Attempts), oneLine(result))
+			oneLine(session.AssignedWorkerID), session.AttemptCount, oneLine(result))
 	}
 	return writer.Flush()
 }

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -41,12 +41,17 @@ func newAPIClient(ctx context.Context, value string, client *http.Client) (apiCl
 	if parsed.Path != "" && parsed.Path != "/" {
 		return apiClient{}, errors.New("server URL must not contain a path")
 	}
+	host := parsed.Hostname()
 	port, err := strconv.ParseUint(parsed.Port(), 10, 16)
-	if parsed.Hostname() == "" || err != nil || port == 0 {
+	if host == "" || err != nil || port == 0 {
 		return apiClient{}, errors.New("server URL must include a loopback host and nonzero port")
 	}
-	if err := validateLoopbackHost(ctx, parsed.Hostname()); err != nil {
+	if err := validateLoopbackHost(ctx, host); err != nil {
 		return apiClient{}, err
+	}
+	if strings.EqualFold(host, "localhost") {
+		// ProxyFromEnvironment exempts exact lowercase localhost only.
+		parsed.Host = net.JoinHostPort("localhost", parsed.Port())
 	}
 	parsed.Path = ""
 	clientCopy := *client
@@ -63,7 +68,7 @@ func validateLoopbackHost(ctx context.Context, host string) error {
 		}
 		return errors.New("server URL host must be loopback")
 	}
-	if !strings.EqualFold(strings.TrimSuffix(host, "."), "localhost") {
+	if !strings.EqualFold(host, "localhost") {
 		return errors.New("server URL host must be a loopback IP or localhost")
 	}
 	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
@@ -81,7 +86,7 @@ func validateLoopbackHost(ctx context.Context, host string) error {
 	return nil
 }
 
-func (c apiClient) get(ctx context.Context, path string, target any) error {
+func (c apiClient) get(ctx context.Context, path string, target any, responseLimit int64) error {
 	requestURL := *c.endpoint
 	reference, err := url.Parse(path)
 	if err != nil {
@@ -99,12 +104,20 @@ func (c apiClient) get(ctx context.Context, path string, target any) error {
 		return fmt.Errorf("connect to %s: %w", c.endpoint.String(), err)
 	}
 	defer response.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	limit := responseLimit
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		limit = maxResponseBytes
+	}
+	reader := io.Reader(response.Body)
+	if limit > 0 {
+		reader = io.LimitReader(response.Body, limit+1)
+	}
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("read server response: %w", err)
 	}
-	if len(body) > maxResponseBytes {
-		return fmt.Errorf("server response exceeds %d bytes", maxResponseBytes)
+	if limit > 0 && int64(len(body)) > limit {
+		return fmt.Errorf("server response exceeds %d bytes", limit)
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
 		status := oneLine(response.Status)
@@ -130,7 +143,7 @@ func (c apiClient) get(ctx context.Context, path string, target any) error {
 
 func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) error {
 	var page protocol.RunPage
-	if err := client.get(ctx, "/api/v1/runs?limit=50", &page); err != nil {
+	if err := client.get(ctx, "/api/v1/runs?limit=50", &page, maxResponseBytes); err != nil {
 		return err
 	}
 	if jsonOutput {
@@ -155,7 +168,9 @@ func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) 
 
 func (c command) show(ctx context.Context, client apiClient, runID string, jsonOutput bool) error {
 	var detail protocol.RunDetail
-	if err := client.get(ctx, "/api/v1/runs/"+url.PathEscape(runID), &detail); err != nil {
+	// Run details include an unbounded retry history, so no finite byte cap can
+	// cover every valid response. The command deadline still bounds the read.
+	if err := client.get(ctx, "/api/v1/runs/"+url.PathEscape(runID), &detail, 0); err != nil {
 		return err
 	}
 	if jsonOutput {
@@ -185,7 +200,7 @@ func (c command) show(ctx context.Context, client apiClient, runID string, jsonO
 
 func (c command) workers(ctx context.Context, client apiClient, jsonOutput bool) error {
 	var page workerPage
-	if err := client.get(ctx, "/api/v1/workers", &page); err != nil {
+	if err := client.get(ctx, "/api/v1/workers", &page, maxResponseBytes); err != nil {
 		return err
 	}
 	if jsonOutput {

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -2,6 +2,7 @@ package factorycli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -28,7 +30,7 @@ type workerPage struct {
 	Workers []protocol.Worker `json:"workers"`
 }
 
-func newAPIClient(value string, client *http.Client) (apiClient, error) {
+func newAPIClient(ctx context.Context, value string, client *http.Client) (apiClient, error) {
 	parsed, err := url.Parse(value)
 	if err != nil {
 		return apiClient{}, fmt.Errorf("parse server URL: %w", err)
@@ -39,10 +41,11 @@ func newAPIClient(value string, client *http.Client) (apiClient, error) {
 	if parsed.Path != "" && parsed.Path != "/" {
 		return apiClient{}, errors.New("server URL must not contain a path")
 	}
-	if parsed.Hostname() == "" || parsed.Port() == "" || parsed.Port() == "0" {
+	port, err := strconv.ParseUint(parsed.Port(), 10, 16)
+	if parsed.Hostname() == "" || err != nil || port == 0 {
 		return apiClient{}, errors.New("server URL must include a loopback host and nonzero port")
 	}
-	if err := validateLoopbackHost(parsed.Hostname()); err != nil {
+	if err := validateLoopbackHost(ctx, parsed.Hostname()); err != nil {
 		return apiClient{}, err
 	}
 	parsed.Path = ""
@@ -53,7 +56,7 @@ func newAPIClient(value string, client *http.Client) (apiClient, error) {
 	return apiClient{endpoint: parsed, client: &clientCopy}, nil
 }
 
-func validateLoopbackHost(host string) error {
+func validateLoopbackHost(ctx context.Context, host string) error {
 	if address := net.ParseIP(host); address != nil {
 		if address.IsLoopback() {
 			return nil
@@ -63,7 +66,7 @@ func validateLoopbackHost(host string) error {
 	if !strings.EqualFold(strings.TrimSuffix(host, "."), "localhost") {
 		return errors.New("server URL host must be a loopback IP or localhost")
 	}
-	addresses, err := net.LookupIP(host)
+	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if err != nil {
 		return fmt.Errorf("resolve server URL host: %w", err)
 	}
@@ -71,14 +74,14 @@ func validateLoopbackHost(host string) error {
 		return errors.New("server URL host resolved to no addresses")
 	}
 	for _, address := range addresses {
-		if !address.IsLoopback() {
+		if !address.IP.IsLoopback() {
 			return errors.New("server URL host must resolve only to loopback")
 		}
 	}
 	return nil
 }
 
-func (c apiClient) get(path string, target any) error {
+func (c apiClient) get(ctx context.Context, path string, target any) error {
 	requestURL := *c.endpoint
 	reference, err := url.Parse(path)
 	if err != nil {
@@ -86,7 +89,7 @@ func (c apiClient) get(path string, target any) error {
 	}
 	requestURL.Path = reference.Path
 	requestURL.RawQuery = reference.RawQuery
-	request, err := http.NewRequest(http.MethodGet, requestURL.String(), nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
@@ -104,11 +107,12 @@ func (c apiClient) get(path string, target any) error {
 		return fmt.Errorf("server response exceeds %d bytes", maxResponseBytes)
 	}
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		status := oneLine(response.Status)
 		var failure protocol.ErrorBody
 		if err := json.Unmarshal(body, &failure); err == nil && failure.Error.Message != "" {
-			return fmt.Errorf("server returned %s: %s", response.Status, failure.Error.Message)
+			return fmt.Errorf("server returned %s: %s", status, oneLine(failure.Error.Message))
 		}
-		return fmt.Errorf("server returned %s", response.Status)
+		return fmt.Errorf("server returned %s", status)
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	if err := decoder.Decode(target); err != nil {
@@ -124,9 +128,9 @@ func (c apiClient) get(path string, target any) error {
 	return nil
 }
 
-func (c command) status(client apiClient, jsonOutput bool) error {
+func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) error {
 	var page protocol.RunPage
-	if err := client.get("/api/v1/runs?limit=50", &page); err != nil {
+	if err := client.get(ctx, "/api/v1/runs?limit=50", &page); err != nil {
 		return err
 	}
 	if jsonOutput {
@@ -140,18 +144,18 @@ func (c command) status(client apiClient, jsonOutput bool) error {
 	fmt.Fprintln(writer, "RUN ID\tTASK\tSTATE\tSESSIONS\tACTIVE\tSUCCEEDED\tFAILED\tCANCELLED\tUPDATED")
 	for _, run := range page.Runs {
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
-			run.ID, oneLine(run.Task.Name), run.State, run.SessionCount, run.ActiveCount,
+			oneLine(run.ID), oneLine(run.Task.Name), oneLine(string(run.State)), run.SessionCount, run.ActiveCount,
 			run.SucceededCount, run.FailedCount, run.CancelledCount, formatTime(run.UpdatedAt))
 	}
 	if page.NextCursor != "" {
-		fmt.Fprintf(writer, "Next cursor:\t%s\n", page.NextCursor)
+		fmt.Fprintf(writer, "Next cursor:\t%s\n", oneLine(page.NextCursor))
 	}
 	return writer.Flush()
 }
 
-func (c command) show(client apiClient, runID string, jsonOutput bool) error {
+func (c command) show(ctx context.Context, client apiClient, runID string, jsonOutput bool) error {
 	var detail protocol.RunDetail
-	if err := client.get("/api/v1/runs/"+url.PathEscape(runID), &detail); err != nil {
+	if err := client.get(ctx, "/api/v1/runs/"+url.PathEscape(runID), &detail); err != nil {
 		return err
 	}
 	if jsonOutput {
@@ -159,7 +163,7 @@ func (c command) show(client apiClient, runID string, jsonOutput bool) error {
 	}
 	run := detail.Run
 	fmt.Fprintf(c.stdout, "Run: %s\nTask: %s\nState: %s\nSource: %s\nAdmitted: %s\nUpdated: %s\n",
-		run.ID, oneLine(run.Task.Name), run.State, oneLine(run.Source), formatTime(run.AdmittedAt), formatTime(run.UpdatedAt))
+		oneLine(run.ID), oneLine(run.Task.Name), oneLine(string(run.State)), oneLine(run.Source), formatTime(run.AdmittedAt), formatTime(run.UpdatedAt))
 	if len(detail.Sessions) == 0 {
 		fmt.Fprintln(c.stdout, "\nNo Sessions.")
 		return nil
@@ -173,15 +177,15 @@ func (c command) show(client apiClient, runID string, jsonOutput bool) error {
 			result = session.FailureReason
 		}
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%d\t%s\n",
-			session.ID, oneLine(session.RepositoryIdentity), session.State,
-			displayValue(session.AssignedWorkerID), len(session.Attempts), oneLine(result))
+			oneLine(session.ID), oneLine(session.RepositoryIdentity), oneLine(string(session.State)),
+			oneLine(session.AssignedWorkerID), len(session.Attempts), oneLine(result))
 	}
 	return writer.Flush()
 }
 
-func (c command) workers(client apiClient, jsonOutput bool) error {
+func (c command) workers(ctx context.Context, client apiClient, jsonOutput bool) error {
 	var page workerPage
-	if err := client.get("/api/v1/workers", &page); err != nil {
+	if err := client.get(ctx, "/api/v1/workers", &page); err != nil {
 		return err
 	}
 	if jsonOutput {
@@ -195,7 +199,7 @@ func (c command) workers(client apiClient, jsonOutput bool) error {
 	fmt.Fprintln(writer, "WORKER ID\tNAME\tONLINE\tHEALTH\tRUNTIME\tACTIVE\tCAPACITY\tLAST HEARTBEAT")
 	for _, worker := range page.Workers {
 		fmt.Fprintf(writer, "%s\t%s\t%t\t%s\t%s\t%d\t%d\t%s\n",
-			worker.ID, oneLine(worker.Name), worker.Online, worker.Health, worker.Runtime,
+			oneLine(worker.ID), oneLine(worker.Name), worker.Online, oneLine(worker.Health), oneLine(worker.Runtime),
 			worker.ActiveCount, worker.Capacity, formatTime(worker.LastHeartbeat))
 	}
 	return writer.Flush()
@@ -215,13 +219,6 @@ func formatTime(value time.Time) string {
 		return "-"
 	}
 	return value.UTC().Format(time.RFC3339)
-}
-
-func displayValue(value string) string {
-	if value == "" {
-		return "-"
-	}
-	return value
 }
 
 func oneLine(value string) string {

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -193,8 +193,8 @@ func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) 
 		return writeJSON(c.stdout, page)
 	}
 	if len(page.Runs) == 0 {
-		fmt.Fprintln(c.stdout, "No Runs.")
-		return nil
+		_, err := fmt.Fprintln(c.stdout, "No Runs.")
+		return err
 	}
 	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
 	fmt.Fprintln(writer, "RUN ID\tTASK\tSTATE\tSESSIONS\tACTIVE\tSUCCEEDED\tFAILED\tCANCELLED\tUPDATED")
@@ -222,19 +222,28 @@ func (c command) show(ctx context.Context, client apiClient, runID string, jsonO
 	if err := client.get(ctx, path, &summary, maxSummaryResponseBytes); err != nil {
 		return err
 	}
-	fmt.Fprintf(c.stdout, "Run: %s\nTask: %s\nState: %s\nSource: %s\nAdmitted: %s\nUpdated: %s\n",
-		oneLine(summary.ID), oneLine(summary.TaskName), oneLine(string(summary.State)), oneLine(summary.Source), formatTime(summary.AdmittedAt), formatTime(summary.UpdatedAt))
+	if _, err := fmt.Fprintf(c.stdout, "Run: %s\nTask: %s\nState: %s\nSource: %s\nAdmitted: %s\nUpdated: %s\n",
+		oneLine(summary.ID), oneLine(summary.TaskName), oneLine(string(summary.State)), oneLine(summary.Source), formatTime(summary.AdmittedAt), formatTime(summary.UpdatedAt)); err != nil {
+		return fmt.Errorf("write show output: %w", err)
+	}
 	if len(summary.Sessions) == 0 {
-		fmt.Fprintln(c.stdout, "\nNo Sessions.")
+		if _, err := fmt.Fprintln(c.stdout, "\nNo Sessions."); err != nil {
+			return fmt.Errorf("write show output: %w", err)
+		}
 		return nil
 	}
-	fmt.Fprintln(c.stdout)
+	if _, err := fmt.Fprintln(c.stdout); err != nil {
+		return fmt.Errorf("write show output: %w", err)
+	}
 	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
 	fmt.Fprintln(writer, "SESSION ID\tREPOSITORY\tSTATE\tWORKER\tATTEMPTS\tRESULT")
 	for _, session := range summary.Sessions {
 		result := session.Result
 		if result == "" {
 			result = session.FailureReason
+		}
+		if result == "" {
+			result = session.BlockedReason
 		}
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%d\t%s\n",
 			oneLine(session.ID), oneLine(session.RepositoryIdentity), oneLine(string(session.State)),
@@ -256,8 +265,8 @@ func (c command) workers(ctx context.Context, client apiClient, jsonOutput bool)
 		return err
 	}
 	if len(page.Workers) == 0 {
-		fmt.Fprintln(c.stdout, "No Workers.")
-		return nil
+		_, err := fmt.Fprintln(c.stdout, "No Workers.")
+		return err
 	}
 	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
 	fmt.Fprintln(writer, "WORKER ID\tNAME\tONLINE\tHEALTH\tRUNTIME\tACTIVE\tCAPACITY\tLAST HEARTBEAT")

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -184,9 +184,13 @@ func (c apiClient) get(ctx context.Context, path string, target any, responseLim
 	return nil
 }
 
-func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) error {
+func (c command) status(ctx context.Context, client apiClient, jsonOutput bool, cursor string) error {
 	var page protocol.RunListPage
-	if err := client.get(ctx, "/api/v1/runs?limit=50&view=summary", &page, maxResponseBytes); err != nil {
+	query := url.Values{"limit": {"50"}, "view": {"summary"}}
+	if cursor != "" {
+		query.Set("cursor", cursor)
+	}
+	if err := client.get(ctx, "/api/v1/runs?"+query.Encode(), &page, maxResponseBytes); err != nil {
 		return err
 	}
 	if jsonOutput {

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -1,0 +1,251 @@
+package factorycli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"text/tabwriter"
+	"time"
+	"unicode"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const maxResponseBytes = 16 << 20
+
+type apiClient struct {
+	endpoint *url.URL
+	client   *http.Client
+}
+
+type workerPage struct {
+	Workers []protocol.Worker `json:"workers"`
+}
+
+func newAPIClient(value string, client *http.Client) (apiClient, error) {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return apiClient{}, fmt.Errorf("parse server URL: %w", err)
+	}
+	if parsed.Scheme != "http" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return apiClient{}, errors.New("server must be a plain HTTP loopback URL without credentials, query, or fragment")
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return apiClient{}, errors.New("server URL must not contain a path")
+	}
+	if parsed.Hostname() == "" || parsed.Port() == "" || parsed.Port() == "0" {
+		return apiClient{}, errors.New("server URL must include a loopback host and nonzero port")
+	}
+	if err := validateLoopbackHost(parsed.Hostname()); err != nil {
+		return apiClient{}, err
+	}
+	parsed.Path = ""
+	clientCopy := *client
+	clientCopy.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return apiClient{endpoint: parsed, client: &clientCopy}, nil
+}
+
+func validateLoopbackHost(host string) error {
+	if address := net.ParseIP(host); address != nil {
+		if address.IsLoopback() {
+			return nil
+		}
+		return errors.New("server URL host must be loopback")
+	}
+	if !strings.EqualFold(strings.TrimSuffix(host, "."), "localhost") {
+		return errors.New("server URL host must be a loopback IP or localhost")
+	}
+	addresses, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("resolve server URL host: %w", err)
+	}
+	if len(addresses) == 0 {
+		return errors.New("server URL host resolved to no addresses")
+	}
+	for _, address := range addresses {
+		if !address.IsLoopback() {
+			return errors.New("server URL host must resolve only to loopback")
+		}
+	}
+	return nil
+}
+
+func (c apiClient) get(path string, target any) error {
+	requestURL := *c.endpoint
+	reference, err := url.Parse(path)
+	if err != nil {
+		return fmt.Errorf("build request URL: %w", err)
+	}
+	requestURL.Path = reference.Path
+	requestURL.RawQuery = reference.RawQuery
+	request, err := http.NewRequest(http.MethodGet, requestURL.String(), nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	request.Header.Set("Accept", "application/json")
+	response, err := c.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("connect to %s: %w", c.endpoint.String(), err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBytes+1))
+	if err != nil {
+		return fmt.Errorf("read server response: %w", err)
+	}
+	if len(body) > maxResponseBytes {
+		return fmt.Errorf("server response exceeds %d bytes", maxResponseBytes)
+	}
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		var failure protocol.ErrorBody
+		if err := json.Unmarshal(body, &failure); err == nil && failure.Error.Message != "" {
+			return fmt.Errorf("server returned %s: %s", response.Status, failure.Error.Message)
+		}
+		return fmt.Errorf("server returned %s", response.Status)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("decode server response: %w", err)
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("decode server response: multiple JSON values")
+		}
+		return fmt.Errorf("decode server response: %w", err)
+	}
+	return nil
+}
+
+func (c command) status(client apiClient, jsonOutput bool) error {
+	var page protocol.RunPage
+	if err := client.get("/api/v1/runs?limit=50", &page); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(c.stdout, page)
+	}
+	if len(page.Runs) == 0 {
+		fmt.Fprintln(c.stdout, "No Runs.")
+		return nil
+	}
+	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(writer, "RUN ID\tTASK\tSTATE\tSESSIONS\tACTIVE\tSUCCEEDED\tFAILED\tCANCELLED\tUPDATED")
+	for _, run := range page.Runs {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
+			run.ID, oneLine(run.Task.Name), run.State, run.SessionCount, run.ActiveCount,
+			run.SucceededCount, run.FailedCount, run.CancelledCount, formatTime(run.UpdatedAt))
+	}
+	if page.NextCursor != "" {
+		fmt.Fprintf(writer, "Next cursor:\t%s\n", page.NextCursor)
+	}
+	return writer.Flush()
+}
+
+func (c command) show(client apiClient, runID string, jsonOutput bool) error {
+	var detail protocol.RunDetail
+	if err := client.get("/api/v1/runs/"+url.PathEscape(runID), &detail); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(c.stdout, detail)
+	}
+	run := detail.Run
+	fmt.Fprintf(c.stdout, "Run: %s\nTask: %s\nState: %s\nSource: %s\nAdmitted: %s\nUpdated: %s\n",
+		run.ID, oneLine(run.Task.Name), run.State, oneLine(run.Source), formatTime(run.AdmittedAt), formatTime(run.UpdatedAt))
+	if len(detail.Sessions) == 0 {
+		fmt.Fprintln(c.stdout, "\nNo Sessions.")
+		return nil
+	}
+	fmt.Fprintln(c.stdout)
+	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(writer, "SESSION ID\tREPOSITORY\tSTATE\tWORKER\tATTEMPTS\tRESULT")
+	for _, session := range detail.Sessions {
+		result := session.Result
+		if result == "" {
+			result = session.FailureReason
+		}
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%d\t%s\n",
+			session.ID, oneLine(session.RepositoryIdentity), session.State,
+			displayValue(session.AssignedWorkerID), len(session.Attempts), oneLine(result))
+	}
+	return writer.Flush()
+}
+
+func (c command) workers(client apiClient, jsonOutput bool) error {
+	var page workerPage
+	if err := client.get("/api/v1/workers", &page); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(c.stdout, page)
+	}
+	if len(page.Workers) == 0 {
+		fmt.Fprintln(c.stdout, "No Workers.")
+		return nil
+	}
+	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(writer, "WORKER ID\tNAME\tONLINE\tHEALTH\tRUNTIME\tACTIVE\tCAPACITY\tLAST HEARTBEAT")
+	for _, worker := range page.Workers {
+		fmt.Fprintf(writer, "%s\t%s\t%t\t%s\t%s\t%d\t%d\t%s\n",
+			worker.ID, oneLine(worker.Name), worker.Online, worker.Health, worker.Runtime,
+			worker.ActiveCount, worker.Capacity, formatTime(worker.LastHeartbeat))
+	}
+	return writer.Flush()
+}
+
+func writeJSON(output io.Writer, value any) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("write JSON output: %w", err)
+	}
+	return nil
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return "-"
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func displayValue(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func oneLine(value string) string {
+	value = strings.Join(strings.Fields(value), " ")
+	if value == "" {
+		return "-"
+	}
+	var printable strings.Builder
+	for _, character := range value {
+		if unicode.IsPrint(character) {
+			printable.WriteRune(character)
+			continue
+		}
+		if character <= 0xffff {
+			fmt.Fprintf(&printable, "\\u%04X", character)
+		} else {
+			fmt.Fprintf(&printable, "\\U%08X", character)
+		}
+	}
+	value = printable.String()
+	const limit = 80
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	return string(runes[:limit-3]) + "..."
+}

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -185,8 +185,8 @@ func (c apiClient) get(ctx context.Context, path string, target any, responseLim
 }
 
 func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) error {
-	var page protocol.RunPage
-	if err := client.get(ctx, "/api/v1/runs?limit=50", &page, maxResponseBytes); err != nil {
+	var page protocol.RunListPage
+	if err := client.get(ctx, "/api/v1/runs?limit=50&view=summary", &page, maxResponseBytes); err != nil {
 		return err
 	}
 	if jsonOutput {
@@ -200,7 +200,7 @@ func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) 
 	fmt.Fprintln(writer, "RUN ID\tTASK\tSTATE\tSESSIONS\tACTIVE\tSUCCEEDED\tFAILED\tCANCELLED\tUPDATED")
 	for _, run := range page.Runs {
 		fmt.Fprintf(writer, "%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
-			oneLine(run.ID), oneLine(run.Task.Name), oneLine(string(run.State)), run.SessionCount, run.ActiveCount,
+			oneLine(run.ID), oneLine(run.TaskName), oneLine(string(run.State)), run.SessionCount, run.ActiveCount,
 			run.SucceededCount, run.FailedCount, run.CancelledCount, formatTime(run.UpdatedAt))
 	}
 	if page.NextCursor != "" {

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	maxResponseBytes           = 16 << 20
-	maxRunSummaryResponseBytes = 64 << 20
-	maxRunDetailResponseBytes  = 256 << 20
+	maxResponseBytes        = 16 << 20
+	maxSummaryResponseBytes = 64 << 20
+	maxDetailResponseBytes  = 256 << 20
 )
 
 type apiClient struct {
@@ -50,48 +50,83 @@ func newAPIClient(ctx context.Context, value string, client *http.Client) (apiCl
 	if host == "" || err != nil || port == 0 {
 		return apiClient{}, errors.New("server URL must include a loopback host and nonzero port")
 	}
-	pinnedHost, err := validateLoopbackHost(ctx, host)
+	pinnedAddresses, err := validateLoopbackHost(ctx, host)
 	if err != nil {
 		return apiClient{}, err
 	}
 	// Use the validated literal address so proxies and a second DNS lookup
 	// cannot move a loopback-only command away from the local machine.
-	parsed.Host = net.JoinHostPort(pinnedHost, parsed.Port())
+	parsed.Host = net.JoinHostPort(pinnedAddresses[0].String(), parsed.Port())
 	parsed.Path = ""
 	clientCopy := *client
+	if err := pinLoopbackTransport(&clientCopy, pinnedAddresses); err != nil {
+		return apiClient{}, err
+	}
 	clientCopy.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
 	return apiClient{endpoint: parsed, client: &clientCopy}, nil
 }
 
-func validateLoopbackHost(ctx context.Context, host string) (string, error) {
+func validateLoopbackHost(ctx context.Context, host string) ([]net.IP, error) {
 	if address := net.ParseIP(host); address != nil {
 		if address.IsLoopback() {
-			return address.String(), nil
+			return []net.IP{address}, nil
 		}
-		return "", errors.New("server URL host must be loopback")
+		return nil, errors.New("server URL host must be loopback")
 	}
 	if !strings.EqualFold(host, "localhost") {
-		return "", errors.New("server URL host must be a loopback IP or localhost")
+		return nil, errors.New("server URL host must be a loopback IP or localhost")
 	}
 	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if err != nil {
-		return "", fmt.Errorf("resolve server URL host: %w", err)
+		return nil, fmt.Errorf("resolve server URL host: %w", err)
 	}
 	if len(addresses) == 0 {
-		return "", errors.New("server URL host resolved to no addresses")
+		return nil, errors.New("server URL host resolved to no addresses")
 	}
-	var pinned net.IP
+	validated := make([]net.IP, 0, len(addresses))
 	for _, address := range addresses {
 		if !address.IP.IsLoopback() {
-			return "", errors.New("server URL host must resolve only to loopback")
+			return nil, errors.New("server URL host must resolve only to loopback")
 		}
-		if pinned == nil || pinned.To4() == nil && address.IP.To4() != nil {
-			pinned = address.IP
-		}
+		validated = append(validated, append(net.IP(nil), address.IP...))
 	}
-	return pinned.String(), nil
+	return validated, nil
+}
+
+func pinLoopbackTransport(client *http.Client, addresses []net.IP) error {
+	var transport *http.Transport
+	switch configured := client.Transport.(type) {
+	case nil:
+		transport = http.DefaultTransport.(*http.Transport).Clone()
+	case *http.Transport:
+		transport = configured.Clone()
+	default:
+		return errors.New("HTTP client transport does not support loopback address pinning")
+	}
+	dial := transport.DialContext
+	if dial == nil {
+		dialer := &net.Dialer{}
+		dial = dialer.DialContext
+	}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, fmt.Errorf("split HTTP dial address: %w", err)
+		}
+		failures := make([]error, 0, len(addresses))
+		for _, pinned := range addresses {
+			connection, err := dial(ctx, network, net.JoinHostPort(pinned.String(), port))
+			if err == nil {
+				return connection, nil
+			}
+			failures = append(failures, err)
+		}
+		return nil, fmt.Errorf("connect to validated loopback addresses: %w", errors.Join(failures...))
+	}
+	client.Transport = transport
+	return nil
 }
 
 func (c apiClient) get(ctx context.Context, path string, target any, responseLimit int64) error {
@@ -177,14 +212,14 @@ func (c command) status(ctx context.Context, client apiClient, jsonOutput bool) 
 func (c command) show(ctx context.Context, client apiClient, runID string, jsonOutput bool) error {
 	if jsonOutput {
 		var detail protocol.RunDetail
-		if err := client.get(ctx, "/api/v1/runs/"+url.PathEscape(runID), &detail, maxRunDetailResponseBytes); err != nil {
+		if err := client.get(ctx, "/api/v1/runs/"+url.PathEscape(runID), &detail, maxDetailResponseBytes); err != nil {
 			return err
 		}
 		return writeJSON(c.stdout, detail)
 	}
 	var summary protocol.RunSummary
 	path := "/api/v1/runs/" + url.PathEscape(runID) + "?view=summary"
-	if err := client.get(ctx, path, &summary, maxRunSummaryResponseBytes); err != nil {
+	if err := client.get(ctx, path, &summary, maxSummaryResponseBytes); err != nil {
 		return err
 	}
 	fmt.Fprintf(c.stdout, "Run: %s\nTask: %s\nState: %s\nSource: %s\nAdmitted: %s\nUpdated: %s\n",
@@ -209,12 +244,16 @@ func (c command) show(ctx context.Context, client apiClient, runID string, jsonO
 }
 
 func (c command) workers(ctx context.Context, client apiClient, jsonOutput bool) error {
-	var page workerPage
-	if err := client.get(ctx, "/api/v1/workers", &page, maxResponseBytes); err != nil {
-		return err
-	}
 	if jsonOutput {
+		var page workerPage
+		if err := client.get(ctx, "/api/v1/workers", &page, maxDetailResponseBytes); err != nil {
+			return err
+		}
 		return writeJSON(c.stdout, page)
+	}
+	var page protocol.WorkerSummaryPage
+	if err := client.get(ctx, "/api/v1/workers?view=summary", &page, maxSummaryResponseBytes); err != nil {
+		return err
 	}
 	if len(page.Workers) == 0 {
 		fmt.Fprintln(c.stdout, "No Workers.")

--- a/internal/factorycli/command.go
+++ b/internal/factorycli/command.go
@@ -1,0 +1,261 @@
+package factorycli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/owainlewis/factory/internal/buildinfo"
+)
+
+const defaultServer = "http://127.0.0.1:7337"
+
+type Options struct {
+	Arguments   []string
+	Stdout      io.Writer
+	Stderr      io.Writer
+	Environment []string
+	Getenv      func(string) string
+	Executable  func() (string, error)
+	LookPath    func(string) (string, error)
+	Exec        func(string, []string, []string) error
+	HTTPClient  *http.Client
+}
+
+type command struct {
+	stdout      io.Writer
+	stderr      io.Writer
+	environment []string
+	getenv      func(string) string
+	executable  func() (string, error)
+	lookPath    func(string) (string, error)
+	exec        func(string, []string, []string) error
+	client      *http.Client
+}
+
+type usageError struct {
+	message string
+}
+
+func (e *usageError) Error() string { return e.message }
+
+func Run(options Options) int {
+	operation := newCommand(options)
+	if err := operation.run(options.Arguments); err != nil {
+		fmt.Fprintf(operation.stderr, "factory: %s\n", err)
+		var usage *usageError
+		if errors.As(err, &usage) {
+			fmt.Fprintln(operation.stderr, "Run 'factory help' for usage.")
+			return 2
+		}
+		return 1
+	}
+	return 0
+}
+
+func newCommand(options Options) command {
+	if options.Stdout == nil {
+		options.Stdout = io.Discard
+	}
+	if options.Stderr == nil {
+		options.Stderr = io.Discard
+	}
+	if options.Environment == nil {
+		options.Environment = os.Environ()
+	}
+	if options.Getenv == nil {
+		options.Getenv = os.Getenv
+	}
+	if options.Executable == nil {
+		options.Executable = os.Executable
+	}
+	if options.LookPath == nil {
+		options.LookPath = exec.LookPath
+	}
+	if options.Exec == nil {
+		options.Exec = replaceProcess
+	}
+	if options.HTTPClient == nil {
+		options.HTTPClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return command{
+		stdout: options.Stdout, stderr: options.Stderr,
+		environment: options.Environment, getenv: options.Getenv,
+		executable: options.Executable, lookPath: options.LookPath,
+		exec: options.Exec, client: options.HTTPClient,
+	}
+}
+
+func (c command) run(arguments []string) error {
+	if buildinfo.Requested(arguments) {
+		fmt.Fprintln(c.stdout, buildinfo.String("factory"))
+		return nil
+	}
+	root := flag.NewFlagSet("factory", flag.ContinueOnError)
+	root.SetOutput(io.Discard)
+	jsonOutput := root.Bool("json", false, "write one JSON value")
+	server := root.String("server", c.serverEndpoint(), "loopback Factory server URL")
+	if err := root.Parse(arguments); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			c.writeHelp()
+			return nil
+		}
+		return &usageError{message: err.Error()}
+	}
+	remaining := root.Args()
+	if len(remaining) == 0 {
+		return &usageError{message: "a command is required"}
+	}
+	switch remaining[0] {
+	case "help":
+		if len(remaining) != 1 {
+			return &usageError{message: "help does not accept arguments"}
+		}
+		c.writeHelp()
+		return nil
+	case "status":
+		if len(remaining) != 1 {
+			return &usageError{message: "status does not accept arguments"}
+		}
+		client, err := newAPIClient(*server, c.client)
+		if err != nil {
+			return err
+		}
+		return c.status(client, *jsonOutput)
+	case "show":
+		if len(remaining) != 2 || strings.TrimSpace(remaining[1]) == "" {
+			return &usageError{message: "show requires exactly one Run ID"}
+		}
+		if strings.ContainsAny(remaining[1], "/?#") {
+			return &usageError{message: "Run ID must be one URL path segment"}
+		}
+		client, err := newAPIClient(*server, c.client)
+		if err != nil {
+			return err
+		}
+		return c.show(client, remaining[1], *jsonOutput)
+	case "workers":
+		if len(remaining) != 1 {
+			return &usageError{message: "workers does not accept arguments"}
+		}
+		client, err := newAPIClient(*server, c.client)
+		if err != nil {
+			return err
+		}
+		return c.workers(client, *jsonOutput)
+	case "server", "worker":
+		if *jsonOutput {
+			return &usageError{message: "--json is available only for status, show, and workers"}
+		}
+		return c.startProcess(remaining[0], remaining[1:])
+	default:
+		return &usageError{message: fmt.Sprintf("unknown command %q", remaining[0])}
+	}
+}
+
+func (c command) serverEndpoint() string {
+	if value := strings.TrimSpace(c.getenv("FACTORY_SERVER")); value != "" {
+		return value
+	}
+	return defaultServer
+}
+
+func (c command) startProcess(role string, arguments []string) error {
+	if len(arguments) == 0 || arguments[0] != "start" {
+		return &usageError{message: fmt.Sprintf("%s requires the start command", role)}
+	}
+	flags := flag.NewFlagSet("factory "+role+" start", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	config := flags.String("config", "", "TOML configuration path")
+	if err := flags.Parse(arguments[1:]); err != nil {
+		return &usageError{message: err.Error()}
+	}
+	if flags.NArg() != 0 {
+		return &usageError{message: fmt.Sprintf("unexpected %s start arguments: %s", role, strings.Join(flags.Args(), " "))}
+	}
+	configExplicit := false
+	flags.Visit(func(value *flag.Flag) {
+		configExplicit = configExplicit || value.Name == "config"
+	})
+	if configExplicit && strings.TrimSpace(*config) == "" {
+		return &usageError{message: "--config requires a non-empty path"}
+	}
+	binary := "factory-" + role
+	path, err := c.compatibilityBinary(binary)
+	if err != nil {
+		return err
+	}
+	environment := append([]string(nil), c.environment...)
+	if configExplicit {
+		key := "FACTORY_SERVER_CONFIG"
+		if role == "worker" {
+			key = "FACTORY_WORKER_CONFIG"
+		}
+		environment = setEnvironment(environment, key, *config)
+	}
+	if err := c.exec(path, []string{binary}, environment); err != nil {
+		return fmt.Errorf("start %s: %w", role, err)
+	}
+	return nil
+}
+
+func (c command) compatibilityBinary(name string) (string, error) {
+	executable, err := c.executable()
+	if err == nil {
+		if resolved, resolveErr := filepath.EvalSymlinks(executable); resolveErr == nil {
+			executable = resolved
+		}
+		candidate := filepath.Join(filepath.Dir(executable), name)
+		if isExecutable(candidate) {
+			return candidate, nil
+		}
+	}
+	path, lookupErr := c.lookPath(name)
+	if lookupErr == nil && isExecutable(path) {
+		return path, nil
+	}
+	return "", fmt.Errorf("locate %s beside factory or on PATH", name)
+}
+
+func isExecutable(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
+}
+
+func setEnvironment(environment []string, key, value string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(environment)+1)
+	for _, entry := range environment {
+		if !strings.HasPrefix(entry, prefix) {
+			result = append(result, entry)
+		}
+	}
+	return append(result, prefix+value)
+}
+
+func (c command) writeHelp() {
+	fmt.Fprint(c.stdout, `Factory controls the local server and Workers and reads current operations.
+
+Usage:
+  factory [--server URL] [--json] status
+  factory [--server URL] [--json] show RUN_ID
+  factory [--server URL] [--json] workers
+  factory server start [--config PATH]
+  factory worker start [--config PATH]
+  factory version
+
+Options:
+  --json        Write one JSON value to stdout.
+  --server URL  Use this loopback HTTP endpoint (default http://127.0.0.1:7337).
+
+Environment:
+  FACTORY_SERVER  Overrides the endpoint used by finite commands.
+`)
+}

--- a/internal/factorycli/command.go
+++ b/internal/factorycli/command.go
@@ -120,8 +120,22 @@ func (c command) run(arguments []string) error {
 		}
 		return c.writeHelp()
 	case "status":
-		if len(remaining) != 1 {
-			return &usageError{message: "status does not accept arguments"}
+		flags := flag.NewFlagSet("factory status", flag.ContinueOnError)
+		flags.SetOutput(io.Discard)
+		cursor := flags.String("cursor", "", "continue from a status cursor")
+		if err := flags.Parse(remaining[1:]); err != nil {
+			return &usageError{message: err.Error()}
+		}
+		if flags.NArg() != 0 {
+			return &usageError{message: "unexpected status arguments: " + strings.Join(flags.Args(), " ")}
+		}
+		cursorExplicit := false
+		flags.Visit(func(value *flag.Flag) {
+			cursorExplicit = cursorExplicit || value.Name == "cursor"
+		})
+		*cursor = strings.TrimSpace(*cursor)
+		if cursorExplicit && *cursor == "" {
+			return &usageError{message: "--cursor requires a non-empty value"}
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -129,7 +143,7 @@ func (c command) run(arguments []string) error {
 		if err != nil {
 			return err
 		}
-		return c.status(ctx, client, *jsonOutput)
+		return c.status(ctx, client, *jsonOutput, *cursor)
 	case "show":
 		if len(remaining) != 2 || strings.TrimSpace(remaining[1]) == "" {
 			return &usageError{message: "show requires exactly one Run ID"}
@@ -249,7 +263,7 @@ func (c command) writeHelp() error {
 	_, err := fmt.Fprint(c.stdout, `Factory controls the local server and Workers and reads current operations.
 
 Usage:
-  factory [--server URL] [--json] status
+  factory [--server URL] [--json] status [--cursor CURSOR]
   factory [--server URL] [--json] show RUN_ID
   factory [--server URL] [--json] workers
   factory server start [--config PATH]
@@ -259,6 +273,7 @@ Usage:
 Options:
   --json        Write one JSON value to stdout.
   --server URL  Use this loopback HTTP endpoint (default http://127.0.0.1:7337).
+  --cursor      Continue status from a cursor printed by the previous page.
 
 Environment:
   FACTORY_SERVER  Overrides the endpoint used by finite commands.

--- a/internal/factorycli/command.go
+++ b/internal/factorycli/command.go
@@ -96,8 +96,8 @@ func newCommand(options Options) command {
 
 func (c command) run(arguments []string) error {
 	if buildinfo.Requested(arguments) {
-		fmt.Fprintln(c.stdout, buildinfo.String("factory"))
-		return nil
+		_, err := fmt.Fprintln(c.stdout, buildinfo.String("factory"))
+		return err
 	}
 	root := flag.NewFlagSet("factory", flag.ContinueOnError)
 	root.SetOutput(io.Discard)
@@ -105,8 +105,7 @@ func (c command) run(arguments []string) error {
 	server := root.String("server", c.serverEndpoint(), "loopback Factory server URL")
 	if err := root.Parse(arguments); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
-			c.writeHelp()
-			return nil
+			return c.writeHelp()
 		}
 		return &usageError{message: err.Error()}
 	}
@@ -119,8 +118,7 @@ func (c command) run(arguments []string) error {
 		if len(remaining) != 1 {
 			return &usageError{message: "help does not accept arguments"}
 		}
-		c.writeHelp()
-		return nil
+		return c.writeHelp()
 	case "status":
 		if len(remaining) != 1 {
 			return &usageError{message: "status does not accept arguments"}
@@ -247,8 +245,8 @@ func setEnvironment(environment []string, key, value string) []string {
 	return append(result, prefix+value)
 }
 
-func (c command) writeHelp() {
-	fmt.Fprint(c.stdout, `Factory controls the local server and Workers and reads current operations.
+func (c command) writeHelp() error {
+	_, err := fmt.Fprint(c.stdout, `Factory controls the local server and Workers and reads current operations.
 
 Usage:
   factory [--server URL] [--json] status
@@ -265,4 +263,5 @@ Options:
 Environment:
   FACTORY_SERVER  Overrides the endpoint used by finite commands.
 `)
+	return err
 }

--- a/internal/factorycli/command.go
+++ b/internal/factorycli/command.go
@@ -1,6 +1,7 @@
 package factorycli
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -124,11 +125,13 @@ func (c command) run(arguments []string) error {
 		if len(remaining) != 1 {
 			return &usageError{message: "status does not accept arguments"}
 		}
-		client, err := newAPIClient(*server, c.client)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		client, err := newAPIClient(ctx, *server, c.client)
 		if err != nil {
 			return err
 		}
-		return c.status(client, *jsonOutput)
+		return c.status(ctx, client, *jsonOutput)
 	case "show":
 		if len(remaining) != 2 || strings.TrimSpace(remaining[1]) == "" {
 			return &usageError{message: "show requires exactly one Run ID"}
@@ -136,20 +139,24 @@ func (c command) run(arguments []string) error {
 		if strings.ContainsAny(remaining[1], "/?#") {
 			return &usageError{message: "Run ID must be one URL path segment"}
 		}
-		client, err := newAPIClient(*server, c.client)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		client, err := newAPIClient(ctx, *server, c.client)
 		if err != nil {
 			return err
 		}
-		return c.show(client, remaining[1], *jsonOutput)
+		return c.show(ctx, client, remaining[1], *jsonOutput)
 	case "workers":
 		if len(remaining) != 1 {
 			return &usageError{message: "workers does not accept arguments"}
 		}
-		client, err := newAPIClient(*server, c.client)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		client, err := newAPIClient(ctx, *server, c.client)
 		if err != nil {
 			return err
 		}
-		return c.workers(client, *jsonOutput)
+		return c.workers(ctx, client, *jsonOutput)
 	case "server", "worker":
 		if *jsonOutput {
 			return &usageError{message: "--json is available only for status, show, and workers"}

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -1,0 +1,284 @@
+package factorycli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
+	now := time.Date(2026, time.August, 22, 10, 11, 12, 0, time.FixedZone("BST", 3600))
+	run := protocol.Run{
+		ID: "run-1", Task: protocol.TaskSnapshot{Name: "Review Factory"},
+		State: protocol.RunRunning, Source: "manual", SessionCount: 1, ActiveCount: 1,
+		AdmittedAt: now, UpdatedAt: now,
+	}
+	detail := protocol.RunDetail{Run: run, Sessions: []protocol.Session{{
+		ID: "session-1", RepositoryIdentity: "github.com/owainlewis/factory",
+		State: protocol.SessionRunning, AssignedWorkerID: "worker-1",
+		Attempts: []protocol.Attempt{{ID: "attempt-1"}}, Result: "safe\x1b[2Junsafe\x00end\n" + strings.Repeat("🙂", 100),
+	}}}
+	worker := protocol.Worker{
+		ID: "worker-1", Name: "local", Online: true, Health: "healthy",
+		Runtime: "codex", ActiveCount: 1, Capacity: 10, LastHeartbeat: now,
+	}
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		paths = append(paths, request.URL.RequestURI())
+		output.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/api/v1/runs":
+			json.NewEncoder(output).Encode(protocol.RunPage{Runs: []protocol.Run{run}})
+		case "/api/v1/runs/run-1":
+			json.NewEncoder(output).Encode(detail)
+		case "/api/v1/workers":
+			json.NewEncoder(output).Encode(workerPage{Workers: []protocol.Worker{worker}})
+		default:
+			http.NotFound(output, request)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	tests := []struct {
+		arguments []string
+		contains  []string
+	}{
+		{[]string{"--server", server.URL, "status"}, []string{"RUN ID", "run-1", "Review Factory", "2026-08-22T09:11:12Z"}},
+		{[]string{"--server", server.URL, "show", "run-1"}, []string{"Run: run-1", "SESSION ID", "github.com/owainlewis/factory", "ATTEMPTS", `safe\u001B[2Junsafe\u0000end`}},
+		{[]string{"--server", server.URL, "workers"}, []string{"WORKER ID", "worker-1", "healthy", "codex"}},
+	}
+	for _, test := range tests {
+		var stdout, stderr bytes.Buffer
+		if code := Run(Options{Arguments: test.arguments, Stdout: &stdout, Stderr: &stderr}); code != 0 {
+			t.Fatalf("Run(%v) = %d, stderr %q", test.arguments, code, stderr.String())
+		}
+		for _, want := range test.contains {
+			if !strings.Contains(stdout.String(), want) {
+				t.Fatalf("Run(%v) output %q does not contain %q", test.arguments, stdout.String(), want)
+			}
+		}
+		if stderr.Len() != 0 {
+			t.Fatalf("Run(%v) stderr = %q", test.arguments, stderr.String())
+		}
+		if !utf8.ValidString(stdout.String()) {
+			t.Fatalf("Run(%v) wrote invalid UTF-8: %q", test.arguments, stdout.String())
+		}
+		if strings.ContainsAny(stdout.String(), "\x00\x1b") {
+			t.Fatalf("Run(%v) wrote terminal control bytes: %q", test.arguments, stdout.String())
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run(Options{Arguments: []string{"--server", server.URL, "--json", "status"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
+		t.Fatalf("JSON status = %d, stderr %q", code, stderr.String())
+	}
+	var page protocol.RunPage
+	if err := json.Unmarshal(stdout.Bytes(), &page); err != nil || len(page.Runs) != 1 || page.Runs[0].ID != "run-1" {
+		t.Fatalf("JSON status = %#v, error %v", page, err)
+	}
+	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50,/api/v1/runs/run-1,/api/v1/workers,/api/v1/runs?limit=50"; got != want {
+		t.Fatalf("API paths = %q, want %q", got, want)
+	}
+}
+
+func TestFiniteCommandsRejectRedirectsWithoutMutatingTheHTTPClient(t *testing.T) {
+	targetCalled := false
+	target := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+		targetCalled = true
+		json.NewEncoder(output).Encode(protocol.RunPage{})
+	}))
+	t.Cleanup(target.Close)
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		http.Redirect(output, request, target.URL, http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+	client := &http.Client{Timeout: time.Second}
+	var stderr bytes.Buffer
+	code := Run(Options{
+		Arguments: []string{"--server", server.URL, "status"}, Stderr: &stderr,
+		HTTPClient: client,
+	})
+	if code != 1 || !strings.Contains(stderr.String(), "server returned 302 Found") {
+		t.Fatalf("redirect = %d, stderr %q", code, stderr.String())
+	}
+	if targetCalled {
+		t.Fatal("redirect target received a request")
+	}
+	if client.CheckRedirect != nil {
+		t.Fatal("caller's HTTP client was mutated")
+	}
+}
+
+func TestFiniteCommandsReportEmptyResultsAndServerErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		output.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/api/v1/runs":
+			json.NewEncoder(output).Encode(protocol.RunPage{})
+		case "/api/v1/workers":
+			json.NewEncoder(output).Encode(workerPage{})
+		default:
+			output.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(output).Encode(protocol.ErrorBody{Error: protocol.APIError{Code: "not_found", Message: "Run was not found"}})
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	for _, test := range []struct {
+		command string
+		want    string
+	}{{"status", "No Runs."}, {"workers", "No Workers."}} {
+		var stdout bytes.Buffer
+		if code := Run(Options{Arguments: []string{"--server", server.URL, test.command}, Stdout: &stdout}); code != 0 || !strings.Contains(stdout.String(), test.want) {
+			t.Fatalf("%s = code %d, output %q", test.command, code, stdout.String())
+		}
+	}
+	var stderr bytes.Buffer
+	if code := Run(Options{Arguments: []string{"--server", server.URL, "show", "missing"}, Stderr: &stderr}); code != 1 {
+		t.Fatalf("missing show = %d, stderr %q", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "404 Not Found: Run was not found") {
+		t.Fatalf("missing show stderr = %q", stderr.String())
+	}
+}
+
+func TestFiniteCommandsRejectUnsafeEndpointsAndMalformedResponses(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://127.0.0.1:7337", "http://example.com:7337", "http://127.0.0.1:0",
+		"http://127.0.0.1:7337/path", "http://user@127.0.0.1:7337",
+	} {
+		var stderr bytes.Buffer
+		if code := Run(Options{Arguments: []string{"--server", endpoint, "status"}, Stderr: &stderr}); code != 1 {
+			t.Fatalf("endpoint %q = %d, stderr %q", endpoint, code, stderr.String())
+		}
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(output, "not-json")
+	}))
+	t.Cleanup(server.Close)
+	var stderr bytes.Buffer
+	if code := Run(Options{Arguments: []string{"--server", server.URL, "status"}, Stderr: &stderr}); code != 1 || !strings.Contains(stderr.String(), "decode server response") {
+		t.Fatalf("malformed response = %d, stderr %q", code, stderr.String())
+	}
+}
+
+func TestStartCommandsExecCompatibilityBinariesWithConfig(t *testing.T) {
+	bin := t.TempDir()
+	for _, name := range []string{"factory", "factory-server", "factory-worker"} {
+		path := filepath.Join(bin, name)
+		if err := os.WriteFile(path, []byte("binary"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	tests := []struct {
+		role string
+		key  string
+	}{
+		{"server", "FACTORY_SERVER_CONFIG"},
+		{"worker", "FACTORY_WORKER_CONFIG"},
+	}
+	for _, test := range tests {
+		t.Run(test.role, func(t *testing.T) {
+			var path string
+			var arguments, environment []string
+			var stderr bytes.Buffer
+			code := Run(Options{
+				Arguments: []string{test.role, "start", "--config", "config.toml"},
+				Stderr:    &stderr, Environment: []string{test.key + "=old", "KEEP=value"},
+				Executable: func() (string, error) { return filepath.Join(bin, "factory"), nil },
+				LookPath:   func(string) (string, error) { return "", errors.New("not found") },
+				Exec: func(gotPath string, gotArguments, gotEnvironment []string) error {
+					path, arguments, environment = gotPath, gotArguments, gotEnvironment
+					return nil
+				},
+			})
+			if code != 0 || stderr.Len() != 0 {
+				t.Fatalf("start = %d, stderr %q", code, stderr.String())
+			}
+			resolvedBin, err := filepath.EvalSymlinks(bin)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if path != filepath.Join(resolvedBin, "factory-"+test.role) || len(arguments) != 1 || arguments[0] != "factory-"+test.role {
+				t.Fatalf("exec = %q %#v", path, arguments)
+			}
+			if got := strings.Join(environment, ","); got != "KEEP=value,"+test.key+"=config.toml" {
+				t.Fatalf("environment = %q", got)
+			}
+		})
+	}
+}
+
+func TestStartCommandsReturnUsefulUsageAndLookupErrors(t *testing.T) {
+	tests := []struct {
+		arguments []string
+		code      int
+		want      string
+	}{
+		{nil, 2, "a command is required"},
+		{[]string{"server"}, 2, "server requires the start command"},
+		{[]string{"worker", "start", "extra"}, 2, "unexpected worker start arguments"},
+		{[]string{"server", "start", "--config="}, 2, "--config requires a non-empty path"},
+		{[]string{"--json", "server", "start"}, 2, "--json is available only"},
+		{[]string{"server", "start"}, 1, "locate factory-server"},
+	}
+	for _, test := range tests {
+		var stderr bytes.Buffer
+		code := Run(Options{
+			Arguments: test.arguments, Stderr: &stderr,
+			Executable: func() (string, error) { return "/missing/factory", nil },
+			LookPath:   func(string) (string, error) { return "", errors.New("not found") },
+		})
+		if code != test.code || !strings.Contains(stderr.String(), test.want) {
+			t.Fatalf("Run(%v) = %d, stderr %q; want %d containing %q", test.arguments, code, stderr.String(), test.code, test.want)
+		}
+	}
+}
+
+func TestHelpIsConciseAndDoesNotAdvertiseFutureCommands(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := Run(Options{Arguments: []string{"help"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
+		t.Fatalf("help = %d, stderr %q", code, stderr.String())
+	}
+	for _, want := range []string{"factory server start", "factory worker start", "factory [--server URL] [--json] status", "FACTORY_SERVER"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("help %q does not contain %q", stdout.String(), want)
+		}
+	}
+	for _, forbidden := range []string{"factory build", "factory run", "factory update", "factory answer"} {
+		if strings.Contains(stdout.String(), forbidden) {
+			t.Fatalf("help advertises %q: %q", forbidden, stdout.String())
+		}
+	}
+}
+
+func TestFactoryServerEnvironmentOverridesDefault(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(output).Encode(protocol.RunPage{})
+	}))
+	t.Cleanup(server.Close)
+	var stdout, stderr bytes.Buffer
+	code := Run(Options{
+		Arguments: []string{"status"}, Stdout: &stdout, Stderr: &stderr,
+		Getenv: func(key string) string {
+			if key == "FACTORY_SERVER" {
+				return "  " + server.URL + "  "
+			}
+			return ""
+		},
+	})
+	if code != 0 || stdout.String() != "No Runs.\n" {
+		t.Fatalf("environment endpoint = %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
+	}
+}

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -159,7 +160,7 @@ func TestFiniteCommandsReportEmptyResultsAndServerErrors(t *testing.T) {
 func TestFiniteCommandsRejectUnsafeEndpointsAndMalformedResponses(t *testing.T) {
 	for _, endpoint := range []string{
 		"https://127.0.0.1:7337", "http://example.com:7337", "http://127.0.0.1:0", "http://127.0.0.1:00", "http://127.0.0.1:65536",
-		"http://127.0.0.1:7337/path", "http://user@127.0.0.1:7337",
+		"http://127.0.0.1:7337/path", "http://user@127.0.0.1:7337", "http://localhost.:7337",
 	} {
 		var stderr bytes.Buffer
 		if code := Run(Options{Arguments: []string{"--server", endpoint, "status"}, Stderr: &stderr}); code != 1 {
@@ -173,6 +174,72 @@ func TestFiniteCommandsRejectUnsafeEndpointsAndMalformedResponses(t *testing.T) 
 	var stderr bytes.Buffer
 	if code := Run(Options{Arguments: []string{"--server", server.URL, "status"}, Stderr: &stderr}); code != 1 || !strings.Contains(stderr.String(), "decode server response") {
 		t.Fatalf("malformed response = %d, stderr %q", code, stderr.String())
+	}
+}
+
+func TestFiniteCommandsNormalizeLocalhostBeforeProxySelection(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+		output.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(output).Encode(protocol.RunPage{})
+	}))
+	t.Cleanup(target.Close)
+	targetURL, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxyHits := 0
+	proxy := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		proxyHits++
+	}))
+	t.Cleanup(proxy.Close)
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = func(request *http.Request) (*url.URL, error) {
+		if request.URL.Hostname() == "localhost" {
+			return nil, nil
+		}
+		return proxyURL, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run(Options{
+		Arguments:  []string{"--server", "http://LOCALHOST:" + targetURL.Port(), "status"},
+		Stdout:     &stdout,
+		Stderr:     &stderr,
+		HTTPClient: &http.Client{Transport: transport},
+	})
+	if code != 0 || !strings.Contains(stdout.String(), "No Runs.") || proxyHits != 0 {
+		t.Fatalf("uppercase localhost = %d, stdout %q, stderr %q, proxy hits %d", code, stdout.String(), stderr.String(), proxyHits)
+	}
+}
+
+func TestShowAllowsRunDetailsLargerThanListLimit(t *testing.T) {
+	result := strings.Repeat("x", maxResponseBytes)
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+		output.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(output).Encode(protocol.RunDetail{
+			Run: protocol.Run{ID: "run-large", Task: protocol.TaskSnapshot{Name: "Large run"}},
+			Sessions: []protocol.Session{{
+				ID: "session-large", RepositoryIdentity: "github.com/owainlewis/factory",
+				State: protocol.SessionSucceeded, Result: result,
+			}},
+		}); err != nil {
+			t.Error(err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var stderr bytes.Buffer
+	code := Run(Options{
+		Arguments: []string{"--server", server.URL, "show", "run-large"},
+		Stdout:    io.Discard,
+		Stderr:    &stderr,
+	})
+	if code != 0 {
+		t.Fatalf("large show = %d, stderr %q", code, stderr.String())
 	}
 }
 

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -1,10 +1,13 @@
 package factorycli
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -20,8 +23,8 @@ import (
 func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 	now := time.Date(2026, time.August, 22, 10, 11, 12, 0, time.FixedZone("BST", 3600))
 	run := protocol.Run{
-		ID: "run-1", Task: protocol.TaskSnapshot{Name: "Review Factory"},
-		State: protocol.RunRunning, Source: "manual", SessionCount: 1, ActiveCount: 1,
+		ID: "run-\x1b[2J1", Task: protocol.TaskSnapshot{Name: "Review Factory"},
+		State: protocol.RunState("running\x00"), Source: "manual", SessionCount: 1, ActiveCount: 1,
 		AdmittedAt: now, UpdatedAt: now,
 	}
 	detail := protocol.RunDetail{Run: run, Sessions: []protocol.Session{{
@@ -31,7 +34,7 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 	}}}
 	worker := protocol.Worker{
 		ID: "worker-1", Name: "local", Online: true, Health: "healthy",
-		Runtime: "codex", ActiveCount: 1, Capacity: 10, LastHeartbeat: now,
+		Runtime: "codex\x1b[2J", ActiveCount: 1, Capacity: 10, LastHeartbeat: now,
 	}
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
@@ -39,7 +42,7 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		output.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
 		case "/api/v1/runs":
-			json.NewEncoder(output).Encode(protocol.RunPage{Runs: []protocol.Run{run}})
+			json.NewEncoder(output).Encode(protocol.RunPage{Runs: []protocol.Run{run}, NextCursor: "cursor\x1b[2J"})
 		case "/api/v1/runs/run-1":
 			json.NewEncoder(output).Encode(detail)
 		case "/api/v1/workers":
@@ -54,9 +57,9 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		arguments []string
 		contains  []string
 	}{
-		{[]string{"--server", server.URL, "status"}, []string{"RUN ID", "run-1", "Review Factory", "2026-08-22T09:11:12Z"}},
-		{[]string{"--server", server.URL, "show", "run-1"}, []string{"Run: run-1", "SESSION ID", "github.com/owainlewis/factory", "ATTEMPTS", `safe\u001B[2Junsafe\u0000end`}},
-		{[]string{"--server", server.URL, "workers"}, []string{"WORKER ID", "worker-1", "healthy", "codex"}},
+		{[]string{"--server", server.URL, "status"}, []string{"RUN ID", `run-\u001B[2J1`, "Review Factory", `running\u0000`, `cursor\u001B[2J`, "2026-08-22T09:11:12Z"}},
+		{[]string{"--server", server.URL, "show", "run-1"}, []string{`Run: run-\u001B[2J1`, "SESSION ID", "github.com/owainlewis/factory", "ATTEMPTS", `safe\u001B[2Junsafe\u0000end`}},
+		{[]string{"--server", server.URL, "workers"}, []string{"WORKER ID", "worker-1", "healthy", `codex\u001B[2J`}},
 	}
 	for _, test := range tests {
 		var stdout, stderr bytes.Buffer
@@ -84,7 +87,7 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		t.Fatalf("JSON status = %d, stderr %q", code, stderr.String())
 	}
 	var page protocol.RunPage
-	if err := json.Unmarshal(stdout.Bytes(), &page); err != nil || len(page.Runs) != 1 || page.Runs[0].ID != "run-1" {
+	if err := json.Unmarshal(stdout.Bytes(), &page); err != nil || len(page.Runs) != 1 || page.Runs[0].ID != "run-\x1b[2J1" {
 		t.Fatalf("JSON status = %#v, error %v", page, err)
 	}
 	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50,/api/v1/runs/run-1,/api/v1/workers,/api/v1/runs?limit=50"; got != want {
@@ -155,7 +158,7 @@ func TestFiniteCommandsReportEmptyResultsAndServerErrors(t *testing.T) {
 
 func TestFiniteCommandsRejectUnsafeEndpointsAndMalformedResponses(t *testing.T) {
 	for _, endpoint := range []string{
-		"https://127.0.0.1:7337", "http://example.com:7337", "http://127.0.0.1:0",
+		"https://127.0.0.1:7337", "http://example.com:7337", "http://127.0.0.1:0", "http://127.0.0.1:00", "http://127.0.0.1:65536",
 		"http://127.0.0.1:7337/path", "http://user@127.0.0.1:7337",
 	} {
 		var stderr bytes.Buffer
@@ -170,6 +173,50 @@ func TestFiniteCommandsRejectUnsafeEndpointsAndMalformedResponses(t *testing.T) 
 	var stderr bytes.Buffer
 	if code := Run(Options{Arguments: []string{"--server", server.URL, "status"}, Stderr: &stderr}); code != 1 || !strings.Contains(stderr.String(), "decode server response") {
 		t.Fatalf("malformed response = %d, stderr %q", code, stderr.String())
+	}
+}
+
+func TestFiniteCommandsSanitizeHTTPReasonPhrases(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	served := make(chan error, 1)
+	go func() {
+		connection, err := listener.Accept()
+		if err != nil {
+			served <- err
+			return
+		}
+		defer connection.Close()
+		reader := bufio.NewReader(connection)
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				served <- readErr
+				return
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		_, err = io.WriteString(connection, "HTTP/1.1 500 BAD\x1b[2JSTATUS\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+		served <- err
+	}()
+	var stderr bytes.Buffer
+	code := Run(Options{
+		Arguments: []string{"--server", "http://" + listener.Addr().String(), "status"},
+		Stderr:    &stderr,
+	})
+	if err := <-served; err != nil {
+		t.Fatal(err)
+	}
+	if code != 1 || !strings.Contains(stderr.String(), `500 BAD\u001B[2JSTATUS`) {
+		t.Fatalf("unsafe HTTP status = %d, stderr %q", code, stderr.String())
+	}
+	if strings.ContainsRune(stderr.String(), '\x1b') {
+		t.Fatalf("unsafe HTTP status wrote a terminal control byte: %q", stderr.String())
 	}
 }
 

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -3,6 +3,7 @@ package factorycli
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -46,6 +47,11 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		ID: "worker-1", Name: "local", Online: true, Health: "healthy",
 		Runtime: "codex\x1b[2J", ActiveCount: 1, Capacity: 10, LastHeartbeat: now,
 	}
+	workerSummary := protocol.WorkerSummaryPage{Workers: []protocol.WorkerSummary{{
+		ID: worker.ID, Name: worker.Name, Online: worker.Online, Health: worker.Health,
+		Runtime: worker.Runtime, ActiveCount: worker.ActiveCount, Capacity: worker.Capacity,
+		LastHeartbeat: worker.LastHeartbeat,
+	}}}
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
 		paths = append(paths, request.URL.RequestURI())
@@ -60,7 +66,11 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 				json.NewEncoder(output).Encode(detail)
 			}
 		case "/api/v1/workers":
-			json.NewEncoder(output).Encode(workerPage{Workers: []protocol.Worker{worker}})
+			if request.URL.Query().Get("view") == "summary" {
+				json.NewEncoder(output).Encode(workerSummary)
+			} else {
+				json.NewEncoder(output).Encode(workerPage{Workers: []protocol.Worker{worker}})
+			}
 		default:
 			http.NotFound(output, request)
 		}
@@ -112,7 +122,15 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil || len(shown.Sessions) != 1 || len(shown.Sessions[0].Attempts) != 1 {
 		t.Fatalf("JSON show = %#v, error %v", shown, err)
 	}
-	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50,/api/v1/runs/run-1?view=summary,/api/v1/workers,/api/v1/runs?limit=50,/api/v1/runs/run-1"; got != want {
+	stdout.Reset()
+	if code := Run(Options{Arguments: []string{"--server", server.URL, "--json", "workers"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
+		t.Fatalf("JSON workers = %d, stderr %q", code, stderr.String())
+	}
+	var workers workerPage
+	if err := json.Unmarshal(stdout.Bytes(), &workers); err != nil || len(workers.Workers) != 1 || workers.Workers[0].ID != worker.ID {
+		t.Fatalf("JSON workers = %#v, error %v", workers, err)
+	}
+	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50,/api/v1/runs/run-1?view=summary,/api/v1/workers?view=summary,/api/v1/runs?limit=50,/api/v1/runs/run-1,/api/v1/workers"; got != want {
 		t.Fatalf("API paths = %q, want %q", got, want)
 	}
 }
@@ -234,6 +252,32 @@ func TestFiniteCommandsNormalizeLocalhostBeforeProxySelection(t *testing.T) {
 	})
 	if code != 0 || !strings.Contains(stdout.String(), "No Runs.") || proxyHits != 0 {
 		t.Fatalf("uppercase localhost = %d, stdout %q, stderr %q, proxy hits %d", code, stdout.String(), stderr.String(), proxyHits)
+	}
+}
+
+func TestPinnedTransportTriesEveryValidatedLoopbackAddress(t *testing.T) {
+	var attempts []string
+	transport := &http.Transport{DialContext: func(_ context.Context, _, address string) (net.Conn, error) {
+		attempts = append(attempts, address)
+		if address == "[::1]:7337" {
+			client, server := net.Pipe()
+			server.Close()
+			return client, nil
+		}
+		return nil, errors.New("not listening")
+	}}
+	client := &http.Client{Transport: transport}
+	if err := pinLoopbackTransport(client, []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")}); err != nil {
+		t.Fatal(err)
+	}
+	pinned := client.Transport.(*http.Transport)
+	connection, err := pinned.DialContext(context.Background(), "tcp", "127.0.0.1:7337")
+	if err != nil {
+		t.Fatal(err)
+	}
+	connection.Close()
+	if got, want := strings.Join(attempts, ","), "127.0.0.1:7337,[::1]:7337"; got != want {
+		t.Fatalf("dial attempts = %q, want %q", got, want)
 	}
 }
 

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -29,6 +29,11 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		State: protocol.RunState("running\x00"), Source: "manual", SessionCount: 1, ActiveCount: 1,
 		AdmittedAt: now, UpdatedAt: now,
 	}
+	runList := protocol.RunListSummary{
+		ID: run.ID, TaskName: run.Task.Name, State: run.State, Source: run.Source,
+		SessionCount: run.SessionCount, ActiveCount: run.ActiveCount,
+		AdmittedAt: run.AdmittedAt, UpdatedAt: run.UpdatedAt,
+	}
 	detail := protocol.RunDetail{Run: run, Sessions: []protocol.Session{{
 		ID: "session-1", RepositoryIdentity: "github.com/owainlewis/factory",
 		State: protocol.SessionRunning, AssignedWorkerID: "worker-1",
@@ -58,7 +63,7 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		output.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
 		case "/api/v1/runs":
-			if err := json.NewEncoder(output).Encode(protocol.RunPage{Runs: []protocol.Run{run}, NextCursor: "cursor\x1b[2J"}); err != nil {
+			if err := json.NewEncoder(output).Encode(protocol.RunListPage{Runs: []protocol.RunListSummary{runList}, NextCursor: "cursor\x1b[2J"}); err != nil {
 				t.Error(err)
 			}
 		case "/api/v1/runs/run-1":
@@ -120,7 +125,7 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 	if code := Run(Options{Arguments: []string{"--server", server.URL, "--json", "status"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
 		t.Fatalf("JSON status = %d, stderr %q", code, stderr.String())
 	}
-	var page protocol.RunPage
+	var page protocol.RunListPage
 	if err := json.Unmarshal(stdout.Bytes(), &page); err != nil || len(page.Runs) != 1 || page.Runs[0].ID != "run-\x1b[2J1" {
 		t.Fatalf("JSON status = %#v, error %v", page, err)
 	}
@@ -140,7 +145,7 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &workers); err != nil || len(workers.Workers) != 1 || workers.Workers[0].ID != worker.ID {
 		t.Fatalf("JSON workers = %#v, error %v", workers, err)
 	}
-	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50,/api/v1/runs/run-1?view=summary,/api/v1/workers?view=summary,/api/v1/runs?limit=50,/api/v1/runs/run-1,/api/v1/workers"; got != want {
+	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50&view=summary,/api/v1/runs/run-1?view=summary,/api/v1/workers?view=summary,/api/v1/runs?limit=50&view=summary,/api/v1/runs/run-1,/api/v1/workers"; got != want {
 		t.Fatalf("API paths = %q, want %q", got, want)
 	}
 }
@@ -149,7 +154,7 @@ func TestFiniteCommandsRejectRedirectsWithoutMutatingTheHTTPClient(t *testing.T)
 	targetCalled := false
 	target := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
 		targetCalled = true
-		if err := json.NewEncoder(output).Encode(protocol.RunPage{}); err != nil {
+		if err := json.NewEncoder(output).Encode(protocol.RunListPage{}); err != nil {
 			t.Error(err)
 		}
 	}))
@@ -180,7 +185,7 @@ func TestFiniteCommandsReportEmptyResultsAndServerErrors(t *testing.T) {
 		output.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
 		case "/api/v1/runs":
-			if err := json.NewEncoder(output).Encode(protocol.RunPage{}); err != nil {
+			if err := json.NewEncoder(output).Encode(protocol.RunListPage{}); err != nil {
 				t.Error(err)
 			}
 		case "/api/v1/workers":
@@ -237,7 +242,7 @@ func TestFiniteCommandsRejectUnsafeEndpointsAndMalformedResponses(t *testing.T) 
 func TestFiniteCommandsNormalizeLocalhostBeforeProxySelection(t *testing.T) {
 	target := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
 		output.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(output).Encode(protocol.RunPage{}); err != nil {
+		if err := json.NewEncoder(output).Encode(protocol.RunListPage{}); err != nil {
 			t.Error(err)
 		}
 	}))
@@ -493,7 +498,7 @@ func TestHelpIsConciseAndDoesNotAdvertiseFutureCommands(t *testing.T) {
 
 func TestFactoryServerEnvironmentOverridesDefault(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
-		if err := json.NewEncoder(output).Encode(protocol.RunPage{}); err != nil {
+		if err := json.NewEncoder(output).Encode(protocol.RunListPage{}); err != nil {
 			t.Error(err)
 		}
 	}))

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -33,6 +33,15 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		State: protocol.SessionRunning, AssignedWorkerID: "worker-1",
 		Attempts: []protocol.Attempt{{ID: "attempt-1"}}, Result: "safe\x1b[2Junsafe\x00end\n" + strings.Repeat("🙂", 100),
 	}}}
+	summary := protocol.RunSummary{
+		ID: run.ID, TaskName: run.Task.Name, State: run.State, Source: run.Source,
+		AdmittedAt: run.AdmittedAt, UpdatedAt: run.UpdatedAt,
+		Sessions: []protocol.RunSessionSummary{{
+			ID: detail.Sessions[0].ID, RepositoryIdentity: detail.Sessions[0].RepositoryIdentity,
+			State: detail.Sessions[0].State, AssignedWorkerID: detail.Sessions[0].AssignedWorkerID,
+			AttemptCount: len(detail.Sessions[0].Attempts), Result: detail.Sessions[0].Result,
+		}},
+	}
 	worker := protocol.Worker{
 		ID: "worker-1", Name: "local", Online: true, Health: "healthy",
 		Runtime: "codex\x1b[2J", ActiveCount: 1, Capacity: 10, LastHeartbeat: now,
@@ -45,7 +54,11 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		case "/api/v1/runs":
 			json.NewEncoder(output).Encode(protocol.RunPage{Runs: []protocol.Run{run}, NextCursor: "cursor\x1b[2J"})
 		case "/api/v1/runs/run-1":
-			json.NewEncoder(output).Encode(detail)
+			if request.URL.Query().Get("view") == "summary" {
+				json.NewEncoder(output).Encode(summary)
+			} else {
+				json.NewEncoder(output).Encode(detail)
+			}
 		case "/api/v1/workers":
 			json.NewEncoder(output).Encode(workerPage{Workers: []protocol.Worker{worker}})
 		default:
@@ -91,7 +104,15 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &page); err != nil || len(page.Runs) != 1 || page.Runs[0].ID != "run-\x1b[2J1" {
 		t.Fatalf("JSON status = %#v, error %v", page, err)
 	}
-	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50,/api/v1/runs/run-1,/api/v1/workers,/api/v1/runs?limit=50"; got != want {
+	stdout.Reset()
+	if code := Run(Options{Arguments: []string{"--server", server.URL, "--json", "show", "run-1"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
+		t.Fatalf("JSON show = %d, stderr %q", code, stderr.String())
+	}
+	var shown protocol.RunDetail
+	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil || len(shown.Sessions) != 1 || len(shown.Sessions[0].Attempts) != 1 {
+		t.Fatalf("JSON show = %#v, error %v", shown, err)
+	}
+	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50,/api/v1/runs/run-1?view=summary,/api/v1/workers,/api/v1/runs?limit=50,/api/v1/runs/run-1"; got != want {
 		t.Fatalf("API paths = %q, want %q", got, want)
 	}
 }
@@ -198,7 +219,7 @@ func TestFiniteCommandsNormalizeLocalhostBeforeProxySelection(t *testing.T) {
 	}
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.Proxy = func(request *http.Request) (*url.URL, error) {
-		if request.URL.Hostname() == "localhost" {
+		if address := net.ParseIP(request.URL.Hostname()); address != nil && address.IsLoopback() {
 			return nil, nil
 		}
 		return proxyURL, nil
@@ -216,13 +237,16 @@ func TestFiniteCommandsNormalizeLocalhostBeforeProxySelection(t *testing.T) {
 	}
 }
 
-func TestShowAllowsRunDetailsLargerThanListLimit(t *testing.T) {
+func TestShowAllowsSummariesLargerThanListLimit(t *testing.T) {
 	result := strings.Repeat("x", maxResponseBytes)
-	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		if request.URL.Query().Get("view") != "summary" {
+			t.Errorf("show query = %q", request.URL.RawQuery)
+		}
 		output.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(output).Encode(protocol.RunDetail{
-			Run: protocol.Run{ID: "run-large", Task: protocol.TaskSnapshot{Name: "Large run"}},
-			Sessions: []protocol.Session{{
+		if err := json.NewEncoder(output).Encode(protocol.RunSummary{
+			ID: "run-large", TaskName: "Large run",
+			Sessions: []protocol.RunSessionSummary{{
 				ID: "session-large", RepositoryIdentity: "github.com/owainlewis/factory",
 				State: protocol.SessionSucceeded, Result: result,
 			}},

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -58,18 +58,28 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 		output.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
 		case "/api/v1/runs":
-			json.NewEncoder(output).Encode(protocol.RunPage{Runs: []protocol.Run{run}, NextCursor: "cursor\x1b[2J"})
+			if err := json.NewEncoder(output).Encode(protocol.RunPage{Runs: []protocol.Run{run}, NextCursor: "cursor\x1b[2J"}); err != nil {
+				t.Error(err)
+			}
 		case "/api/v1/runs/run-1":
 			if request.URL.Query().Get("view") == "summary" {
-				json.NewEncoder(output).Encode(summary)
+				if err := json.NewEncoder(output).Encode(summary); err != nil {
+					t.Error(err)
+				}
 			} else {
-				json.NewEncoder(output).Encode(detail)
+				if err := json.NewEncoder(output).Encode(detail); err != nil {
+					t.Error(err)
+				}
 			}
 		case "/api/v1/workers":
 			if request.URL.Query().Get("view") == "summary" {
-				json.NewEncoder(output).Encode(workerSummary)
+				if err := json.NewEncoder(output).Encode(workerSummary); err != nil {
+					t.Error(err)
+				}
 			} else {
-				json.NewEncoder(output).Encode(workerPage{Workers: []protocol.Worker{worker}})
+				if err := json.NewEncoder(output).Encode(workerPage{Workers: []protocol.Worker{worker}}); err != nil {
+					t.Error(err)
+				}
 			}
 		default:
 			http.NotFound(output, request)
@@ -139,7 +149,9 @@ func TestFiniteCommandsRejectRedirectsWithoutMutatingTheHTTPClient(t *testing.T)
 	targetCalled := false
 	target := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
 		targetCalled = true
-		json.NewEncoder(output).Encode(protocol.RunPage{})
+		if err := json.NewEncoder(output).Encode(protocol.RunPage{}); err != nil {
+			t.Error(err)
+		}
 	}))
 	t.Cleanup(target.Close)
 	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
@@ -168,12 +180,18 @@ func TestFiniteCommandsReportEmptyResultsAndServerErrors(t *testing.T) {
 		output.Header().Set("Content-Type", "application/json")
 		switch request.URL.Path {
 		case "/api/v1/runs":
-			json.NewEncoder(output).Encode(protocol.RunPage{})
+			if err := json.NewEncoder(output).Encode(protocol.RunPage{}); err != nil {
+				t.Error(err)
+			}
 		case "/api/v1/workers":
-			json.NewEncoder(output).Encode(workerPage{})
+			if err := json.NewEncoder(output).Encode(workerPage{}); err != nil {
+				t.Error(err)
+			}
 		default:
 			output.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(output).Encode(protocol.ErrorBody{Error: protocol.APIError{Code: "not_found", Message: "Run was not found"}})
+			if err := json.NewEncoder(output).Encode(protocol.ErrorBody{Error: protocol.APIError{Code: "not_found", Message: "Run was not found"}}); err != nil {
+				t.Error(err)
+			}
 		}
 	}))
 	t.Cleanup(server.Close)
@@ -219,7 +237,9 @@ func TestFiniteCommandsRejectUnsafeEndpointsAndMalformedResponses(t *testing.T) 
 func TestFiniteCommandsNormalizeLocalhostBeforeProxySelection(t *testing.T) {
 	target := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
 		output.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(output).Encode(protocol.RunPage{})
+		if err := json.NewEncoder(output).Encode(protocol.RunPage{}); err != nil {
+			t.Error(err)
+		}
 	}))
 	t.Cleanup(target.Close)
 	targetURL, err := url.Parse(target.URL)
@@ -308,6 +328,32 @@ func TestShowAllowsSummariesLargerThanListLimit(t *testing.T) {
 	})
 	if code != 0 {
 		t.Fatalf("large show = %d, stderr %q", code, stderr.String())
+	}
+}
+
+func TestShowUsesBlockedReasonAndReturnsOutputErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
+		output.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(output).Encode(protocol.RunSummary{
+			ID: "run-blocked", TaskName: "Blocked run", State: protocol.RunBlocked,
+			Sessions: []protocol.RunSessionSummary{{
+				ID: "session-blocked", RepositoryIdentity: "github.com/owainlewis/factory",
+				State: protocol.SessionBlocked, BlockedReason: "Repository is disabled.",
+			}},
+		}); err != nil {
+			t.Error(err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var stdout, stderr bytes.Buffer
+	arguments := []string{"--server", server.URL, "show", "run-blocked"}
+	if code := Run(Options{Arguments: arguments, Stdout: &stdout, Stderr: &stderr}); code != 0 || !strings.Contains(stdout.String(), "Repository is disabled.") {
+		t.Fatalf("blocked show = %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
+	}
+	stderr.Reset()
+	if code := Run(Options{Arguments: arguments, Stdout: failingWriter{}, Stderr: &stderr}); code != 1 || !strings.Contains(stderr.String(), "write show output") {
+		t.Fatalf("failed show output = %d, stderr %q", code, stderr.String())
 	}
 }
 
@@ -447,7 +493,9 @@ func TestHelpIsConciseAndDoesNotAdvertiseFutureCommands(t *testing.T) {
 
 func TestFactoryServerEnvironmentOverridesDefault(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, _ *http.Request) {
-		json.NewEncoder(output).Encode(protocol.RunPage{})
+		if err := json.NewEncoder(output).Encode(protocol.RunPage{}); err != nil {
+			t.Error(err)
+		}
 	}))
 	t.Cleanup(server.Close)
 	var stdout, stderr bytes.Buffer
@@ -463,4 +511,10 @@ func TestFactoryServerEnvironmentOverridesDefault(t *testing.T) {
 	if code != 0 || stdout.String() != "No Runs.\n" {
 		t.Fatalf("environment endpoint = %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
 	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("output is closed")
 }

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -122,6 +122,10 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
+	if code := Run(Options{Arguments: []string{"--server", server.URL, "status", "--cursor", "next_page-2"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
+		t.Fatalf("cursor status = %d, stderr %q", code, stderr.String())
+	}
+	stdout.Reset()
 	if code := Run(Options{Arguments: []string{"--server", server.URL, "--json", "status"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
 		t.Fatalf("JSON status = %d, stderr %q", code, stderr.String())
 	}
@@ -145,7 +149,7 @@ func TestFiniteCommandsUseLoopbackAPIWithHumanAndJSONOutput(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &workers); err != nil || len(workers.Workers) != 1 || workers.Workers[0].ID != worker.ID {
 		t.Fatalf("JSON workers = %#v, error %v", workers, err)
 	}
-	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50&view=summary,/api/v1/runs/run-1?view=summary,/api/v1/workers?view=summary,/api/v1/runs?limit=50&view=summary,/api/v1/runs/run-1,/api/v1/workers"; got != want {
+	if got, want := strings.Join(paths, ","), "/api/v1/runs?limit=50&view=summary,/api/v1/runs/run-1?view=summary,/api/v1/workers?view=summary,/api/v1/runs?cursor=next_page-2&limit=50&view=summary,/api/v1/runs?limit=50&view=summary,/api/v1/runs/run-1,/api/v1/workers"; got != want {
 		t.Fatalf("API paths = %q, want %q", got, want)
 	}
 }
@@ -460,6 +464,8 @@ func TestStartCommandsReturnUsefulUsageAndLookupErrors(t *testing.T) {
 		want      string
 	}{
 		{nil, 2, "a command is required"},
+		{[]string{"status", "extra"}, 2, "unexpected status arguments"},
+		{[]string{"status", "--cursor="}, 2, "--cursor requires a non-empty value"},
 		{[]string{"server"}, 2, "server requires the start command"},
 		{[]string{"worker", "start", "extra"}, 2, "unexpected worker start arguments"},
 		{[]string{"server", "start", "--config="}, 2, "--config requires a non-empty path"},
@@ -484,7 +490,7 @@ func TestHelpIsConciseAndDoesNotAdvertiseFutureCommands(t *testing.T) {
 	if code := Run(Options{Arguments: []string{"help"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
 		t.Fatalf("help = %d, stderr %q", code, stderr.String())
 	}
-	for _, want := range []string{"factory server start", "factory worker start", "factory [--server URL] [--json] status", "FACTORY_SERVER"} {
+	for _, want := range []string{"factory server start", "factory worker start", "factory [--server URL] [--json] status [--cursor CURSOR]", "FACTORY_SERVER"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("help %q does not contain %q", stdout.String(), want)
 		}

--- a/internal/factorycli/process_unix.go
+++ b/internal/factorycli/process_unix.go
@@ -1,0 +1,9 @@
+//go:build darwin || linux
+
+package factorycli
+
+import "syscall"
+
+func replaceProcess(path string, arguments, environment []string) error {
+	return syscall.Exec(path, arguments, environment)
+}

--- a/internal/factorycli/process_unsupported.go
+++ b/internal/factorycli/process_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package factorycli
+
+import "errors"
+
+func replaceProcess(string, []string, []string) error {
+	return errors.New("Factory process commands require macOS or Linux")
+}

--- a/internal/protocol/tasks.go
+++ b/internal/protocol/tasks.go
@@ -255,6 +255,26 @@ type RunDetail struct {
 	Sessions         []Session       `json:"sessions"`
 }
 
+type RunSummary struct {
+	ID         string              `json:"id"`
+	TaskName   string              `json:"task_name"`
+	State      RunState            `json:"state"`
+	Source     string              `json:"source"`
+	AdmittedAt time.Time           `json:"admitted_at"`
+	UpdatedAt  time.Time           `json:"updated_at"`
+	Sessions   []RunSessionSummary `json:"sessions"`
+}
+
+type RunSessionSummary struct {
+	ID                 string       `json:"id"`
+	RepositoryIdentity string       `json:"repository_identity"`
+	State              SessionState `json:"state"`
+	AssignedWorkerID   string       `json:"assigned_worker_id,omitempty"`
+	AttemptCount       int          `json:"attempt_count"`
+	Result             string       `json:"result,omitempty"`
+	FailureReason      string       `json:"failure_reason,omitempty"`
+}
+
 type RunPage struct {
 	Runs       []Run  `json:"runs"`
 	NextCursor string `json:"next_cursor,omitempty"`

--- a/internal/protocol/tasks.go
+++ b/internal/protocol/tasks.go
@@ -269,6 +269,7 @@ type RunSessionSummary struct {
 	ID                 string       `json:"id"`
 	RepositoryIdentity string       `json:"repository_identity"`
 	State              SessionState `json:"state"`
+	BlockedReason      string       `json:"blocked_reason,omitempty"`
 	AssignedWorkerID   string       `json:"assigned_worker_id,omitempty"`
 	AttemptCount       int          `json:"attempt_count"`
 	Result             string       `json:"result,omitempty"`

--- a/internal/protocol/tasks.go
+++ b/internal/protocol/tasks.go
@@ -403,6 +403,30 @@ type RunSummary struct {
 	Sessions   []RunSessionSummary `json:"sessions"`
 }
 
+type RunListSummary struct {
+	ID              string     `json:"id"`
+	TaskName        string     `json:"task_name"`
+	State           RunState   `json:"state"`
+	Source          string     `json:"source"`
+	NeedsAttention  bool       `json:"needs_attention"`
+	SessionCount    int        `json:"session_count"`
+	SucceededCount  int        `json:"succeeded_count"`
+	ReadyCount      int        `json:"ready_count"`
+	NeedsInputCount int        `json:"needs_input_count"`
+	NoChangeCount   int        `json:"no_change_count"`
+	FailedCount     int        `json:"failed_count"`
+	CancelledCount  int        `json:"cancelled_count"`
+	ActiveCount     int        `json:"active_count"`
+	AdmittedAt      time.Time  `json:"admitted_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	TerminalAt      *time.Time `json:"terminal_at,omitempty"`
+}
+
+type RunListPage struct {
+	Runs       []RunListSummary `json:"runs"`
+	NextCursor string           `json:"next_cursor,omitempty"`
+}
+
 type RunSessionSummary struct {
 	ID                 string       `json:"id"`
 	RepositoryIdentity string       `json:"repository_identity"`

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -172,6 +172,21 @@ type Worker struct {
 	LastHeartbeat              time.Time          `json:"last_heartbeat"`
 }
 
+type WorkerSummary struct {
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	Runtime       string    `json:"runtime"`
+	Capacity      int       `json:"capacity"`
+	ActiveCount   int       `json:"active_count"`
+	Health        string    `json:"health"`
+	Online        bool      `json:"online"`
+	LastHeartbeat time.Time `json:"last_heartbeat"`
+}
+
+type WorkerSummaryPage struct {
+	Workers []WorkerSummary `json:"workers"`
+}
+
 type WorkerEnrollment struct {
 	WorkerID        string    `json:"worker_id"`
 	EnrollmentToken string    `json:"enrollment_token"`

--- a/internal/releasebuilder/builder.go
+++ b/internal/releasebuilder/builder.go
@@ -167,10 +167,10 @@ func Build(ctx context.Context, options Options) error {
 			"-X", "github.com/owainlewis/factory/internal/buildinfo.Commit=" + options.Commit,
 		}, " ")
 		environment := releaseGoEnvironment("CGO_ENABLED=0", "GOOS="+target.OS, "GOARCH="+target.Arch)
-		if err := runCommand(ctx, root, environment, "go", "build", "-mod=readonly", "-trimpath", "-buildvcs=false", "-ldflags", ldflags, "-o", binaryDirectory, "./cmd/factory-server", "./cmd/factory-worker"); err != nil {
+		if err := runCommand(ctx, root, environment, "go", "build", "-mod=readonly", "-trimpath", "-buildvcs=false", "-ldflags", ldflags, "-o", binaryDirectory, "./cmd/factory", "./cmd/factory-server", "./cmd/factory-worker"); err != nil {
 			return err
 		}
-		for _, binary := range []string{"factory-server", "factory-worker"} {
+		for _, binary := range []string{"factory", "factory-server", "factory-worker"} {
 			if err := verifyBuildMetadata(ctx, filepath.Join(binaryDirectory, binary), target, options.Version, options.Commit); err != nil {
 				return err
 			}
@@ -178,6 +178,7 @@ func Build(ctx context.Context, options Options) error {
 		archiveName := archiveName(options.Version, target)
 		archivePath := filepath.Join(output, archiveName)
 		files := []archiveFile{
+			{name: "factory", path: filepath.Join(binaryDirectory, "factory"), mode: 0o755},
 			{name: "factory-server", path: filepath.Join(binaryDirectory, "factory-server"), mode: 0o755},
 			{name: "factory-worker", path: filepath.Join(binaryDirectory, "factory-worker"), mode: 0o755},
 			{name: "LICENSE", path: filepath.Join(root, "LICENSE"), mode: 0o644},
@@ -922,7 +923,7 @@ func Verify(ctx context.Context, repositoryRoot, directory, version, commit stri
 		return err
 	}
 	archiveDirectory := filepath.Join(extracted, archiveRoot(version, target))
-	for _, binary := range []string{"factory-server", "factory-worker"} {
+	for _, binary := range []string{"factory", "factory-server", "factory-worker"} {
 		path := filepath.Join(archiveDirectory, binary)
 		if err := verifyBuildMetadata(ctx, path, target, version, commit); err != nil {
 			return err

--- a/scripts/test-build.sh
+++ b/scripts/test-build.sh
@@ -63,7 +63,8 @@ mkdir -p "$temporary/home"
 
 test -x "$temporary/home/.factory/bin/factory-server"
 test -x "$temporary/home/.factory/bin/factory-worker"
-test "$(wc -l <"$temporary/default-go.log" | tr -d ' ')" = "2"
+test -x "$temporary/home/.factory/bin/factory"
+test "$(wc -l <"$temporary/default-go.log" | tr -d ' ')" = "3"
 
 set +e
 output=$(
@@ -170,8 +171,10 @@ PATH="$temporary/bin:/usr/bin:/bin" \
 
 test -x "$temporary/output/factory-server"
 test -x "$temporary/output/factory-worker"
+test -x "$temporary/output/factory"
 test ! -e "$temporary/output/factory-poller"
-test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "2"
+test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "3"
+grep -q 'build -o .*factory ./cmd/factory' "$temporary/go.log"
 grep -q 'build -o .*factory-server ./cmd/factory-server' "$temporary/go.log"
 grep -q 'build -o .*factory-worker ./cmd/factory-worker' "$temporary/go.log"
 
@@ -211,7 +214,7 @@ if ! printf '%s\n' "$output" |
   echo "$output" >&2
   exit 1
 fi
-test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "2"
+test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "3"
 
 mkdir -p "$temporary/ui-bin"
 cat >"$temporary/ui-bin/node" <<'EOF'

--- a/scripts/test-release.sh
+++ b/scripts/test-release.sh
@@ -42,6 +42,7 @@ if [ -n "$native" ]; then
   archive_root="factory_${version#v}_${native_os}_${native_arch}"
   mkdir -p "$temporary/rollback/archive" "$temporary/rollback/bin" "$temporary/rollback/state"
   tar -xzf "$temporary/first/$archive_root.tar.gz" -C "$temporary/rollback/archive"
+  install -m 0755 "$temporary/rollback/archive/$archive_root/factory" "$temporary/rollback/bin/factory"
   install -m 0755 "$temporary/rollback/archive/$archive_root/factory-server" "$temporary/rollback/bin/factory-server"
   install -m 0755 "$temporary/rollback/archive/$archive_root/factory-worker" "$temporary/rollback/bin/factory-worker"
   printf 'pre-upgrade database\n' > "$temporary/rollback/state/factory.sqlite3"
@@ -50,6 +51,7 @@ if [ -n "$native" ]; then
   mv "$temporary/rollback/state/factory.sqlite3" "$temporary/rollback/state/factory.sqlite3.failed"
   cp -p "$temporary/rollback/state/factory.sqlite3.before-upgrade" "$temporary/rollback/state/factory.sqlite3"
   cmp "$temporary/rollback/state/factory.sqlite3.before-upgrade" "$temporary/rollback/state/factory.sqlite3"
+  "$temporary/rollback/bin/factory" version | grep -F "$version" >/dev/null
   "$temporary/rollback/bin/factory-server" version | grep -F "$version" >/dev/null
   "$temporary/rollback/bin/factory-worker" version | grep -F "$commit" >/dev/null
 fi


### PR DESCRIPTION
## Summary

- add one `factory` command that starts the existing server or Worker and reads current Runs, Run details, and Workers from the loopback API
- provide stable human and JSON output, strict endpoint validation, redirect rejection, and safe terminal rendering
- ship the unified binary beside compatibility binaries in local and reproducible release builds, with current docs and architecture

## Verification

- `go test ./cmd/... ./internal/...`
- `GOTOOLCHAIN=go1.26.6 just check`
- `just test-worker-race` (192 Worker tests)
- `just test-release`
- real isolated smoke: start server and Worker through `factory`, query status and Workers in human and JSON modes, SIGTERM both, verify `worker_stopped` and `server_stopped` with no leaked process
- fresh independent review: Approve, no findings

Closes #340
Parent: #338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a unified `factory` command for starting the server or Worker.
  - Added table or JSON commands for run status, run details, and Worker availability.
  - Added concise, paginated run and Worker summary views, including status cursors and blocked-session details.
  - Added configuration-file and server endpoint options, plus version and help commands.

- **Release Improvements**
  - Release archives now include `factory` for Linux and macOS on amd64 and arm64.
  - Binaries report embedded version and source commit information.

- **Documentation**
  - Updated quick-start, architecture, local usage, and release documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->