### PR TITLE
feat: add scoped agent updates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -202,7 +202,9 @@ static repository paths remain readable through Worker configuration.
 `cmd/factory` delegates parsing and finite HTTP work to `internal/factorycli`.
 The `status`, `show`, and `workers` commands decode protocol resources and write
 either stable tabular output or one JSON value. They do not import SQLite or
-Worker packages.
+Worker packages. An injected `factory update` command instead connects only to
+a private Attempt-scoped Unix socket using the Work ID, Attempt ID, and update
+token supplied by the Worker.
 
 The `server start` and `worker start` commands replace the CLI process with the
 matching compatibility executable beside it or on `PATH`. An explicit config
@@ -242,6 +244,14 @@ manager:
 - renews active leases every ten seconds;
 - starts up to the configured number of isolated sessions;
 - reconciles manifests, worktrees, and owned process groups after restart.
+
+Only a frozen `agent_update` Attempt receives a private update socket and
+token. The Worker validates that capability locally, resolves ready pull
+request evidence with GitHub and Git, and forwards a typed update under its own
+lease. The agent-facing request never contains an operator credential, Worker
+credential, or Attempt lease token. Outcome reports ask the supervisor to stop
+the process group, then the Worker completes the Attempt only after verified
+process stop and any required delivery postflight check.
 
 The supervisor is a subprocess of `factory-worker`. It anchors ownership of the
 runtime process group. Unix process-group behavior is required, so Windows

