### PR TITLE
feat: persist Work lifecycle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -333,9 +333,11 @@ admission path.
 - Only the embedded SQLite orchestration path exists.
 - Cloud Run execution profiles and elastic dispatch are designed but not
   implemented.
-- Durable agent-update fields exist, but the Worker-local update transport,
-  semantic completion, resumable questions, and operator Work commands are not
-  implemented yet. Existing execution remains process-exit based.
+- Durable agent-update fields, persistent-backend admission, and missing-outcome
+  failure enforcement exist. Worker-local Work-update transport, write
+  endpoints, successful semantic completion, resumable questions, and operator
+  Work commands are not implemented yet. Existing execution remains
+  process-exit-based.
 - Managed repository acquisition supports GitHub through `gh`.
 - The current Worker resolves a repository's base commit during Attempt
   preparation, so a later retry can observe a newer default branch commit.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,16 +2,9 @@
 
 > **Status:** Current implementation
 >
-> **Verification basis:** `origin/main` at commit `e767947`
->
-> **Future direction:** The proposed
-> [agent-directed software factory](docs/software-factory/design.md) adds
-> work-item admission and agent-owned semantic status while preserving the
-> current Worker lifecycle. The proposed
-> [Cloud Run agent backend](docs/cloud-run-agents/design.md) adds elastic
-> execution. This document describes only code that exists today.
+> **Verification basis:** implementation and tests in this repository
 
-## 1. Executive summary
+## Executive summary
 
 Factory is a local-first control plane for repeatable software-engineering
 agents. An operator saves a prompt and execution settings as a Task. Running
@@ -25,8 +18,8 @@ The implementation has three main parts:
   the embedded browser UI.
 - `factory-worker` owns runtime health, repository caches, worktrees, agent
   processes, and cleanup or retention.
-- SQLite stores Tasks, Runs, Sessions, executions, Attempts, events, Workers,
-  and repositories.
+- SQLite stores Tasks, Runs, Session-backed Work, durable Work updates,
+  executions, Attempts, events, Workers, and repositories.
 
 The operator API is loopback-only. Workers make outbound polling requests to
 the server. Remote VM Workers use a separate TLS listener and per-Worker bearer
@@ -38,7 +31,7 @@ artifacts, and credentials are not implemented yet. The contract keeps Factory
 as the source of truth and preserves the persistent Worker path as the built-in
 `persistent-auto` default.
 
-## 2. System context
+### System architecture
 
 ```text
 Operator browser
@@ -66,7 +59,20 @@ The control plane decides what should run and records what happened. A Worker
 decides how to execute one claim safely on its machine. The agent runtime is a
 child process and does not receive a control-plane operator credential.
 
-## 3. Current product model
+### Dependency hierarchy
+
+```text
+commands and browser -> HTTP API -> control-plane store -> SQLite
+factory-worker       -> typed protocol -> control-plane store
+factory-worker       -> runtime adapters -> agent child processes
+```
+
+Product and Worker code depend on `internal/protocol`. Worker code does not
+depend on `internal/controlplane`. Only the control plane writes lifecycle
+state to SQLite. Work is user-facing lifecycle truth. Execution and Attempt
+remain process and lease truth.
+
+## Current product model
 
 ### Task
 
@@ -77,29 +83,43 @@ A Task is a reusable definition containing:
 - timeout and per-Run concurrency limit;
 - one or more managed repositories;
 - optional cron schedule and IANA timezone;
-- mutable generation and archived state.
+- mutable generation and archived state;
+- an outcome contract: `process_exit` or `agent_update`.
 
 A Task may also save an execution-profile ID. Missing profile data means
 `persistent-auto`, so existing rows need no migration. Manual Run requests may
 override the saved profile; scheduled Runs use the saved default.
 
-Updates use an expected generation. Admission snapshots the Task so later
-edits do not change existing Runs. A manual run uses an idempotency key.
+Existing and newly created Tasks default to `process_exit`. An explicit
+conversion to `agent_update` increments the generation and requires the
+persistent backend. Updates use an expected generation. Admission snapshots
+the Task and outcome contract so later edits do not change existing Runs. A
+manual run uses an idempotency key.
 Scheduled admission polls every ten seconds and preserves the frozen pending
 snapshot while retrying a failed admission.
 
 ### Run and Session
 
-One Task admission creates one Run and one Session per selected repository.
-A Run stores the Task snapshot, immutable execution-profile version, backend,
-runtime, provider, model, timeout, resource class, commit-resolution policy,
-source (`manual` or `schedule`), schedule time, and aggregate state. A Session
-stores the same frozen execution choice with its resolved prompt, repository
-identity, assigned Worker, result, and failure state.
+One Task admission creates one Run and one Session-backed Work record per
+selected repository. A Run stores the Task snapshot, immutable execution
+profile version, backend, runtime, provider, model, timeout, resource class,
+commit-resolution policy, outcome contract, ordered target snapshot, source
+(`manual` or `schedule`), schedule time, and aggregate state. Work stores the
+same frozen execution choice with target identity, source reference, context,
+stable publish branch, repository identity, ownership, waiting reason,
+progress, checkpoint, pending resume, pull-request evidence, predecessor,
+result, and terminal fields.
 
-Session states are `blocked`, `queued`, `preparing`, `running`, `succeeded`,
-`failed`, and `cancelled`. Run state is derived from all Sessions as `blocked`,
-`queued`, `running`, `succeeded`, `failed`, `partial`, or `cancelled`.
+Work can represent `queued`, `running`, `needs-input`, `ready`, `succeeded`,
+`failed`, `no-change`, and `cancelled`. The backing Session table also retains
+the compatibility routing states `blocked` and `preparing`. Run state and
+counts are derived from Work as `blocked`, `queued`, `running`, `succeeded`,
+`failed`, `partial`, or `cancelled`.
+
+Work updates store typed status, actor, request, Attempt, sequence, message,
+checkpoint, and pull-request fields. Storage allows at most 199 progress
+updates and reserves one outcome update per Attempt. Progress messages are at
+most 2 KiB and outcome messages are at most 8 KiB.
 
 A Session starts blocked when no eligible Worker can currently accept it. A
 later claim can route it when a healthy Worker advertises the runtime and
@@ -135,7 +155,7 @@ Workers clone them on demand with `gh`, keep at most 100 cache entries, fetch
 before an Attempt, and resolve the current base branch and commit. Legacy
 static repository paths remain readable through Worker configuration.
 
-## 4. Architectural invariants
+## Architectural invariants
 
 1. SQLite and the control plane are the authority for Run and Attempt state.
 2. A claim is assigned only to its selected, healthy, online Worker with a ready
@@ -155,12 +175,15 @@ static repository paths remain readable through Worker configuration.
 8. Plain HTTP accepts loopback clients only. Remote Workers require TLS,
    one-time enrollment bound to a stable Worker ID, and a stored bearer
    credential.
-9. Task admission snapshots prompt, runtime, repositories, timeout,
-   concurrency, generation, and schedule context.
+9. Task admission snapshots prompt, runtime, ordered targets, timeout,
+   concurrency, generation, outcome contract, execution choice, and schedule
+   context.
 10. Operator builds embed committed `web/dist` assets and do not require Node.js
     at runtime.
+11. Claim protocol version 3 gates every persistent Worker claim. Older Workers
+    receive `worker_upgrade_required`, including for process-exit Work.
 
-## 5. Components
+## Components
 
 ### Control plane
 
@@ -223,14 +246,16 @@ the same-origin API.
 uses an SPA fallback, immutable caching for versioned assets, and restrictive
 security headers. Node.js is needed only when UI source changes.
 
-## 6. Critical flows
+## Critical flows
 
 ### Task admission
 
 1. The operator runs a Task with a request key, or the scheduler claims a
    due occurrence.
-2. The server freezes the Task generation and repository list.
-3. One Run and one Session per repository are inserted transactionally.
+2. The server freezes the Task generation, outcome contract, execution choice,
+   and ordered target list.
+3. One Run and one Session-backed Work record per repository are inserted
+   transactionally.
 4. Routing selects compatible Workers where possible. Unroutable Sessions stay
    blocked with a reason.
 5. The same manual request key or scheduled occurrence cannot admit duplicate
@@ -265,7 +290,7 @@ Only failed or cancelled Sessions can be retried. Retry preserves the Session
 and Attempt history, selects a currently eligible Worker, and creates the next
 Attempt when claimed.
 
-## 7. API and security boundaries
+## API and security boundaries
 
 The local listener exposes health plus operator and Worker routes under
 `/api/v1`: Workers, repositories, Tasks, Runs, overview, Attempts, and event
@@ -282,53 +307,35 @@ Agents may execute repository code using credentials already available on the
 Worker host. Worktrees isolate Git state, not hostile code. The product must not
 describe a Worker as a security sandbox.
 
-## 8. Persistence and migration
+## Persistence and migration
 
 Migrations are embedded from `migrations/` and applied in order. Migration 27
-introduces the current lifecycle model. Migration 28 adds the current
-single-claim protocol and rejects incompatible old Workers; that protocol is at
-version 2, because the claim payload replaced its target field with a Session.
-Migration 30 renames the operator model to Tasks, Runs, and Sessions without
-changing behaviour, and refuses to apply if the new table names are already in
-use. Supported legacy
+introduces the current lifecycle model. Migration 28 adds the single-claim
+protocol and rejects incompatible old Workers. Migration 30 renames the
+operator model to Tasks, Runs, and Sessions without changing behaviour, and
+refuses to apply if the new table names are already in use. Migration 31 adds
+the durable Work lifecycle, ordered Run targets, outcome contracts, bounded
+Work updates, and claim protocol version 3. It preserves existing rows as
+`process_exit`. Supported legacy
 Definitions, schedules, repositories, and execution history are converted;
 unsupported legacy provider admission is blocked and reported rather than
 silently discarded.
 
 Current lifecycle tables include `tasks`, `task_repositories`, `runs`,
-`sessions`, `executions`, `attempts`, `attempt_events`, `workers`,
+`sessions`, `work_updates`, `executions`, `attempts`, `attempt_events`, `workers`,
 `repositories`, Worker repository state, claim request deduplication, and
 Worker enrollment or credentials. Older migration tables may remain for
 history and upgrade compatibility but are not part of the current UI or
 admission path.
 
-## 9. Future execution backend boundary
-
-The product direction separates three choices:
-
-| Choice | Current | Proposed |
-| --- | --- | --- |
-| Execution backend | Persistent local or VM Worker | Cloud Run Job |
-| Agent runtime | Pi, Codex, Claude Code | Same runtime contract |
-| Provider and model | Local subscription or API access | API-backed access |
-
-Persistent Workers remain the best path for subscription sessions, warm
-caches, and inspectable worktrees. Cloud Run is intended for bursty parallel
-Runs where a disposable container and API-backed model are acceptable.
-
-The proposed adapter does not make Cloud Run the scheduler or database.
-Factory still owns frozen input, Attempt identity, retry, cancellation, events,
-cost history, and the terminal result. Cloud Run owns disposable compute. A
-verified patch or Git recovery artifact replaces the retained-worktree
-guarantee for ephemeral execution. See the
-[Cloud Run design](docs/cloud-run-agents/design.md) for dispatch fencing,
-outbound control, least-privilege identity, failure recovery, and rollout.
-
-## 10. Known limitations
+## Known limitations
 
 - Only the embedded SQLite orchestration path exists.
 - Cloud Run execution profiles and elastic dispatch are designed but not
   implemented.
+- Durable agent-update fields exist, but the Worker-local update transport,
+  semantic completion, resumable questions, and operator Work commands are not
+  implemented yet. Existing execution remains process-exit based.
 - Managed repository acquisition supports GitHub through `gh`.
 - The current Worker resolves a repository's base commit during Attempt
   preparation, so a later retry can observe a newer default branch commit.
@@ -337,13 +344,13 @@ outbound control, least-privilege identity, failure recovery, and rollout.
 - Execution isolates worktrees and process groups but does not sandbox hostile
   repository code or network egress.
 
-## 11. Source map
+## Source map
 
 | Area | Primary files |
 | --- | --- |
 | Server startup and config | `cmd/factory-server/main.go`, `cmd/factory-server/config.go` |
 | HTTP routes and auth | `internal/controlplane/http.go`, `internal/controlplane/worker_auth.go` |
-| Task and Run model | `internal/controlplane/tasks.go`, `internal/protocol/tasks.go` |
+| Task, Run, and Work model | `internal/controlplane/tasks.go`, `internal/controlplane/work.go`, `internal/protocol/tasks.go` |
 | Schedule admission | `internal/controlplane/task_scheduler.go`, `internal/controlplane/schedule_cron.go` |
 | Routing and claims | `internal/controlplane/task_claim.go`, `internal/controlplane/state.go` |
 | Lease sweep and recovery | `internal/controlplane/server.go`, `internal/controlplane/recovery.go` |
@@ -351,5 +358,14 @@ outbound control, least-privilege identity, failure recovery, and rollout.
 | Attempt execution | `internal/worker/attempt_lifecycle.go`, `internal/worker/supervisor.go`, `internal/worker/events.go` |
 | Git and worktrees | `internal/worker/git.go`, `internal/worker/repository_cache.go`, `internal/worker/reconcile.go` |
 | Protocol limits and types | `internal/protocol/types.go`, `internal/protocol/prompt.go` |
-| Schema | `migrations/027_routines_work.sql`, `migrations/028_work_claim_protocol.sql`, `migrations/030_task_run_session.sql` |
+| Schema | `migrations/027_routines_work.sql`, `migrations/030_task_run_session.sql`, `migrations/031_work_lifecycle.sql` |
 | Browser UI | `web/src/App.tsx`, `web/src/Tasks.tsx`, `web/src/Runs.tsx`, `web/src/Workers.tsx`, `web/src/Repositories.tsx` |
+
+## Verification
+
+`internal/controlplane/work_lifecycle_test.go` proves outcome-contract freezing,
+backend compatibility, Work states, bounded update history, replacement guards,
+ordered targets, and legacy prompt limits. `tasks_migration_test.go` opens
+populated historical databases and proves identity, lifecycle, scheduled
+process-exit completion, and foreign-key preservation. Repository-wide proof is
+provided by `just format-check`, `just vet`, `just boundary`, and `just test`.

--- a/internal/controlplane/execution_profiles_test.go
+++ b/internal/controlplane/execution_profiles_test.go
@@ -371,7 +371,8 @@ func TestFakeCloudCancellationIsFactoryOwned(t *testing.T) {
 		t.Fatal(err)
 	}
 	run, _ = store.Run(context.Background(), run.Run.ID)
-	if run.Run.State != protocol.RunCancelled || run.Sessions[0].Attempts[0].State != "cancelled" {
+	if run.Run.State != protocol.RunCancelled || run.Sessions[0].Attempts[0].State != "cancelled" ||
+		run.Sessions[0].TerminalMessage != "Cancelled by operator." {
 		t.Fatalf("cancelled fake Attempt = %#v", run)
 	}
 }
@@ -411,6 +412,7 @@ func TestFakeCloudRunningAttemptHonorsFrozenTimeout(t *testing.T) {
 	}
 	run, _ = store.Run(context.Background(), run.Run.ID)
 	if run.Run.State != protocol.RunFailed || run.Sessions[0].FailureReason != fakeCloudTimeoutReason ||
+		run.Sessions[0].TerminalMessage != fakeCloudTimeoutReason ||
 		len(run.Sessions[0].Attempts) != 1 || run.Sessions[0].Attempts[0].State != "failed" {
 		t.Fatalf("timed-out fake Attempt = %#v", run)
 	}

--- a/internal/controlplane/execution_profiles_test.go
+++ b/internal/controlplane/execution_profiles_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/owainlewis/factory/internal/protocol"
 )
@@ -493,9 +494,10 @@ func TestUnhealthyAndIncompatibleProfilesBlockWithoutAttempt(t *testing.T) {
 	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
 		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
 	})
+	healthReason := strings.Repeat("🧪", protocol.MaxWaitingReasonBytes/2+1)
 	unhealthy, err := store.CreateExecutionProfile(context.Background(), protocol.SaveExecutionProfileRequest{
 		Name: "Unhealthy cloud", Kind: protocol.BackendFakeCloudRun, Runtime: protocol.RuntimeCodex,
-		Provider: "openrouter", Model: "test", Enabled: true, Healthy: false, HealthReason: "model secret missing",
+		Provider: "openrouter", Model: "test", Enabled: true, Healthy: false, HealthReason: healthReason,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -505,7 +507,7 @@ func TestUnhealthyAndIncompatibleProfilesBlockWithoutAttempt(t *testing.T) {
 	for _, test := range []struct {
 		key, profile, reason string
 	}{
-		{key: "unhealthy", profile: unhealthy.ID, reason: "model secret missing"},
+		{key: "unhealthy", profile: unhealthy.ID, reason: healthReason},
 		{key: "incompatible", profile: incompatible.ID, reason: "does not support runtime codex"},
 	} {
 		run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
@@ -517,6 +519,11 @@ func TestUnhealthyAndIncompatibleProfilesBlockWithoutAttempt(t *testing.T) {
 		if run.Run.State != protocol.RunBlocked || len(run.Sessions[0].Attempts) != 0 ||
 			run.Sessions[0].AssignedWorkerID != "" || !strings.Contains(run.Sessions[0].BlockedReason, test.reason) {
 			t.Fatalf("blocked profile Run = %#v", run)
+		}
+		if len([]byte(run.Sessions[0].WaitingReason)) > protocol.MaxWaitingReasonBytes ||
+			!utf8.ValidString(run.Sessions[0].WaitingReason) {
+			t.Fatalf("waiting reason bytes=%d valid=%v", len([]byte(run.Sessions[0].WaitingReason)),
+				utf8.ValidString(run.Sessions[0].WaitingReason))
 		}
 	}
 }

--- a/internal/controlplane/fake_cloud.go
+++ b/internal/controlplane/fake_cloud.go
@@ -77,7 +77,8 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 		ORDER BY attempt.created_at, attempt.id LIMIT 1
 	`).Scan(&cancelledAttempt, &cancelledExecution)
 	if err == nil {
-		if err := completeFakeCloudAttempt(ctx, tx, cancelledAttempt, cancelledExecution, "cancelled", "", "Cancelled by operator.", now); err != nil {
+		if err := completeFakeCloudAttempt(ctx, tx, cancelledAttempt, cancelledExecution,
+			"cancelled", "", "Cancelled by operator.", "Cancelled by operator.", now); err != nil {
 			return false, err
 		}
 		if err := tx.Commit(); err != nil {
@@ -103,7 +104,8 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 		ORDER BY attempt.started_at, attempt.id LIMIT 1
 	`, now).Scan(&timedOutAttempt, &timedOutExecution)
 	if err == nil {
-		if err := completeFakeCloudAttempt(ctx, tx, timedOutAttempt, timedOutExecution, "failed", "", fakeCloudTimeoutReason, now); err != nil {
+		if err := completeFakeCloudAttempt(ctx, tx, timedOutAttempt, timedOutExecution,
+			"failed", "", fakeCloudTimeoutReason, fakeCloudTimeoutReason, now); err != nil {
 			return false, err
 		}
 		if err := tx.Commit(); err != nil {
@@ -253,7 +255,7 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 		return false, unavailable(err)
 	}
 	if outcome == "succeeded" || outcome == "failed" {
-		if err := completeFakeCloudAttempt(ctx, tx, attemptID, executionID, outcome, result, failure, now); err != nil {
+		if err := completeFakeCloudAttempt(ctx, tx, attemptID, executionID, outcome, result, failure, "", now); err != nil {
 			return false, err
 		}
 	}
@@ -273,7 +275,7 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 func completeFakeCloudAttempt(
 	ctx context.Context,
 	tx *sql.Tx,
-	attemptID, executionID, state, result, failure string,
+	attemptID, executionID, state, result, failure, terminalMessage string,
 	now int64,
 ) error {
 	if _, err := tx.ExecContext(ctx, `
@@ -291,10 +293,10 @@ func completeFakeCloudAttempt(
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE sessions SET state = ?, cancellation_requested = CASE WHEN ? = 'cancelled' THEN 1 ELSE cancellation_requested END,
 		       terminal_at = ?, result = ?, failure_reason = ?,
-		       terminal_message = '', execution_owner = 'none'
+		       terminal_message = ?, execution_owner = 'none'
 		WHERE id = (SELECT session_id FROM executions WHERE id = ?)
 		  AND state IN ('preparing','running')
-	`, state, state, now, nullString(result), nullString(failure), executionID); err != nil {
+	`, state, state, now, nullString(result), nullString(failure), terminalMessage, executionID); err != nil {
 		return unavailable(err)
 	}
 	if _, err := tx.ExecContext(ctx, `

--- a/internal/controlplane/fake_cloud.go
+++ b/internal/controlplane/fake_cloud.go
@@ -169,7 +169,8 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 			return false, unavailable(err)
 		}
 		released, err := tx.ExecContext(ctx, `
-			UPDATE sessions SET state = 'queued', blocked_reason = NULL, assigned_worker_id = ? WHERE id = ?
+				UPDATE sessions SET state = 'queued', blocked_reason = NULL, assigned_worker_id = ?,
+				       waiting_reason = '', execution_owner = 'none' WHERE id = ?
 			  AND state = 'blocked'
 		`, workerID, blockedSession)
 		if err != nil {
@@ -244,7 +245,11 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 	if _, err := tx.ExecContext(ctx, `UPDATE executions SET state = 'running', updated_at = ? WHERE id = ? AND state = 'queued'`, now, executionID); err != nil {
 		return false, unavailable(err)
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE sessions SET state = 'running', started_at = COALESCE(started_at, ?) WHERE id = ? AND state = 'queued'`, now, sessionID); err != nil {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE sessions SET state = 'running', started_at = COALESCE(started_at, ?),
+		       execution_owner = 'worker_attempt'
+		WHERE id = ? AND state = 'queued'
+	`, now, sessionID); err != nil {
 		return false, unavailable(err)
 	}
 	if outcome == "succeeded" || outcome == "failed" {
@@ -285,7 +290,8 @@ func completeFakeCloudAttempt(
 	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE sessions SET state = ?, cancellation_requested = CASE WHEN ? = 'cancelled' THEN 1 ELSE cancellation_requested END,
-		       terminal_at = ?, result = ?, failure_reason = ?
+		       terminal_at = ?, result = ?, failure_reason = ?,
+		       terminal_message = '', execution_owner = 'none'
 		WHERE id = (SELECT session_id FROM executions WHERE id = ?)
 		  AND state IN ('preparing','running')
 	`, state, state, now, nullString(result), nullString(failure), executionID); err != nil {

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -27,6 +27,27 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 		return nil, unavailable(err)
 	}
 	defer tx.Rollback()
+	var capacity, healthy, claimProtocolVersion, synthetic int
+	var lastHeartbeat int64
+	err = tx.QueryRowContext(ctx, `
+		SELECT capacity, health = 'healthy', last_heartbeat, claim_protocol_version, synthetic
+		FROM workers WHERE id = ?
+	`, workerID).Scan(&capacity, &healthy, &lastHeartbeat, &claimProtocolVersion, &synthetic)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, unavailable(err)
+	}
+	if synthetic != 0 {
+		return nil, conflict("synthetic_worker_isolated", "synthetic cloud Workers cannot use Worker claim routes")
+	}
+	if claimProtocolVersion != protocol.ClaimProtocolVersion {
+		return nil, conflict(
+			"worker_upgrade_required",
+			"the Worker uses an incompatible claim protocol; upgrade it before claiming a Session",
+		)
+	}
 
 	var storedDigest []byte
 	var storedAttempt sql.NullString
@@ -72,27 +93,6 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 		return nil, unavailable(err)
 	}
 
-	var capacity, healthy, claimProtocolVersion, synthetic int
-	var lastHeartbeat int64
-	err = tx.QueryRowContext(ctx, `
-		SELECT capacity, health = 'healthy', last_heartbeat, claim_protocol_version, synthetic
-		FROM workers WHERE id = ?
-	`, workerID).Scan(&capacity, &healthy, &lastHeartbeat, &claimProtocolVersion, &synthetic)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, unavailable(err)
-	}
-	if synthetic != 0 {
-		return nil, conflict("synthetic_worker_isolated", "synthetic cloud Workers cannot use Worker claim routes")
-	}
-	if claimProtocolVersion != protocol.ClaimProtocolVersion {
-		return nil, conflict(
-			"worker_upgrade_required",
-			"the Worker uses an incompatible claim protocol; upgrade it before claiming a Session",
-		)
-	}
 	var active int
 	if err := tx.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM attempts
@@ -212,7 +212,8 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 		return nil, conflict("claim_conflict", "execution is no longer queued")
 	}
 	if _, err := tx.ExecContext(ctx, `
-		UPDATE sessions SET state = 'preparing', assigned_worker_id = ?, blocked_reason = NULL
+		UPDATE sessions SET state = 'preparing', assigned_worker_id = ?, blocked_reason = NULL,
+		       waiting_reason = '', execution_owner = 'worker_attempt'
 		WHERE id = (SELECT session_id FROM executions WHERE id = ?) AND state = 'queued'
 	`, workerID, executionID); err != nil {
 		return nil, unavailable(err)
@@ -274,7 +275,11 @@ func (s *Store) claimDetail(ctx context.Context, attemptID string) (protocol.Cla
 	row = s.db.QueryRowContext(ctx, `
 		SELECT session.id, session.run_id, json_extract(run.task_snapshot, '$.name'),
 		       session.resolved_prompt, session.repository_id, session.timeout_seconds,
-		       e.assigned_worker_id, e.required_runtime, e.state, session.admitted_at
+		       e.assigned_worker_id, e.required_runtime, e.state, session.admitted_at,
+		       run.outcome_contract, session.target_position, session.target_key,
+		       session.target_kind, session.repository_identity, session.source_kind,
+		       session.source_key, session.source_reference, session.context_snapshot,
+		       session.publish_branch
 		FROM sessions session
 		JOIN runs run ON run.id = session.run_id
 		JOIN executions e ON e.session_id = session.id
@@ -284,10 +289,16 @@ func (s *Store) claimDetail(ctx context.Context, attemptID string) (protocol.Cla
 	if err = row.Scan(&claim.Session.ID, &claim.Session.RunID, &claim.Session.TaskName,
 		&claim.Session.Prompt, &claim.Session.RepositoryID, &claim.Session.TimeoutSeconds,
 		&claim.Session.WorkerID, &claim.Session.RequiredRuntime, &claim.Session.State,
-		&admittedAt); err != nil {
+		&admittedAt, &claim.Session.OutcomeContract, &claim.Session.Target.Position,
+		&claim.Session.Target.TargetKey, &claim.Session.Target.TargetKind,
+		&claim.Session.Target.RepositoryIdentity, &claim.Session.Target.SourceKind,
+		&claim.Session.Target.SourceKey, &claim.Session.Target.SourceReference,
+		&claim.Session.Target.ContextSnapshot, &claim.Session.Target.PublishBranch); err != nil {
 		return claim, unavailable(err)
 	}
 	claim.Session.AdmittedAt = fromMillis(admittedAt)
+	claim.Session.Target.ID = claim.Session.ID
+	claim.Session.Target.RepositoryID = claim.Session.RepositoryID
 	err = s.db.QueryRowContext(ctx, `
 		SELECT r.id, wr.display_key,
 		       COALESCE(
@@ -378,7 +389,8 @@ func (s *Store) StartAttempt(ctx context.Context, attemptID string, input protoc
 			return protocol.Attempt{}, unavailable(err)
 		}
 		if _, err := tx.ExecContext(ctx, `
-			UPDATE sessions SET state = 'running', started_at = COALESCE(started_at, ?)
+			UPDATE sessions SET state = 'running', started_at = COALESCE(started_at, ?),
+			       execution_owner = 'worker_attempt'
 			WHERE id = (SELECT session_id FROM executions WHERE id = ?) AND state = 'preparing'
 		`, now, lease.executionID); err != nil {
 			return protocol.Attempt{}, unavailable(err)
@@ -612,7 +624,9 @@ func (s *Store) CompleteAttempt(ctx context.Context, attemptID string, input pro
 		return protocol.Attempt{}, unavailable(err)
 	}
 	if _, err := tx.ExecContext(ctx, `
-		UPDATE sessions SET state = ?, terminal_at = ?, result = ?, failure_reason = ?
+		UPDATE sessions SET state = ?, terminal_at = ?, result = ?, failure_reason = ?,
+		       terminal_message = '',
+		       execution_owner = 'none'
 		WHERE id = (SELECT session_id FROM executions WHERE id = ?)
 		  AND state IN ('preparing', 'running')
 	`, input.State, now, nullString(input.Result), nullString(input.Error), lease.executionID); err != nil {
@@ -709,7 +723,8 @@ func (s *Store) SweepExpired(ctx context.Context) ([]ExpiredLease, error) {
 				return nil, unavailable(err)
 			}
 			if _, err := tx.ExecContext(ctx, `
-				UPDATE sessions SET state = 'failed', terminal_at = ?, failure_reason = 'lease expired'
+				UPDATE sessions SET state = 'failed', terminal_at = ?, failure_reason = 'lease expired',
+				       terminal_message = 'lease expired', execution_owner = 'none'
 				WHERE id = (SELECT session_id FROM executions WHERE id = ?)
 				  AND state IN ('preparing', 'running')
 			`, now, value.ExecutionID); err != nil {

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -320,22 +320,28 @@ func (s *Store) claimDetail(ctx context.Context, attemptID string) (protocol.Cla
 }
 
 type leaseState struct {
-	attemptState   string
-	executionID    string
-	executionState string
-	digest         []byte
-	expiry         int64
-	cancel         bool
+	attemptState    string
+	executionID     string
+	executionState  string
+	outcomeContract protocol.OutcomeContract
+	digest          []byte
+	expiry          int64
+	cancel          bool
 }
 
 func loadLease(ctx context.Context, tx *sql.Tx, attemptID string) (leaseState, error) {
 	var value leaseState
 	var cancel int
 	err := tx.QueryRowContext(ctx, `
-		SELECT a.state, a.execution_id, e.state, a.lease_digest, a.lease_expires_at, e.cancellation_requested
-		FROM attempts a JOIN executions e ON e.id = a.execution_id
+		SELECT a.state, a.execution_id, e.state, run.outcome_contract,
+		       a.lease_digest, a.lease_expires_at, e.cancellation_requested
+		FROM attempts a
+		JOIN executions e ON e.id = a.execution_id
+		JOIN sessions session ON session.id = e.session_id
+		JOIN runs run ON run.id = session.run_id
 		WHERE a.id = ?
-	`, attemptID).Scan(&value.attemptState, &value.executionID, &value.executionState, &value.digest, &value.expiry, &cancel)
+	`, attemptID).Scan(&value.attemptState, &value.executionID, &value.executionState,
+		&value.outcomeContract, &value.digest, &value.expiry, &cancel)
 	if errors.Is(err, sql.ErrNoRows) {
 		return value, ErrNotFound
 	}
@@ -608,6 +614,15 @@ func (s *Store) CompleteAttempt(ctx context.Context, attemptID string, input pro
 	if err := verifyActiveLease(lease, input.LeaseToken, now); err != nil {
 		return protocol.Attempt{}, err
 	}
+	terminalMessage := ""
+	if lease.cancel {
+		input.State, input.Result, input.Error = "cancelled", "", ""
+		terminalMessage = "Cancelled by operator."
+	} else if lease.outcomeContract == protocol.OutcomeAgentUpdate && input.State == "succeeded" {
+		const missingOutcome = "Agent exited without reporting an outcome."
+		input.State, input.Result, input.Error = "failed", "", missingOutcome
+		terminalMessage = missingOutcome
+	}
 	if input.State == "succeeded" && lease.attemptState != "running" {
 		return protocol.Attempt{}, conflict("invalid_transition", "only a running attempt can succeed")
 	}
@@ -625,11 +640,11 @@ func (s *Store) CompleteAttempt(ctx context.Context, attemptID string, input pro
 	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE sessions SET state = ?, terminal_at = ?, result = ?, failure_reason = ?,
-		       terminal_message = '',
+		       terminal_message = ?,
 		       execution_owner = 'none'
 		WHERE id = (SELECT session_id FROM executions WHERE id = ?)
 		  AND state IN ('preparing', 'running')
-	`, input.State, now, nullString(input.Result), nullString(input.Error), lease.executionID); err != nil {
+	`, input.State, now, nullString(input.Result), nullString(input.Error), terminalMessage, lease.executionID); err != nil {
 		return protocol.Attempt{}, unavailable(err)
 	}
 	if err := updateRunLifecycle(ctx, tx, lease.executionID, now); err != nil {

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -1126,7 +1126,8 @@ func (s *Store) SetManagedRepositoryEnabled(
 		}
 		if _, err := tx.ExecContext(ctx, `
 			UPDATE sessions SET state = 'blocked', assigned_worker_id = NULL,
-			       blocked_reason = 'Repository is disabled.'
+			       blocked_reason = 'Repository is disabled.',
+			       waiting_reason = 'Repository is disabled.', execution_owner = 'none'
 			WHERE repository_id = ? AND state = 'queued'
 		`, repositoryID); err != nil {
 			return protocol.ManagedRepository{}, unavailable(err)

--- a/internal/controlplane/task_claim.go
+++ b/internal/controlplane/task_claim.go
@@ -75,7 +75,8 @@ func (s *Store) materializeBlockedSessionForWorker(
 				return unavailable(err)
 			}
 			result, err := tx.ExecContext(ctx, `
-				UPDATE sessions SET state = 'queued', blocked_reason = NULL, assigned_worker_id = ?
+				UPDATE sessions SET state = 'queued', blocked_reason = NULL, assigned_worker_id = ?,
+				       waiting_reason = '', execution_owner = 'none'
 				WHERE id = ? AND state = 'blocked'
 			`, selection.workerID, value.id)
 			if err != nil {
@@ -190,7 +191,7 @@ func updateRunLifecycle(ctx context.Context, tx *sql.Tx, executionID string, now
 			WHEN NOT EXISTS (
 				SELECT 1 FROM sessions session
 				WHERE session.run_id = runs.id
-				  AND session.state IN ('blocked','queued','preparing','running')
+				  AND session.state IN ('blocked','queued','preparing','running','needs-input')
 			) THEN ? ELSE NULL END
 		WHERE id = ?
 	`, now, now, runID); err != nil {

--- a/internal/controlplane/task_scheduler.go
+++ b/internal/controlplane/task_scheduler.go
@@ -127,10 +127,11 @@ func loadCurrentTaskSnapshot(ctx context.Context, tx *sql.Tx, id string) (protoc
 	var snapshot protocol.TaskSnapshot
 	err := tx.QueryRowContext(ctx, `
 		SELECT id, name, prompt, runtime, COALESCE(execution_profile_id, ''), timeout_seconds, concurrency_limit, generation,
-		       cron, timezone
+		       outcome_contract, cron, timezone
 		FROM tasks WHERE id = ?
 	`, id).Scan(&snapshot.ID, &snapshot.Name, &snapshot.Prompt, &snapshot.Runtime,
 		&snapshot.ExecutionProfileID, &snapshot.TimeoutSeconds, &snapshot.ConcurrencyLimit, &snapshot.Generation,
+		&snapshot.OutcomeContract,
 		&snapshot.ScheduleCron, &snapshot.ScheduleTimezone)
 	if err != nil {
 		return snapshot, unavailable(err)
@@ -165,6 +166,9 @@ func loadPendingTaskSnapshot(ctx context.Context, tx *sql.Tx, id string, encoded
 	}
 	if snapshot.ID == "" {
 		snapshot.ID = id
+	}
+	if snapshot.OutcomeContract == "" {
+		snapshot.OutcomeContract = protocol.OutcomeProcessExit
 	}
 	if len(snapshot.Repositories) != 0 {
 		return snapshot, nil

--- a/internal/controlplane/tasks.go
+++ b/internal/controlplane/tasks.go
@@ -72,6 +72,7 @@ type normalizedTask struct {
 	cron               string
 	timezone           string
 	nextDueAt          *time.Time
+	outcomeContract    protocol.OutcomeContract
 }
 
 func normalizeTask(input protocol.SaveTaskRequest, now time.Time) (normalizedTask, error) {
@@ -86,6 +87,7 @@ func normalizeTask(input protocol.SaveTaskRequest, now time.Time) (normalizedTas
 		scheduleEnabled:    input.Schedule.Enabled,
 		cron:               strings.TrimSpace(input.Schedule.Cron),
 		timezone:           strings.TrimSpace(input.Schedule.Timezone),
+		outcomeContract:    protocol.OutcomeContract(strings.TrimSpace(string(input.OutcomeContract))),
 	}
 	value.nameKey = normalizeTitleKey(value.name)
 	if value.executionProfileID == protocol.PersistentAutoProfileID {
@@ -102,6 +104,10 @@ func normalizeTask(input protocol.SaveTaskRequest, now time.Time) (normalizedTas
 	}
 	if !protocol.SupportedRuntime(value.runtime) {
 		return value, invalid("invalid_task_runtime", "runtime is not supported")
+	}
+	if value.outcomeContract != "" && value.outcomeContract != protocol.OutcomeProcessExit &&
+		value.outcomeContract != protocol.OutcomeAgentUpdate {
+		return value, invalid("invalid_outcome_contract", "outcome_contract must be process_exit or agent_update")
 	}
 	if value.timeoutSeconds == 0 {
 		value.timeoutSeconds = int(defaultTaskTimeout.Seconds())
@@ -168,6 +174,9 @@ func (s *Store) CreateTask(ctx context.Context, input protocol.SaveTaskRequest) 
 		return protocol.Task{}, unavailable(err)
 	}
 	defer tx.Rollback()
+	if value.outcomeContract == "" {
+		value.outcomeContract = protocol.OutcomeProcessExit
+	}
 	var count int
 	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM tasks WHERE migration_only = 0 AND read_only = 0`).Scan(&count); err != nil {
 		return protocol.Task{}, unavailable(err)
@@ -179,6 +188,9 @@ func (s *Store) CreateTask(ctx context.Context, input protocol.SaveTaskRequest) 
 		return protocol.Task{}, err
 	}
 	if err := validateTaskExecutionProfile(ctx, tx, value.executionProfileID); err != nil {
+		return protocol.Task{}, err
+	}
+	if err := validateOutcomeContractBackend(ctx, tx, value.outcomeContract, value.executionProfileID); err != nil {
 		return protocol.Task{}, err
 	}
 	id, err := newID()
@@ -193,11 +205,11 @@ func (s *Store) CreateTask(ctx context.Context, input protocol.SaveTaskRequest) 
 	_, err = tx.ExecContext(ctx, `
 		INSERT INTO tasks(
 			id, name, name_key, prompt, runtime, timeout_seconds,
-			concurrency_limit, execution_profile_id, generation, archived, migration_only, schedule_enabled,
+			concurrency_limit, execution_profile_id, outcome_contract, generation, archived, migration_only, schedule_enabled,
 			cron, timezone, next_due_at, schedule_health_status, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 0, 0, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, 0, ?, ?, ?, ?, ?, ?, ?)
 	`, id, value.name, value.nameKey, value.prompt, value.runtime, value.timeoutSeconds,
-		value.concurrencyLimit, nullableString(value.executionProfileID), value.scheduleEnabled, nullableString(value.cron), nullableString(value.timezone),
+		value.concurrencyLimit, nullableString(value.executionProfileID), value.outcomeContract, value.scheduleEnabled, nullableString(value.cron), nullableString(value.timezone),
 		next, taskScheduleHealth(value.scheduleEnabled), now, now)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE") {
@@ -234,13 +246,14 @@ func (s *Store) UpdateTask(ctx context.Context, id string, input protocol.SaveTa
 		return protocol.Task{}, err
 	}
 	var archived, migrationOnly, readOnly int
+	var currentOutcome protocol.OutcomeContract
 	var pendingDue, scheduleRetry sql.NullInt64
 	var scheduleHealthStatus, scheduleHealthCode string
 	err = tx.QueryRowContext(ctx, `
-		SELECT archived, migration_only, read_only, pending_due_at, schedule_retry_at,
+		SELECT archived, migration_only, read_only, outcome_contract, pending_due_at, schedule_retry_at,
 		       schedule_health_status, schedule_health_code
 		FROM tasks WHERE id = ?
-	`, id).Scan(&archived, &migrationOnly, &readOnly, &pendingDue, &scheduleRetry,
+	`, id).Scan(&archived, &migrationOnly, &readOnly, &currentOutcome, &pendingDue, &scheduleRetry,
 		&scheduleHealthStatus, &scheduleHealthCode)
 	if errors.Is(err, sql.ErrNoRows) {
 		return protocol.Task{}, ErrNotFound
@@ -257,6 +270,18 @@ func (s *Store) UpdateTask(ctx context.Context, id string, input protocol.SaveTa
 	if archived != 0 && value.scheduleEnabled {
 		return protocol.Task{}, conflict("task_archived", "an archived Task cannot be scheduled")
 	}
+	if value.outcomeContract == "" {
+		value.outcomeContract = currentOutcome
+	}
+	if currentOutcome == protocol.OutcomeAgentUpdate && value.outcomeContract == protocol.OutcomeProcessExit {
+		return protocol.Task{}, conflict(
+			"outcome_contract_conversion_invalid",
+			"agent_update cannot be converted back to process_exit",
+		)
+	}
+	if err := validateOutcomeContractBackend(ctx, tx, value.outcomeContract, value.executionProfileID); err != nil {
+		return protocol.Task{}, err
+	}
 	now := s.now().UnixMilli()
 	var next any
 	if value.scheduleEnabled && value.nextDueAt != nil && !pendingDue.Valid {
@@ -267,7 +292,7 @@ func (s *Store) UpdateTask(ctx context.Context, id string, input protocol.SaveTa
 	result, err := tx.ExecContext(ctx, `
 		UPDATE tasks SET
 			name = ?, name_key = ?, prompt = ?, runtime = ?, timeout_seconds = ?,
-			concurrency_limit = ?, execution_profile_id = ?, generation = generation + 1, schedule_enabled = ?,
+			concurrency_limit = ?, execution_profile_id = ?, outcome_contract = ?, generation = generation + 1, schedule_enabled = ?,
 			cron = CASE WHEN pending_due_at IS NOT NULL AND ? = 0 THEN cron ELSE ? END,
 			timezone = CASE WHEN pending_due_at IS NOT NULL AND ? = 0 THEN timezone ELSE ? END,
 			next_due_at = CASE WHEN pending_due_at IS NULL THEN ? ELSE next_due_at END,
@@ -283,7 +308,7 @@ func (s *Store) UpdateTask(ctx context.Context, id string, input protocol.SaveTa
 			updated_at = ?
 		WHERE id = ? AND generation = ?
 	`, value.name, value.nameKey, value.prompt, value.runtime, value.timeoutSeconds,
-		value.concurrencyLimit, nullableString(value.executionProfileID), value.scheduleEnabled, value.scheduleEnabled, nullableString(value.cron),
+		value.concurrencyLimit, nullableString(value.executionProfileID), value.outcomeContract, value.scheduleEnabled, value.scheduleEnabled, nullableString(value.cron),
 		value.scheduleEnabled, nullableString(value.timezone),
 		next, value.scheduleEnabled, preserveBlockedOccurrence, value.scheduleEnabled,
 		preserveBlockedOccurrence, preserveBlockedOccurrence, now, id, input.ExpectedGeneration)
@@ -348,6 +373,38 @@ func validateTaskExecutionProfile(ctx context.Context, tx *sql.Tx, id string) er
 	return nil
 }
 
+func validateOutcomeContractBackend(
+	ctx context.Context,
+	tx *sql.Tx,
+	contract protocol.OutcomeContract,
+	profileID string,
+) error {
+	if contract != protocol.OutcomeAgentUpdate || profileID == "" || profileID == protocol.PersistentAutoProfileID {
+		return nil
+	}
+	var backend string
+	err := tx.QueryRowContext(ctx, `
+		SELECT version.kind
+		FROM execution_profiles profile
+		JOIN execution_profile_versions version
+		  ON version.profile_id = profile.id AND version.version = profile.current_version
+		WHERE profile.id = ?
+	`, profileID).Scan(&backend)
+	if errors.Is(err, sql.ErrNoRows) {
+		return invalid("execution_profile_not_found", "the selected execution profile does not exist")
+	}
+	if err != nil {
+		return unavailable(err)
+	}
+	if backend != protocol.BackendPersistent {
+		return conflict(
+			"agent_update_backend_unsupported",
+			"agent_update requires the persistent execution backend",
+		)
+	}
+	return nil
+}
+
 func replaceTaskRepositories(ctx context.Context, tx *sql.Tx, taskID string, ids []string) error {
 	if _, err := tx.ExecContext(ctx, `DELETE FROM task_repositories WHERE task_id = ?`, taskID); err != nil {
 		return unavailable(err)
@@ -390,6 +447,73 @@ func (s *Store) SetTaskArchived(ctx context.Context, id string, input protocol.S
 			return protocol.Task{}, conflict("task_read_only", "historical Task revisions are read-only")
 		}
 		return protocol.Task{}, conflict("task_generation_conflict", "the Task changed; refresh and try again")
+	}
+	return s.Task(ctx, id)
+}
+
+func (s *Store) SetTaskOutcomeContract(
+	ctx context.Context,
+	id string,
+	input protocol.SetTaskOutcomeContractRequest,
+) (protocol.Task, error) {
+	if input.OutcomeContract != protocol.OutcomeProcessExit && input.OutcomeContract != protocol.OutcomeAgentUpdate {
+		return protocol.Task{}, invalid("invalid_outcome_contract", "outcome_contract must be process_exit or agent_update")
+	}
+	if input.ExpectedGeneration < 1 {
+		return protocol.Task{}, invalid("task_generation_required", "expected_generation is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return protocol.Task{}, unavailable(err)
+	}
+	defer tx.Rollback()
+	var generation, archived, migrationOnly, readOnly int
+	var current protocol.OutcomeContract
+	var profileID sql.NullString
+	err = tx.QueryRowContext(ctx, `
+		SELECT generation, outcome_contract, execution_profile_id, archived, migration_only, read_only
+		FROM tasks WHERE id = ?
+	`, id).Scan(&generation, &current, &profileID, &archived, &migrationOnly, &readOnly)
+	if errors.Is(err, sql.ErrNoRows) {
+		return protocol.Task{}, ErrNotFound
+	}
+	if err != nil {
+		return protocol.Task{}, unavailable(err)
+	}
+	if generation != input.ExpectedGeneration {
+		return protocol.Task{}, conflict("task_generation_conflict", "the Task changed; refresh and try again")
+	}
+	if archived != 0 || migrationOnly != 0 || readOnly != 0 {
+		return protocol.Task{}, conflict("task_read_only", "only an active editable Task can change outcome contract")
+	}
+	if current == input.OutcomeContract {
+		if err := tx.Commit(); err != nil {
+			return protocol.Task{}, unavailable(err)
+		}
+		return s.Task(ctx, id)
+	}
+	if current == protocol.OutcomeAgentUpdate && input.OutcomeContract == protocol.OutcomeProcessExit {
+		return protocol.Task{}, conflict(
+			"outcome_contract_conversion_invalid",
+			"agent_update cannot be converted back to process_exit",
+		)
+	}
+	if err := validateOutcomeContractBackend(ctx, tx, input.OutcomeContract, profileID.String); err != nil {
+		return protocol.Task{}, err
+	}
+	now := s.now().UnixMilli()
+	result, err := tx.ExecContext(ctx, `
+		UPDATE tasks SET outcome_contract = ?, generation = generation + 1, updated_at = ?
+		WHERE id = ? AND generation = ?
+	`, input.OutcomeContract, now, id, input.ExpectedGeneration)
+	if err != nil {
+		return protocol.Task{}, unavailable(err)
+	}
+	if changed, _ := result.RowsAffected(); changed != 1 {
+		return protocol.Task{}, conflict("task_generation_conflict", "the Task changed; refresh and try again")
+	}
+	if err := tx.Commit(); err != nil {
+		return protocol.Task{}, unavailable(err)
 	}
 	return s.Task(ctx, id)
 }
@@ -475,11 +599,11 @@ func (s *Store) Task(ctx context.Context, id string) (protocol.Task, error) {
 	var created, updated int64
 	err := s.db.QueryRowContext(ctx, `
 		SELECT id, name, prompt, runtime, COALESCE(execution_profile_id, ''), timeout_seconds, concurrency_limit,
-		       generation, archived, read_only, schedule_enabled, cron, timezone, next_due_at, pending_due_at,
+		       generation, outcome_contract, archived, read_only, schedule_enabled, cron, timezone, next_due_at, pending_due_at,
 		       schedule_health_status, schedule_health_code, schedule_health_message, created_at, updated_at
 		FROM tasks WHERE id = ? AND migration_only = 0
 	`, id).Scan(&task.ID, &task.Name, &task.Prompt, &task.Runtime, &task.ExecutionProfileID,
-		&task.TimeoutSeconds, &task.ConcurrencyLimit, &task.Generation, &archived, &readOnly,
+		&task.TimeoutSeconds, &task.ConcurrencyLimit, &task.Generation, &task.OutcomeContract, &archived, &readOnly,
 		&scheduleEnabled, &cron, &timezone, &nextDue, &pendingDue, &task.Schedule.HealthStatus,
 		&task.Schedule.HealthCode, &task.Schedule.HealthMessage, &created, &updated)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -524,14 +648,14 @@ func (s *Store) Task(ctx context.Context, id string) (protocol.Task, error) {
 	task.RepositoryCount = len(task.Repositories)
 	_ = s.db.QueryRowContext(ctx, `
 		SELECT COALESCE((SELECT CASE
-			WHEN SUM(session.state IN ('blocked','queued','preparing','running')) = 0 THEN CASE
-				WHEN SUM(session.state = 'succeeded') = COUNT(*) THEN 'succeeded'
+			WHEN SUM(session.state IN ('blocked','queued','preparing','running','needs-input')) = 0 THEN CASE
+				WHEN SUM(session.state IN ('ready','succeeded','no-change')) = COUNT(*) THEN 'succeeded'
 				WHEN SUM(session.state = 'cancelled') = COUNT(*) THEN 'cancelled'
-				WHEN SUM(session.state = 'succeeded') = 0 AND SUM(session.state = 'failed') > 0 THEN 'failed'
+				WHEN SUM(session.state IN ('ready','succeeded','no-change')) = 0 AND SUM(session.state = 'failed') > 0 THEN 'failed'
 				ELSE 'partial' END
 			WHEN SUM(session.state IN ('preparing','running')) > 0
-			  OR SUM(session.state IN ('succeeded','failed','cancelled')) > 0 THEN 'running'
-			WHEN SUM(session.state = 'blocked') = SUM(session.state IN ('blocked','queued','preparing','running')) THEN 'blocked'
+			  OR SUM(session.state IN ('ready','succeeded','failed','no-change','cancelled')) > 0 THEN 'running'
+			WHEN SUM(session.state IN ('blocked','needs-input')) = SUM(session.state IN ('blocked','queued','preparing','running','needs-input')) THEN 'blocked'
 			ELSE 'queued' END
 		FROM runs recent JOIN sessions session ON session.run_id = recent.id
 		WHERE recent.task_id = ? GROUP BY recent.id ORDER BY recent.admitted_at DESC LIMIT 1), '')
@@ -589,6 +713,9 @@ func (s *Store) admitTask(
 	snapshot := protocol.TaskSnapshot{}
 	if frozen != nil {
 		snapshot = *frozen
+		if snapshot.OutcomeContract == "" {
+			snapshot.OutcomeContract = protocol.OutcomeProcessExit
+		}
 		var archived, migrationOnly, readOnly, scheduleEnabled int
 		var pendingDue sql.NullInt64
 		err := tx.QueryRowContext(ctx, `
@@ -617,10 +744,11 @@ func (s *Store) admitTask(
 		var archived, migrationOnly, readOnly int
 		err := tx.QueryRowContext(ctx, `
 			SELECT id, name, prompt, runtime, COALESCE(execution_profile_id, ''), timeout_seconds, concurrency_limit,
-			       generation, archived, migration_only, read_only
+			       generation, outcome_contract, archived, migration_only, read_only
 			FROM tasks WHERE id = ?
 		`, taskID).Scan(&snapshot.ID, &snapshot.Name, &snapshot.Prompt, &snapshot.Runtime,
-			&snapshot.ExecutionProfileID, &snapshot.TimeoutSeconds, &snapshot.ConcurrencyLimit, &snapshot.Generation, &archived, &migrationOnly, &readOnly)
+			&snapshot.ExecutionProfileID, &snapshot.TimeoutSeconds, &snapshot.ConcurrencyLimit, &snapshot.Generation,
+			&snapshot.OutcomeContract, &archived, &migrationOnly, &readOnly)
 		if errors.Is(err, sql.ErrNoRows) {
 			return protocol.RunDetail{}, false, ErrNotFound
 		}
@@ -661,6 +789,12 @@ func (s *Store) admitTask(
 	if err != nil {
 		return protocol.RunDetail{}, false, err
 	}
+	if snapshot.OutcomeContract == protocol.OutcomeAgentUpdate && execution.Backend != protocol.BackendPersistent {
+		return protocol.RunDetail{}, false, conflict(
+			"agent_update_backend_unsupported",
+			"agent_update requires the persistent execution backend",
+		)
+	}
 	snapshotJSON, err := json.Marshal(snapshot)
 	if err != nil {
 		return protocol.RunDetail{}, false, unavailable(err)
@@ -693,10 +827,11 @@ func (s *Store) admitTask(
 	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO runs(id, request_key, request_digest, task_id, task_snapshot, source,
-		                 scheduled_at, requested_execution_profile_id, execution_snapshot, admitted_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		                 scheduled_at, requested_execution_profile_id, execution_snapshot,
+		                 outcome_contract, admitted_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, runID, requestKey, digest, taskID, snapshotJSON, source, scheduled,
-		nullableString(requestedProfileID), executionJSON, now, now); err != nil {
+		nullableString(requestedProfileID), executionJSON, snapshot.OutcomeContract, now, now); err != nil {
 		return protocol.RunDetail{}, false, unavailable(err)
 	}
 	resolvedPrompt := snapshot.Prompt
@@ -716,13 +851,21 @@ func (s *Store) admitTask(
 		return protocol.RunDetail{}, false, conflict("resolved_prompt_too_large", "the frozen Task prompt exceeds 64 KiB")
 	}
 	materialized := 0
-	for _, repository := range snapshot.Repositories {
+	targets := make([]protocol.WorkTarget, 0, len(snapshot.Repositories))
+	for position, repository := range snapshot.Repositories {
 		if !protocol.AgentPromptFits(snapshot.Name, repository.RemoteIdentity, resolvedPrompt) {
 			return protocol.RunDetail{}, false, conflict("agent_prompt_too_large", "the frozen Task prompt cannot fit the Worker request")
 		}
 		sessionID, err := newID()
 		if err != nil {
 			return protocol.RunDetail{}, false, unavailable(err)
+		}
+		target := protocol.WorkTarget{
+			ID: sessionID, Position: position, TargetKey: "repository:" + repository.ID,
+			TargetKind: "repository", RepositoryID: repository.ID,
+			RepositoryIdentity: repository.RemoteIdentity, SourceKind: "repository",
+			SourceKey: repository.ID, SourceReference: repository.RemoteIdentity,
+			PublishBranch: workPublishBranch(sessionID),
 		}
 		state, blockedReason := "blocked", taskConcurrencyBlockedReason
 		var assigned any
@@ -750,14 +893,20 @@ func (s *Store) admitTask(
 				id, run_id, repository_id, repository_identity, resolved_prompt, required_runtime,
 				timeout_seconds, state, blocked_reason, assigned_worker_id, admitted_at,
 				execution_profile_id, execution_profile_version, execution_backend, execution_provider,
-				execution_model, resource_class, commit_resolution_policy
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, sessionID, runID, repository.ID, repository.RemoteIdentity, resolvedPrompt, snapshot.Runtime,
+					execution_model, resource_class, commit_resolution_policy
+					, target_position, target_key, target_kind, source_kind, source_key,
+					source_reference, context_snapshot, publish_branch, execution_owner, waiting_reason
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`, sessionID, runID, repository.ID, repository.RemoteIdentity, resolvedPrompt, snapshot.Runtime,
 			execution.TimeoutSeconds, state, nullableString(blockedReason), assigned, now,
 			execution.ProfileID, execution.ProfileVersion, execution.Backend, execution.Provider,
-			execution.Model, execution.ResourceClass, execution.CommitResolutionPolicy); err != nil {
+			execution.Model, execution.ResourceClass, execution.CommitResolutionPolicy,
+			target.Position, target.TargetKey, target.TargetKind, target.SourceKind, target.SourceKey,
+			target.SourceReference, target.ContextSnapshot, target.PublishBranch, protocol.ExecutionOwnerNone,
+			boundedUTF8Bytes(blockedReason, protocol.MaxWaitingReasonBytes)); err != nil {
 			return protocol.RunDetail{}, false, unavailable(err)
 		}
+		targets = append(targets, target)
 		if state == "queued" {
 			executionID, err := newID()
 			if err != nil {
@@ -771,11 +920,37 @@ func (s *Store) admitTask(
 			}
 		}
 	}
+	targetsJSON, err := json.Marshal(targets)
+	if err != nil {
+		return protocol.RunDetail{}, false, unavailable(err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE runs SET targets_snapshot = ? WHERE id = ?`, targetsJSON, runID); err != nil {
+		return protocol.RunDetail{}, false, unavailable(err)
+	}
 	if err := tx.Commit(); err != nil {
 		return protocol.RunDetail{}, false, unavailable(err)
 	}
 	detail, err := s.Run(ctx, runID)
 	return detail, true, err
+}
+
+func workPublishBranch(workID string) string {
+	compact := strings.ReplaceAll(workID, "-", "")
+	if len(compact) > 16 {
+		compact = compact[:16]
+	}
+	return "factory/work-" + compact
+}
+
+func boundedUTF8Bytes(value string, maximum int) string {
+	if len(value) <= maximum {
+		return value
+	}
+	value = value[:maximum]
+	for !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+	return value
 }
 
 func loadExecutionSnapshot(
@@ -936,15 +1111,17 @@ func (s *Store) RunPage(ctx context.Context, limit int, cursor string) (protocol
 
 func (s *Store) Run(ctx context.Context, id string) (protocol.RunDetail, error) {
 	var detail protocol.RunDetail
-	var snapshot, executionSnapshot []byte
+	var snapshot, executionSnapshot, targetsSnapshot []byte
 	var scheduledAt, terminalAt sql.NullInt64
 	var providerSnapshot sql.NullString
 	var admittedAt, updatedAt int64
 	err := s.db.QueryRowContext(ctx, `
-		SELECT id, task_id, task_snapshot, execution_snapshot, source, scheduled_at, provider_snapshot,
+		SELECT id, task_id, task_snapshot, execution_snapshot, outcome_contract, targets_snapshot,
+		       source, scheduled_at, provider_snapshot,
 		       admitted_at, updated_at, terminal_at
 		FROM runs run WHERE id = ?
-	`, id).Scan(&detail.Run.ID, &detail.Run.TaskID, &snapshot, &executionSnapshot, &detail.Run.Source,
+	`, id).Scan(&detail.Run.ID, &detail.Run.TaskID, &snapshot, &executionSnapshot,
+		&detail.Run.OutcomeContract, &targetsSnapshot, &detail.Run.Source,
 		&scheduledAt, &providerSnapshot, &admittedAt, &updatedAt, &terminalAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return detail, ErrNotFound
@@ -956,6 +1133,9 @@ func (s *Store) Run(ctx context.Context, id string) (protocol.RunDetail, error) 
 		return detail, unavailable(err)
 	}
 	if err := json.Unmarshal(executionSnapshot, &detail.Run.Execution); err != nil {
+		return detail, unavailable(err)
+	}
+	if err := json.Unmarshal(targetsSnapshot, &detail.Run.Targets); err != nil {
 		return detail, unavailable(err)
 	}
 	if providerSnapshot.Valid {
@@ -977,8 +1157,14 @@ func (s *Store) Run(ctx context.Context, id string) (protocol.RunDetail, error) 
 		       session.execution_provider, session.execution_model, session.resource_class, session.commit_resolution_policy,
 		       session.state, session.blocked_reason, session.assigned_worker_id,
 		       session.cancellation_requested, session.retry_may_repeat_effects,
-		       session.admitted_at, session.started_at, session.terminal_at, session.result, session.failure_reason
-		FROM sessions session WHERE session.run_id = ? ORDER BY session.admitted_at, session.id
+		       session.admitted_at, session.started_at, session.terminal_at, session.result, session.failure_reason,
+		       session.target_position, session.target_key, session.target_kind, session.source_kind,
+		       session.source_key, session.source_reference, session.context_snapshot, session.publish_branch,
+		       COALESCE(session.predecessor_work_id, ''), session.execution_owner, session.waiting_reason,
+		       session.latest_progress, session.question, session.checkpoint_sha, session.pending_resume_sha,
+		       session.pull_request_url, session.pull_request_head_branch, session.pull_request_head_sha,
+		       session.terminal_message
+		FROM sessions session WHERE session.run_id = ? ORDER BY session.target_position, session.id
 	`, id)
 	if err != nil {
 		return detail, unavailable(err)
@@ -994,13 +1180,21 @@ func (s *Store) Run(ctx context.Context, id string) (protocol.RunDetail, error) 
 			&session.Execution.ProfileID, &session.Execution.ProfileVersion, &session.Execution.Backend,
 			&session.Execution.Provider, &session.Execution.Model, &session.Execution.ResourceClass,
 			&session.Execution.CommitResolutionPolicy, &session.State,
-			&blockedReason, &workerID, &cancellation, &retry, &admitted, &started, &terminal, &result, &failure); err != nil {
+			&blockedReason, &workerID, &cancellation, &retry, &admitted, &started, &terminal, &result, &failure,
+			&session.Target.Position, &session.Target.TargetKey, &session.Target.TargetKind,
+			&session.Target.SourceKind, &session.Target.SourceKey, &session.Target.SourceReference,
+			&session.Target.ContextSnapshot, &session.Target.PublishBranch, &session.PredecessorWorkID,
+			&session.ExecutionOwner, &session.WaitingReason, &session.LatestProgress, &session.Question,
+			&session.CheckpointSHA, &session.PendingResumeSHA, &session.PullRequestURL,
+			&session.PullRequestHeadBranch, &session.PullRequestHeadSHA, &session.TerminalMessage); err != nil {
 			rows.Close()
 			return detail, unavailable(err)
 		}
 		session.BlockedReason, session.AssignedWorkerID = blockedReason.String, workerID.String
 		session.Execution.Runtime, session.Execution.TimeoutSeconds = session.RequiredRuntime, session.TimeoutSeconds
 		session.CancellationRequested, session.RetryMayRepeatEffects = cancellation != 0, retry != 0
+		session.Target.ID, session.Target.RepositoryID = session.ID, session.RepositoryID
+		session.Target.RepositoryIdentity = session.RepositoryIdentity
 		session.AdmittedAt, session.Result, session.FailureReason = fromMillis(admitted), result.String, failure.String
 		if started.Valid {
 			value := fromMillis(started.Int64)
@@ -1065,7 +1259,8 @@ func (s *Store) Run(ctx context.Context, id string) (protocol.RunDetail, error) 
 
 func applyRunAggregate(run *protocol.Run, sessions []protocol.Session, now time.Time) {
 	run.SessionCount = len(sessions)
-	run.SucceededCount, run.FailedCount, run.CancelledCount, run.ActiveCount = 0, 0, 0, 0
+	run.SucceededCount, run.ReadyCount, run.NeedsInputCount, run.NoChangeCount = 0, 0, 0, 0
+	run.FailedCount, run.CancelledCount, run.ActiveCount = 0, 0, 0
 	blocked, actionableBlocked, queued, running := 0, 0, 0, 0
 	for _, session := range sessions {
 		switch session.State {
@@ -1078,10 +1273,18 @@ func applyRunAggregate(run *protocol.Run, sessions []protocol.Session, now time.
 			queued++
 		case protocol.SessionPreparing, protocol.SessionRunning:
 			running++
+		case protocol.SessionNeedsInput:
+			blocked++
+			actionableBlocked++
+			run.NeedsInputCount++
+		case protocol.SessionReady:
+			run.ReadyCount++
 		case protocol.SessionSucceeded:
 			run.SucceededCount++
 		case protocol.SessionFailed:
 			run.FailedCount++
+		case protocol.SessionNoChange:
+			run.NoChangeCount++
 		case protocol.SessionCancelled:
 			run.CancelledCount++
 		}
@@ -1089,7 +1292,8 @@ func applyRunAggregate(run *protocol.Run, sessions []protocol.Session, now time.
 	run.ActiveCount = blocked + queued + running
 	if run.ActiveCount > 0 {
 		switch {
-		case running > 0 || run.SucceededCount+run.FailedCount+run.CancelledCount > 0:
+		case running > 0 || run.SucceededCount+run.ReadyCount+run.NoChangeCount+
+			run.FailedCount+run.CancelledCount > 0:
 			run.State = protocol.RunRunning
 		case blocked == run.ActiveCount:
 			run.State = protocol.RunBlocked
@@ -1097,10 +1301,11 @@ func applyRunAggregate(run *protocol.Run, sessions []protocol.Session, now time.
 			run.State = protocol.RunQueued
 		}
 	} else {
+		successful := run.SucceededCount + run.ReadyCount + run.NoChangeCount
 		switch {
-		case run.SucceededCount == run.SessionCount:
+		case successful == run.SessionCount:
 			run.State = protocol.RunSucceeded
-		case run.SucceededCount == 0 && run.FailedCount > 0:
+		case successful == 0 && run.FailedCount > 0:
 			run.State = protocol.RunFailed
 		case run.CancelledCount == run.SessionCount:
 			run.State = protocol.RunCancelled
@@ -1128,10 +1333,12 @@ func (s *Store) CancelRun(ctx context.Context, runID string) (protocol.RunDetail
 	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE sessions SET
-			state = CASE WHEN state IN ('blocked','queued') THEN 'cancelled' ELSE state END,
+			state = CASE WHEN state IN ('blocked','queued','needs-input') OR execution_owner = 'operator' THEN 'cancelled' ELSE state END,
 			cancellation_requested = CASE WHEN state IN ('preparing','running') THEN 1 ELSE cancellation_requested END,
-			terminal_at = CASE WHEN state IN ('blocked','queued') THEN ? ELSE terminal_at END
-		WHERE run_id = ? AND state IN ('blocked','queued','preparing','running')
+			terminal_at = CASE WHEN state IN ('blocked','queued','needs-input') OR execution_owner = 'operator' THEN ? ELSE terminal_at END,
+			execution_owner = CASE WHEN state IN ('blocked','queued','needs-input') OR execution_owner = 'operator' THEN 'none' ELSE execution_owner END,
+			terminal_message = CASE WHEN state IN ('blocked','queued','needs-input') OR execution_owner = 'operator' THEN 'Cancelled by operator.' ELSE terminal_message END
+		WHERE run_id = ? AND state IN ('blocked','queued','preparing','running','needs-input')
 	`, now, runID); err != nil {
 		return protocol.RunDetail{}, unavailable(err)
 	}
@@ -1149,7 +1356,7 @@ func (s *Store) CancelRun(ctx context.Context, runID string) (protocol.RunDetail
 		UPDATE runs SET updated_at = ?, terminal_at = CASE
 			WHEN NOT EXISTS (
 				SELECT 1 FROM sessions session WHERE session.run_id = runs.id
-				  AND session.state IN ('blocked','queued','preparing','running')
+				  AND session.state IN ('blocked','queued','preparing','running','needs-input')
 			) THEN ? ELSE NULL END
 		WHERE id = ?
 	`, now, now, runID); err != nil {
@@ -1176,14 +1383,16 @@ func (s *Store) CancelSession(ctx context.Context, runID, sessionID string) (pro
 	} else if err != nil {
 		return protocol.RunDetail{}, unavailable(err)
 	}
-	if state != "blocked" && state != "queued" && state != "preparing" && state != "running" {
+	if state != "blocked" && state != "queued" && state != "preparing" && state != "running" && state != "needs-input" {
 		return protocol.RunDetail{}, conflict("session_cancel_not_allowed", "only active Sessions can be cancelled")
 	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE sessions SET
-			state = CASE WHEN state IN ('blocked','queued') THEN 'cancelled' ELSE state END,
+			state = CASE WHEN state IN ('blocked','queued','needs-input') OR execution_owner = 'operator' THEN 'cancelled' ELSE state END,
 			cancellation_requested = CASE WHEN state IN ('preparing','running') THEN 1 ELSE cancellation_requested END,
-			terminal_at = CASE WHEN state IN ('blocked','queued') THEN ? ELSE terminal_at END
+			terminal_at = CASE WHEN state IN ('blocked','queued','needs-input') OR execution_owner = 'operator' THEN ? ELSE terminal_at END,
+			execution_owner = CASE WHEN state IN ('blocked','queued','needs-input') OR execution_owner = 'operator' THEN 'none' ELSE execution_owner END,
+			terminal_message = CASE WHEN state IN ('blocked','queued','needs-input') OR execution_owner = 'operator' THEN 'Cancelled by operator.' ELSE terminal_message END
 		WHERE id = ? AND run_id = ?
 	`, now, sessionID, runID); err != nil {
 		return protocol.RunDetail{}, unavailable(err)
@@ -1201,7 +1410,7 @@ func (s *Store) CancelSession(ctx context.Context, runID, sessionID string) (pro
 		UPDATE runs SET updated_at = ?, terminal_at = CASE
 			WHEN NOT EXISTS (
 				SELECT 1 FROM sessions session WHERE session.run_id = runs.id
-				  AND session.state IN ('blocked','queued','preparing','running')
+				  AND session.state IN ('blocked','queued','preparing','running','needs-input')
 			) THEN ? ELSE NULL END
 		WHERE id = ?
 	`, now, now, runID); err != nil {
@@ -1221,13 +1430,16 @@ func (s *Store) RetrySession(ctx context.Context, expectedRunID, sessionID strin
 	}
 	defer tx.Rollback()
 	var runID, state, repositoryID, identity, runtime, backend, profileID string
+	var targetKind, sourceKind, sourceKey string
+	var owner protocol.ExecutionOwner
 	var profileVersion int
 	err = tx.QueryRowContext(ctx, `
 		SELECT run_id, state, repository_id, repository_identity, required_runtime,
-		       execution_backend, execution_profile_id, execution_profile_version
+		       execution_backend, execution_profile_id, execution_profile_version,
+		       target_kind, source_kind, source_key, execution_owner
 		FROM sessions WHERE id = ? AND run_id = ?
 	`, sessionID, expectedRunID).Scan(&runID, &state, &repositoryID, &identity, &runtime,
-		&backend, &profileID, &profileVersion)
+		&backend, &profileID, &profileVersion, &targetKind, &sourceKind, &sourceKey, &owner)
 	if errors.Is(err, sql.ErrNoRows) {
 		return protocol.RunDetail{}, ErrNotFound
 	}
@@ -1236,6 +1448,12 @@ func (s *Store) RetrySession(ctx context.Context, expectedRunID, sessionID strin
 	}
 	if state != "failed" && state != "cancelled" {
 		return protocol.RunDetail{}, conflict("session_retry_not_allowed", "only failed or cancelled Sessions can be retried")
+	}
+	if owner != protocol.ExecutionOwnerNone {
+		return protocol.RunDetail{}, conflict("work_owned", "owned Work cannot be retried")
+	}
+	if err := validateWorkRetryGuards(ctx, tx, sessionID, repositoryID, targetKind, sourceKind, sourceKey); err != nil {
+		return protocol.RunDetail{}, err
 	}
 	var activeSessions, concurrencyLimit int
 	if err := tx.QueryRowContext(ctx, `
@@ -1315,7 +1533,8 @@ func (s *Store) RetrySession(ctx context.Context, expectedRunID, sessionID strin
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE sessions SET state = 'queued', blocked_reason = NULL, assigned_worker_id = ?,
 		       cancellation_requested = 0, retry_may_repeat_effects = 1,
-		       started_at = NULL, terminal_at = NULL, result = NULL, failure_reason = NULL
+		       started_at = NULL, terminal_at = NULL, result = NULL, failure_reason = NULL,
+		       terminal_message = '', waiting_reason = '', execution_owner = 'none'
 		WHERE id = ?
 	`, assignedWorkerID, sessionID); err != nil {
 		return protocol.RunDetail{}, unavailable(err)
@@ -1343,13 +1562,16 @@ func (s *Store) Overview(ctx context.Context) (protocol.Overview, error) {
 		SELECT
 			COALESCE(SUM(EXISTS (
 				SELECT 1 FROM sessions session
-				WHERE session.run_id = run.id AND session.state IN ('blocked','queued','preparing','running')
+				WHERE session.run_id = run.id AND session.state IN ('blocked','queued','preparing','running','needs-input')
 			)), 0),
 			COALESCE(SUM(
 				(terminal_at IS NULL AND EXISTS (
 					SELECT 1 FROM sessions session
-					WHERE session.run_id = run.id AND session.state = 'blocked'
-					  AND COALESCE(session.blocked_reason, '') != ?
+					WHERE session.run_id = run.id AND (
+					  session.state = 'needs-input' OR (
+					    session.state = 'blocked' AND COALESCE(session.blocked_reason, '') != ?
+					  )
+					)
 				)) OR
 				(terminal_at >= ? AND EXISTS (
 					SELECT 1 FROM sessions session

--- a/internal/controlplane/tasks_migration_test.go
+++ b/internal/controlplane/tasks_migration_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/owainlewis/factory/internal/protocol"
 	"github.com/owainlewis/factory/migrations"
@@ -44,6 +45,19 @@ func TestTasksMigrationPreservesPopulatedLegacyHistory(t *testing.T) {
 	}
 	if taskCount != 4 || distinctNames != 4 {
 		t.Fatalf("operator Tasks = %d, distinct names = %d", taskCount, distinctNames)
+	}
+	var incompatibleTasks, incompatibleRuns int
+	if err := db.QueryRowContext(ctx, `
+		SELECT
+			(SELECT COUNT(*) FROM tasks WHERE outcome_contract != 'process_exit'),
+			(SELECT COUNT(*) FROM runs
+			 WHERE outcome_contract != 'process_exit'
+			    OR json_extract(task_snapshot, '$.outcome_contract') != 'process_exit')
+	`).Scan(&incompatibleTasks, &incompatibleRuns); err != nil {
+		t.Fatal(err)
+	}
+	if incompatibleTasks != 0 || incompatibleRuns != 0 {
+		t.Fatalf("legacy outcome contracts changed: Tasks %d, Runs %d", incompatibleTasks, incompatibleRuns)
 	}
 	var taskToolColumns, sessionToolColumns int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('tasks') WHERE name = 'allowed_tools'`).
@@ -201,6 +215,100 @@ func TestTasksMigrationPreservesPopulatedLegacyHistory(t *testing.T) {
 		scheduleKind != "scheduled" || scheduleCron != "0 9 * * *" || scheduleTimezone != "UTC" || legacyTool != "git" {
 		t.Fatalf("admitted schedule snapshot = %d, %q, %q, %q, %q, tool %q",
 			scheduledAt, scheduleOccurrence, scheduleKind, scheduleCron, scheduleTimezone, legacyTool)
+	}
+	migratedScheduled, err := store.Run(ctx, "run-scheduled")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if migratedScheduled.Run.OutcomeContract != protocol.OutcomeProcessExit ||
+		len(migratedScheduled.Run.Targets) != len(migratedScheduled.Sessions) ||
+		migratedScheduled.Run.State != protocol.RunSucceeded ||
+		migratedScheduled.Sessions[0].State != protocol.SessionSucceeded ||
+		len(migratedScheduled.Sessions[0].Attempts) != 1 ||
+		migratedScheduled.Sessions[0].Attempts[0].State != "succeeded" {
+		t.Fatalf("migrated scheduled process-exit Run = %#v", migratedScheduled)
+	}
+	legacyWorker, err := store.Worker(ctx, "worker-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var scheduledRepositoryIdentity string
+	if err := db.QueryRowContext(ctx, `SELECT remote_identity FROM repositories WHERE id = 'repo-1'`).
+		Scan(&scheduledRepositoryIdentity); err != nil {
+		t.Fatal(err)
+	}
+	repositories := []protocol.RepositoryRegistration{{
+		Key: "factory", RemoteIdentity: scheduledRepositoryIdentity,
+	}}
+	if _, err := store.RegisterWorker(ctx, legacyWorker.ID, protocol.WorkerRegistration{
+		Name: legacyWorker.Name, Labels: legacyWorker.Labels, WorkerVersion: "test-v3",
+		ClaimProtocolVersion: protocol.ClaimProtocolVersion, Runtime: legacyWorker.Runtime,
+		RuntimeVersion: "codex-test-v3", Capacity: legacyWorker.Capacity,
+		ActiveCount: 0, Health: "healthy", Repositories: repositories,
+		RetainedWorktrees: legacyWorker.RetainedWorktrees,
+	}); err != nil {
+		t.Fatalf("re-register migrated Worker: %v", err)
+	}
+	var pendingSnapshot []byte
+	if err := db.QueryRowContext(ctx, `
+		SELECT pending_snapshot_json FROM tasks WHERE id = 'automation-schedule'
+	`).Scan(&pendingSnapshot); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frozenPending, err := loadPendingTaskSnapshot(ctx, tx, "automation-schedule", pendingSnapshot)
+	if err != nil {
+		_ = tx.Rollback()
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	pendingAt := fromMillis(pendingDue)
+	nextScheduled, created, err := store.admitTask(
+		ctx,
+		"automation-schedule",
+		"schedule",
+		fmt.Sprintf("schedule:automation-schedule:%d:%d", frozenPending.Generation, pendingDue),
+		&pendingAt,
+		&frozenPending,
+		"",
+	)
+	if err != nil || !created {
+		t.Fatalf("admit migrated pending schedule = %#v, created %v, err %v", nextScheduled, created, err)
+	}
+	if err := store.finishTaskOccurrence(ctx, "automation-schedule", pendingAt, true, nil); err != nil {
+		t.Fatalf("finish migrated pending occurrence: %v", err)
+	}
+	claim, err := store.Claim(ctx, legacyWorker.ID, protocol.ClaimRequest{
+		RequestID: "migrated-next-schedule", LeaseToken: tokenA,
+	})
+	if err != nil || claim == nil || claim.Session.RunID != nextScheduled.Run.ID {
+		t.Fatalf("claim migrated next schedule = %#v, err %v", claim, err)
+	}
+	if claim.Session.OutcomeContract != protocol.OutcomeProcessExit {
+		t.Fatalf("migrated pending claim contract = %q", claim.Session.OutcomeContract)
+	}
+	if _, err := store.StartAttempt(ctx, claim.Attempt.ID, protocol.StartAttemptRequest{LeaseToken: tokenA}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CompleteAttempt(ctx, claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "succeeded", Result: "next legacy schedule completed",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	nextScheduled, err = store.Run(ctx, nextScheduled.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nextScheduled.Run.OutcomeContract != protocol.OutcomeProcessExit ||
+		nextScheduled.Run.State != protocol.RunSucceeded ||
+		len(nextScheduled.Sessions) != 1 || nextScheduled.Sessions[0].State != protocol.SessionSucceeded ||
+		nextScheduled.Sessions[0].Result != "next legacy schedule completed" {
+		t.Fatalf("completed migrated next schedule = %#v", nextScheduled)
 	}
 	throttled, err := store.Run(ctx, "run-throttled")
 	if err != nil {
@@ -878,6 +986,106 @@ func TestTaskRenameMigrationPreservesPopulatedRows(t *testing.T) {
 			Scan(&exists); err != nil || exists != 1 {
 			t.Fatalf("renamed index %s exists = %d, err %v", name, exists, err)
 		}
+	}
+}
+
+func TestWorkLifecycleMigrationPreservesFrozenTargetOrder(t *testing.T) {
+	ctx := context.Background()
+	db := openMigrationTestDatabase(t, t.TempDir()+"/pre-work-lifecycle.sqlite3")
+	store := &Store{db: db, now: time.Now, sweepEvery: 5 * time.Second}
+	t.Cleanup(func() { _ = db.Close() })
+	applyMigrationsBefore(t, ctx, store, "030_task_run_session.sql")
+	if _, err := db.ExecContext(ctx, preRenameFixture); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE work SET routine_snapshot = '{
+		  "id":"routine-1",
+		  "name":"Weekly scan",
+		  "runtime":"codex",
+		  "timeout_seconds":3600,
+		  "concurrency_limit":10,
+		  "generation":1,
+		  "repositories":[
+		    {"id":"repo-2","remote_identity":"github.com/example/neo"},
+		    {"id":"repo-1","remote_identity":"github.com/example/factory"}
+		  ]
+		}' WHERE id = 'work-1';
+		INSERT INTO routine_repositories(routine_id, position, repository_id)
+		VALUES ('routine-1', 1, 'repo-2');
+		INSERT INTO work_targets(
+		  id, work_id, repository_id, repository_identity, resolved_prompt,
+		  required_runtime, timeout_seconds, state, blocked_reason, admitted_at
+		) VALUES (
+		  'zzz-target-2', 'work-1', 'repo-2', 'github.com/example/neo', 'Review.',
+		  'codex', 3600, 'blocked', 'Waiting for an available Routine concurrency slot.', 10
+		);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	legacyResult := strings.Repeat("r", protocol.MaxResultBytes)
+	legacyError := strings.Repeat("e", protocol.MaxErrorBytes)
+	legacyBlockedReason := strings.Repeat("🧪", protocol.MaxWaitingReasonBytes/2+1)
+	if _, err := db.ExecContext(ctx, `
+		UPDATE work_targets
+		SET result = ?, failure_reason = ?, blocked_reason = ?
+		WHERE id = 'target-1'
+	`, legacyResult, legacyError, legacyBlockedReason); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	var result, failure, blockedReason, waitingReason, terminalMessage string
+	if err := db.QueryRowContext(ctx, `
+		SELECT result, failure_reason, blocked_reason, waiting_reason, terminal_message
+		FROM sessions WHERE id = 'target-1'
+	`).Scan(&result, &failure, &blockedReason, &waitingReason, &terminalMessage); err != nil {
+		t.Fatal(err)
+	}
+	if result != legacyResult || failure != legacyError || blockedReason != legacyBlockedReason {
+		t.Fatal("migration did not preserve full legacy outcome or blocked payloads")
+	}
+	if len([]byte(waitingReason)) > protocol.MaxWaitingReasonBytes || !utf8.ValidString(waitingReason) ||
+		waitingReason != strings.Repeat("🧪", 512) {
+		t.Fatalf("migrated waiting reason is not a safe bounded projection: bytes=%d valid=%v",
+			len([]byte(waitingReason)), utf8.ValidString(waitingReason))
+	}
+	if terminalMessage != "" {
+		t.Fatalf("legacy process-exit outcome copied to terminal message: bytes=%d", len(terminalMessage))
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, target_position FROM sessions WHERE run_id = 'work-1' ORDER BY target_position
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		var position int
+		if err := rows.Scan(&id, &position); err != nil {
+			t.Fatal(err)
+		}
+		if position != len(ids) {
+			t.Fatalf("target %q position = %d, want %d", id, position, len(ids))
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 2 || ids[0] != "zzz-target-2" || ids[1] != "target-1" {
+		t.Fatalf("migrated target order = %#v", ids)
+	}
+	detail, err := store.Run(ctx, "work-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Run.Targets) != 2 || detail.Run.Targets[0].ID != "zzz-target-2" ||
+		detail.Run.Targets[1].ID != "target-1" {
+		t.Fatalf("frozen target snapshot order = %#v", detail.Run.Targets)
 	}
 }
 

--- a/internal/controlplane/tasks_test.go
+++ b/internal/controlplane/tasks_test.go
@@ -325,6 +325,8 @@ func TestRunAggregateUsesCanonicalPrecedence(t *testing.T) {
 		{name: "blocked", states: []protocol.SessionState{protocol.SessionBlocked}, expect: protocol.RunBlocked, active: 1},
 		{name: "queued", states: []protocol.SessionState{protocol.SessionQueued}, expect: protocol.RunQueued, active: 1},
 		{name: "mixed active", states: []protocol.SessionState{protocol.SessionSucceeded, protocol.SessionQueued}, expect: protocol.RunRunning, active: 1},
+		{name: "ready and queued", states: []protocol.SessionState{protocol.SessionReady, protocol.SessionQueued}, expect: protocol.RunRunning, active: 1},
+		{name: "no change and blocked", states: []protocol.SessionState{protocol.SessionNoChange, protocol.SessionBlocked}, expect: protocol.RunRunning, active: 1},
 		{name: "failed and cancelled", states: []protocol.SessionState{protocol.SessionFailed, protocol.SessionCancelled}, expect: protocol.RunFailed},
 		{name: "partial", states: []protocol.SessionState{protocol.SessionSucceeded, protocol.SessionFailed}, expect: protocol.RunPartial},
 	}
@@ -763,6 +765,36 @@ func TestIncompatibleWorkerCannotReceiveOrClaimTaskRun(t *testing.T) {
 		RequestID: "legacy-claim", LeaseToken: tokenA,
 	}); !serviceErrorCode(err, "worker_upgrade_required") {
 		t.Fatalf("legacy claim error = %v", err)
+	}
+}
+
+func TestClaimReplayRequiresCurrentProtocolVersion(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 1, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Replay protocol fence", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+		RequestKey: "replay-protocol-fence",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	input := protocol.ClaimRequest{RequestID: "replay-protocol-fence", LeaseToken: tokenA}
+	claim, err := store.Claim(context.Background(), worker.ID, input)
+	if err != nil || claim == nil {
+		t.Fatalf("initial claim = %#v, err %v", claim, err)
+	}
+	if _, err := store.db.Exec(`UPDATE workers SET claim_protocol_version = 2 WHERE id = ?`, worker.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Claim(context.Background(), worker.ID, input); !serviceErrorCode(err, "worker_upgrade_required") {
+		t.Fatalf("incompatible replay error = %v, want worker_upgrade_required", err)
 	}
 }
 

--- a/internal/controlplane/work.go
+++ b/internal/controlplane/work.go
@@ -1,0 +1,151 @@
+package controlplane
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const (
+	defaultWorkUpdatePageSize = 100
+	maxWorkUpdatePageSize     = 200
+)
+
+// Work returns the product-facing Work record backed by the existing Session
+// row. Keeping the adapter here lets existing Run and Session clients remain
+// compatible while later operator surfaces adopt Work directly.
+func (s *Store) Work(ctx context.Context, id string) (protocol.Work, error) {
+	var runID string
+	err := s.db.QueryRowContext(ctx, `SELECT run_id FROM sessions WHERE id = ?`, id).Scan(&runID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return protocol.Work{}, ErrNotFound
+	}
+	if err != nil {
+		return protocol.Work{}, unavailable(err)
+	}
+	detail, err := s.Run(ctx, runID)
+	if err != nil {
+		return protocol.Work{}, err
+	}
+	for _, work := range detail.Sessions {
+		if work.ID == id {
+			return work, nil
+		}
+	}
+	return protocol.Work{}, ErrNotFound
+}
+
+func (s *Store) WorkUpdates(
+	ctx context.Context,
+	workID string,
+	limit int,
+	after int,
+) (protocol.WorkUpdatePage, error) {
+	if limit == 0 {
+		limit = defaultWorkUpdatePageSize
+	}
+	if limit < 1 || limit > maxWorkUpdatePageSize {
+		return protocol.WorkUpdatePage{}, invalid("invalid_limit", "limit must be between 1 and 200")
+	}
+	if after < 0 {
+		return protocol.WorkUpdatePage{}, invalid("invalid_cursor", "after must not be negative")
+	}
+	var exists int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sessions WHERE id = ?`, workID).Scan(&exists); err != nil {
+		return protocol.WorkUpdatePage{}, unavailable(err)
+	}
+	if exists == 0 {
+		return protocol.WorkUpdatePage{}, ErrNotFound
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, work_id, COALESCE(attempt_id, ''), request_id, sequence, status, message,
+		       pull_request_url, pull_request_head_branch, pull_request_head_sha,
+		       checkpoint_sha, actor, accepted_at
+		FROM work_updates
+		WHERE work_id = ? AND sequence > ?
+		ORDER BY sequence
+		LIMIT ?
+	`, workID, after, limit+1)
+	if err != nil {
+		return protocol.WorkUpdatePage{}, unavailable(err)
+	}
+	defer rows.Close()
+	updates := make([]protocol.WorkUpdate, 0, limit+1)
+	for rows.Next() {
+		var update protocol.WorkUpdate
+		var acceptedAt int64
+		if err := rows.Scan(&update.ID, &update.WorkID, &update.AttemptID, &update.RequestID,
+			&update.Sequence, &update.Status, &update.Message, &update.PullRequestURL,
+			&update.PullRequestHeadBranch, &update.PullRequestHeadSHA, &update.CheckpointSHA,
+			&update.Actor, &acceptedAt); err != nil {
+			return protocol.WorkUpdatePage{}, unavailable(err)
+		}
+		update.AcceptedAt = fromMillis(acceptedAt)
+		updates = append(updates, update)
+	}
+	if err := rows.Err(); err != nil {
+		return protocol.WorkUpdatePage{}, unavailable(err)
+	}
+	page := protocol.WorkUpdatePage{Updates: updates, NextAfter: after}
+	if len(page.Updates) > limit {
+		page.Updates = page.Updates[:limit]
+		page.HasMore = true
+	}
+	if len(page.Updates) != 0 {
+		page.NextAfter = page.Updates[len(page.Updates)-1].Sequence
+	}
+	return page, nil
+}
+
+func validateWorkRetryGuards(
+	ctx context.Context,
+	tx *sql.Tx,
+	workID, repositoryID, targetKind, sourceKind, sourceKey string,
+) error {
+	var replacementCount int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM sessions WHERE predecessor_work_id = ?
+	`, workID).Scan(&replacementCount); err != nil {
+		return unavailable(err)
+	}
+	if replacementCount != 0 {
+		return conflict("work_replaced", "replaced Work cannot be retried")
+	}
+	var matchingNonterminal int
+	var err error
+	if targetKind == "work_item" {
+		err = tx.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM sessions
+			WHERE id != ? AND repository_id = ? AND source_kind = ? AND source_key = ?
+			  AND state IN ('blocked', 'queued', 'preparing', 'running', 'needs-input')
+		`, workID, repositoryID, sourceKind, sourceKey).Scan(&matchingNonterminal)
+	} else {
+		err = tx.QueryRowContext(ctx, `
+			WITH RECURSIVE lineage(work_id, root_id) AS (
+				SELECT id, id FROM sessions WHERE predecessor_work_id IS NULL
+				UNION ALL
+				SELECT child.id, lineage.root_id
+				FROM sessions child
+				JOIN lineage ON child.predecessor_work_id = lineage.work_id
+			)
+			SELECT COUNT(*)
+			FROM sessions candidate
+			JOIN lineage candidate_lineage ON candidate_lineage.work_id = candidate.id
+			JOIN lineage retried_lineage ON retried_lineage.work_id = ?
+			WHERE candidate.id != ?
+			  AND candidate.repository_id = ?
+			  AND candidate_lineage.root_id = retried_lineage.root_id
+			  AND candidate.state IN ('blocked', 'queued', 'preparing', 'running', 'needs-input')
+		`, workID, workID, repositoryID).Scan(&matchingNonterminal)
+	}
+	if err != nil {
+		return unavailable(err)
+	}
+	if matchingNonterminal != 0 {
+		return conflict("matching_work_active", "matching nonterminal Work already exists")
+	}
+	return nil
+}

--- a/internal/controlplane/work_lifecycle_test.go
+++ b/internal/controlplane/work_lifecycle_test.go
@@ -444,3 +444,150 @@ func TestFakeCloudCompletionPreservesMaximumLegacyResult(t *testing.T) {
 			len(work.Result), len(work.TerminalMessage))
 	}
 }
+
+func TestAgentUpdateProcessExitWithoutOutcomeFailsVisibly(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Missing semantic outcome", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID}, OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+		RequestKey: "missing-semantic-outcome",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(context.Background(), worker.ID, protocol.ClaimRequest{
+		RequestID: "missing-semantic-outcome", LeaseToken: tokenA,
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, err %v", claim, err)
+	}
+	if _, err := store.StartAttempt(context.Background(), claim.Attempt.ID, protocol.StartAttemptRequest{
+		LeaseToken: tokenA,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "succeeded", Result: "unreported prose success",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const missingOutcome = "Agent exited without reporting an outcome."
+	work, err := store.Work(context.Background(), run.Sessions[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err = store.Run(context.Background(), run.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.State != "failed" || attempt.Result != "" || attempt.Error != missingOutcome ||
+		work.State != protocol.WorkFailed || work.Result != "" || work.FailureReason != missingOutcome ||
+		work.TerminalMessage != missingOutcome || run.Run.State != protocol.RunFailed {
+		t.Fatalf("missing semantic outcome completion = attempt %#v, Work %#v, Run %#v",
+			attempt, work, run.Run)
+	}
+}
+
+func TestAgentUpdateCompletionPreservesInfrastructureFailure(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Preparation failure", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID}, OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+		RequestKey: "preparation-failure",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(context.Background(), worker.ID, protocol.ClaimRequest{
+		RequestID: "preparation-failure", LeaseToken: tokenA,
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, err %v", claim, err)
+	}
+	const preparationFailure = "repository preparation failed"
+	attempt, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "failed", Error: preparationFailure,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	work, err := store.Work(context.Background(), run.Sessions[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.State != "failed" || attempt.Error != preparationFailure ||
+		work.State != protocol.WorkFailed || work.FailureReason != preparationFailure {
+		t.Fatalf("agent-update infrastructure failure = Attempt %#v, Work %#v", attempt, work)
+	}
+}
+
+func TestPendingCancellationWinsAgentUpdateCompletion(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Cancellation wins", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID}, OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+		RequestKey: "cancellation-wins",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(context.Background(), worker.ID, protocol.ClaimRequest{
+		RequestID: "cancellation-wins", LeaseToken: tokenA,
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, err %v", claim, err)
+	}
+	if _, err := store.StartAttempt(context.Background(), claim.Attempt.ID, protocol.StartAttemptRequest{
+		LeaseToken: tokenA,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CancelSession(context.Background(), run.Run.ID, run.Sessions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	attempt, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "succeeded", Result: "late success",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	work, err := store.Work(context.Background(), run.Sessions[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err = store.Run(context.Background(), run.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.State != "cancelled" || attempt.Result != "" || attempt.Error != "" ||
+		work.State != protocol.WorkCancelled || work.Result != "" || work.FailureReason != "" ||
+		work.TerminalMessage != "Cancelled by operator." || run.Run.State != protocol.RunCancelled {
+		t.Fatalf("late completion after cancellation = Attempt %#v, Work %#v, Run %#v",
+			attempt, work, run.Run)
+	}
+}

--- a/internal/controlplane/work_lifecycle_test.go
+++ b/internal/controlplane/work_lifecycle_test.go
@@ -1,0 +1,446 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestOutcomeContractConversionFreezesAdmittedRuns(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Contract conversion", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.OutcomeContract != protocol.OutcomeProcessExit {
+		t.Fatalf("legacy Task outcome contract = %q", task.OutcomeContract)
+	}
+	legacyRun, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+		RequestKey: "before-conversion",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	converted, err := store.SetTaskOutcomeContract(context.Background(), task.ID, protocol.SetTaskOutcomeContractRequest{
+		OutcomeContract: protocol.OutcomeAgentUpdate, ExpectedGeneration: task.Generation,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if converted.Generation != task.Generation+1 || converted.OutcomeContract != protocol.OutcomeAgentUpdate {
+		t.Fatalf("converted Task = %#v", converted)
+	}
+	if _, err := store.SetTaskOutcomeContract(context.Background(), task.ID, protocol.SetTaskOutcomeContractRequest{
+		OutcomeContract: protocol.OutcomeProcessExit, ExpectedGeneration: converted.Generation,
+	}); !serviceErrorCode(err, "outcome_contract_conversion_invalid") {
+		t.Fatalf("reverse conversion error = %v", err)
+	}
+	legacyRun, err = store.Run(context.Background(), legacyRun.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacyRun.Run.OutcomeContract != protocol.OutcomeProcessExit ||
+		legacyRun.Run.Task.OutcomeContract != protocol.OutcomeProcessExit {
+		t.Fatalf("admitted Run contract changed = %#v", legacyRun.Run)
+	}
+	agentRun, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+		RequestKey: "after-conversion",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agentRun.Run.OutcomeContract != protocol.OutcomeAgentUpdate ||
+		agentRun.Run.Execution.Backend != protocol.BackendPersistent {
+		t.Fatalf("new agent-directed Run = %#v", agentRun.Run)
+	}
+}
+
+func TestAgentUpdateRejectsFakeCloudWithoutStateChange(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	profile := createFakeProfile(t, store, "Legacy synthetic", protocol.RuntimeCodex, "succeeded")
+	task := createProfileTask(t, store, worker.Repositories[0].ID, profile.ID)
+
+	if _, err := store.SetTaskOutcomeContract(context.Background(), task.ID, protocol.SetTaskOutcomeContractRequest{
+		OutcomeContract: protocol.OutcomeAgentUpdate, ExpectedGeneration: task.Generation,
+	}); !serviceErrorCode(err, "agent_update_backend_unsupported") {
+		t.Fatalf("conversion error = %v", err)
+	}
+	unchanged, err := store.Task(context.Background(), task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unchanged.Generation != task.Generation || unchanged.OutcomeContract != protocol.OutcomeProcessExit {
+		t.Fatalf("rejected conversion changed Task = %#v", unchanged)
+	}
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "legacy-cloud-next"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.DispatchFakeCloud(context.Background(), 10); err != nil {
+		t.Fatal(err)
+	}
+	run, err = store.Run(context.Background(), run.Run.ID)
+	if err != nil || run.Run.State != protocol.RunSucceeded || run.Run.OutcomeContract != protocol.OutcomeProcessExit {
+		t.Fatalf("legacy synthetic completion = %#v, err %v", run, err)
+	}
+
+	persistent, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Agent persistent", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID}, OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RunTask(context.Background(), persistent.ID, protocol.RunTaskRequest{
+		RequestKey: "agent-cloud-override", ExecutionProfileID: profile.ID,
+	}); !serviceErrorCode(err, "agent_update_backend_unsupported") {
+		t.Fatalf("agent-update admission override error = %v", err)
+	}
+	var runCount int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM runs WHERE request_key = 'agent-cloud-override'`).Scan(&runCount); err != nil {
+		t.Fatal(err)
+	}
+	if runCount != 0 {
+		t.Fatal("unsupported agent-update admission wrote a Run")
+	}
+}
+
+func TestWorkLifecycleStatesTargetsAndUpdateBounds(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Durable Work", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID}, OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "durable-work"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workID := run.Sessions[0].ID
+	if len(run.Run.Targets) != 1 || run.Run.Targets[0].ID != workID ||
+		run.Run.Targets[0].Position != 0 || run.Run.Targets[0].PublishBranch == "" {
+		t.Fatalf("frozen ordered targets = %#v", run.Run.Targets)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions SET execution_owner = 'worker_attempt' WHERE id = ?
+	`, workID); err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Fatalf("queued Work accepted an owner: %v", err)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions SET state = 'running', execution_owner = 'none' WHERE id = ?
+	`, workID); err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Fatalf("running Work accepted no owner: %v", err)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions SET state = 'preparing', execution_owner = 'operator' WHERE id = ?
+	`, workID); err == nil || !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Fatalf("preparing Work accepted operator ownership: %v", err)
+	}
+	unchanged, err := store.Work(context.Background(), workID)
+	if err != nil || unchanged.State != protocol.WorkQueued || unchanged.ExecutionOwner != protocol.ExecutionOwnerNone {
+		t.Fatalf("invalid ownership changed Work = %#v, err %v", unchanged, err)
+	}
+
+	states := []struct {
+		state protocol.WorkState
+		set   string
+		args  []any
+	}{
+		{protocol.WorkQueued, `execution_owner = 'none', terminal_at = NULL`, nil},
+		{protocol.WorkRunning, `execution_owner = 'worker_attempt', terminal_at = NULL`, nil},
+		{protocol.WorkNeedsInput, `execution_owner = 'none', question = 'Which behavior?', checkpoint_sha = 'abc', pending_resume_sha = 'abc', terminal_at = NULL`, nil},
+		{protocol.WorkReady, `execution_owner = 'none', pull_request_url = 'https://github.com/owainlewis/factory/pull/1', terminal_at = 1`, nil},
+		{protocol.WorkFailed, `execution_owner = 'none', terminal_at = 1`, nil},
+		{protocol.WorkNoChange, `execution_owner = 'none', terminal_at = 1`, nil},
+		{protocol.WorkCancelled, `execution_owner = 'none', terminal_at = 1`, nil},
+		{protocol.WorkSucceeded, `execution_owner = 'none', terminal_at = 1`, nil},
+	}
+	for _, test := range states {
+		if _, err := store.db.Exec(`UPDATE sessions SET state = ?, `+test.set+` WHERE id = ?`, test.state, workID); err != nil {
+			t.Fatalf("store state %q: %v", test.state, err)
+		}
+		work, err := store.Work(context.Background(), workID)
+		if err != nil || work.State != test.state {
+			t.Fatalf("read state %q = %#v, err %v", test.state, work, err)
+		}
+	}
+
+	if _, err := store.db.Exec(`UPDATE sessions SET state = 'queued', execution_owner = 'none', terminal_at = NULL WHERE id = ?`, workID); err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(context.Background(), worker.ID, protocol.ClaimRequest{RequestID: "bounded-updates", LeaseToken: tokenA})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, err %v", claim, err)
+	}
+	for index := 1; index <= protocol.MaxProgressPerAttempt; index++ {
+		_, err := store.db.Exec(`
+			INSERT INTO work_updates(id, work_id, attempt_id, request_id, sequence, status, message, actor, accepted_at)
+			VALUES (?, ?, ?, ?, ?, 'running', 'progress', 'agent', ?)
+		`, fmt.Sprintf("update-%03d", index), workID, claim.Attempt.ID,
+			fmt.Sprintf("request-%03d", index), index, index)
+		if err != nil {
+			t.Fatalf("progress update %d: %v", index, err)
+		}
+	}
+	if _, err := store.db.Exec(`
+		INSERT INTO work_updates(id, work_id, attempt_id, request_id, sequence, status, message, actor, accepted_at)
+		VALUES ('too-many-progress', ?, ?, 'too-many-progress', 200, 'running', 'progress', 'agent', 200)
+	`, workID, claim.Attempt.ID); err == nil || !strings.Contains(err.Error(), "progress update limit") {
+		t.Fatalf("200th progress error = %v", err)
+	}
+	if _, err := store.db.Exec(`
+		INSERT INTO work_updates(id, work_id, attempt_id, request_id, sequence, status, message, actor, accepted_at)
+		VALUES ('outcome', ?, ?, 'outcome', 200, 'failed', 'blocked', 'agent', 200)
+	`, workID, claim.Attempt.ID); err != nil {
+		t.Fatalf("reserved outcome slot: %v", err)
+	}
+	page, err := store.WorkUpdates(context.Background(), workID, 100, 0)
+	if err != nil || len(page.Updates) != 100 || !page.HasMore || page.NextAfter != 100 {
+		t.Fatalf("bounded update page = %#v, err %v", page, err)
+	}
+}
+
+func TestRetryRejectsReplacedWorkTransactionally(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Replacement guard", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "first"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions SET state = 'failed', terminal_at = 1, terminal_message = 'failed'
+		WHERE id = ?
+	`, first.Sessions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "replacement"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE sessions SET predecessor_work_id = ? WHERE id = ?`,
+		first.Sessions[0].ID, second.Sessions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RetrySession(context.Background(), first.Run.ID, first.Sessions[0].ID); !serviceErrorCode(err, "work_replaced") {
+		t.Fatalf("retry replaced Work error = %v", err)
+	}
+	work, err := store.Work(context.Background(), first.Sessions[0].ID)
+	if err != nil || work.State != protocol.WorkFailed || work.RetryMayRepeatEffects {
+		t.Fatalf("rejected retry changed Work = %#v, err %v", work, err)
+	}
+}
+
+func TestRepositoryRetryRejectsMatchingNonterminalLineage(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Lineage guard", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runs := make([]protocol.RunDetail, 3)
+	for index := range runs {
+		runs[index], _, err = store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+			RequestKey: fmt.Sprintf("lineage-%d", index),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	rootID := runs[0].Sessions[0].ID
+	retriedID := runs[1].Sessions[0].ID
+	activeSiblingID := runs[2].Sessions[0].ID
+	if _, err := store.db.Exec(`
+		UPDATE sessions
+		SET state = 'failed', terminal_at = 1, assigned_worker_id = NULL
+		WHERE id IN (?, ?)
+	`, rootID, retriedID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions SET predecessor_work_id = ? WHERE id IN (?, ?)
+	`, rootID, retriedID, activeSiblingID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RetrySession(context.Background(), runs[1].Run.ID, retriedID); !serviceErrorCode(err, "matching_work_active") {
+		t.Fatalf("same-lineage retry error = %v, want matching_work_active", err)
+	}
+	work, err := store.Work(context.Background(), retriedID)
+	if err != nil || work.State != protocol.WorkFailed || work.RetryMayRepeatEffects {
+		t.Fatalf("rejected lineage retry changed Work = %#v, err %v", work, err)
+	}
+}
+
+func TestRepositoryRetryAllowsIndependentProcedureRun(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Independent retry", Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "failed-root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+		RequestKey: "independent-active-root",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions SET state = 'failed', terminal_at = 1, assigned_worker_id = NULL WHERE id = ?
+	`, failed.Sessions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RetrySession(context.Background(), failed.Run.ID, failed.Sessions[0].ID); err != nil {
+		t.Fatalf("independent Procedure Run blocked retry: %v", err)
+	}
+}
+
+func TestMaximumLegacyProcessExitPromptRemainsAdmissible(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Maximum legacy prompt", Prompt: strings.Repeat("x", protocol.MaxTaskPromptBytes),
+		Runtime: protocol.RuntimeCodex, RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "maximum-legacy"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Run.OutcomeContract != protocol.OutcomeProcessExit || len(run.Sessions[0].ResolvedPrompt) != protocol.MaxTaskPromptBytes {
+		t.Fatalf("maximum legacy Run = %#v", run.Run)
+	}
+}
+
+func TestProcessExitCompletionPreservesMaximumLegacyPayloads(t *testing.T) {
+	tests := []struct {
+		name, state, result, failure string
+	}{
+		{name: "result", state: "succeeded", result: strings.Repeat("r", protocol.MaxResultBytes)},
+		{name: "error", state: "failed", failure: strings.Repeat("e", protocol.MaxErrorBytes)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newTestStore(t)
+			worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+				Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+			})
+			task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+				Name: "Maximum " + test.name, Prompt: "Review.", Runtime: protocol.RuntimeCodex,
+				RepositoryIDs: []string{worker.Repositories[0].ID},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+				RequestKey: "maximum-" + test.name,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			claim, err := store.Claim(context.Background(), worker.ID, protocol.ClaimRequest{
+				RequestID: "maximum-" + test.name, LeaseToken: tokenA,
+			})
+			if err != nil || claim == nil {
+				t.Fatalf("claim = %#v, err %v", claim, err)
+			}
+			if test.state == "succeeded" {
+				if _, err := store.StartAttempt(context.Background(), claim.Attempt.ID, protocol.StartAttemptRequest{
+					LeaseToken: tokenA,
+				}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			attempt, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+				LeaseToken: tokenA, State: test.state, Result: test.result, Error: test.failure,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			work, err := store.Work(context.Background(), run.Sessions[0].ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if attempt.Result != test.result || attempt.Error != test.failure ||
+				work.Result != test.result || work.FailureReason != test.failure {
+				t.Fatal("maximum process-exit payload was not preserved")
+			}
+			if work.TerminalMessage != "" {
+				t.Fatalf("process-exit payload copied to terminal message: bytes=%d", len(work.TerminalMessage))
+			}
+		})
+	}
+}
+
+func TestFakeCloudCompletionPreservesMaximumLegacyResult(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	maximumResult := strings.Repeat("r", protocol.MaxResultBytes)
+	profile, err := store.CreateExecutionProfile(context.Background(), protocol.SaveExecutionProfileRequest{
+		Name: "Maximum result cloud", Kind: protocol.BackendFakeCloudRun, Runtime: protocol.RuntimeCodex,
+		Provider: "openrouter", Model: "test", Enabled: true, Healthy: true,
+		FakeOutcome: "succeeded", FakeResult: maximumResult,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := createProfileTask(t, store, worker.Repositories[0].ID, profile.ID)
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "maximum-cloud"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.DispatchFakeCloud(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+	work, err := store.Work(context.Background(), run.Sessions[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if work.Result != maximumResult || work.TerminalMessage != "" {
+		t.Fatalf("maximum fake-cloud result compatibility: result bytes=%d terminal bytes=%d",
+			len(work.Result), len(work.TerminalMessage))
+	}
+}

--- a/internal/protocol/tasks.go
+++ b/internal/protocol/tasks.go
@@ -6,9 +6,25 @@ import (
 )
 
 const (
-	MaxTasks            = 500
-	MaxTaskRepositories = 100
-	MaxTaskPromptBytes  = 64 * 1024
+	MaxTasks                = 500
+	MaxTaskRepositories     = 100
+	MaxTaskPromptBytes      = 64 * 1024
+	MaxWorkTargets          = 100
+	MaxProgressBytes        = 2 * 1024
+	MaxOutcomeBytes         = 8 * 1024
+	MaxWaitingReasonBytes   = 2 * 1024
+	MaxTerminalMessageBytes = 8 * 1024
+	MaxQuestionBytes        = 8 * 1024
+	MaxAnswerBytes          = 8 * 1024
+	MaxUpdatesPerAttempt    = 200
+	MaxProgressPerAttempt   = 199
+)
+
+type OutcomeContract string
+
+const (
+	OutcomeProcessExit OutcomeContract = "process_exit"
+	OutcomeAgentUpdate OutcomeContract = "agent_update"
 )
 
 type TaskSchedule struct {
@@ -37,6 +53,7 @@ type Task struct {
 	TimeoutSeconds     int              `json:"timeout_seconds"`
 	ConcurrencyLimit   int              `json:"concurrency_limit"`
 	Generation         int              `json:"generation"`
+	OutcomeContract    OutcomeContract  `json:"outcome_contract"`
 	Archived           bool             `json:"archived"`
 	ReadOnly           bool             `json:"read_only"`
 	Repositories       []TaskRepository `json:"repositories"`
@@ -62,16 +79,18 @@ type SessionExecution struct {
 // ClaimedSession contains the immutable input a Worker needs to execute a
 // single repository session. It intentionally uses only the Tasks model.
 type ClaimedSession struct {
-	ID              string    `json:"id"`
-	RunID           string    `json:"run_id"`
-	TaskName        string    `json:"task_name"`
-	Prompt          string    `json:"prompt"`
-	WorkerID        string    `json:"worker_id"`
-	RepositoryID    string    `json:"repository_id"`
-	RequiredRuntime string    `json:"required_runtime"`
-	TimeoutSeconds  int       `json:"timeout_seconds"`
-	State           string    `json:"state"`
-	AdmittedAt      time.Time `json:"admitted_at"`
+	ID              string          `json:"id"`
+	RunID           string          `json:"run_id"`
+	TaskName        string          `json:"task_name"`
+	Prompt          string          `json:"prompt"`
+	WorkerID        string          `json:"worker_id"`
+	RepositoryID    string          `json:"repository_id"`
+	RequiredRuntime string          `json:"required_runtime"`
+	TimeoutSeconds  int             `json:"timeout_seconds"`
+	OutcomeContract OutcomeContract `json:"outcome_contract"`
+	Target          WorkTarget      `json:"target"`
+	State           string          `json:"state"`
+	AdmittedAt      time.Time       `json:"admitted_at"`
 }
 
 type TaskPage struct {
@@ -80,21 +99,27 @@ type TaskPage struct {
 }
 
 type SaveTaskRequest struct {
-	RequestKey         string       `json:"request_key,omitempty"`
-	Name               string       `json:"name"`
-	Prompt             string       `json:"prompt"`
-	Runtime            string       `json:"runtime"`
-	ExecutionProfileID string       `json:"execution_profile_id,omitempty"`
-	TimeoutSeconds     int          `json:"timeout_seconds"`
-	ConcurrencyLimit   int          `json:"concurrency_limit"`
-	RepositoryIDs      []string     `json:"repository_ids"`
-	Schedule           TaskSchedule `json:"schedule"`
-	ExpectedGeneration int          `json:"expected_generation,omitempty"`
+	RequestKey         string          `json:"request_key,omitempty"`
+	Name               string          `json:"name"`
+	Prompt             string          `json:"prompt"`
+	Runtime            string          `json:"runtime"`
+	ExecutionProfileID string          `json:"execution_profile_id,omitempty"`
+	TimeoutSeconds     int             `json:"timeout_seconds"`
+	ConcurrencyLimit   int             `json:"concurrency_limit"`
+	RepositoryIDs      []string        `json:"repository_ids"`
+	Schedule           TaskSchedule    `json:"schedule"`
+	ExpectedGeneration int             `json:"expected_generation,omitempty"`
+	OutcomeContract    OutcomeContract `json:"outcome_contract,omitempty"`
 }
 
 type SetTaskArchivedRequest struct {
 	Archived           *bool `json:"archived"`
 	ExpectedGeneration int   `json:"expected_generation"`
+}
+
+type SetTaskOutcomeContractRequest struct {
+	OutcomeContract    OutcomeContract `json:"outcome_contract"`
+	ExpectedGeneration int             `json:"expected_generation"`
 }
 
 type RunTaskRequest struct {
@@ -109,14 +134,65 @@ type DiscardTaskOccurrenceRequest struct {
 type SessionState string
 
 const (
-	SessionBlocked   SessionState = "blocked"
-	SessionQueued    SessionState = "queued"
-	SessionPreparing SessionState = "preparing"
-	SessionRunning   SessionState = "running"
-	SessionSucceeded SessionState = "succeeded"
-	SessionFailed    SessionState = "failed"
-	SessionCancelled SessionState = "cancelled"
+	SessionBlocked    SessionState = "blocked"
+	SessionQueued     SessionState = "queued"
+	SessionPreparing  SessionState = "preparing"
+	SessionRunning    SessionState = "running"
+	SessionNeedsInput SessionState = "needs-input"
+	SessionReady      SessionState = "ready"
+	SessionSucceeded  SessionState = "succeeded"
+	SessionFailed     SessionState = "failed"
+	SessionNoChange   SessionState = "no-change"
+	SessionCancelled  SessionState = "cancelled"
 )
+
+type WorkState = SessionState
+
+const (
+	WorkQueued     WorkState = SessionQueued
+	WorkRunning    WorkState = SessionRunning
+	WorkNeedsInput WorkState = SessionNeedsInput
+	WorkReady      WorkState = SessionReady
+	WorkSucceeded  WorkState = SessionSucceeded
+	WorkFailed     WorkState = SessionFailed
+	WorkNoChange   WorkState = SessionNoChange
+	WorkCancelled  WorkState = SessionCancelled
+)
+
+type ExecutionOwner string
+
+const (
+	ExecutionOwnerNone          ExecutionOwner = "none"
+	ExecutionOwnerWorkerAttempt ExecutionOwner = "worker_attempt"
+	ExecutionOwnerOperator      ExecutionOwner = "operator"
+)
+
+type WorkUpdateStatus string
+
+const (
+	WorkUpdateRunning    WorkUpdateStatus = "running"
+	WorkUpdateReady      WorkUpdateStatus = "ready"
+	WorkUpdateNeedsInput WorkUpdateStatus = "needs-input"
+	WorkUpdateFailed     WorkUpdateStatus = "failed"
+	WorkUpdateNoChange   WorkUpdateStatus = "no-change"
+)
+
+func SupportedWorkUpdateStatus(status WorkUpdateStatus) bool {
+	return status == WorkUpdateRunning || status == WorkUpdateReady ||
+		status == WorkUpdateNeedsInput || status == WorkUpdateFailed || status == WorkUpdateNoChange
+}
+
+type WorkUpdateActor string
+
+const (
+	WorkUpdateActorAgent    WorkUpdateActor = "agent"
+	WorkUpdateActorOperator WorkUpdateActor = "operator"
+	WorkUpdateActorSystem   WorkUpdateActor = "system"
+)
+
+func SupportedWorkUpdateActor(actor WorkUpdateActor) bool {
+	return actor == WorkUpdateActorAgent || actor == WorkUpdateActorOperator || actor == WorkUpdateActorSystem
+}
 
 type RunState string
 
@@ -139,9 +215,50 @@ type TaskSnapshot struct {
 	TimeoutSeconds     int              `json:"timeout_seconds,omitempty"`
 	ConcurrencyLimit   int              `json:"concurrency_limit,omitempty"`
 	Generation         int              `json:"generation"`
+	OutcomeContract    OutcomeContract  `json:"outcome_contract"`
 	Repositories       []TaskRepository `json:"repositories,omitempty"`
 	ScheduleCron       string           `json:"cron,omitempty"`
 	ScheduleTimezone   string           `json:"timezone,omitempty"`
+}
+
+// ProcedureSnapshot is the product name for the immutable Task snapshot.
+// The alias keeps existing Task and scheduled Run clients source compatible.
+type ProcedureSnapshot = TaskSnapshot
+
+type WorkTarget struct {
+	ID                 string `json:"id"`
+	Position           int    `json:"position"`
+	TargetKey          string `json:"target_key"`
+	TargetKind         string `json:"target_kind"`
+	RepositoryID       string `json:"repository_id"`
+	RepositoryIdentity string `json:"repository_identity"`
+	SourceKind         string `json:"source_kind"`
+	SourceKey          string `json:"source_key"`
+	SourceReference    string `json:"source_reference"`
+	ContextSnapshot    string `json:"context_snapshot,omitempty"`
+	PublishBranch      string `json:"publish_branch"`
+}
+
+type WorkUpdate struct {
+	ID                    string           `json:"id"`
+	WorkID                string           `json:"work_id"`
+	AttemptID             string           `json:"attempt_id,omitempty"`
+	RequestID             string           `json:"request_id"`
+	Sequence              int              `json:"sequence"`
+	Status                WorkUpdateStatus `json:"status"`
+	Message               string           `json:"message"`
+	PullRequestURL        string           `json:"pull_request_url,omitempty"`
+	PullRequestHeadBranch string           `json:"pull_request_head_branch,omitempty"`
+	PullRequestHeadSHA    string           `json:"pull_request_head_sha,omitempty"`
+	CheckpointSHA         string           `json:"checkpoint_sha,omitempty"`
+	Actor                 WorkUpdateActor  `json:"actor"`
+	AcceptedAt            time.Time        `json:"accepted_at"`
+}
+
+type WorkUpdatePage struct {
+	Updates   []WorkUpdate `json:"updates"`
+	NextAfter int          `json:"next_after,omitempty"`
+	HasMore   bool         `json:"has_more"`
 }
 
 const (
@@ -227,26 +344,47 @@ type Session struct {
 	TerminalAt            *time.Time        `json:"terminal_at,omitempty"`
 	Result                string            `json:"result,omitempty"`
 	FailureReason         string            `json:"failure_reason,omitempty"`
+	Target                WorkTarget        `json:"target"`
+	PredecessorWorkID     string            `json:"predecessor_work_id,omitempty"`
+	ExecutionOwner        ExecutionOwner    `json:"execution_owner"`
+	WaitingReason         string            `json:"waiting_reason,omitempty"`
+	LatestProgress        string            `json:"latest_progress,omitempty"`
+	Question              string            `json:"question,omitempty"`
+	CheckpointSHA         string            `json:"checkpoint_sha,omitempty"`
+	PendingResumeSHA      string            `json:"pending_resume_sha,omitempty"`
+	PullRequestURL        string            `json:"pull_request_url,omitempty"`
+	PullRequestHeadBranch string            `json:"pull_request_head_branch,omitempty"`
+	PullRequestHeadSHA    string            `json:"pull_request_head_sha,omitempty"`
+	TerminalMessage       string            `json:"terminal_message,omitempty"`
+	Updates               []WorkUpdate      `json:"updates,omitempty"`
 	Attempts              []Attempt         `json:"attempts,omitempty"`
 }
 
+// Work is the product-facing name for the durable Session-backed lifecycle.
+type Work = Session
+
 type Run struct {
-	ID             string            `json:"id"`
-	TaskID         string            `json:"task_id"`
-	Task           TaskSnapshot      `json:"task"`
-	Execution      ExecutionSnapshot `json:"execution"`
-	Source         string            `json:"source"`
-	ScheduledAt    *time.Time        `json:"scheduled_at,omitempty"`
-	State          RunState          `json:"state"`
-	NeedsAttention bool              `json:"needs_attention"`
-	SessionCount   int               `json:"session_count"`
-	SucceededCount int               `json:"succeeded_count"`
-	FailedCount    int               `json:"failed_count"`
-	CancelledCount int               `json:"cancelled_count"`
-	ActiveCount    int               `json:"active_count"`
-	AdmittedAt     time.Time         `json:"admitted_at"`
-	UpdatedAt      time.Time         `json:"updated_at"`
-	TerminalAt     *time.Time        `json:"terminal_at,omitempty"`
+	ID              string            `json:"id"`
+	TaskID          string            `json:"task_id"`
+	Task            TaskSnapshot      `json:"task"`
+	Execution       ExecutionSnapshot `json:"execution"`
+	OutcomeContract OutcomeContract   `json:"outcome_contract"`
+	Targets         []WorkTarget      `json:"targets"`
+	Source          string            `json:"source"`
+	ScheduledAt     *time.Time        `json:"scheduled_at,omitempty"`
+	State           RunState          `json:"state"`
+	NeedsAttention  bool              `json:"needs_attention"`
+	SessionCount    int               `json:"session_count"`
+	SucceededCount  int               `json:"succeeded_count"`
+	ReadyCount      int               `json:"ready_count"`
+	NeedsInputCount int               `json:"needs_input_count"`
+	NoChangeCount   int               `json:"no_change_count"`
+	FailedCount     int               `json:"failed_count"`
+	CancelledCount  int               `json:"cancelled_count"`
+	ActiveCount     int               `json:"active_count"`
+	AdmittedAt      time.Time         `json:"admitted_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+	TerminalAt      *time.Time        `json:"terminal_at,omitempty"`
 }
 
 type RunDetail struct {

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -34,10 +34,10 @@ const (
 	MaxEventPageSize          = 500
 	MinWorkerCapacity         = 1
 	MaxWorkerCapacity         = 100
-	// ClaimProtocolVersion moved to 2 when the claim payload replaced its
-	// target field with session. A Worker registered under version 1 cannot
-	// decode a version 2 claim, so it must re-register before it can claim.
-	ClaimProtocolVersion = 2
+	// ClaimProtocolVersion moved to 3 when claims began freezing the Work
+	// lifecycle and outcome contract. Mixed server and Worker versions are not
+	// supported, including for compatibility process-exit Work.
+	ClaimProtocolVersion = 3
 )
 
 func SupportedRuntime(value string) bool {

--- a/internal/protocol/work_test.go
+++ b/internal/protocol/work_test.go
@@ -1,0 +1,30 @@
+package protocol
+
+import "testing"
+
+func TestWorkUpdateTypesAcceptOnlyProtocolValues(t *testing.T) {
+	for _, status := range []WorkUpdateStatus{
+		WorkUpdateRunning, WorkUpdateReady, WorkUpdateNeedsInput, WorkUpdateFailed, WorkUpdateNoChange,
+	} {
+		if !SupportedWorkUpdateStatus(status) {
+			t.Fatalf("supported status %q was rejected", status)
+		}
+	}
+	for _, status := range []WorkUpdateStatus{"queued", "succeeded", "cancelled", "misspelled"} {
+		if SupportedWorkUpdateStatus(status) {
+			t.Fatalf("unsupported status %q was accepted", status)
+		}
+	}
+	for _, actor := range []WorkUpdateActor{
+		WorkUpdateActorAgent, WorkUpdateActorOperator, WorkUpdateActorSystem,
+	} {
+		if !SupportedWorkUpdateActor(actor) {
+			t.Fatalf("supported actor %q was rejected", actor)
+		}
+	}
+	for _, actor := range []WorkUpdateActor{"worker", "human", "misspelled"} {
+		if SupportedWorkUpdateActor(actor) {
+			t.Fatalf("unsupported actor %q was accepted", actor)
+		}
+	}
+}

--- a/migrations/031_work_lifecycle.sql
+++ b/migrations/031_work_lifecycle.sql
@@ -1,0 +1,227 @@
+-- factory: foreign-keys-off
+
+-- Existing Tasks and Runs retain their exit-based completion contract. New
+-- agent-directed Procedures may opt in explicitly, and every admitted Run
+-- stores the selected contract independently of later Task changes.
+ALTER TABLE tasks ADD COLUMN outcome_contract TEXT NOT NULL DEFAULT 'process_exit'
+    CHECK (outcome_contract IN ('process_exit', 'agent_update'));
+
+ALTER TABLE runs ADD COLUMN outcome_contract TEXT NOT NULL DEFAULT 'process_exit'
+    CHECK (outcome_contract IN ('process_exit', 'agent_update'));
+ALTER TABLE runs ADD COLUMN targets_snapshot TEXT NOT NULL DEFAULT '[]'
+    CHECK (json_valid(targets_snapshot) AND json_type(targets_snapshot) = 'array');
+
+UPDATE runs
+SET task_snapshot = json_set(task_snapshot, '$.outcome_contract', 'process_exit');
+
+-- Rebuild Sessions as the additive backing store for Work. This removes the
+-- old one-Session-per-repository constraint, widens the state check, and keeps
+-- every existing column and identifier so historical foreign keys remain
+-- valid. Existing blocked and preparing states stay readable as compatibility
+-- execution states while new Work uses the product lifecycle states.
+CREATE TABLE sessions_work_lifecycle (
+    id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL REFERENCES "runs"(id) ON DELETE CASCADE,
+    repository_id TEXT NOT NULL REFERENCES repositories(id),
+    repository_identity TEXT NOT NULL,
+    resolved_prompt TEXT NOT NULL,
+    required_runtime TEXT NOT NULL CHECK (required_runtime IN ('pi', 'codex', 'claude-code')),
+    timeout_seconds INTEGER NOT NULL CHECK (timeout_seconds BETWEEN 1 AND 28800),
+    state TEXT NOT NULL CHECK (state IN (
+        'blocked', 'queued', 'preparing', 'running', 'needs-input',
+        'ready', 'succeeded', 'failed', 'no-change', 'cancelled'
+    )),
+    blocked_reason TEXT,
+    assigned_worker_id TEXT REFERENCES workers(id),
+    cancellation_requested INTEGER NOT NULL DEFAULT 0 CHECK (cancellation_requested IN (0, 1)),
+    retry_may_repeat_effects INTEGER NOT NULL DEFAULT 0 CHECK (retry_may_repeat_effects IN (0, 1)),
+    admitted_at INTEGER NOT NULL,
+    started_at INTEGER,
+    terminal_at INTEGER,
+    result TEXT,
+    failure_reason TEXT,
+    execution_profile_id TEXT NOT NULL DEFAULT 'persistent-auto',
+    execution_profile_version INTEGER NOT NULL DEFAULT 1 CHECK (execution_profile_version >= 1),
+    execution_backend TEXT NOT NULL DEFAULT 'persistent'
+        CHECK (execution_backend IN ('persistent', 'fake_cloud_run')),
+    execution_provider TEXT NOT NULL DEFAULT 'worker',
+    execution_model TEXT NOT NULL DEFAULT 'worker-default',
+    resource_class TEXT NOT NULL DEFAULT 'worker',
+    commit_resolution_policy TEXT NOT NULL DEFAULT 'resolve_per_attempt'
+        CHECK (commit_resolution_policy IN ('resolve_per_attempt', 'frozen_commit')),
+    target_position INTEGER NOT NULL DEFAULT 0 CHECK (target_position BETWEEN 0 AND 99),
+    target_key TEXT NOT NULL DEFAULT '' CHECK (length(CAST(target_key AS BLOB)) <= 1024),
+    target_kind TEXT NOT NULL DEFAULT 'repository'
+        CHECK (target_kind IN ('work_item', 'repository')),
+    source_kind TEXT NOT NULL DEFAULT 'repository'
+        CHECK (source_kind IN ('github_issue', 'opaque', 'repository')),
+    source_key TEXT NOT NULL DEFAULT '' CHECK (length(CAST(source_key AS BLOB)) <= 1024),
+    source_reference TEXT NOT NULL DEFAULT '' CHECK (length(CAST(source_reference AS BLOB)) <= 2048),
+    context_snapshot TEXT NOT NULL DEFAULT '' CHECK (length(CAST(context_snapshot AS BLOB)) <= 65536),
+    publish_branch TEXT NOT NULL DEFAULT '' CHECK (length(CAST(publish_branch AS BLOB)) <= 255),
+    predecessor_work_id TEXT REFERENCES sessions_work_lifecycle(id),
+    execution_owner TEXT NOT NULL DEFAULT 'none'
+        CHECK (execution_owner IN ('none', 'worker_attempt', 'operator')),
+    waiting_reason TEXT NOT NULL DEFAULT '' CHECK (length(CAST(waiting_reason AS BLOB)) <= 2048),
+    latest_progress TEXT NOT NULL DEFAULT '' CHECK (length(CAST(latest_progress AS BLOB)) <= 2048),
+    question TEXT NOT NULL DEFAULT '' CHECK (length(CAST(question AS BLOB)) <= 8192),
+    checkpoint_sha TEXT NOT NULL DEFAULT '' CHECK (length(checkpoint_sha) <= 64),
+    pending_resume_sha TEXT NOT NULL DEFAULT '' CHECK (length(pending_resume_sha) <= 64),
+    pull_request_url TEXT NOT NULL DEFAULT '' CHECK (length(CAST(pull_request_url AS BLOB)) <= 2048),
+    pull_request_head_branch TEXT NOT NULL DEFAULT '' CHECK (length(CAST(pull_request_head_branch AS BLOB)) <= 255),
+    pull_request_head_sha TEXT NOT NULL DEFAULT '' CHECK (length(pull_request_head_sha) <= 64),
+    terminal_message TEXT NOT NULL DEFAULT '' CHECK (length(CAST(terminal_message AS BLOB)) <= 8192),
+    CHECK (
+        (state = 'preparing' AND execution_owner = 'worker_attempt')
+        OR (state = 'running' AND execution_owner IN ('worker_attempt', 'operator'))
+        OR (state NOT IN ('preparing', 'running') AND execution_owner = 'none')
+    ),
+    CHECK (state != 'needs-input' OR (question != '' AND checkpoint_sha != '' AND pending_resume_sha != '')),
+    CHECK (state != 'ready' OR pull_request_url != ''),
+    CHECK (state NOT IN ('ready', 'succeeded', 'failed', 'no-change', 'cancelled') OR terminal_at IS NOT NULL)
+);
+
+INSERT INTO sessions_work_lifecycle(
+    id, run_id, repository_id, repository_identity, resolved_prompt, required_runtime,
+    timeout_seconds, state, blocked_reason, assigned_worker_id, cancellation_requested,
+    retry_may_repeat_effects, admitted_at, started_at, terminal_at, result, failure_reason,
+    execution_profile_id, execution_profile_version, execution_backend, execution_provider,
+    execution_model, resource_class, commit_resolution_policy, target_position, target_key,
+    target_kind, source_kind, source_key, source_reference, context_snapshot, publish_branch,
+    execution_owner, waiting_reason, terminal_message
+)
+SELECT
+    session.id, session.run_id, session.repository_id, session.repository_identity,
+    session.resolved_prompt, session.required_runtime, session.timeout_seconds, session.state,
+    session.blocked_reason, session.assigned_worker_id, session.cancellation_requested,
+    session.retry_may_repeat_effects, session.admitted_at, session.started_at, session.terminal_at,
+    session.result, session.failure_reason, session.execution_profile_id,
+    session.execution_profile_version, session.execution_backend, session.execution_provider,
+    session.execution_model, session.resource_class, session.commit_resolution_policy,
+    COALESCE(
+        (
+            SELECT CAST(target.key AS INTEGER)
+            FROM runs frozen_run, json_each(frozen_run.task_snapshot, '$.repositories') target
+            WHERE frozen_run.id = session.run_id
+              AND CASE WHEN target.type = 'object'
+                  THEN json_extract(target.value, '$.id') ELSE target.value END = session.repository_id
+            LIMIT 1
+        ),
+        (
+            SELECT CAST(target.key AS INTEGER)
+            FROM runs frozen_run, json_each(frozen_run.task_snapshot, '$.repository_ids') target
+            WHERE frozen_run.id = session.run_id AND target.value = session.repository_id
+            LIMIT 1
+        ),
+        session.fallback_position
+    ),
+    'repository:' || session.repository_id,
+    'repository', 'repository', session.repository_id, session.repository_identity, '',
+    'factory/work-' || substr(replace(session.id, '-', ''), 1, 16),
+    CASE WHEN session.state IN ('preparing', 'running') THEN 'worker_attempt' ELSE 'none' END,
+    CASE
+        WHEN length(CAST(COALESCE(session.blocked_reason, '') AS BLOB)) <= 2048
+            THEN COALESCE(session.blocked_reason, '')
+        -- SQLite substrings TEXT by characters. A 512-character prefix is
+        -- valid UTF-8 and at most 2048 bytes, even for four-byte code points.
+        ELSE substr(session.blocked_reason, 1, 512)
+    END,
+    -- Legacy process-exit outcomes remain in result/failure_reason. Copying
+    -- them here would reject their valid 256 KiB/64 KiB limits against the
+    -- deliberately narrower agent-update terminal message.
+    ''
+FROM (
+    SELECT existing.*,
+           ROW_NUMBER() OVER (
+               PARTITION BY existing.run_id ORDER BY existing.admitted_at, existing.id
+           ) - 1 AS fallback_position
+    FROM sessions existing
+) session;
+
+DROP TABLE sessions;
+ALTER TABLE sessions_work_lifecycle RENAME TO sessions;
+
+CREATE INDEX sessions_run_order ON sessions(run_id, target_position, id);
+CREATE INDEX sessions_claim_order ON sessions(state, admitted_at, id);
+CREATE INDEX sessions_backend_claim ON sessions(execution_backend, state, admitted_at, id);
+CREATE INDEX sessions_predecessor ON sessions(predecessor_work_id);
+CREATE UNIQUE INDEX sessions_run_target_key
+    ON sessions(run_id, target_key) WHERE target_key != '';
+CREATE UNIQUE INDEX sessions_run_target_position
+    ON sessions(run_id, target_position) WHERE target_key != '';
+CREATE INDEX sessions_retry_identity
+    ON sessions(repository_id, source_kind, source_key, state);
+
+UPDATE runs
+SET targets_snapshot = COALESCE((
+    SELECT json_group_array(json(target_json))
+    FROM (
+        SELECT json_object(
+            'id', session.id,
+            'position', session.target_position,
+            'target_key', session.target_key,
+            'target_kind', session.target_kind,
+            'repository_id', session.repository_id,
+            'repository_identity', session.repository_identity,
+            'source_kind', session.source_kind,
+            'source_key', session.source_key,
+            'source_reference', session.source_reference,
+            'context_snapshot', session.context_snapshot,
+            'publish_branch', session.publish_branch
+        ) AS target_json
+        FROM sessions session
+        WHERE session.run_id = runs.id
+        ORDER BY session.target_position
+    ) ordered_targets
+), '[]');
+
+-- The full update history is durable and bounded per Attempt. The reserved
+-- outcome slot means an agent can always finish after 199 progress updates.
+CREATE TABLE work_updates (
+    id TEXT PRIMARY KEY,
+    work_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    attempt_id TEXT REFERENCES attempts(id),
+    request_id TEXT NOT NULL CHECK (length(CAST(request_id AS BLOB)) BETWEEN 1 AND 200),
+    sequence INTEGER NOT NULL CHECK (sequence > 0),
+    status TEXT NOT NULL CHECK (status IN ('running', 'ready', 'needs-input', 'failed', 'no-change')),
+    message TEXT NOT NULL CHECK (
+        length(CAST(message AS BLOB)) BETWEEN 1 AND
+        CASE WHEN status = 'running' THEN 2048 ELSE 8192 END
+    ),
+    pull_request_url TEXT NOT NULL DEFAULT '' CHECK (length(CAST(pull_request_url AS BLOB)) <= 2048),
+    pull_request_head_branch TEXT NOT NULL DEFAULT '' CHECK (length(CAST(pull_request_head_branch AS BLOB)) <= 255),
+    pull_request_head_sha TEXT NOT NULL DEFAULT '' CHECK (length(pull_request_head_sha) <= 64),
+    checkpoint_sha TEXT NOT NULL DEFAULT '' CHECK (length(checkpoint_sha) <= 64),
+    actor TEXT NOT NULL CHECK (actor IN ('agent', 'operator', 'system')),
+    accepted_at INTEGER NOT NULL,
+    UNIQUE (work_id, sequence),
+    CHECK (status != 'ready' OR pull_request_url != ''),
+    CHECK (status != 'needs-input' OR checkpoint_sha != '')
+);
+
+CREATE UNIQUE INDEX work_updates_attempt_request
+    ON work_updates(attempt_id, request_id) WHERE attempt_id IS NOT NULL;
+CREATE UNIQUE INDEX work_updates_operator_request
+    ON work_updates(work_id, request_id) WHERE attempt_id IS NULL;
+CREATE UNIQUE INDEX work_updates_attempt_outcome
+    ON work_updates(attempt_id) WHERE attempt_id IS NOT NULL AND status != 'running';
+CREATE INDEX work_updates_work_order ON work_updates(work_id, sequence);
+
+CREATE TRIGGER work_updates_attempt_limit
+BEFORE INSERT ON work_updates
+WHEN NEW.attempt_id IS NOT NULL AND (
+    SELECT COUNT(*) FROM work_updates WHERE attempt_id = NEW.attempt_id
+) >= 200
+BEGIN
+    SELECT RAISE(ABORT, 'work update limit reached');
+END;
+
+CREATE TRIGGER work_updates_progress_limit
+BEFORE INSERT ON work_updates
+WHEN NEW.attempt_id IS NOT NULL AND NEW.status = 'running' AND (
+    SELECT COUNT(*) FROM work_updates
+    WHERE attempt_id = NEW.attempt_id AND status = 'running'
+) >= 199
+BEGIN
+    SELECT RAISE(ABORT, 'work progress update limit reached');
+END;


### PR DESCRIPTION
## Summary

- add the durable Work-backed Session schema, ordered frozen targets, Procedure outcome contracts, typed bounded update history, ownership, recovery, and terminal fields
- preserve legacy process-exit Runs, maximum result/error and prompt limits, scheduled occurrence behavior, and fake cloud completion through migration 031
- enforce claim protocol v3, Work-derived Run aggregation, one-way agent-update conversion, retry replacement and predecessor-lineage guards, and exact ownership constraints
- document the implemented lifecycle foundation in ARCHITECTURE.md

## Verification

- `go test ./internal/controlplane ./internal/protocol ./migrations`
- `just format-check`
- `just vet`
- `just boundary`
- `just test`
- `git diff --check`
- fresh read-only review: Approve, no material findings

Closes #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable task completion modes for process-based or agent-driven outcomes.
  - Introduced work targets, ownership tracking, progress updates, checkpoints, questions, and pull-request details.
  - Added ready, no-change, and needs-input work states.
  - Added paginated work-update history and expanded run summaries.

- **Bug Fixes**
  - Improved cancellation, retry, expiration, and completion handling.
  - Added validation to prevent incompatible or duplicate work claims.
  - Preserved lifecycle data and target ordering during migrations.

- **Documentation**
  - Updated architecture documentation for the current task, run, and work lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->