--- a/internal/controlplane/agent_update_test.go
+++ b/internal/controlplane/agent_update_test.go
@@ -1,0 +1,223 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func claimRunningAgentWork(t *testing.T, store *Store, requestKey string) (protocol.RunDetail, protocol.Claim) {
+	t.Helper()
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Agent updates", Prompt: "Report an outcome.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID}, OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: requestKey})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(context.Background(), worker.ID, protocol.ClaimRequest{
+		RequestID: requestKey, LeaseToken: tokenA,
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, err %v", claim, err)
+	}
+	if _, err := store.StartAttempt(context.Background(), claim.Attempt.ID, protocol.StartAttemptRequest{LeaseToken: tokenA}); err != nil {
+		t.Fatal(err)
+	}
+	return run, *claim
+}
+
+func TestAgentUpdateProgressOutcomeAndSemanticCompletion(t *testing.T) {
+	store := newTestStore(t)
+	run, claim := claimRunningAgentWork(t, store, "agent-update-completion")
+	progressID := "10000000-0000-4000-8000-000000000001"
+	progress, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, RequestID: progressID, Status: protocol.WorkUpdateRunning, Message: "Running focused tests.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if progress.Sequence != 1 || progress.WorkID != run.Sessions[0].ID || progress.Actor != protocol.WorkUpdateActorAgent {
+		t.Fatalf("progress = %#v", progress)
+	}
+	outcome, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, RequestID: "10000000-0000-4000-8000-000000000002",
+		Status: protocol.WorkUpdateFailed, Message: "The dependency is unavailable.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Sequence != 2 {
+		t.Fatalf("outcome = %#v", outcome)
+	}
+	attempt, err := store.CompleteAttempt(context.Background(), claim.Attempt.ID, protocol.CompleteAttemptRequest{
+		LeaseToken: tokenA, State: "succeeded", Result: "arbitrary prose must be ignored",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	work, err := store.Work(context.Background(), run.Sessions[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attempt.State != "succeeded" || attempt.Result != "" || attempt.Error != "" ||
+		work.State != protocol.WorkFailed || work.FailureReason != outcome.Message ||
+		work.TerminalMessage != outcome.Message || work.LatestProgress != progress.Message {
+		t.Fatalf("semantic completion = Attempt %#v, Work %#v", attempt, work)
+	}
+}
+
+func TestAgentUpdateExactReplayPrecedesLeaseExpiry(t *testing.T) {
+	store := newTestStore(t)
+	_, claim := claimRunningAgentWork(t, store, "agent-update-replay")
+	request := protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, RequestID: "20000000-0000-4000-8000-000000000001",
+		Status: protocol.WorkUpdateRunning, Message: "Waiting for CI.",
+	}
+	stored, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE attempts SET lease_expires_at = ? WHERE id = ?`,
+		time.Now().Add(-time.Minute).UnixMilli(), claim.Attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, request)
+	if err != nil || replayed.ID != stored.ID {
+		t.Fatalf("expired exact replay = %#v, err %v", replayed, err)
+	}
+	changed := request
+	changed.Message = "Changed after expiry."
+	if _, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, changed); !serviceErrorCode(err, "update_request_conflict") {
+		t.Fatalf("changed expired replay error = %v", err)
+	}
+	request.RequestID = "20000000-0000-4000-8000-000000000002"
+	if _, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, request); !serviceErrorCode(err, "lease_not_owner") {
+		t.Fatalf("new expired request error = %v", err)
+	}
+	request.LeaseToken = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	request.RequestID = "20000000-0000-4000-8000-000000000001"
+	if _, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, request); !serviceErrorCode(err, "lease_not_owner") {
+		t.Fatalf("wrong-token replay error = %v", err)
+	}
+}
+
+func TestReadyAgentUpdateReplayNeedsNoFreshDeliveryEvidence(t *testing.T) {
+	store := newTestStore(t)
+	_, claim := claimRunningAgentWork(t, store, "agent-update-ready-replay")
+	request := protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, RequestID: "21000000-0000-4000-8000-000000000001",
+		Status: protocol.WorkUpdateReady, Message: "Pull request is ready.",
+		PullRequestURL:        "https://github.com/owainlewis/factory/pull/342",
+		PullRequestHeadBranch: "factory/work-ready",
+		PullRequestHeadSHA:    strings.Repeat("a", 40),
+	}
+	stored, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE attempts SET lease_expires_at = ? WHERE id = ?`,
+		time.Now().Add(-time.Minute).UnixMilli(), claim.Attempt.ID); err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, ReplayOnly: true, RequestID: request.RequestID,
+		Status: request.Status, Message: request.Message, PullRequestURL: request.PullRequestURL,
+	})
+	if err != nil || replayed.ID != stored.ID || replayed.PullRequestHeadSHA != request.PullRequestHeadSHA {
+		t.Fatalf("ready replay = %#v, err %v", replayed, err)
+	}
+}
+
+func TestAgentUpdateReservesOutcomeAfter199ProgressReports(t *testing.T) {
+	store := newTestStore(t)
+	_, claim := claimRunningAgentWork(t, store, "agent-update-limit")
+	for index := 0; index < protocol.MaxProgressPerAttempt; index++ {
+		requestID := fmt.Sprintf("30000000-0000-4000-8000-%012d", index)
+		if _, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, protocol.AttemptUpdateRequest{
+			LeaseToken: tokenA, RequestID: requestID, Status: protocol.WorkUpdateRunning, Message: "Progress.",
+		}); err != nil {
+			t.Fatalf("progress %d: %v", index, err)
+		}
+	}
+	if _, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, RequestID: "30000000-0000-4000-8000-999999999999",
+		Status: protocol.WorkUpdateRunning, Message: "Too much progress.",
+	}); !serviceErrorCode(err, "progress_update_limit") {
+		t.Fatalf("progress limit error = %v", err)
+	}
+	if _, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, RequestID: "30000000-0000-4000-8000-999999999998",
+		Status: protocol.WorkUpdateNoChange, Message: "No defensible change exists.",
+	}); err != nil {
+		t.Fatalf("reserved outcome: %v", err)
+	}
+	page, err := store.WorkUpdates(context.Background(), claim.Session.ID, 200, 0)
+	if err != nil || len(page.Updates) != protocol.MaxUpdatesPerAttempt {
+		t.Fatalf("updates = %d, err %v", len(page.Updates), err)
+	}
+}
+
+func TestAgentUpdateRejectsProcessExitAndOutcomeConflicts(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Legacy", Prompt: "Exit normally.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "legacy-update-reject"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := store.Claim(context.Background(), worker.ID, protocol.ClaimRequest{
+		RequestID: "legacy-update-reject", LeaseToken: tokenA,
+	})
+	if err != nil || claim == nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StartAttempt(context.Background(), claim.Attempt.ID, protocol.StartAttemptRequest{LeaseToken: tokenA}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AppendAgentUpdate(context.Background(), claim.Attempt.ID, protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, RequestID: "40000000-0000-4000-8000-000000000001",
+		Status: protocol.WorkUpdateFailed, Message: "Should be rejected.",
+	}); !serviceErrorCode(err, "agent_update_not_allowed") {
+		t.Fatalf("legacy update error = %v", err)
+	}
+
+	_, agentClaim := claimRunningAgentWork(t, store, "outcome-conflict")
+	first := protocol.AttemptUpdateRequest{
+		LeaseToken: tokenA, RequestID: "40000000-0000-4000-8000-000000000002",
+		Status: protocol.WorkUpdateNoChange, Message: "Nothing to change.",
+	}
+	stored, err := store.AppendAgentUpdate(context.Background(), agentClaim.Attempt.ID, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first.RequestID = "40000000-0000-4000-8000-000000000003"
+	repeated, err := store.AppendAgentUpdate(context.Background(), agentClaim.Attempt.ID, first)
+	if err != nil || repeated.ID != stored.ID {
+		t.Fatalf("identical second outcome = %#v, err %v", repeated, err)
+	}
+	first.Message = strings.Repeat("x", 8)
+	first.RequestID = "40000000-0000-4000-8000-000000000004"
+	if _, err := store.AppendAgentUpdate(context.Background(), agentClaim.Attempt.ID, first); !serviceErrorCode(err, "outcome_already_reported") {
+		t.Fatalf("different outcome error = %v", err)
+	}
+}

--- a/internal/controlplane/agent_update_test.go
+++ b/internal/controlplane/agent_update_test.go
@@ -89,7 +89,7 @@ func TestAgentUpdateExactReplayPrecedesLeaseExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.db.Exec(`UPDATE attempts SET lease_expires_at = ? WHERE id = ?`,
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE attempts SET lease_expires_at = ? WHERE id = ?`,
 		time.Now().Add(-time.Minute).UnixMilli(), claim.Attempt.ID); err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestReadyAgentUpdateReplayNeedsNoFreshDeliveryEvidence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.db.Exec(`UPDATE attempts SET lease_expires_at = ? WHERE id = ?`,
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE attempts SET lease_expires_at = ? WHERE id = ?`,
 		time.Now().Add(-time.Minute).UnixMilli(), claim.Attempt.ID); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -104,6 +104,7 @@ func NewHandler(store *Store, logger *slog.Logger) http.Handler {
 	mux.HandleFunc("PUT /api/v1/attempts/{attempt_id}/heartbeat", api.heartbeat)
 	mux.HandleFunc("GET /api/v1/attempts/{attempt_id}/events", api.getEvents)
 	mux.HandleFunc("POST /api/v1/attempts/{attempt_id}/events", api.appendEvents)
+	mux.HandleFunc("POST /api/v1/attempts/{attempt_id}/updates", api.appendAgentUpdate)
 	mux.HandleFunc("POST /api/v1/attempts/{attempt_id}/complete", api.completeAttempt)
 	return api.requestLog(mux, true)
 }
@@ -125,6 +126,7 @@ func NewRemoteWorkerHandler(store *Store, logger *slog.Logger) http.Handler {
 	mux.Handle("POST /api/v1/attempts/{attempt_id}/start", api.remoteAttemptAuth(http.HandlerFunc(api.startAttempt)))
 	mux.Handle("PUT /api/v1/attempts/{attempt_id}/heartbeat", api.remoteAttemptAuth(http.HandlerFunc(api.heartbeat)))
 	mux.Handle("POST /api/v1/attempts/{attempt_id}/events", api.remoteAttemptAuth(http.HandlerFunc(api.appendEvents)))
+	mux.Handle("POST /api/v1/attempts/{attempt_id}/updates", api.remoteAttemptAuth(http.HandlerFunc(api.appendAgentUpdate)))
 	mux.Handle("POST /api/v1/attempts/{attempt_id}/complete", api.remoteAttemptAuth(http.HandlerFunc(api.completeAttempt)))
 	return api.requestLog(mux, false)
 }
@@ -595,6 +597,22 @@ func (a *API) appendEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *API) appendAgentUpdate(w http.ResponseWriter, r *http.Request) {
+	if !prepareMutation(w, r, protocol.MaxBodyBytes) {
+		return
+	}
+	var input protocol.AttemptUpdateRequest
+	if !decodeJSON(w, r, &input) {
+		return
+	}
+	update, err := a.store.AppendAgentUpdate(r.Context(), r.PathValue("attempt_id"), input)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, update)
 }
 
 func (a *API) getEvents(w http.ResponseWriter, r *http.Request) {

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -615,13 +615,42 @@ func (s *Store) CompleteAttempt(ctx context.Context, attemptID string, input pro
 		return protocol.Attempt{}, err
 	}
 	terminalMessage := ""
+	workState := protocol.WorkState(input.State)
+	failureReason := input.Error
+	var outcome protocol.WorkUpdate
+	hasOutcome := false
 	if lease.cancel {
 		input.State, input.Result, input.Error = "cancelled", "", ""
+		workState, failureReason = protocol.WorkCancelled, ""
 		terminalMessage = "Cancelled by operator."
 	} else if lease.outcomeContract == protocol.OutcomeAgentUpdate && input.State == "succeeded" {
-		const missingOutcome = "Agent exited without reporting an outcome."
-		input.State, input.Result, input.Error = "failed", "", missingOutcome
-		terminalMessage = missingOutcome
+		outcome, hasOutcome, err = attemptOutcome(ctx, tx, attemptID)
+		if err != nil {
+			return protocol.Attempt{}, err
+		}
+		if !hasOutcome {
+			const missingOutcome = "Agent exited without reporting an outcome."
+			input.State, input.Result, input.Error = "failed", "", missingOutcome
+			workState, failureReason, terminalMessage = protocol.WorkFailed, missingOutcome, missingOutcome
+		} else {
+			// The Attempt succeeded because the agent completed its reporting
+			// contract. Work state remains the semantic outcome reported by the
+			// agent, and arbitrary final runtime prose is not interpreted.
+			input.Result, input.Error = "", ""
+			terminalMessage = outcome.Message
+			switch outcome.Status {
+			case protocol.WorkUpdateReady:
+				workState = protocol.WorkReady
+			case protocol.WorkUpdateNeedsInput:
+				workState = protocol.WorkNeedsInput
+			case protocol.WorkUpdateFailed:
+				workState, failureReason = protocol.WorkFailed, outcome.Message
+			case protocol.WorkUpdateNoChange:
+				workState = protocol.WorkNoChange
+			default:
+				return protocol.Attempt{}, conflict("outcome_missing", "the Attempt has no ending outcome report")
+			}
+		}
 	}
 	if input.State == "succeeded" && lease.attemptState != "running" {
 		return protocol.Attempt{}, conflict("invalid_transition", "only a running attempt can succeed")
@@ -638,13 +667,33 @@ func (s *Store) CompleteAttempt(ctx context.Context, attemptID string, input pro
 	`, input.State, now, lease.executionID); err != nil {
 		return protocol.Attempt{}, unavailable(err)
 	}
-	if _, err := tx.ExecContext(ctx, `
+	if hasOutcome && workState == protocol.WorkNeedsInput {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE sessions SET state = 'needs-input', terminal_at = NULL, result = NULL,
+			       failure_reason = NULL, terminal_message = ?, question = ?,
+			       checkpoint_sha = ?, pending_resume_sha = ?, execution_owner = 'none'
+			WHERE id = (SELECT session_id FROM executions WHERE id = ?)
+			  AND state = 'running'
+		`, terminalMessage, outcome.Message, outcome.CheckpointSHA, outcome.CheckpointSHA, lease.executionID); err != nil {
+			return protocol.Attempt{}, unavailable(err)
+		}
+	} else if hasOutcome {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE sessions SET state = ?, terminal_at = ?, result = NULL, failure_reason = ?,
+			       terminal_message = ?, pull_request_url = ?, pull_request_head_branch = ?,
+			       pull_request_head_sha = ?, execution_owner = 'none'
+			WHERE id = (SELECT session_id FROM executions WHERE id = ?)
+			  AND state = 'running'
+		`, workState, now, nullString(failureReason), terminalMessage, outcome.PullRequestURL,
+			outcome.PullRequestHeadBranch, outcome.PullRequestHeadSHA, lease.executionID); err != nil {
+			return protocol.Attempt{}, unavailable(err)
+		}
+	} else if _, err := tx.ExecContext(ctx, `
 		UPDATE sessions SET state = ?, terminal_at = ?, result = ?, failure_reason = ?,
-		       terminal_message = ?,
-		       execution_owner = 'none'
+		       terminal_message = ?, execution_owner = 'none'
 		WHERE id = (SELECT session_id FROM executions WHERE id = ?)
 		  AND state IN ('preparing', 'running')
-	`, input.State, now, nullString(input.Result), nullString(input.Error), terminalMessage, lease.executionID); err != nil {
+	`, workState, now, nullString(input.Result), nullString(failureReason), terminalMessage, lease.executionID); err != nil {
 		return protocol.Attempt{}, unavailable(err)
 	}
 	if err := updateRunLifecycle(ctx, tx, lease.executionID, now); err != nil {

--- a/internal/controlplane/work.go
+++ b/internal/controlplane/work.go
@@ -2,8 +2,12 @@ package controlplane
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/owainlewis/factory/internal/protocol"
 )
@@ -12,6 +16,321 @@ const (
 	defaultWorkUpdatePageSize = 100
 	maxWorkUpdatePageSize     = 200
 )
+
+func (s *Store) AppendAgentUpdate(
+	ctx context.Context,
+	attemptID string,
+	input protocol.AttemptUpdateRequest,
+) (protocol.WorkUpdate, error) {
+	if !validUUID(attemptID) || !validUUID(input.RequestID) {
+		return protocol.WorkUpdate{}, invalid("invalid_update_identity", "attempt_id and request_id must be UUIDs")
+	}
+	if err := validateToken(input.LeaseToken); err != nil {
+		return protocol.WorkUpdate{}, err
+	}
+	if !protocol.SupportedWorkUpdateStatus(input.Status) {
+		return protocol.WorkUpdate{}, invalid(
+			"invalid_update_status",
+			"status must be running, ready, needs-input, failed, or no-change",
+		)
+	}
+	if !utf8.ValidString(input.Message) || strings.TrimSpace(input.Message) == "" {
+		return protocol.WorkUpdate{}, invalid("invalid_update_message", "message must be non-empty UTF-8 text")
+	}
+	messageLimit := protocol.MaxOutcomeBytes
+	if input.Status == protocol.WorkUpdateRunning {
+		messageLimit = protocol.MaxProgressBytes
+	}
+	if len([]byte(input.Message)) > messageLimit {
+		return protocol.WorkUpdate{}, &ServiceError{
+			Code: "update_message_too_large", Message: "update message exceeds its status limit", Status: 413,
+		}
+	}
+	if len([]byte(input.PullRequestURL)) > 2048 || len([]byte(input.PullRequestHeadBranch)) > 255 ||
+		len(input.PullRequestHeadSHA) > 64 || len(input.CheckpointSHA) > 64 {
+		return protocol.WorkUpdate{}, invalid("invalid_update_evidence", "update evidence exceeds its storage limit")
+	}
+	if input.Status == protocol.WorkUpdateReady {
+		if input.PullRequestURL == "" || (!input.ReplayOnly && (input.PullRequestHeadBranch == "" ||
+			!validCommitSHA(input.PullRequestHeadSHA))) || input.CheckpointSHA != "" {
+			return protocol.WorkUpdate{}, invalid(
+				"invalid_delivery_evidence",
+				"ready requires a pull request URL, head branch, and full head SHA",
+			)
+		}
+	} else if input.PullRequestURL != "" || input.PullRequestHeadBranch != "" || input.PullRequestHeadSHA != "" {
+		return protocol.WorkUpdate{}, invalid("unexpected_delivery_evidence", "only ready accepts pull request evidence")
+	}
+	if input.Status == protocol.WorkUpdateNeedsInput {
+		if !input.ReplayOnly && !validCommitSHA(input.CheckpointSHA) {
+			return protocol.WorkUpdate{}, invalid("invalid_checkpoint", "needs-input requires a full checkpoint SHA")
+		}
+	} else if input.CheckpointSHA != "" {
+		return protocol.WorkUpdate{}, invalid("unexpected_checkpoint", "only needs-input accepts a checkpoint SHA")
+	}
+	if input.ReplayOnly && (input.PullRequestHeadBranch != "" || input.PullRequestHeadSHA != "" || input.CheckpointSHA != "") {
+		return protocol.WorkUpdate{}, invalid("unexpected_replay_evidence", "replay lookup cannot include Worker-derived evidence")
+	}
+
+	digest, err := agentUpdateRequestDigest(input)
+	if err != nil {
+		return protocol.WorkUpdate{}, unavailable(err)
+	}
+	now := s.now().UnixMilli()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return protocol.WorkUpdate{}, unavailable(err)
+	}
+	defer tx.Rollback()
+	lease, err := loadLease(ctx, tx, attemptID)
+	if err != nil {
+		return protocol.WorkUpdate{}, err
+	}
+	if !equalDigest(lease.digest, digestToken(input.LeaseToken)) {
+		return protocol.WorkUpdate{}, conflict("lease_not_owner", "the lease token does not own this attempt")
+	}
+	if stored, storedDigest, found, err := storedAgentUpdateRequest(ctx, tx, attemptID, input.RequestID); err != nil {
+		return protocol.WorkUpdate{}, err
+	} else if found {
+		if !equalDigest(storedDigest, digest) {
+			return protocol.WorkUpdate{}, conflict(
+				"update_request_conflict",
+				"request_id was already used with different update fields",
+			)
+		}
+		if err := tx.Commit(); err != nil {
+			return protocol.WorkUpdate{}, unavailable(err)
+		}
+		return stored, nil
+	}
+	if input.ReplayOnly {
+		return protocol.WorkUpdate{}, &ServiceError{
+			Code: "update_request_not_found", Message: "the update request has not been stored", Status: 404,
+		}
+	}
+	if err := verifyActiveLease(lease, input.LeaseToken, now); err != nil {
+		return protocol.WorkUpdate{}, err
+	}
+	if lease.outcomeContract != protocol.OutcomeAgentUpdate {
+		return protocol.WorkUpdate{}, conflict(
+			"agent_update_not_allowed",
+			"this Attempt uses process-exit completion and cannot accept semantic updates",
+		)
+	}
+	if lease.attemptState != "running" || lease.executionState != "running" || lease.cancel {
+		return protocol.WorkUpdate{}, conflict("update_not_active", "the Attempt is not active for updates")
+	}
+	var workID, workState, owner string
+	if err := tx.QueryRowContext(ctx, `
+		SELECT session.id, session.state, session.execution_owner
+		FROM sessions session
+		JOIN executions execution ON execution.session_id = session.id
+		WHERE execution.id = ?
+	`, lease.executionID).Scan(&workID, &workState, &owner); err != nil {
+		return protocol.WorkUpdate{}, unavailable(err)
+	}
+	if workState != string(protocol.WorkRunning) || owner != string(protocol.ExecutionOwnerWorkerAttempt) {
+		return protocol.WorkUpdate{}, conflict("update_not_active", "the Work is not owned by this active Attempt")
+	}
+
+	existingOutcome, hasOutcome, err := attemptOutcome(ctx, tx, attemptID)
+	if err != nil {
+		return protocol.WorkUpdate{}, err
+	}
+	if hasOutcome {
+		if input.Status == protocol.WorkUpdateRunning {
+			return protocol.WorkUpdate{}, conflict("outcome_already_reported", "progress cannot follow an outcome report")
+		}
+		if !sameAgentUpdate(existingOutcome, input) {
+			return protocol.WorkUpdate{}, conflict("outcome_already_reported", "a different outcome was already reported")
+		}
+		if err := storeAgentUpdateRequest(ctx, tx, attemptID, input.RequestID, digest, existingOutcome.ID, now); err != nil {
+			return protocol.WorkUpdate{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return protocol.WorkUpdate{}, unavailable(err)
+		}
+		return existingOutcome, nil
+	}
+	if input.Status == protocol.WorkUpdateRunning {
+		var progressCount int
+		if err := tx.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM work_updates WHERE attempt_id = ? AND status = 'running'
+		`, attemptID).Scan(&progressCount); err != nil {
+			return protocol.WorkUpdate{}, unavailable(err)
+		}
+		if progressCount >= protocol.MaxProgressPerAttempt {
+			return protocol.WorkUpdate{}, &ServiceError{
+				Code: "progress_update_limit", Message: "the Attempt already has 199 progress updates; its outcome slot is reserved", Status: 409,
+			}
+		}
+	}
+	var sequence int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT COALESCE(MAX(sequence), 0) + 1 FROM work_updates WHERE work_id = ?
+	`, workID).Scan(&sequence); err != nil {
+		return protocol.WorkUpdate{}, unavailable(err)
+	}
+	updateID, err := newID()
+	if err != nil {
+		return protocol.WorkUpdate{}, unavailable(err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO work_updates(
+			id, work_id, attempt_id, request_id, sequence, status, message,
+			pull_request_url, pull_request_head_branch, pull_request_head_sha,
+			checkpoint_sha, actor, accepted_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'agent', ?)
+	`, updateID, workID, attemptID, input.RequestID, sequence, input.Status, input.Message,
+		input.PullRequestURL, input.PullRequestHeadBranch, input.PullRequestHeadSHA,
+		input.CheckpointSHA, now); err != nil {
+		return protocol.WorkUpdate{}, unavailable(err)
+	}
+	if err := storeAgentUpdateRequest(ctx, tx, attemptID, input.RequestID, digest, updateID, now); err != nil {
+		return protocol.WorkUpdate{}, err
+	}
+	if input.Status == protocol.WorkUpdateRunning {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE sessions SET latest_progress = ? WHERE id = ? AND state = 'running'
+		`, input.Message, workID); err != nil {
+			return protocol.WorkUpdate{}, unavailable(err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return protocol.WorkUpdate{}, unavailable(err)
+	}
+	return s.workUpdate(ctx, updateID)
+}
+
+func validCommitSHA(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, character := range value {
+		if (character < '0' || character > '9') && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func agentUpdateRequestDigest(input protocol.AttemptUpdateRequest) ([]byte, error) {
+	// The digest covers only fields supplied through the agent-visible local
+	// protocol. Worker-derived delivery and checkpoint evidence can change in
+	// the environment, but an exact agent retry must still replay its original
+	// durable result.
+	body, err := json.Marshal(struct {
+		RequestID      string                    `json:"request_id"`
+		Status         protocol.WorkUpdateStatus `json:"status"`
+		Message        string                    `json:"message"`
+		PullRequestURL string                    `json:"pull_request_url,omitempty"`
+	}{
+		RequestID: input.RequestID, Status: input.Status, Message: input.Message,
+		PullRequestURL: input.PullRequestURL,
+	})
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(body)
+	return digest[:], nil
+}
+
+func storedAgentUpdateRequest(
+	ctx context.Context,
+	tx *sql.Tx,
+	attemptID, requestID string,
+) (protocol.WorkUpdate, []byte, bool, error) {
+	var update protocol.WorkUpdate
+	var acceptedAt int64
+	var digest []byte
+	err := tx.QueryRowContext(ctx, `
+		SELECT stored_update.id, stored_update.work_id, COALESCE(stored_update.attempt_id, ''), stored_update.request_id,
+		       stored_update.sequence, stored_update.status, stored_update.message, stored_update.pull_request_url,
+		       stored_update.pull_request_head_branch, stored_update.pull_request_head_sha,
+		       stored_update.checkpoint_sha, stored_update.actor, stored_update.accepted_at, request.request_digest
+		FROM agent_update_requests request
+		JOIN work_updates stored_update ON stored_update.id = request.update_id
+		WHERE request.attempt_id = ? AND request.request_id = ?
+	`, attemptID, requestID).Scan(
+		&update.ID, &update.WorkID, &update.AttemptID, &update.RequestID, &update.Sequence,
+		&update.Status, &update.Message, &update.PullRequestURL, &update.PullRequestHeadBranch,
+		&update.PullRequestHeadSHA, &update.CheckpointSHA, &update.Actor, &acceptedAt, &digest,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return protocol.WorkUpdate{}, nil, false, nil
+	}
+	if err != nil {
+		return protocol.WorkUpdate{}, nil, false, unavailable(err)
+	}
+	update.AcceptedAt = fromMillis(acceptedAt)
+	return update, digest, true, nil
+}
+
+func attemptOutcome(ctx context.Context, tx *sql.Tx, attemptID string) (protocol.WorkUpdate, bool, error) {
+	var update protocol.WorkUpdate
+	var acceptedAt int64
+	err := tx.QueryRowContext(ctx, `
+		SELECT id, work_id, COALESCE(attempt_id, ''), request_id, sequence, status, message,
+		       pull_request_url, pull_request_head_branch, pull_request_head_sha,
+		       checkpoint_sha, actor, accepted_at
+		FROM work_updates WHERE attempt_id = ? AND status != 'running'
+	`, attemptID).Scan(&update.ID, &update.WorkID, &update.AttemptID, &update.RequestID,
+		&update.Sequence, &update.Status, &update.Message, &update.PullRequestURL,
+		&update.PullRequestHeadBranch, &update.PullRequestHeadSHA, &update.CheckpointSHA,
+		&update.Actor, &acceptedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return protocol.WorkUpdate{}, false, nil
+	}
+	if err != nil {
+		return protocol.WorkUpdate{}, false, unavailable(err)
+	}
+	update.AcceptedAt = fromMillis(acceptedAt)
+	return update, true, nil
+}
+
+func sameAgentUpdate(update protocol.WorkUpdate, input protocol.AttemptUpdateRequest) bool {
+	return update.Status == input.Status && update.Message == input.Message &&
+		update.PullRequestURL == input.PullRequestURL &&
+		update.PullRequestHeadBranch == input.PullRequestHeadBranch &&
+		update.PullRequestHeadSHA == input.PullRequestHeadSHA &&
+		update.CheckpointSHA == input.CheckpointSHA
+}
+
+func storeAgentUpdateRequest(
+	ctx context.Context,
+	tx *sql.Tx,
+	attemptID, requestID string,
+	digest []byte,
+	updateID string,
+	now int64,
+) error {
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO agent_update_requests(attempt_id, request_id, request_digest, update_id, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, attemptID, requestID, digest, updateID, now); err != nil {
+		return unavailable(err)
+	}
+	return nil
+}
+
+func (s *Store) workUpdate(ctx context.Context, id string) (protocol.WorkUpdate, error) {
+	var update protocol.WorkUpdate
+	var acceptedAt int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT id, work_id, COALESCE(attempt_id, ''), request_id, sequence, status, message,
+		       pull_request_url, pull_request_head_branch, pull_request_head_sha,
+		       checkpoint_sha, actor, accepted_at
+		FROM work_updates WHERE id = ?
+	`, id).Scan(&update.ID, &update.WorkID, &update.AttemptID, &update.RequestID,
+		&update.Sequence, &update.Status, &update.Message, &update.PullRequestURL,
+		&update.PullRequestHeadBranch, &update.PullRequestHeadSHA, &update.CheckpointSHA,
+		&update.Actor, &acceptedAt)
+	if err != nil {
+		return protocol.WorkUpdate{}, unavailable(err)
+	}
+	update.AcceptedAt = fromMillis(acceptedAt)
+	return update, nil
+}
 
 // Work returns the product-facing Work record backed by the existing Session
 // row. Keeping the adapter here lets existing Run and Session clients remain

--- a/internal/factorycli/command.go
+++ b/internal/factorycli/command.go
@@ -169,6 +169,19 @@ func (c command) run(arguments []string) error {
 			return err
 		}
 		return c.workers(ctx, client, *jsonOutput)
+	case "update":
+		flags := flag.NewFlagSet("factory update", flag.ContinueOnError)
+		flags.SetOutput(io.Discard)
+		status := flags.String("status", "", "progress or outcome status")
+		message := flags.String("message", "", "bounded update message")
+		pullRequest := flags.String("pr", "", "GitHub pull request URL for ready")
+		if err := flags.Parse(remaining[1:]); err != nil {
+			return &usageError{message: err.Error()}
+		}
+		if flags.NArg() != 0 {
+			return &usageError{message: "unexpected update arguments: " + strings.Join(flags.Args(), " ")}
+		}
+		return c.agentUpdate(*status, *message, *pullRequest, *jsonOutput)
 	case "server", "worker":
 		if *jsonOutput {
 			return &usageError{message: "--json is available only for status, show, and workers"}
@@ -266,6 +279,7 @@ Usage:
   factory [--server URL] [--json] status [--cursor CURSOR]
   factory [--server URL] [--json] show RUN_ID
   factory [--server URL] [--json] workers
+  factory [--json] update --status STATUS --message MESSAGE [--pr URL]
   factory server start [--config PATH]
   factory worker start [--config PATH]
   factory version

--- a/internal/factorycli/update.go
+++ b/internal/factorycli/update.go
@@ -49,6 +49,9 @@ func (c command) agentUpdate(status, message, pullRequest string, jsonOutput boo
 	if !protocol.SupportedWorkUpdateStatus(updateStatus) {
 		return &usageError{message: "--status must be running, ready, needs-input, failed, or no-change"}
 	}
+	if updateStatus == protocol.WorkUpdateNeedsInput {
+		return &usageError{message: "needs-input is unavailable until verified checkpoint support is enabled"}
+	}
 	if !utf8.ValidString(message) || strings.TrimSpace(message) == "" {
 		return &usageError{message: "--message must be non-empty UTF-8 text"}
 	}

--- a/internal/factorycli/update.go
+++ b/internal/factorycli/update.go
@@ -113,7 +113,7 @@ func sendAgentUpdate(
 		return protocol.WorkUpdate{}, fmt.Errorf("inspect Factory update socket: %w", err)
 	}
 	if info.Mode()&os.ModeSocket == 0 || info.Mode().Perm()&0o077 != 0 {
-		return protocol.WorkUpdate{}, errors.New("Factory update socket must be a private Unix socket")
+		return protocol.WorkUpdate{}, errors.New("update socket must be a private Unix socket")
 	}
 	body, err := json.Marshal(input)
 	if err != nil {

--- a/internal/factorycli/update.go
+++ b/internal/factorycli/update.go
@@ -1,0 +1,179 @@
+package factorycli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+type agentUpdateFailure struct {
+	Error struct {
+		Code      string `json:"code"`
+		Message   string `json:"message"`
+		Retriable bool   `json:"retriable"`
+	} `json:"error"`
+}
+
+type agentUpdateError struct {
+	status    int
+	code      string
+	message   string
+	retriable bool
+}
+
+func (err *agentUpdateError) Error() string {
+	return fmt.Sprintf("Worker update endpoint returned %d %s: %s", err.status, err.code, err.message)
+}
+
+func (c command) agentUpdate(status, message, pullRequest string, jsonOutput bool) error {
+	workID := strings.TrimSpace(c.getenv("FACTORY_WORK_ID"))
+	attemptID := strings.TrimSpace(c.getenv("FACTORY_ATTEMPT_ID"))
+	socket := strings.TrimSpace(c.getenv("FACTORY_UPDATE_SOCKET"))
+	token := c.getenv("FACTORY_UPDATE_TOKEN")
+	if workID == "" || attemptID == "" || socket == "" || token == "" {
+		return errors.New("update requires an injected active agent-update Attempt context")
+	}
+	updateStatus := protocol.WorkUpdateStatus(strings.TrimSpace(status))
+	if !protocol.SupportedWorkUpdateStatus(updateStatus) {
+		return &usageError{message: "--status must be running, ready, needs-input, failed, or no-change"}
+	}
+	if !utf8.ValidString(message) || strings.TrimSpace(message) == "" {
+		return &usageError{message: "--message must be non-empty UTF-8 text"}
+	}
+	limit := protocol.MaxOutcomeBytes
+	if updateStatus == protocol.WorkUpdateRunning {
+		limit = protocol.MaxProgressBytes
+	}
+	if len([]byte(message)) > limit {
+		return &usageError{message: fmt.Sprintf("--message exceeds the %d-byte limit for %s", limit, updateStatus)}
+	}
+	if updateStatus == protocol.WorkUpdateReady && strings.TrimSpace(pullRequest) == "" {
+		return &usageError{message: "ready requires --pr"}
+	}
+	if updateStatus != protocol.WorkUpdateReady && pullRequest != "" {
+		return &usageError{message: "--pr is accepted only with ready"}
+	}
+	requestID, err := randomUpdateRequestID()
+	if err != nil {
+		return fmt.Errorf("generate update request ID: %w", err)
+	}
+	input := protocol.AgentUpdateRequest{
+		WorkID: workID, AttemptID: attemptID, UpdateToken: token, RequestID: requestID,
+		Status: updateStatus, Message: message, PullRequestURL: pullRequest,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	update, err := sendAgentUpdate(ctx, socket, input)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		return writeJSON(c.stdout, update)
+	}
+	_, err = fmt.Fprintf(c.stdout, "Factory accepted %s update for Work %s.\n", update.Status, update.WorkID)
+	return err
+}
+
+func randomUpdateRequestID() (string, error) {
+	var value [16]byte
+	if _, err := io.ReadFull(rand.Reader, value[:]); err != nil {
+		return "", err
+	}
+	value[6] = (value[6] & 0x0f) | 0x40
+	value[8] = (value[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		value[0:4], value[4:6], value[6:8], value[8:10], value[10:16]), nil
+}
+
+func sendAgentUpdate(
+	ctx context.Context,
+	socket string,
+	input protocol.AgentUpdateRequest,
+) (protocol.WorkUpdate, error) {
+	if !strings.HasPrefix(socket, "/") {
+		return protocol.WorkUpdate{}, errors.New("FACTORY_UPDATE_SOCKET must be an absolute path")
+	}
+	info, err := os.Lstat(socket)
+	if err != nil {
+		return protocol.WorkUpdate{}, fmt.Errorf("inspect Factory update socket: %w", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 || info.Mode().Perm()&0o077 != 0 {
+		return protocol.WorkUpdate{}, errors.New("Factory update socket must be a private Unix socket")
+	}
+	body, err := json.Marshal(input)
+	if err != nil {
+		return protocol.WorkUpdate{}, fmt.Errorf("encode agent update: %w", err)
+	}
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			var dialer net.Dialer
+			return dialer.DialContext(ctx, "unix", socket)
+		},
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport}
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt != 0 {
+			timer := time.NewTimer(time.Duration(attempt) * 200 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return protocol.WorkUpdate{}, ctx.Err()
+			case <-timer.C:
+			}
+		}
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://factory.local/update", bytes.NewReader(body))
+		if err != nil {
+			return protocol.WorkUpdate{}, fmt.Errorf("create agent update request: %w", err)
+		}
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Accept", "application/json")
+		response, err := client.Do(request)
+		if err != nil {
+			lastErr = fmt.Errorf("send agent update: %w", err)
+			continue
+		}
+		responseBody, readErr := io.ReadAll(io.LimitReader(response.Body, protocol.MaxBodyBytes+1))
+		closeErr := response.Body.Close()
+		if readErr != nil || closeErr != nil {
+			lastErr = fmt.Errorf("read agent update response: %w", errors.Join(readErr, closeErr))
+			continue
+		}
+		if len(responseBody) > protocol.MaxBodyBytes {
+			return protocol.WorkUpdate{}, errors.New("agent update response exceeds 1 MiB")
+		}
+		if response.StatusCode >= 200 && response.StatusCode < 300 {
+			var update protocol.WorkUpdate
+			if err := json.Unmarshal(responseBody, &update); err != nil {
+				return protocol.WorkUpdate{}, fmt.Errorf("decode agent update response: %w", err)
+			}
+			return update, nil
+		}
+		var failure agentUpdateFailure
+		if err := json.Unmarshal(responseBody, &failure); err != nil || failure.Error.Code == "" {
+			return protocol.WorkUpdate{}, fmt.Errorf("Worker update endpoint returned %s", response.Status)
+		}
+		lastErr = &agentUpdateError{
+			status: response.StatusCode, code: failure.Error.Code,
+			message: failure.Error.Message, retriable: failure.Error.Retriable,
+		}
+		if !failure.Error.Retriable {
+			return protocol.WorkUpdate{}, lastErr
+		}
+	}
+	return protocol.WorkUpdate{}, lastErr
+}

--- a/internal/factorycli/update_test.go
+++ b/internal/factorycli/update_test.go
@@ -2,6 +2,7 @@ package factorycli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
@@ -21,7 +22,8 @@ func TestAgentUpdateUsesOnlyInjectedUnixSocketContext(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(directory) })
 	socket := filepath.Join(directory, "update.sock")
-	listener, err := net.Listen("unix", socket)
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(context.Background(), "unix", socket)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/factorycli/update_test.go
+++ b/internal/factorycli/update_test.go
@@ -1,0 +1,97 @@
+package factorycli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestAgentUpdateUsesOnlyInjectedUnixSocketContext(t *testing.T) {
+	directory, err := os.MkdirTemp("/tmp", "factory-cli-update-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(directory) })
+	socket := filepath.Join(directory, "update.sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	if err := os.Chmod(socket, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	requests := make(chan protocol.AgentUpdateRequest, 1)
+	server := &http.Server{Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		var input protocol.AgentUpdateRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Errorf("decode update: %v", err)
+			writer.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		requests <- input
+		writer.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(writer).Encode(protocol.WorkUpdate{
+			ID: "update-1", WorkID: input.WorkID, AttemptID: input.AttemptID,
+			RequestID: input.RequestID, Status: input.Status, Message: input.Message,
+		})
+	})}
+	go server.Serve(listener)
+	defer server.Close()
+
+	environment := map[string]string{
+		"FACTORY_WORK_ID":       "work-1",
+		"FACTORY_ATTEMPT_ID":    "attempt-1",
+		"FACTORY_UPDATE_SOCKET": socket,
+		"FACTORY_UPDATE_TOKEN":  "agent-token",
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run(Options{
+		Arguments: []string{"update", "--status", "running", "--message", "Running tests."},
+		Stdout:    &stdout, Stderr: &stderr,
+		Getenv: func(key string) string { return environment[key] },
+	})
+	if code != 0 || stderr.Len() != 0 || !strings.Contains(stdout.String(), "accepted running") {
+		t.Fatalf("Run update = %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
+	}
+	select {
+	case input := <-requests:
+		if input.WorkID != "work-1" || input.AttemptID != "attempt-1" || input.UpdateToken != "agent-token" ||
+			input.Status != protocol.WorkUpdateRunning || input.Message != "Running tests." || input.RequestID == "" {
+			t.Fatalf("agent update request = %#v", input)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("agent update request was not received")
+	}
+}
+
+func TestAgentUpdateRequiresContextAndReadyEvidence(t *testing.T) {
+	var stderr bytes.Buffer
+	if code := Run(Options{
+		Arguments: []string{"update", "--status", "running", "--message", "Progress."},
+		Stderr:    &stderr, Getenv: func(string) string { return "" },
+	}); code != 1 || !strings.Contains(stderr.String(), "injected active agent-update") {
+		t.Fatalf("missing context = %d, stderr %q", code, stderr.String())
+	}
+	stderr.Reset()
+	if code := Run(Options{
+		Arguments: []string{"update", "--status", "ready", "--message", "Ready."},
+		Stderr:    &stderr,
+		Getenv: func(key string) string {
+			return map[string]string{
+				"FACTORY_WORK_ID": "work", "FACTORY_ATTEMPT_ID": "attempt",
+				"FACTORY_UPDATE_SOCKET": "/tmp/update", "FACTORY_UPDATE_TOKEN": "token",
+			}[key]
+		},
+	}); code != 2 || !strings.Contains(stderr.String(), "ready requires --pr") {
+		t.Fatalf("missing ready PR = %d, stderr %q", code, stderr.String())
+	}
+}

--- a/internal/factorycli/update_test.go
+++ b/internal/factorycli/update_test.go
@@ -94,4 +94,17 @@ func TestAgentUpdateRequiresContextAndReadyEvidence(t *testing.T) {
 	}); code != 2 || !strings.Contains(stderr.String(), "ready requires --pr") {
 		t.Fatalf("missing ready PR = %d, stderr %q", code, stderr.String())
 	}
+	stderr.Reset()
+	if code := Run(Options{
+		Arguments: []string{"update", "--status", "needs-input", "--message", "Need a decision."},
+		Stderr:    &stderr,
+		Getenv: func(key string) string {
+			return map[string]string{
+				"FACTORY_WORK_ID": "work", "FACTORY_ATTEMPT_ID": "attempt",
+				"FACTORY_UPDATE_SOCKET": "/tmp/update", "FACTORY_UPDATE_TOKEN": "token",
+			}[key]
+		},
+	}); code != 2 || !strings.Contains(stderr.String(), "needs-input is unavailable") {
+		t.Fatalf("needs-input availability = %d, stderr %q", code, stderr.String())
+	}
 }

--- a/internal/protocol/tasks.go
+++ b/internal/protocol/tasks.go
@@ -255,6 +255,36 @@ type WorkUpdate struct {
 	AcceptedAt            time.Time        `json:"accepted_at"`
 }
 
+// AgentUpdateRequest is the credential-free request sent from the injected
+// factory helper to the Worker-local socket. The token scopes the request to
+// one Attempt; Worker and lease credentials are deliberately absent.
+type AgentUpdateRequest struct {
+	WorkID         string           `json:"work_id"`
+	AttemptID      string           `json:"attempt_id"`
+	UpdateToken    string           `json:"update_token"`
+	RequestID      string           `json:"request_id"`
+	Status         WorkUpdateStatus `json:"status"`
+	Message        string           `json:"message"`
+	PullRequestURL string           `json:"pull_request_url,omitempty"`
+}
+
+// AttemptUpdateRequest is the Worker-to-control-plane form of an agent
+// update. Delivery evidence has already been checked by the Worker for new
+// requests. ReplayOnly asks for a durable exact-request lookup before mutable
+// delivery state is checked again. The lease token never crosses the
+// Worker-local update protocol.
+type AttemptUpdateRequest struct {
+	LeaseToken            string           `json:"lease_token"`
+	ReplayOnly            bool             `json:"replay_only,omitempty"`
+	RequestID             string           `json:"request_id"`
+	Status                WorkUpdateStatus `json:"status"`
+	Message               string           `json:"message"`
+	PullRequestURL        string           `json:"pull_request_url,omitempty"`
+	PullRequestHeadBranch string           `json:"pull_request_head_branch,omitempty"`
+	PullRequestHeadSHA    string           `json:"pull_request_head_sha,omitempty"`
+	CheckpointSHA         string           `json:"checkpoint_sha,omitempty"`
+}
+
 type WorkUpdatePage struct {
 	Updates   []WorkUpdate `json:"updates"`
 	NextAfter int          `json:"next_after,omitempty"`

--- a/internal/worker/agent_update.go
+++ b/internal/worker/agent_update.go
@@ -1,0 +1,387 @@
+package worker
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const agentUpdatePath = "/update"
+
+type agentUpdateServer struct {
+	server     *http.Server
+	listener   net.Listener
+	socketPath string
+	token      string
+	closeOnce  sync.Once
+}
+
+type updateValidationError struct {
+	code      string
+	message   string
+	retriable bool
+	err       error
+}
+
+func (err *updateValidationError) Error() string {
+	if err.err != nil {
+		return err.message + ": " + err.err.Error()
+	}
+	return err.message
+}
+
+func (manager *Manager) startAgentUpdateServer(
+	claim protocol.Claim,
+	leaseToken string,
+	handle *attemptHandle,
+	repository Repository,
+	value worktree,
+) (*agentUpdateServer, error) {
+	token, err := manager.randomSecret()
+	if err != nil {
+		return nil, fmt.Errorf("generate agent update token: %w", err)
+	}
+	directory := filepath.Join(manager.dataDirectory, "updates")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return nil, fmt.Errorf("create agent update directory: %w", err)
+	}
+	info, err := os.Lstat(directory)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("agent update directory must be a real directory")
+	}
+	if err := os.Chmod(directory, 0o700); err != nil {
+		return nil, fmt.Errorf("protect agent update directory: %w", err)
+	}
+	socketPath := filepath.Join(directory, "u-"+strings.ReplaceAll(claim.Attempt.ID, "-", "")[:16]+".sock")
+	if len(socketPath) >= 104 {
+		return nil, errors.New("Worker data directory is too long for the agent update socket")
+	}
+	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("remove stale agent update socket: %w", err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen on agent update socket: %w", err)
+	}
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		listener.Close()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("protect agent update socket: %w", err)
+	}
+
+	updateServer := &agentUpdateServer{listener: listener, socketPath: socketPath, token: token}
+	digest := sha256.Sum256([]byte(token))
+	handler := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		manager.handleAgentUpdate(writer, request, claim, leaseToken, digest, handle, repository, value)
+	})
+	updateServer.server = &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       5 * time.Second,
+		MaxHeaderBytes:    16 << 10,
+	}
+	go func() {
+		if serveErr := updateServer.server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			manager.logger.Error("agent_update_server_failed", "attempt_id", claim.Attempt.ID, "error", serveErr)
+			handle.stop("failed")
+		}
+	}()
+	return updateServer, nil
+}
+
+func (server *agentUpdateServer) close() {
+	if server == nil {
+		return
+	}
+	server.closeOnce.Do(func() {
+		_ = server.server.Close()
+		_ = server.listener.Close()
+		_ = os.Remove(server.socketPath)
+	})
+}
+
+func (manager *Manager) handleAgentUpdate(
+	writer http.ResponseWriter,
+	request *http.Request,
+	claim protocol.Claim,
+	leaseToken string,
+	tokenDigest [sha256.Size]byte,
+	handle *attemptHandle,
+	repository Repository,
+	value worktree,
+) {
+	writer.Header().Set("Content-Type", "application/json")
+	if request.Method != http.MethodPost || request.URL.Path != agentUpdatePath || request.URL.RawQuery != "" {
+		writeAgentUpdateError(writer, http.StatusNotFound, "not_found", "agent update endpoint not found", false)
+		return
+	}
+	mediaType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		writeAgentUpdateError(writer, http.StatusUnsupportedMediaType, "json_required", "Content-Type must be application/json", false)
+		return
+	}
+	request.Body = http.MaxBytesReader(writer, request.Body, protocol.MaxBodyBytes)
+	decoder := json.NewDecoder(request.Body)
+	decoder.DisallowUnknownFields()
+	var input protocol.AgentUpdateRequest
+	if err := decoder.Decode(&input); err != nil {
+		writeAgentUpdateError(writer, http.StatusBadRequest, "invalid_json", "request body must be one JSON object", false)
+		return
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		writeAgentUpdateError(writer, http.StatusBadRequest, "invalid_json", "request body must contain one JSON object", false)
+		return
+	}
+	presentedDigest := sha256.Sum256([]byte(input.UpdateToken))
+	if subtle.ConstantTimeCompare(tokenDigest[:], presentedDigest[:]) != 1 {
+		writeAgentUpdateError(writer, http.StatusUnauthorized, "update_token_invalid", "the update token does not own this Attempt", false)
+		return
+	}
+	if input.WorkID != claim.Session.ID || input.AttemptID != claim.Attempt.ID {
+		writeAgentUpdateError(writer, http.StatusForbidden, "update_scope_mismatch", "the update capability is scoped to another Work or Attempt", false)
+		return
+	}
+	if input.Status == protocol.WorkUpdateNeedsInput {
+		writeAgentUpdateError(writer, http.StatusConflict, "checkpoint_required", "needs-input requires a verified durable checkpoint", false)
+		return
+	}
+
+	forward := protocol.AttemptUpdateRequest{
+		LeaseToken: leaseToken, RequestID: input.RequestID, Status: input.Status,
+		Message: input.Message, PullRequestURL: input.PullRequestURL,
+	}
+	replayed, replayErr := manager.client.update(request.Context(), claim.Attempt.ID, protocol.AttemptUpdateRequest{
+		LeaseToken: leaseToken, ReplayOnly: true, RequestID: input.RequestID, Status: input.Status,
+		Message: input.Message, PullRequestURL: input.PullRequestURL,
+	})
+	if replayErr == nil {
+		respondAcceptedAgentUpdate(writer, replayed, handle)
+		return
+	}
+	var replayAPIError *APIError
+	if !errors.As(replayErr, &replayAPIError) || replayAPIError.Code != "update_request_not_found" {
+		writeControlPlaneUpdateError(writer, replayErr)
+		return
+	}
+	if input.Status == protocol.WorkUpdateReady {
+		evidence, validationErr := manager.validateReadyDelivery(request.Context(), claim, repository, value, input.PullRequestURL)
+		if validationErr != nil {
+			status := http.StatusConflict
+			if validationErr.retriable {
+				status = http.StatusServiceUnavailable
+			}
+			writeAgentUpdateError(writer, status, validationErr.code, validationErr.message, validationErr.retriable)
+			return
+		}
+		forward.PullRequestHeadBranch = evidence.HeadBranch
+		forward.PullRequestHeadSHA = evidence.HeadSHA
+	}
+	update, err := manager.client.update(request.Context(), claim.Attempt.ID, forward)
+	if err != nil {
+		writeControlPlaneUpdateError(writer, err)
+		return
+	}
+	respondAcceptedAgentUpdate(writer, update, handle)
+}
+
+func writeControlPlaneUpdateError(writer http.ResponseWriter, err error) {
+	var apiError *APIError
+	if errors.As(err, &apiError) {
+		writeAgentUpdateError(writer, apiError.Status, apiError.Code, apiError.Message, apiError.Status >= 500)
+		return
+	}
+	writeAgentUpdateError(writer, http.StatusServiceUnavailable, "control_plane_unavailable", "the control plane could not accept the update", true)
+}
+
+func respondAcceptedAgentUpdate(writer http.ResponseWriter, update protocol.WorkUpdate, handle *attemptHandle) {
+	if update.Status != protocol.WorkUpdateRunning {
+		handle.recordOutcome(update)
+	}
+	writer.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(writer).Encode(update)
+	if flusher, ok := writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	if update.Status != protocol.WorkUpdateRunning {
+		handle.stopForOutcome()
+	}
+}
+
+func writeAgentUpdateError(writer http.ResponseWriter, status int, code, message string, retriable bool) {
+	writer.WriteHeader(status)
+	_ = json.NewEncoder(writer).Encode(struct {
+		Error struct {
+			Code      string `json:"code"`
+			Message   string `json:"message"`
+			Retriable bool   `json:"retriable"`
+		} `json:"error"`
+	}{Error: struct {
+		Code      string `json:"code"`
+		Message   string `json:"message"`
+		Retriable bool   `json:"retriable"`
+	}{Code: code, Message: message, Retriable: retriable}})
+}
+
+type readyDeliveryEvidence struct {
+	HeadBranch string
+	HeadSHA    string
+}
+
+type gitHubPullRequest struct {
+	HTMLURL string `json:"html_url"`
+	Head    struct {
+		Ref  string `json:"ref"`
+		SHA  string `json:"sha"`
+		Repo struct {
+			FullName string `json:"full_name"`
+		} `json:"repo"`
+	} `json:"head"`
+}
+
+func (manager *Manager) validateReadyDelivery(
+	ctx context.Context,
+	claim protocol.Claim,
+	repository Repository,
+	value worktree,
+	pullRequestURL string,
+) (readyDeliveryEvidence, *updateValidationError) {
+	owner, name, number, err := parseGitHubPullRequestURL(pullRequestURL)
+	if err != nil {
+		return readyDeliveryEvidence{}, &updateValidationError{code: "invalid_pull_request", message: err.Error()}
+	}
+	expectedRepository := strings.TrimPrefix(strings.ToLower(claim.Repository.RemoteIdentity), "github.com/")
+	if !strings.EqualFold(owner+"/"+name, expectedRepository) {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "delivery_repository_mismatch", message: "the pull request belongs to a different repository",
+		}
+	}
+	stdout, stderr, commandErr := runCommand(ctx, manager.options.GitHubExecutable, value.Path, 256<<10,
+		"api", "--method", "GET", "repos/"+owner+"/"+name+"/pulls/"+strconv.FormatInt(number, 10))
+	if commandErr != nil {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "github_validation_unavailable", message: "GitHub pull request validation is temporarily unavailable",
+			retriable: true, err: commandFailure("read pull request", stdout, stderr, commandErr),
+		}
+	}
+	var pullRequest gitHubPullRequest
+	if err := json.Unmarshal(stdout, &pullRequest); err != nil || pullRequest.Head.Ref == "" ||
+		!commitPattern.MatchString(pullRequest.Head.SHA) || pullRequest.Head.Repo.FullName == "" {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "github_validation_unavailable", message: "GitHub returned incomplete pull request evidence", retriable: true,
+		}
+	}
+	if !strings.EqualFold(pullRequest.Head.Repo.FullName, expectedRepository) {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "delivery_repository_mismatch", message: "the pull request head belongs to a different repository",
+		}
+	}
+	if pullRequest.Head.Ref != claim.Session.Target.PublishBranch {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "delivery_branch_mismatch", message: "the pull request head branch does not match the Work publish branch",
+		}
+	}
+
+	release, err := manager.repositoryLocks.acquire(ctx, repositoryCoordinationKey(repository))
+	if err != nil {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "delivery_validation_unavailable", message: "repository delivery validation is temporarily unavailable", retriable: true, err: err,
+		}
+	}
+	defer release()
+	if err := validateRegisteredOrigin(ctx, manager.options.GitExecutable, repository); err != nil {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "delivery_validation_unavailable", message: "repository origin validation failed", retriable: true, err: err,
+		}
+	}
+	remoteSHA, err := remotePublishCommit(ctx, manager.options.GitExecutable, repository, claim.Session.Target.PublishBranch)
+	if err != nil {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "publish_ref_unavailable", message: "the Work publish branch could not be fetched", retriable: true, err: err,
+		}
+	}
+	stdout, stderr, err = runGitCommand(ctx, manager.options.GitExecutable, value.Path, 64<<10, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "delivery_validation_unavailable", message: "local HEAD could not be resolved", retriable: true,
+			err: commandFailure("resolve local HEAD", stdout, stderr, err),
+		}
+	}
+	localSHA := strings.TrimSpace(string(stdout))
+	if localSHA != remoteSHA || localSHA != pullRequest.Head.SHA {
+		return readyDeliveryEvidence{}, &updateValidationError{
+			code: "delivery_head_mismatch", message: "local HEAD, the fetched publish ref, and the pull request head SHA must match",
+		}
+	}
+	return readyDeliveryEvidence{HeadBranch: pullRequest.Head.Ref, HeadSHA: pullRequest.Head.SHA}, nil
+}
+
+func parseGitHubPullRequestURL(value string) (string, string, int64, error) {
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme != "https" || !strings.EqualFold(parsed.Host, "github.com") ||
+		parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", "", 0, errors.New("ready requires an HTTPS github.com pull request URL")
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) != 4 || parts[0] == "" || parts[1] == "" || parts[2] != "pull" {
+		return "", "", 0, errors.New("ready requires a URL shaped like https://github.com/OWNER/REPOSITORY/pull/NUMBER")
+	}
+	owner, ownerErr := url.PathUnescape(parts[0])
+	name, nameErr := url.PathUnescape(parts[1])
+	number, numberErr := strconv.ParseInt(parts[3], 10, 64)
+	if ownerErr != nil || nameErr != nil || numberErr != nil || number < 1 || strings.ContainsAny(owner+name, "/\\") {
+		return "", "", 0, errors.New("pull request URL contains invalid repository or number fields")
+	}
+	return owner, name, number, nil
+}
+
+func remotePublishCommit(
+	ctx context.Context,
+	gitExecutable string,
+	repository Repository,
+	branch string,
+) (string, error) {
+	if err := validateBaseBranch(ctx, gitExecutable, repository, branch); err != nil {
+		return "", err
+	}
+	stdout, stderr, err := runGitCommand(ctx, gitExecutable, repository.Path, 64<<10,
+		"ls-remote", "--refs", "origin", "refs/heads/"+branch)
+	if err != nil {
+		return "", commandFailure("resolve publish branch", stdout, stderr, err)
+	}
+	fields := strings.Fields(string(stdout))
+	if len(fields) != 2 || fields[1] != "refs/heads/"+branch || !commitPattern.MatchString(fields[0]) {
+		return "", errors.New("publish branch does not exist")
+	}
+	commit := fields[0]
+	stdout, stderr, err = runGitCommand(ctx, gitExecutable, repository.Path, 256<<10,
+		"fetch", "--no-tags", "--no-write-fetch-head", "--refmap=", "origin", "refs/heads/"+branch)
+	if err != nil {
+		return "", commandFailure("fetch publish branch", stdout, stderr, err)
+	}
+	stdout, stderr, err = runGitCommand(ctx, gitExecutable, repository.Path, 64<<10,
+		"rev-parse", "--verify", commit+"^{commit}")
+	if err != nil || strings.TrimSpace(string(stdout)) != commit {
+		if err == nil {
+			err = errors.New("fetched publish branch did not contain its advertised commit")
+		}
+		return "", commandFailure("verify fetched publish branch", stdout, stderr, err)
+	}
+	return commit, nil
+}

--- a/internal/worker/agent_update.go
+++ b/internal/worker/agent_update.go
@@ -93,6 +93,8 @@ func (manager *Manager) startAgentUpdateServer(
 	updateServer.server = &http.Server{
 		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      35 * time.Second,
 		IdleTimeout:       5 * time.Second,
 		MaxHeaderBytes:    16 << 10,
 	}

--- a/internal/worker/agent_update_e2e_test.go
+++ b/internal/worker/agent_update_e2e_test.go
@@ -27,7 +27,7 @@ func TestAgentUpdateSupervisorHelper(t *testing.T) {
 }
 
 func TestFakeAgentReportsProgressAndOutcomeThroughRealWorkerEndpoint(t *testing.T) {
-	if _, err := execLookPath("curl"); err != nil {
+	if _, err := exec.LookPath("curl"); err != nil {
 		t.Skip("curl is required for the fake-agent endpoint smoke test")
 	}
 	root, err := os.MkdirTemp("/tmp", "factory-agent-e2e-")
@@ -137,10 +137,6 @@ func TestFakeAgentReportsProgressAndOutcomeThroughRealWorkerEndpoint(t *testing.
 	if len(work.Attempts) != 1 || work.Attempts[0].State != "succeeded" {
 		t.Fatalf("fake-agent Attempt = %#v", work.Attempts)
 	}
-}
-
-var execLookPath = func(name string) (string, error) {
-	return exec.LookPath(name)
 }
 
 func writeEndpointFakeCodex(t *testing.T, path string) {

--- a/internal/worker/agent_update_e2e_test.go
+++ b/internal/worker/agent_update_e2e_test.go
@@ -1,0 +1,174 @@
+package worker
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/controlplane"
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestAgentUpdateSupervisorHelper(t *testing.T) {
+	if os.Getenv("FACTORY_TEST_SUPERVISOR_HELPER") != "1" {
+		return
+	}
+	control := os.NewFile(3, "factory-worker-control")
+	if err := RunSupervisor(control, os.Stdin, os.Stdout, os.Stderr); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func TestFakeAgentReportsProgressAndOutcomeThroughRealWorkerEndpoint(t *testing.T) {
+	if _, err := execLookPath("curl"); err != nil {
+		t.Skip("curl is required for the fake-agent endpoint smoke test")
+	}
+	root, err := os.MkdirTemp("/tmp", "factory-agent-e2e-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	remote := filepath.Join(root, "remote.git")
+	repositoryPath := filepath.Join(root, "repository")
+	runTestCommand(t, root, "git", "init", "--bare", remote)
+	runTestCommand(t, root, "git", "clone", remote, repositoryPath)
+	runTestCommand(t, repositoryPath, "git", "config", "user.email", "factory@example.com")
+	runTestCommand(t, repositoryPath, "git", "config", "user.name", "Factory Test")
+	if err := os.WriteFile(filepath.Join(repositoryPath, "README.md"), []byte("test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runTestCommand(t, repositoryPath, "git", "add", "README.md")
+	runTestCommand(t, repositoryPath, "git", "commit", "-m", "test: seed repository")
+	runTestCommand(t, repositoryPath, "git", "branch", "-M", "main")
+	runTestCommand(t, repositoryPath, "git", "push", "-u", "origin", "main")
+	runTestCommand(t, remote, "git", "symbolic-ref", "HEAD", "refs/heads/main")
+
+	serverRoot, err := os.MkdirTemp("/tmp", "factory-server-e2e-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(serverRoot) })
+	store, err := controlplane.Open(context.Background(), filepath.Join(serverRoot, "factory.sqlite3"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	server := httptest.NewServer(controlplane.NewHandler(store, slog.New(slog.NewTextHandler(io.Discard, nil))))
+	defer server.Close()
+
+	fakeCodex := filepath.Join(root, "codex")
+	writeEndpointFakeCodex(t, fakeCodex)
+	t.Setenv("FACTORY_TEST_SUPERVISOR_HELPER", "1")
+	options := testOptions(fakeCodex)
+	options.HTTPClient = server.Client()
+	options.SupervisorCommand = []string{os.Args[0], "-test.run=TestAgentUpdateSupervisorHelper"}
+	options.PollInterval = 10 * time.Millisecond
+	options.RegistrationInterval = 20 * time.Millisecond
+	manager, err := New(Config{
+		Server: server.URL, Name: "agent-update-e2e", Runtime: protocol.RuntimeCodex,
+		MaxConcurrent: 1, DataDirectory: filepath.Join(root, "worker"),
+		Repositories: map[string]RepositoryConfig{"factory": {Path: repositoryPath, BaseBranch: "main"}},
+	}, options, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- manager.Run(ctx) }()
+	defer func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("Manager shutdown: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("Manager did not stop")
+		}
+	}()
+
+	var registered protocol.Worker
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		registered, err = store.Worker(context.Background(), manager.ID())
+		if err == nil && len(registered.Repositories) == 1 && registered.Health == "healthy" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil || len(registered.Repositories) != 1 || registered.Health != "healthy" {
+		t.Fatalf("Worker registration = %#v, err %v", registered, err)
+	}
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Endpoint smoke", Prompt: "Report progress and no change.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{registered.Repositories[0].ID}, OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{RequestKey: "endpoint-smoke"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var work protocol.Work
+	deadline = time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		work, err = store.Work(context.Background(), run.Sessions[0].ID)
+		if err == nil && work.State == protocol.WorkNoChange {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	if err != nil || work.State != protocol.WorkNoChange {
+		t.Fatalf("fake-agent Work = %#v, err %v", work, err)
+	}
+	updates, err := store.WorkUpdates(context.Background(), work.ID, 10, 0)
+	if err != nil || len(updates.Updates) != 2 || updates.Updates[0].Status != protocol.WorkUpdateRunning ||
+		updates.Updates[1].Status != protocol.WorkUpdateNoChange {
+		t.Fatalf("fake-agent updates = %#v, err %v", updates, err)
+	}
+	if len(work.Attempts) != 1 || work.Attempts[0].State != "succeeded" {
+		t.Fatalf("fake-agent Attempt = %#v", work.Attempts)
+	}
+}
+
+var execLookPath = func(name string) (string, error) {
+	return exec.LookPath(name)
+}
+
+func writeEndpointFakeCodex(t *testing.T, path string) {
+	t.Helper()
+	script := `#!/bin/sh
+set -eu
+if [ "${1:-}" = "--version" ]; then
+  echo codex-test
+  exit 0
+fi
+if [ "${1:-}" = "login" ]; then
+  echo 'Logged in'
+  exit 0
+fi
+result_path=""
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "--output-last-message" ]; then result_path="$argument"; fi
+  previous="$argument"
+done
+printf 'fake agent completed\n' > "$result_path"
+progress='{"work_id":"'"$FACTORY_WORK_ID"'","attempt_id":"'"$FACTORY_ATTEMPT_ID"'","update_token":"'"$FACTORY_UPDATE_TOKEN"'","request_id":"60000000-0000-4000-8000-000000000001","status":"running","message":"Fake agent is checking the task."}'
+outcome='{"work_id":"'"$FACTORY_WORK_ID"'","attempt_id":"'"$FACTORY_ATTEMPT_ID"'","update_token":"'"$FACTORY_UPDATE_TOKEN"'","request_id":"60000000-0000-4000-8000-000000000002","status":"no-change","message":"No defensible change exists."}'
+curl --silent --show-error --fail --unix-socket "$FACTORY_UPDATE_SOCKET" -H 'Content-Type: application/json' --data "$progress" http://factory.local/update >/dev/null
+curl --silent --show-error --fail --unix-socket "$FACTORY_UPDATE_SOCKET" -H 'Content-Type: application/json' --data "$outcome" http://factory.local/update >/dev/null
+sleep 30
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/worker/agent_update_test.go
+++ b/internal/worker/agent_update_test.go
@@ -1,0 +1,307 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestWorkerLocalAgentUpdateScopesTokenAndForwardsWithoutWorkerCredentials(t *testing.T) {
+	var forwarded atomic.Int32
+	controlPlane := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		forwarded.Add(1)
+		if request.Header.Get("Authorization") != "" {
+			t.Errorf("local control-plane request unexpectedly had authorization")
+		}
+		var input protocol.AttemptUpdateRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Errorf("decode forwarded update: %v", err)
+		}
+		if input.LeaseToken != strings.Repeat("l", 64) || input.Status != protocol.WorkUpdateNoChange {
+			t.Errorf("forwarded update = %#v", input)
+		}
+		_ = json.NewEncoder(writer).Encode(protocol.WorkUpdate{
+			ID: "update-1", WorkID: testWorkID, AttemptID: testAttemptID,
+			RequestID: input.RequestID, Status: input.Status, Message: input.Message,
+		})
+	}))
+	defer controlPlane.Close()
+	dataDirectory, err := os.MkdirTemp("/tmp", "factory-worker-update-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dataDirectory) })
+
+	manager := &Manager{
+		options:       Options{Random: bytes.NewReader(bytes.Repeat([]byte{7}, 64))},
+		dataDirectory: dataDirectory, client: newClient(controlPlane.URL, controlPlane.Client()),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := &attemptHandle{context: ctx, cancel: cancel, done: make(chan struct{}), heartbeatDone: make(chan struct{})}
+	close(handle.heartbeatDone)
+	claim := protocol.Claim{
+		Attempt: protocol.Attempt{ID: testAttemptID},
+		Session: protocol.ClaimedSession{ID: testWorkID, OutcomeContract: protocol.OutcomeAgentUpdate},
+	}
+	server, err := manager.startAgentUpdateServer(claim, strings.Repeat("l", 64), handle, Repository{}, worktree{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.close()
+	info, err := os.Stat(server.socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("socket mode = %v", info.Mode().Perm())
+	}
+
+	wrong := protocol.AgentUpdateRequest{
+		WorkID: testWorkID, AttemptID: testAttemptID, UpdateToken: "wrong",
+		RequestID: "50000000-0000-4000-8000-000000000001",
+		Status:    protocol.WorkUpdateNoChange, Message: "No change.",
+	}
+	if status := postWorkerUpdate(t, server.socketPath, wrong, nil); status != http.StatusUnauthorized {
+		t.Fatalf("wrong token status = %d", status)
+	}
+	if forwarded.Load() != 0 {
+		t.Fatal("wrong token reached the control plane")
+	}
+	wrong.UpdateToken = server.token
+	var accepted protocol.WorkUpdate
+	if status := postWorkerUpdate(t, server.socketPath, wrong, &accepted); status != http.StatusOK {
+		t.Fatalf("accepted update status = %d", status)
+	}
+	if accepted.Status != protocol.WorkUpdateNoChange || forwarded.Load() != 1 {
+		t.Fatalf("accepted = %#v, forwarded = %d", accepted, forwarded.Load())
+	}
+	if outcome, ok := handle.reportedOutcome(); !ok || outcome.Status != protocol.WorkUpdateNoChange {
+		t.Fatalf("reported outcome = %#v, %t", outcome, ok)
+	}
+}
+
+type outcomeObservingWriter struct {
+	header http.Header
+	handle *attemptHandle
+	want   protocol.WorkUpdateStatus
+	t      *testing.T
+}
+
+func (writer *outcomeObservingWriter) Header() http.Header {
+	return writer.header
+}
+
+func (writer *outcomeObservingWriter) WriteHeader(status int) {
+	writer.t.Helper()
+	if status != http.StatusOK {
+		writer.t.Fatalf("response status = %d", status)
+	}
+	outcome, ok := writer.handle.reportedOutcome()
+	if !ok || outcome.Status != writer.want {
+		writer.t.Fatalf("outcome at response exposure = %#v, %t", outcome, ok)
+	}
+}
+
+func (writer *outcomeObservingWriter) Write(body []byte) (int, error) {
+	return len(body), nil
+}
+
+func TestAcceptedOutcomeIsRecordedBeforeReadyOrFailedResponse(t *testing.T) {
+	for _, status := range []protocol.WorkUpdateStatus{protocol.WorkUpdateReady, protocol.WorkUpdateFailed} {
+		t.Run(string(status), func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			handle := &attemptHandle{context: ctx, cancel: cancel}
+			writer := &outcomeObservingWriter{
+				header: make(http.Header), handle: handle, want: status, t: t,
+			}
+			respondAcceptedAgentUpdate(writer, protocol.WorkUpdate{Status: status}, handle)
+		})
+	}
+}
+
+func TestReadyReplaySkipsMutableDeliveryValidation(t *testing.T) {
+	var forwarded atomic.Int32
+	controlPlane := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		forwarded.Add(1)
+		var input protocol.AttemptUpdateRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Errorf("decode forwarded update: %v", err)
+		}
+		if !input.ReplayOnly {
+			t.Errorf("ready replay unexpectedly requested fresh acceptance: %#v", input)
+		}
+		_ = json.NewEncoder(writer).Encode(protocol.WorkUpdate{
+			ID: "stored-ready", WorkID: testWorkID, AttemptID: testAttemptID,
+			RequestID: input.RequestID, Status: protocol.WorkUpdateReady, Message: input.Message,
+			PullRequestURL: input.PullRequestURL, PullRequestHeadBranch: "factory/work-ready",
+			PullRequestHeadSHA: strings.Repeat("a", 40),
+		})
+	}))
+	defer controlPlane.Close()
+	manager := &Manager{
+		options: Options{GitExecutable: "missing-git", GitHubExecutable: "missing-gh"},
+		client:  newClient(controlPlane.URL, controlPlane.Client()),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := &attemptHandle{context: ctx, cancel: cancel}
+	input := protocol.AgentUpdateRequest{
+		WorkID: testWorkID, AttemptID: testAttemptID, UpdateToken: "token",
+		RequestID: "51000000-0000-4000-8000-000000000001", Status: protocol.WorkUpdateReady,
+		Message: "Ready.", PullRequestURL: "https://github.com/owainlewis/factory/pull/342",
+	}
+	body, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, "http://factory.local/update", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	manager.handleAgentUpdate(recorder, request, protocol.Claim{
+		Attempt: protocol.Attempt{ID: testAttemptID},
+		Session: protocol.ClaimedSession{ID: testWorkID},
+	}, "lease", sha256.Sum256([]byte("token")), handle, Repository{}, worktree{})
+	if recorder.Code != http.StatusOK || forwarded.Load() != 1 {
+		t.Fatalf("ready replay status = %d, forwarded = %d, body = %s", recorder.Code, forwarded.Load(), recorder.Body.String())
+	}
+}
+
+const (
+	testWorkID    = "11111111-1111-4111-8111-111111111111"
+	testAttemptID = "22222222-2222-4222-8222-222222222222"
+)
+
+func postWorkerUpdate(t *testing.T, socket string, input protocol.AgentUpdateRequest, output any) int {
+	t.Helper()
+	body, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &http.Transport{DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "unix", socket)
+	}}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+	request, err := http.NewRequest(http.MethodPost, "http://factory.local/update", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if output != nil {
+		if err := json.NewDecoder(response.Body).Decode(output); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return response.StatusCode
+}
+
+func TestReadyDeliveryRequiresMatchingRepositoryBranchAndFetchedHead(t *testing.T) {
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	checkout := filepath.Join(root, "checkout")
+	runTestCommand(t, root, "git", "init", "--bare", remote)
+	runTestCommand(t, root, "git", "clone", remote, checkout)
+	runTestCommand(t, checkout, "git", "config", "user.email", "factory@example.com")
+	runTestCommand(t, checkout, "git", "config", "user.name", "Factory Test")
+	if err := os.WriteFile(filepath.Join(checkout, "proof.txt"), []byte("proof\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runTestCommand(t, checkout, "git", "add", "proof.txt")
+	runTestCommand(t, checkout, "git", "commit", "-m", "test: delivery proof")
+	const publishBranch = "factory/work-1111111111111111"
+	runTestCommand(t, checkout, "git", "branch", "-M", publishBranch)
+	runTestCommand(t, checkout, "git", "push", "origin", "HEAD:refs/heads/"+publishBranch)
+	head := strings.TrimSpace(runTestCommand(t, checkout, "git", "rev-parse", "HEAD"))
+	repository, err := resolveRepository("factory", checkout, "git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gh := filepath.Join(root, "gh")
+	writeFakeGitHubPR(t, gh, head, publishBranch, "owainlewis/factory")
+	manager := &Manager{options: Options{GitExecutable: "git", GitHubExecutable: gh}}
+	claim := protocol.Claim{
+		Attempt: protocol.Attempt{ID: testAttemptID},
+		Session: protocol.ClaimedSession{
+			ID: testWorkID, Target: protocol.WorkTarget{PublishBranch: publishBranch},
+		},
+		Repository: protocol.Repository{RemoteIdentity: "github.com/owainlewis/factory"},
+	}
+	evidence, validationErr := manager.validateReadyDelivery(
+		context.Background(), claim, repository, worktree{Path: checkout},
+		"https://github.com/owainlewis/factory/pull/123",
+	)
+	if validationErr != nil || evidence.HeadSHA != head || evidence.HeadBranch != publishBranch {
+		t.Fatalf("ready evidence = %#v, err %v", evidence, validationErr)
+	}
+	writeFakeGitHubPR(t, gh, strings.Repeat("a", 40), publishBranch, "owainlewis/factory")
+	if _, validationErr := manager.validateReadyDelivery(
+		context.Background(), claim, repository, worktree{Path: checkout},
+		"https://github.com/owainlewis/factory/pull/123",
+	); validationErr == nil || validationErr.code != "delivery_head_mismatch" || validationErr.retriable {
+		t.Fatalf("mismatched delivery error = %#v", validationErr)
+	}
+	manager.options.GitHubExecutable = filepath.Join(root, "missing-gh")
+	if _, validationErr := manager.validateReadyDelivery(
+		context.Background(), claim, repository, worktree{Path: checkout},
+		"https://github.com/owainlewis/factory/pull/123",
+	); validationErr == nil || validationErr.code != "github_validation_unavailable" || !validationErr.retriable {
+		t.Fatalf("provider outage error = %#v", validationErr)
+	}
+}
+
+func runTestCommand(t *testing.T, directory, name string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command(name, arguments...)
+	command.Dir = directory
+	body, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v: %v: %s", name, arguments, err, body)
+	}
+	return string(body)
+}
+
+func writeFakeGitHubPR(t *testing.T, path, head, branch, repository string) {
+	t.Helper()
+	body, err := json.Marshal(gitHubPullRequest{
+		HTMLURL: "https://github.com/owainlewis/factory/pull/123",
+		Head: struct {
+			Ref  string `json:"ref"`
+			SHA  string `json:"sha"`
+			Repo struct {
+				FullName string `json:"full_name"`
+			} `json:"repo"`
+		}{Ref: branch, SHA: head, Repo: struct {
+			FullName string `json:"full_name"`
+		}{FullName: repository}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\nprintf '%s' '" + string(body) + "'\n"
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/worker/attempt_lifecycle.go
+++ b/internal/worker/attempt_lifecycle.go
@@ -250,8 +250,8 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 	sender := newEventSender(handle.context, manager.client, claim.Attempt.ID, token, claim.Execution.RequiredRuntime)
 	message := manager.waitForSupervisorWithEvents(process, sender)
 	sender.closeAndWait(5 * time.Second)
-	if message.Reason == "supervisor_error" {
-		handle.stop("failed")
+	if reason := attemptStopReasonForSupervisor(message.Reason); reason != "" {
+		handle.stop(reason)
 	}
 	manager.finishWithWorktree(claim, token, handle, repository, value,
 		terminalState(message), message.Result, message.Error)
@@ -589,9 +589,9 @@ func (manager *Manager) finishWithWorktree(
 		manager.markUnhealthy("manifest_write", err)
 		errorText = firstNonEmpty(errorText, err.Error())
 	}
-	completed := manager.complete(claim.Attempt.ID, token, state, result, errorText, handle)
+	completedAttempt, completed := manager.complete(claim.Attempt.ID, token, state, result, errorText, handle)
 	retainReportedFailure := reported && outcome.Status == protocol.WorkUpdateFailed
-	if completed && state == "succeeded" && !retainReportedFailure {
+	if shouldCleanCompletedWorktree(completed, completedAttempt.State, retainReportedFailure) {
 		err := manager.cleanCompletedWorktree(claim.Attempt.ID)
 		if err == nil {
 			if err := manager.recordDisposed(claim.Attempt.ID); err != nil {
@@ -613,6 +613,10 @@ func (manager *Manager) finishWithWorktree(
 	}
 	reason := firstNonEmpty(errorText, state+" attempt retained for inspection")
 	manager.retain(claim, repository, value, reason)
+}
+
+func shouldCleanCompletedWorktree(completed bool, authoritativeState string, retainReportedFailure bool) bool {
+	return completed && authoritativeState == "succeeded" && !retainReportedFailure
 }
 
 func (manager *Manager) registerAfterAttempt(handle *attemptHandle) {
@@ -652,7 +656,7 @@ func (manager *Manager) complete(
 	result string,
 	errorText string,
 	handle *attemptHandle,
-) bool {
+) (protocol.Attempt, bool) {
 	timeout := requestTimeout
 	if remaining := time.Until(handle.leaseExpiry()); remaining > 0 && remaining < timeout {
 		timeout = remaining
@@ -663,11 +667,11 @@ func (manager *Manager) complete(
 			"attempt_id", attemptID,
 			"error_class", "lease_expired",
 		)
-		return false
+		return protocol.Attempt{}, false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	_, err := manager.client.complete(ctx, attemptID, protocol.CompleteAttemptRequest{
+	completed, err := manager.client.complete(ctx, attemptID, protocol.CompleteAttemptRequest{
 		LeaseToken: token, State: state, Result: result, Error: errorText,
 	})
 	if err != nil {
@@ -676,10 +680,10 @@ func (manager *Manager) complete(
 			"attempt_id", attemptID,
 			"error_class", apiErrorClass(err),
 		)
-		return false
+		return protocol.Attempt{}, false
 	}
 	manager.logger.Info("attempt_completed", "attempt_id", attemptID, "state", state)
-	return true
+	return completed, true
 }
 
 func (manager *Manager) retain(claim protocol.Claim, repository Repository, value worktree, reason string) {
@@ -762,6 +766,17 @@ func terminalState(message supervisorMessage) string {
 	return "failed"
 }
 
+func attemptStopReasonForSupervisor(reason string) string {
+	switch reason {
+	case "cancelled", "lease_lost", "timeout":
+		return reason
+	case "parent_lost", "supervisor_error":
+		return "failed"
+	default:
+		return ""
+	}
+}
+
 func buildPrompt(claim protocol.Claim, value worktree) string {
 	prompt := protocol.FormatAgentPrompt(
 		claim.Session.TaskName,
@@ -775,8 +790,8 @@ func buildPrompt(claim protocol.Claim, value worktree) string {
 	}
 	return prompt + "\n\nFactory update contract:\n" +
 		"This Work is unfinished until you call factory update. Use status running for useful progress only. " +
-		"Before exiting, report exactly one outcome: ready, needs-input, failed, or no-change. " +
-		"Ready requires --pr with the GitHub pull request URL. Needs-input ends this Attempt and requires committed, pushed partial work. " +
+		"Before exiting, report exactly one available outcome: ready, failed, or no-change. " +
+		"Ready requires --pr with the GitHub pull request URL. Needs-input is unavailable until verified checkpoint support is enabled. " +
 		"Always include a concise non-empty --message."
 }
 

--- a/internal/worker/attempt_lifecycle.go
+++ b/internal/worker/attempt_lifecycle.go
@@ -27,6 +27,7 @@ type attemptHandle struct {
 	expiry        time.Time
 	supervisor    *supervisorProcess
 	manifestReady bool
+	outcome       *protocol.WorkUpdate
 }
 
 func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim, token string) {
@@ -156,6 +157,15 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 		return
 	}
 	defer os.Remove(path)
+	var updateServer *agentUpdateServer
+	if claim.Session.OutcomeContract == protocol.OutcomeAgentUpdate {
+		updateServer, err = manager.startAgentUpdateServer(claim, token, handle, repository, value)
+		if err != nil {
+			manager.finishWithWorktree(claim, token, handle, repository, value, "failed", "", err.Error())
+			return
+		}
+		defer updateServer.close()
+	}
 	process, err := startSupervisor(manager.options.SupervisorCommand, supervisorInit{
 		Runtime:           claim.Execution.RequiredRuntime,
 		RuntimeExecutable: manager.runtimeExecutable(claim.Execution.RequiredRuntime),
@@ -165,6 +175,9 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 		TimeoutSeconds:    remainingTimeoutSeconds(sessionDeadline),
 		RunID:             claim.Session.RunID,
 		SessionID:         claim.Session.ID,
+		AttemptID:         updateServerAttemptID(updateServer, claim.Attempt.ID),
+		UpdateSocket:      updateServerSocket(updateServer),
+		UpdateToken:       updateServerToken(updateServer),
 	}, os.Stderr)
 	if err != nil {
 		manager.finishWithWorktree(claim, token, handle, repository, value, "failed", "", err.Error())
@@ -237,6 +250,9 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 	sender := newEventSender(handle.context, manager.client, claim.Attempt.ID, token, claim.Execution.RequiredRuntime)
 	message := manager.waitForSupervisorWithEvents(process, sender)
 	sender.closeAndWait(5 * time.Second)
+	if message.Reason == "supervisor_error" {
+		handle.stop("failed")
+	}
 	manager.finishWithWorktree(claim, token, handle, repository, value,
 		terminalState(message), message.Result, message.Error)
 }
@@ -396,6 +412,33 @@ func (handle *attemptHandle) stopReason() string {
 	return handle.reason
 }
 
+func (handle *attemptHandle) recordOutcome(update protocol.WorkUpdate) {
+	handle.mutex.Lock()
+	if handle.outcome == nil {
+		copy := update
+		handle.outcome = &copy
+	}
+	handle.mutex.Unlock()
+}
+
+func (handle *attemptHandle) stopForOutcome() {
+	handle.mutex.Lock()
+	process := handle.supervisor
+	handle.mutex.Unlock()
+	if process != nil {
+		_ = process.send("outcome_reported")
+	}
+}
+
+func (handle *attemptHandle) reportedOutcome() (protocol.WorkUpdate, bool) {
+	handle.mutex.Lock()
+	defer handle.mutex.Unlock()
+	if handle.outcome == nil {
+		return protocol.WorkUpdate{}, false
+	}
+	return *handle.outcome, true
+}
+
 func (manager *Manager) waitForSupervisorWithEvents(
 	process *supervisorProcess,
 	sender *eventSender,
@@ -426,7 +469,11 @@ func (manager *Manager) waitForSupervisorMessage(process *supervisorProcess) sup
 			if message.Type == "exit" || message.Type == "output" {
 				if message.Type == "exit" {
 					_ = process.closeControl()
-					process.markStopped()
+					if message.StopUnverified {
+						manager.emergencyStop(process, errors.New(firstNonEmpty(message.Error, "process stop was not verified")))
+					} else {
+						process.markStopped()
+					}
 				}
 				return message
 			}
@@ -435,7 +482,11 @@ func (manager *Manager) waitForSupervisorMessage(process *supervisorProcess) sup
 			case message := <-process.messages:
 				if message.Type == "exit" || message.Type == "output" {
 					if message.Type == "exit" {
-						process.markStopped()
+						if message.StopUnverified {
+							manager.emergencyStop(process, errors.New(firstNonEmpty(message.Error, "process stop was not verified")))
+						} else {
+							process.markStopped()
+						}
 					}
 					return message
 				}
@@ -506,7 +557,29 @@ func (manager *Manager) finishWithWorktree(
 ) {
 	manager.beginCapacityHandoff()
 	defer manager.finishCapacityHandoff(handle)
+	if handle.processStillActive() {
+		reason := firstNonEmpty(errorText, "Attempt process-group shutdown could not be verified.")
+		manager.markUnhealthy("process_group_stop", errors.New(reason))
+		manager.retain(claim, repository, value, reason)
+		return
+	}
 
+	outcome, reported := handle.reportedOutcome()
+	if reported && handle.stopReason() == "" {
+		state, result, errorText = "succeeded", "", ""
+		if outcome.Status == protocol.WorkUpdateReady {
+			validationContext, cancelValidation := context.WithTimeout(context.Background(), 2*gitCommandTimeout)
+			evidence, validationErr := manager.validateReadyDelivery(
+				validationContext, claim, repository, value, outcome.PullRequestURL,
+			)
+			cancelValidation()
+			if validationErr != nil || evidence.HeadBranch != outcome.PullRequestHeadBranch ||
+				evidence.HeadSHA != outcome.PullRequestHeadSHA {
+				state = "failed"
+				errorText = "Delivery evidence could not be revalidated after the agent process stopped."
+			}
+		}
+	}
 	result = boundedText(result, protocol.MaxResultBytes)
 	errorText = boundedText(errorText, protocol.MaxErrorBytes)
 	if err := manager.persistLifecycle(claim.Attempt.ID, manifestCompleted, func(manifest *attemptManifest) {
@@ -517,7 +590,8 @@ func (manager *Manager) finishWithWorktree(
 		errorText = firstNonEmpty(errorText, err.Error())
 	}
 	completed := manager.complete(claim.Attempt.ID, token, state, result, errorText, handle)
-	if completed && state == "succeeded" {
+	retainReportedFailure := reported && outcome.Status == protocol.WorkUpdateFailed
+	if completed && state == "succeeded" && !retainReportedFailure {
 		err := manager.cleanCompletedWorktree(claim.Attempt.ID)
 		if err == nil {
 			if err := manager.recordDisposed(claim.Attempt.ID); err != nil {
@@ -682,17 +756,49 @@ func terminalState(message supervisorMessage) string {
 	if message.Reason == "exited" && message.ExitCode == 0 {
 		return "succeeded"
 	}
+	if message.Reason == "outcome_reported" {
+		return "succeeded"
+	}
 	return "failed"
 }
 
 func buildPrompt(claim protocol.Claim, value worktree) string {
-	return protocol.FormatAgentPrompt(
+	prompt := protocol.FormatAgentPrompt(
 		claim.Session.TaskName,
 		claim.Repository.RemoteIdentity,
 		value.Branch,
 		value.BaseBranch,
 		claim.Session.Prompt,
 	)
+	if claim.Session.OutcomeContract != protocol.OutcomeAgentUpdate {
+		return prompt
+	}
+	return prompt + "\n\nFactory update contract:\n" +
+		"This Work is unfinished until you call factory update. Use status running for useful progress only. " +
+		"Before exiting, report exactly one outcome: ready, needs-input, failed, or no-change. " +
+		"Ready requires --pr with the GitHub pull request URL. Needs-input ends this Attempt and requires committed, pushed partial work. " +
+		"Always include a concise non-empty --message."
+}
+
+func updateServerSocket(server *agentUpdateServer) string {
+	if server == nil {
+		return ""
+	}
+	return server.socketPath
+}
+
+func updateServerAttemptID(server *agentUpdateServer, attemptID string) string {
+	if server == nil {
+		return ""
+	}
+	return attemptID
+}
+
+func updateServerToken(server *agentUpdateServer) string {
+	if server == nil {
+		return ""
+	}
+	return server.token
 }
 
 func apiErrorClass(err error) string {

--- a/internal/worker/attempt_lifecycle.go
+++ b/internal/worker/attempt_lifecycle.go
@@ -28,13 +28,15 @@ type attemptHandle struct {
 	supervisor    *supervisorProcess
 	manifestReady bool
 	outcome       *protocol.WorkUpdate
+	deadline      time.Time
 }
 
 func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim, token string) {
+	sessionDeadline := claim.Attempt.CreatedAt.Add(time.Duration(claim.Session.TimeoutSeconds) * time.Second)
 	attemptContext, cancel := context.WithCancel(parent)
 	handle := &attemptHandle{
 		context: attemptContext, cancel: cancel, done: make(chan struct{}),
-		heartbeatDone: make(chan struct{}), expiry: claim.Attempt.LeaseExpiresAt,
+		heartbeatDone: make(chan struct{}), expiry: claim.Attempt.LeaseExpiresAt, deadline: sessionDeadline,
 	}
 	manager.stateMutex.Lock()
 	manager.active[claim.Attempt.ID] = handle
@@ -51,7 +53,6 @@ func (manager *Manager) runAttempt(parent context.Context, claim protocol.Claim,
 	}()
 	go manager.heartbeatAttempt(handle, claim.Attempt.ID, token)
 
-	sessionDeadline := claim.Attempt.CreatedAt.Add(time.Duration(claim.Session.TimeoutSeconds) * time.Second)
 	sessionTimer := time.AfterFunc(time.Until(sessionDeadline), func() {
 		handle.stop("timeout")
 	})
@@ -565,7 +566,7 @@ func (manager *Manager) finishWithWorktree(
 	}
 
 	outcome, reported := handle.reportedOutcome()
-	if reported && handle.stopReason() == "" {
+	if reported && handle.stopReasonAt(time.Now()) == "" {
 		state, result, errorText = "succeeded", "", ""
 		if outcome.Status == protocol.WorkUpdateReady {
 			validationContext, cancelValidation := context.WithTimeout(context.Background(), 2*gitCommandTimeout)
@@ -580,6 +581,9 @@ func (manager *Manager) finishWithWorktree(
 			}
 		}
 	}
+	state, result, errorText = terminalForFinalStop(
+		handle.stopReasonAt(time.Now()), state, result, errorText,
+	)
 	result = boundedText(result, protocol.MaxResultBytes)
 	errorText = boundedText(errorText, protocol.MaxErrorBytes)
 	if err := manager.persistLifecycle(claim.Attempt.ID, manifestCompleted, func(manifest *attemptManifest) {
@@ -647,6 +651,17 @@ func (handle *attemptHandle) processStillActive() bool {
 	process := handle.supervisor
 	handle.mutex.Unlock()
 	return process != nil && !process.isStopped()
+}
+
+func (handle *attemptHandle) stopReasonAt(now time.Time) string {
+	handle.mutex.Lock()
+	reason := handle.reason
+	deadline := handle.deadline
+	handle.mutex.Unlock()
+	if reason == "" && !deadline.IsZero() && !now.Before(deadline) {
+		handle.stop("timeout")
+	}
+	return handle.stopReason()
 }
 
 func (manager *Manager) complete(
@@ -764,6 +779,21 @@ func terminalState(message supervisorMessage) string {
 		return "succeeded"
 	}
 	return "failed"
+}
+
+func terminalForFinalStop(reason, state, result, errorText string) (string, string, string) {
+	switch reason {
+	case "cancelled":
+		return "cancelled", "", "attempt cancelled"
+	case "timeout":
+		return "failed", "", "Session timeout reached"
+	case "lease_lost":
+		return "failed", "", "control-plane lease was lost"
+	case "failed":
+		return "failed", result, firstNonEmpty(errorText, "attempt stopped before completion")
+	default:
+		return state, result, errorText
+	}
 }
 
 func attemptStopReasonForSupervisor(reason string) string {

--- a/internal/worker/attempt_lifecycle_test.go
+++ b/internal/worker/attempt_lifecycle_test.go
@@ -41,7 +41,8 @@ func TestBuildPromptAddsUpdateContractOnlyForAgentUpdateWork(t *testing.T) {
 	prompt := buildPrompt(claim, worktree{Branch: "factory/local", BaseBranch: "main"})
 	for _, expected := range []string{
 		"This Work is unfinished until you call factory update.",
-		"running", "ready", "needs-input", "failed", "no-change", "Ready requires --pr",
+		"running", "ready", "failed", "no-change", "Ready requires --pr",
+		"Needs-input is unavailable until verified checkpoint support is enabled",
 	} {
 		if !strings.Contains(prompt, expected) {
 			t.Fatalf("agent-update prompt missing %q: %s", expected, prompt)
@@ -50,5 +51,40 @@ func TestBuildPromptAddsUpdateContractOnlyForAgentUpdateWork(t *testing.T) {
 	claim.Session.OutcomeContract = protocol.OutcomeProcessExit
 	if legacy := buildPrompt(claim, worktree{Branch: "factory/local", BaseBranch: "main"}); strings.Contains(legacy, "factory update") {
 		t.Fatalf("legacy prompt received update contract: %s", legacy)
+	}
+}
+
+func TestSupervisorStopReasonPreservesLeaseLossAndCancellation(t *testing.T) {
+	for reason, want := range map[string]string{
+		"lease_lost": "lease_lost", "cancelled": "cancelled", "timeout": "timeout",
+		"supervisor_error": "failed", "parent_lost": "failed", "outcome_reported": "", "exited": "",
+	} {
+		if got := attemptStopReasonForSupervisor(reason); got != want {
+			t.Errorf("attemptStopReasonForSupervisor(%q) = %q, want %q", reason, got, want)
+		}
+	}
+}
+
+func TestCompletedWorktreeCleanupUsesAuthoritativeAttemptState(t *testing.T) {
+	for _, testCase := range []struct {
+		name                  string
+		completed             bool
+		authoritativeState    string
+		retainReportedFailure bool
+		want                  bool
+	}{
+		{name: "successful completion", completed: true, authoritativeState: "succeeded", want: true},
+		{name: "cancellation wins", completed: true, authoritativeState: "cancelled"},
+		{name: "reported failure retention", completed: true, authoritativeState: "succeeded", retainReportedFailure: true},
+		{name: "completion rejected", authoritativeState: "succeeded"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := shouldCleanCompletedWorktree(
+				testCase.completed, testCase.authoritativeState, testCase.retainReportedFailure,
+			)
+			if got != testCase.want {
+				t.Fatalf("shouldCleanCompletedWorktree() = %t, want %t", got, testCase.want)
+			}
+		})
 	}
 }

--- a/internal/worker/attempt_lifecycle_test.go
+++ b/internal/worker/attempt_lifecycle_test.go
@@ -1,8 +1,10 @@
 package worker
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/owainlewis/factory/internal/protocol"
 )
@@ -86,5 +88,25 @@ func TestCompletedWorktreeCleanupUsesAuthoritativeAttemptState(t *testing.T) {
 				t.Fatalf("shouldCleanCompletedWorktree() = %t, want %t", got, testCase.want)
 			}
 		})
+	}
+}
+
+func TestFinalStopReasonIsRecheckedAfterPostflight(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	handle := &attemptHandle{context: ctx, cancel: cancel, deadline: time.Now().Add(-time.Second)}
+	if got := handle.stopReasonAt(time.Now()); got != "timeout" {
+		t.Fatalf("expired finalization stop reason = %q", got)
+	}
+	state, result, errorText := terminalForFinalStop(
+		handle.stopReason(), "succeeded", "ready result", "",
+	)
+	if state != "failed" || result != "" || errorText != "Session timeout reached" {
+		t.Fatalf("timeout terminal = %q, %q, %q", state, result, errorText)
+	}
+
+	state, result, errorText = terminalForFinalStop("cancelled", "succeeded", "ready result", "")
+	if state != "cancelled" || result != "" || errorText != "attempt cancelled" {
+		t.Fatalf("cancellation terminal = %q, %q, %q", state, result, errorText)
 	}
 }

--- a/internal/worker/attempt_lifecycle_test.go
+++ b/internal/worker/attempt_lifecycle_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/owainlewis/factory/internal/protocol"
@@ -27,5 +28,27 @@ func TestBuildPromptIncludesGrammaticalSafetyInstruction(t *testing.T) {
 
 	if got := buildPrompt(claim, value); got != want {
 		t.Fatalf("buildPrompt() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildPromptAddsUpdateContractOnlyForAgentUpdateWork(t *testing.T) {
+	claim := protocol.Claim{
+		Session: protocol.ClaimedSession{
+			TaskName: "Report progress", Prompt: "Do the work.", OutcomeContract: protocol.OutcomeAgentUpdate,
+		},
+		Repository: protocol.Repository{RemoteIdentity: "github.com/owainlewis/factory"},
+	}
+	prompt := buildPrompt(claim, worktree{Branch: "factory/local", BaseBranch: "main"})
+	for _, expected := range []string{
+		"This Work is unfinished until you call factory update.",
+		"running", "ready", "needs-input", "failed", "no-change", "Ready requires --pr",
+	} {
+		if !strings.Contains(prompt, expected) {
+			t.Fatalf("agent-update prompt missing %q: %s", expected, prompt)
+		}
+	}
+	claim.Session.OutcomeContract = protocol.OutcomeProcessExit
+	if legacy := buildPrompt(claim, worktree{Branch: "factory/local", BaseBranch: "main"}); strings.Contains(legacy, "factory update") {
+		t.Fatalf("legacy prompt received update contract: %s", legacy)
 	}
 }

--- a/internal/worker/client.go
+++ b/internal/worker/client.go
@@ -312,6 +312,17 @@ func (client *client) events(ctx context.Context, attemptID string, input protoc
 	return err
 }
 
+func (client *client) update(
+	ctx context.Context,
+	attemptID string,
+	input protocol.AttemptUpdateRequest,
+) (protocol.WorkUpdate, error) {
+	var update protocol.WorkUpdate
+	_, err := client.request(ctx, http.MethodPost,
+		"/api/v1/attempts/"+url.PathEscape(attemptID)+"/updates", input, &update)
+	return update, err
+}
+
 func (client *client) complete(ctx context.Context, attemptID string, input protocol.CompleteAttemptRequest) (protocol.Attempt, error) {
 	input = boundedCompletionRequest(input)
 	var attempt protocol.Attempt

--- a/internal/worker/supervisor.go
+++ b/internal/worker/supervisor.go
@@ -37,6 +37,9 @@ type supervisorInit struct {
 	TimeoutSeconds    int    `json:"timeout_seconds"`
 	RunID             string `json:"run_id,omitempty"`
 	SessionID         string `json:"session_id,omitempty"`
+	AttemptID         string `json:"attempt_id,omitempty"`
+	UpdateSocket      string `json:"update_socket,omitempty"`
+	UpdateToken       string `json:"update_token,omitempty"`
 }
 
 type supervisorMessage struct {
@@ -52,6 +55,7 @@ type supervisorMessage struct {
 	Result          string `json:"result,omitempty"`
 	Error           string `json:"error,omitempty"`
 	Truncated       bool   `json:"truncated,omitempty"`
+	StopUnverified  bool   `json:"stop_unverified,omitempty"`
 }
 
 type supervisorProcess struct {
@@ -96,6 +100,9 @@ func RunSupervisor(control *os.File, input io.Reader, output, errorOutput io.Wri
 	}
 	if (init.RunID == "") != (init.SessionID == "") {
 		return errors.New("supervisor Run and Session identities must be supplied together")
+	}
+	if (init.AttemptID == "") != (init.UpdateSocket == "") || (init.AttemptID == "") != (init.UpdateToken == "") {
+		return errors.New("supervisor agent update context must be supplied together")
 	}
 	if init.TimeoutSeconds > int(protocol.MaxTimeout/time.Second) {
 		return errors.New("supervisor timeout exceeds eight hours")
@@ -231,7 +238,7 @@ func superviseRuntime(
 	displayName := runtimeDisplayName(init.Runtime)
 	command := exec.Command(init.RuntimeExecutable, arguments...)
 	command.Dir = init.Worktree
-	command.Env = runtimeEnvironment(init.RunID, init.SessionID)
+	command.Env = runtimeEnvironment(init.RunID, init.SessionID, init.AttemptID, init.UpdateSocket, init.UpdateToken)
 	configureExistingProcessGroup(command, groupID)
 	stdin, err := command.StdinPipe()
 	if err != nil {
@@ -318,6 +325,9 @@ func superviseRuntime(
 			case "timeout":
 				reason = "timeout"
 				running = false
+			case "outcome_reported":
+				reason = "outcome_reported"
+				running = false
 			case "start":
 			}
 		case controlErr := <-controlErrors:
@@ -340,28 +350,27 @@ func superviseRuntime(
 	grace := terminationGrace
 	if reason == "exited" {
 		grace = 0
+	} else if reason == "outcome_reported" {
+		grace = 10 * time.Second
 	}
 	stopErr := stopStartedSupervisorGroup(anchor, anchorIdentity, grace)
-	if stopErr != nil && waitErr == nil {
-		waitErr = stopErr
-	}
+	var childErr error
+	childReaped := reason == "exited"
 	if reason != "exited" {
 		select {
-		case childErr := <-wait:
-			if waitErr == nil {
-				waitErr = childErr
-			}
+		case childErr = <-wait:
+			childReaped = true
 		case <-time.After(2 * time.Second):
-			if waitErr == nil {
-				waitErr = fmt.Errorf("%s process did not reap after group termination", displayName)
-			}
+			childErr = fmt.Errorf("%s process did not reap after group termination", displayName)
 		}
 	}
-	if anchorErr := waitForSupervisorCommand(anchor, supervisorCleanupWait); anchorErr != nil && waitErr == nil {
-		waitErr = fmt.Errorf("reap process-group anchor: %w", anchorErr)
-	}
-	if readersErr := waitForSupervisorReaders(&readers, stdout, stderr, supervisorCleanupWait); readersErr != nil && waitErr == nil {
-		waitErr = readersErr
+	anchorErr := waitForSupervisorCommand(anchor, supervisorCleanupWait)
+	readersErr := waitForSupervisorReaders(&readers, stdout, stderr, supervisorCleanupWait)
+	stopUnverified := stopErr != nil || !childReaped || anchorErr != nil || readersErr != nil
+	waitErr = supervisorCompletionError(reason, waitErr, stopErr, childErr, anchorErr, readersErr)
+	outcomeStopFailed := reason == "outcome_reported" && waitErr != nil
+	if outcomeStopFailed {
+		reason = "supervisor_error"
 	}
 	select {
 	case promptErr := <-promptErrors:
@@ -398,19 +407,21 @@ func superviseRuntime(
 	}
 	_ = os.Remove(init.ResultPath)
 	message := supervisorMessage{
-		Type:      "exit",
-		ExitCode:  exitCode(waitErr),
-		Reason:    reason,
-		Result:    result,
-		Truncated: truncated,
+		Type:           "exit",
+		ExitCode:       exitCode(waitErr),
+		Reason:         reason,
+		Result:         result,
+		Truncated:      truncated,
+		StopUnverified: stopUnverified,
 	}
-	if reason != "exited" {
+	if reason != "exited" && !outcomeStopFailed {
 		message.Error = map[string]string{
 			"cancelled":        "attempt cancelled",
 			"parent_lost":      "worker parent process exited",
 			"lease_lost":       "control-plane lease renewal deadline passed",
 			"timeout":          "Session timeout reached",
 			"supervisor_error": "attempt supervisor failed",
+			"outcome_reported": "",
 		}[reason]
 	}
 	if message.Error == "" && waitErr != nil {
@@ -426,16 +437,43 @@ func superviseRuntime(
 	return writer.send(message)
 }
 
-func runtimeEnvironment(runID, sessionID string) []string {
-	environment := make([]string, 0, len(os.Environ())+2)
+func supervisorCompletionError(reason string, initial, stop, child, anchor, readers error) error {
+	if reason == "outcome_reported" && stop == nil && expectedOutcomeTerminationError(child) {
+		// A signal from the verified process-group stop is expected. All other
+		// stop, reap, anchor, and reader errors remain terminal failures.
+		child = nil
+	}
+	if anchor != nil {
+		anchor = fmt.Errorf("reap process-group anchor: %w", anchor)
+	}
+	return errors.Join(initial, stop, child, anchor, readers)
+}
+
+func expectedOutcomeTerminationError(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ProcessState != nil && exitErr.ProcessState.ExitCode() == -1
+}
+
+func runtimeEnvironment(runID, sessionID, attemptID, updateSocket, updateToken string) []string {
+	environment := make([]string, 0, len(os.Environ())+6)
 	for _, value := range os.Environ() {
 		key, _, _ := strings.Cut(value, "=")
-		if key != "FACTORY_RUN_ID" && key != "FACTORY_SESSION_ID" {
+		if key != "FACTORY_RUN_ID" && key != "FACTORY_SESSION_ID" &&
+			key != "FACTORY_WORK_ID" && key != "FACTORY_ATTEMPT_ID" &&
+			key != "FACTORY_UPDATE_SOCKET" && key != "FACTORY_UPDATE_TOKEN" {
 			environment = append(environment, value)
 		}
 	}
 	if runID != "" {
 		environment = append(environment, "FACTORY_RUN_ID="+runID, "FACTORY_SESSION_ID="+sessionID)
+	}
+	if attemptID != "" {
+		environment = append(environment,
+			"FACTORY_WORK_ID="+sessionID,
+			"FACTORY_ATTEMPT_ID="+attemptID,
+			"FACTORY_UPDATE_SOCKET="+updateSocket,
+			"FACTORY_UPDATE_TOKEN="+updateToken,
+		)
 	}
 	return environment
 }
@@ -552,7 +590,7 @@ func parseControlCommand(command string) (string, time.Duration, error) {
 	fields := strings.Fields(command)
 	if len(fields) == 1 {
 		switch fields[0] {
-		case "start", "cancel", "lease_lost", "fail", "timeout":
+		case "start", "cancel", "lease_lost", "fail", "timeout", "outcome_reported":
 			return fields[0], 0, nil
 		}
 	}

--- a/internal/worker/supervisor.go
+++ b/internal/worker/supervisor.go
@@ -326,7 +326,7 @@ func superviseRuntime(
 				reason = "timeout"
 				running = false
 			case "outcome_reported":
-				reason = "outcome_reported"
+				reason = supervisorOutcomeReason(leaseTimer.C)
 				running = false
 			case "start":
 			}
@@ -435,6 +435,15 @@ func superviseRuntime(
 		}
 	}
 	return writer.send(message)
+}
+
+func supervisorOutcomeReason(leaseTimer <-chan time.Time) string {
+	select {
+	case <-leaseTimer:
+		return "lease_lost"
+	default:
+		return "outcome_reported"
+	}
 }
 
 func supervisorCompletionError(reason string, initial, stop, child, anchor, readers error) error {

--- a/internal/worker/supervisor.go
+++ b/internal/worker/supervisor.go
@@ -451,7 +451,7 @@ func supervisorCompletionError(reason string, initial, stop, child, anchor, read
 
 func expectedOutcomeTerminationError(err error) bool {
 	var exitErr *exec.ExitError
-	return errors.As(err, &exitErr) && exitErr.ProcessState != nil && exitErr.ProcessState.ExitCode() == -1
+	return errors.As(err, &exitErr) && exitErr.ProcessState != nil && exitErr.ExitCode() == -1
 }
 
 func runtimeEnvironment(runID, sessionID, attemptID, updateSocket, updateToken string) []string {

--- a/internal/worker/supervisor_process_test.go
+++ b/internal/worker/supervisor_process_test.go
@@ -443,6 +443,10 @@ func TestRunSupervisorHandlesStopCommandsWhileRunning(t *testing.T) {
 			message: "control-plane lease renewal deadline passed",
 		},
 		{
+			name: "outcome reported", command: "outcome_reported",
+			reason: "outcome_reported", message: "",
+		},
+		{
 			// A renewal this short leaves no room for the termination grace, so
 			// the lease deadline passes almost immediately.
 			name:    "renewal deadline",

--- a/internal/worker/supervisor_test.go
+++ b/internal/worker/supervisor_test.go
@@ -38,6 +38,47 @@ func TestIsSupervisorCommand(t *testing.T) {
 	}
 }
 
+func TestOutcomeCompletionSuppressesOnlyVerifiedSignalExit(t *testing.T) {
+	command := exec.Command("/bin/sh", "-c", "kill -TERM $$")
+	signalErr := command.Run()
+	if !expectedOutcomeTerminationError(signalErr) {
+		t.Fatalf("signal error was not recognized: %v", signalErr)
+	}
+	if err := supervisorCompletionError("outcome_reported", nil, nil, signalErr, nil, nil); err != nil {
+		t.Fatalf("verified outcome termination returned %v", err)
+	}
+
+	stopErr := errors.New("stop failed")
+	anchorErr := errors.New("anchor failed")
+	readerErr := errors.New("readers failed")
+	childErr := errors.New("child exited unexpectedly")
+	for _, testCase := range []struct {
+		name    string
+		initial error
+		stop    error
+		child   error
+		anchor  error
+		readers error
+		want    error
+	}{
+		{name: "initial", initial: childErr, want: childErr},
+		{name: "stop", stop: stopErr, child: signalErr, want: stopErr},
+		{name: "unexpected child", child: childErr, want: childErr},
+		{name: "anchor", child: signalErr, anchor: anchorErr, want: anchorErr},
+		{name: "readers", child: signalErr, readers: readerErr, want: readerErr},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := supervisorCompletionError(
+				"outcome_reported", testCase.initial, testCase.stop, testCase.child,
+				testCase.anchor, testCase.readers,
+			)
+			if !errors.Is(err, testCase.want) {
+				t.Fatalf("completion error = %v, want %v", err, testCase.want)
+			}
+		})
+	}
+}
+
 func TestParseControlCommand(t *testing.T) {
 	cases := []struct {
 		name         string
@@ -51,6 +92,7 @@ func TestParseControlCommand(t *testing.T) {
 		{name: "lease lost", command: "lease_lost", wantAction: "lease_lost"},
 		{name: "fail", command: "fail", wantAction: "fail"},
 		{name: "timeout", command: "timeout", wantAction: "timeout"},
+		{name: "outcome reported", command: "outcome_reported", wantAction: "outcome_reported"},
 		{name: "surrounding space", command: "  cancel  ", wantAction: "cancel"},
 		{name: "renew", command: "renew 1500", wantAction: "renew", wantDuration: 1500 * time.Millisecond},
 		{name: "renew minimum", command: "renew 1", wantAction: "renew", wantDuration: time.Millisecond},
@@ -553,24 +595,36 @@ func TestStreamSupervisorOutputIgnoresEmptyStream(t *testing.T) {
 func TestRuntimeEnvironment(t *testing.T) {
 	t.Setenv("FACTORY_RUN_ID", "stale-run")
 	t.Setenv("FACTORY_SESSION_ID", "stale-session")
+	t.Setenv("FACTORY_WORK_ID", "stale-work")
+	t.Setenv("FACTORY_ATTEMPT_ID", "stale-attempt")
+	t.Setenv("FACTORY_UPDATE_SOCKET", "/stale/socket")
+	t.Setenv("FACTORY_UPDATE_TOKEN", "stale-token")
 	t.Setenv("FACTORY_TEST_MARKER", "kept")
 
-	withIdentity := runtimeEnvironment("run-1", "session-1")
+	withIdentity := runtimeEnvironment("run-1", "session-1", "attempt-1", "/private/update.sock", "update-token")
 	if countEnvironment(withIdentity, "FACTORY_RUN_ID=") != 1 ||
 		countEnvironment(withIdentity, "FACTORY_SESSION_ID=") != 1 {
 		t.Fatalf("environment did not replace stale identity values: %v", identityValues(withIdentity))
 	}
 	if !containsEnvironment(withIdentity, "FACTORY_RUN_ID=run-1") ||
-		!containsEnvironment(withIdentity, "FACTORY_SESSION_ID=session-1") {
+		!containsEnvironment(withIdentity, "FACTORY_SESSION_ID=session-1") ||
+		!containsEnvironment(withIdentity, "FACTORY_WORK_ID=session-1") ||
+		!containsEnvironment(withIdentity, "FACTORY_ATTEMPT_ID=attempt-1") ||
+		!containsEnvironment(withIdentity, "FACTORY_UPDATE_SOCKET=/private/update.sock") ||
+		!containsEnvironment(withIdentity, "FACTORY_UPDATE_TOKEN=update-token") {
 		t.Fatalf("environment missing supplied identity: %v", identityValues(withIdentity))
 	}
 	if !containsEnvironment(withIdentity, "FACTORY_TEST_MARKER=kept") {
 		t.Fatal("environment dropped unrelated variables")
 	}
 
-	withoutIdentity := runtimeEnvironment("", "")
+	withoutIdentity := runtimeEnvironment("", "", "", "", "")
 	if countEnvironment(withoutIdentity, "FACTORY_RUN_ID=") != 0 ||
-		countEnvironment(withoutIdentity, "FACTORY_SESSION_ID=") != 0 {
+		countEnvironment(withoutIdentity, "FACTORY_SESSION_ID=") != 0 ||
+		countEnvironment(withoutIdentity, "FACTORY_WORK_ID=") != 0 ||
+		countEnvironment(withoutIdentity, "FACTORY_ATTEMPT_ID=") != 0 ||
+		countEnvironment(withoutIdentity, "FACTORY_UPDATE_SOCKET=") != 0 ||
+		countEnvironment(withoutIdentity, "FACTORY_UPDATE_TOKEN=") != 0 {
 		t.Fatalf("environment kept identity values: %v", identityValues(withoutIdentity))
 	}
 }
@@ -721,6 +775,21 @@ func TestSupervisorProcessStoppedFlag(t *testing.T) {
 	process.markStopped()
 	if !process.isStopped() {
 		t.Fatal("markStopped did not record a verified stop")
+	}
+}
+
+func TestUnverifiedSupervisorExitDoesNotMarkProcessStopped(t *testing.T) {
+	process := newTestSupervisorProcess()
+	process.messages <- supervisorMessage{
+		Type: "exit", Reason: "supervisor_error", Error: "child did not reap", StopUnverified: true,
+	}
+	manager := &Manager{}
+	message := manager.waitForSupervisorMessage(process)
+	if message.Reason != "supervisor_error" {
+		t.Fatalf("exit message = %#v", message)
+	}
+	if process.isStopped() {
+		t.Fatal("unverified supervisor exit marked the process stopped")
 	}
 }
 

--- a/internal/worker/supervisor_test.go
+++ b/internal/worker/supervisor_test.go
@@ -79,6 +79,17 @@ func TestOutcomeCompletionSuppressesOnlyVerifiedSignalExit(t *testing.T) {
 	}
 }
 
+func TestOutcomeReportedDefersToPendingLeaseLoss(t *testing.T) {
+	leaseTimer := make(chan time.Time, 1)
+	leaseTimer <- time.Now()
+	if got := supervisorOutcomeReason(leaseTimer); got != "lease_lost" {
+		t.Fatalf("pending lease timer outcome = %q", got)
+	}
+	if got := supervisorOutcomeReason(make(chan time.Time)); got != "outcome_reported" {
+		t.Fatalf("active lease outcome = %q", got)
+	}
+}
+
 func TestParseControlCommand(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/migrations/032_agent_update_requests.sql
+++ b/migrations/032_agent_update_requests.sql
@@ -1,0 +1,15 @@
+-- Every accepted agent invocation retains its agent-visible request
+-- fingerprint and exact response. Worker-derived evidence is deliberately not
+-- fingerprinted, so a transport retry does not depend on mutable provider or
+-- repository state. A later invocation may also repeat an already-stored
+-- outcome with a new request ID.
+CREATE TABLE agent_update_requests (
+    attempt_id TEXT NOT NULL REFERENCES attempts(id) ON DELETE CASCADE,
+    request_id TEXT NOT NULL CHECK (length(CAST(request_id AS BLOB)) BETWEEN 1 AND 200),
+    request_digest BLOB NOT NULL CHECK (length(request_digest) = 32),
+    update_id TEXT NOT NULL REFERENCES work_updates(id) ON DELETE CASCADE,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (attempt_id, request_id)
+);
+
+CREATE INDEX agent_update_requests_update ON agent_update_requests(update_id);


### PR DESCRIPTION
## Summary

- add the scoped Worker-local `factory update` capability for frozen `agent_update` Work
- persist idempotent progress and outcomes, including exact replay before mutable delivery validation
- enforce verified process shutdown, ready delivery preflight/postflight, cancellation precedence, and failed-worktree retention
- preserve legacy `process_exit` behavior and document the new trust boundary

## Verification

- `go test ./internal/factorycli ./internal/controlplane ./internal/worker ./internal/protocol`
- `just format-check`
- `just vet`
- `just boundary`
- `just staticcheck`
- `just test`
- `just test-worker-race` (210 tests)
- `just test-tooling`
- `FACTORY_BUILD_DIR=/tmp/factory-issue-342-build just build`
- `just test-release`
- `just test-launcher`
- pinned Go 1.26.6 `govulncheck`: no vulnerabilities found
- fresh review agent: Approve, no actionable findings

Closes #342

Parent: #338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents can now report progress, completion outcomes, checkpoints, questions, and pull-request details.
  * Added an `update` command for submitting agent status and outcome information.
  * Successful pull-request updates now verify repository, branch, commit, and pull-request consistency.
* **Reliability**
  * Updates are safely replayed without creating duplicates.
  * Improved attempt termination and recovery when reported outcomes or process shutdowns encounter errors.
* **Documentation**
  * Documented the agent update delivery and validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->