### PR TITLE
feat: add multi-item build admission

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,10 +7,11 @@
 ## Executive summary
 
 Factory is a local-first control plane for repeatable software-engineering
-agents. An operator saves a prompt and execution settings as a Task. Running
-or scheduling that Task creates a Run with one Session per repository. A
-persistent Worker claims each Session, prepares an isolated Git worktree, runs
-Pi, Codex, or Claude Code, streams events, and reports one terminal result.
+agents. An operator can save a prompt and execution settings as a Task, or use
+`factory build` to admit up to 100 existing work-item references in one Run.
+Each target becomes independent Session-backed Work. A persistent Worker claims
+the Work, prepares an isolated Git worktree, runs Pi, Codex, or Claude Code,
+streams events, and reports one terminal result.
 
 The implementation has four main parts:
 
@@ -42,7 +43,7 @@ Operator browser or `factory` CLI
       | loopback HTTP and JSON
       v
 factory-server
-  |-- Task scheduler and Run admission
+  |-- Task scheduler, Build admission, and Run admission
   |-- routing and lease state machine
   |-- embedded React UI
   `-- SQLite
@@ -136,6 +137,27 @@ later claim can route it when a healthy Worker advertises the runtime and
 repository access. Task concurrency limits how many sibling Sessions may be
 queued or active at once.
 
+### Build admission
+
+`factory build` accepts 1 to 100 ordered HTTPS GitHub issue URLs or opaque
+references. Opaque references require `--repo`. An explicit repository must
+also match every GitHub URL, while an omitted repository permits a GitHub-only
+batch across managed repositories. The server resolves repository state and
+rejects the whole batch before writing when any target is invalid.
+
+Every Build freezes generation 1 of the built-in `standard-build` Procedure,
+the configured default or explicit runtime, persistent execution settings, and
+one immutable target and publish branch per Work. The Procedure text is trusted
+policy. References are labelled as untrusted context and are not fetched by the
+CLI or control plane.
+
+The caller fingerprint covers ordered normalized references, explicit option
+presence and values, and the rebuild flag. Request-key lookup and fingerprint
+comparison happen before repository, runtime-default, duplicate, or predecessor
+reads. Matching replay returns the original Run. Active matching Work blocks a
+duplicate. A rebuild requires a new key and the latest terminal predecessor for
+every target, selected in the same transaction.
+
 ### Execution and Attempt
 
 An Execution is the durable assignment of one Session to one Worker and runtime.
@@ -194,17 +216,29 @@ static repository paths remain readable through Worker configuration.
     endpoint and read current state through bounded API routes.
 12. Claim protocol version 3 gates every persistent Worker claim. Older Workers
     receive `worker_upgrade_required`, including for process-exit Work.
+13. Build admission is all-or-none. Exact request-key replay wins before mutable
+    configuration reads, and one Run cannot contain a duplicate target.
+14. An implicit Build key is written durably before HTTP submission and is not
+    removed until an authoritative admitted, replayed, or pre-commit rejection
+    result has been written and flushed.
 
 ## Components
 
 ### Operator CLI
 
 `cmd/factory` delegates parsing and finite HTTP work to `internal/factorycli`.
-The `status`, `show`, and `workers` commands decode protocol resources and write
-either stable tabular output or one JSON value. They do not import SQLite or
-Worker packages. An injected `factory update` command instead connects only to
-a private Attempt-scoped Unix socket using the Work ID, Attempt ID, and update
-token supplied by the Worker.
+The `build`, `status`, `show`, and `workers` commands use typed protocol
+resources and write either stable tabular output or one JSON value. They do not
+import SQLite or Worker packages. Build syntax normalization is local, but
+managed-state resolution belongs to the server. An injected `factory update`
+command instead connects only to a private Attempt-scoped Unix socket using the
+Work ID, Attempt ID, and update token supplied by the Worker.
+
+When no Build key is supplied, the CLI journals a random key under the private
+operator data directory before sending. A nonblocking OS lock scopes concurrent
+submissions by endpoint and caller fingerprint. Lost responses retain the key
+for replay by a later CLI process. The journal holds at most 100 uncertain
+requests and never evicts one silently.
 
 The `server start` and `worker start` commands replace the CLI process with the
 matching compatibility executable beside it or on `PATH`. An explicit config
@@ -296,6 +330,23 @@ security headers. Node.js is needed only when UI source changes.
 5. The same manual request key or scheduled occurrence cannot admit duplicate
    Runs.
 
+### Build admission
+
+1. The CLI normalizes reference syntax and computes the caller fingerprint.
+2. For an implicit key, it acquires the endpoint/fingerprint lock and durably
+   journals a random request key before sending one HTTP request.
+3. The server checks the key and fingerprint before mutable reads. Exact replay
+   returns the stored Run and different input conflicts.
+4. For a new key, one transaction resolves every enabled managed repository,
+   rejects duplicates, applies active-Work and rebuild guards, and freezes the
+   standard Procedure and runtime.
+5. The transaction inserts one Run and ordered independent Work targets. Work
+   routes immediately when possible or remains visibly blocked for a later
+   scheduler claim. The CLI never starts agents.
+6. The CLI clears an implicit journal entry only after it flushes an admitted,
+   replayed, or typed pre-commit rejection result. Transport, server, malformed
+   response, timeout, interruption, and output errors leave the key pending.
+
 ### Claim and execution
 
 1. A healthy Worker registers capabilities and polls with a fresh claim request
@@ -328,8 +379,8 @@ Attempt when claimed.
 ## API and security boundaries
 
 The local listener exposes health plus operator and Worker routes under
-`/api/v1`: Workers, repositories, Tasks, Runs, overview, Attempts, and event
-history. It rejects non-loopback clients before route handling.
+`/api/v1`: Builds, Workers, repositories, Tasks, Runs, overview, Attempts, and
+event history. It rejects non-loopback clients before route handling.
 
 The optional remote listener exposes only health, enrollment exchange, Worker
 registration and claims, and the active Attempt lifecycle. Creating an
@@ -386,6 +437,7 @@ admission path.
 | Area | Primary files |
 | --- | --- |
 | Operator CLI | `cmd/factory/main.go`, `internal/factorycli/command.go`, `internal/factorycli/client.go` |
+| Build admission and journal | `internal/controlplane/build.go`, `internal/factorycli/build.go`, `internal/factorycli/admission_journal.go`, `internal/protocol/build.go` |
 | Server startup and config | `cmd/factory-server/main.go`, `cmd/factory-server/config.go` |
 | HTTP routes and auth | `internal/controlplane/http.go`, `internal/controlplane/worker_auth.go` |
 | Task, Run, and Work model | `internal/controlplane/tasks.go`, `internal/controlplane/work.go`, `internal/protocol/tasks.go` |
@@ -404,6 +456,11 @@ admission path.
 - `internal/controlplane/work_lifecycle_test.go` proves outcome-contract
   freezing, backend compatibility, Work states, bounded update history,
   replacement guards, ordered targets, and legacy prompt limits.
+- `internal/controlplane/build_test.go`, `internal/protocol/build_test.go`, and
+  `internal/factorycli/build_test.go` prove atomic Build admission,
+  normalization, replay ordering, runtime freezing, duplicate and rebuild
+  guards, scheduler claim, typed commit status, journal recovery, locking, and
+  wait exit codes.
 - `internal/controlplane/tasks_migration_test.go` opens populated historical
   databases and proves identity, lifecycle, scheduled process-exit completion,
   and foreign-key preservation.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Open [http://127.0.0.1:7337](http://127.0.0.1:7337). Edit
 `~/.factory/worker.toml` to enable the agent runtimes installed on your machine.
 Use `~/.factory/bin/factory status` to read current Runs or
 `~/.factory/bin/factory workers` to check the Worker pool from the terminal.
+Use `~/.factory/bin/factory build ISSUE...` to admit up to 100 GitHub issues or
+repository-scoped opaque references as independent Work in one Run.
 The [local guide](docs/local.md) covers authentication, repository setup, and
 the complete first Run.
 
@@ -106,6 +108,7 @@ Implemented today:
 
 - Go control-plane API and embedded React UI
 - durable Tasks, Runs, Sessions, Attempts, leases, events, and cancellation
+- transactional multi-item `factory build` admission with durable replay keys
 - manual and scheduled work across one or many repositories
 - Pi, Codex, and Claude Code Worker capabilities
 - managed repository catalog, Worker caches, and isolated Git worktrees

--- a/cmd/factory-server/config.go
+++ b/cmd/factory-server/config.go
@@ -14,6 +14,7 @@ import (
 type serverBootstrapConfig struct {
 	Listen                         string `toml:"listen"`
 	Database                       string `toml:"database"`
+	DefaultBuildRuntime            string `toml:"default_build_runtime"`
 	WorkerListen                   string `toml:"worker_listen"`
 	WorkerTLSCert                  string `toml:"worker_tls_cert"`
 	WorkerTLSKey                   string `toml:"worker_tls_key"`
@@ -66,6 +67,7 @@ func loadServerBootstrapConfig(dataRoot string) (serverBootstrapConfig, error) {
 	config.path = absolute
 	config.Listen = strings.TrimSpace(config.Listen)
 	config.Database = strings.TrimSpace(config.Database)
+	config.DefaultBuildRuntime = strings.ToLower(strings.TrimSpace(config.DefaultBuildRuntime))
 	config.WorkerListen = strings.TrimSpace(config.WorkerListen)
 	config.WorkerTLSCert = resolveConfigPath(absolute, config.WorkerTLSCert)
 	config.WorkerTLSKey = resolveConfigPath(absolute, config.WorkerTLSKey)

--- a/cmd/factory-server/main.go
+++ b/cmd/factory-server/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/owainlewis/factory/internal/buildinfo"
 	"github.com/owainlewis/factory/internal/controlplane"
+	"github.com/owainlewis/factory/internal/protocol"
 	"github.com/owainlewis/factory/internal/statepath"
 	factoryweb "github.com/owainlewis/factory/web"
 )
@@ -41,6 +42,15 @@ func run() (returnErr error) {
 	bootstrap, err := loadServerBootstrapConfig(dataRoot)
 	if err != nil {
 		return err
+	}
+	if bootstrap.DefaultBuildRuntime == "" {
+		bootstrap.DefaultBuildRuntime = protocol.RuntimeCodex
+	}
+	if !protocol.SupportedRuntime(bootstrap.DefaultBuildRuntime) {
+		return fmt.Errorf(
+			"default_build_runtime must be one of %s",
+			strings.Join(protocol.SupportedRuntimes(), ", "),
+		)
 	}
 	defaultListen := "127.0.0.1:7337"
 	if bootstrap.Listen != "" {
@@ -112,6 +122,9 @@ func run() (returnErr error) {
 
 	store, err := controlplane.Open(rootContext, *database)
 	if err != nil {
+		return err
+	}
+	if err := store.SetDefaultBuildRuntime(bootstrap.DefaultBuildRuntime); err != nil {
 		return err
 	}
 	defer func() {

--- a/cmd/factory-server/main_test.go
+++ b/cmd/factory-server/main_test.go
@@ -89,14 +89,14 @@ func TestServerBootstrapConfigIsOptionalAndResolvesRelativeDatabase(t *testing.T
 	}
 
 	path := filepath.Join(dataRoot, "config.toml")
-	if err := os.WriteFile(path, []byte("listen = \"127.0.0.1:7447\"\ndatabase = \"state/factory.sqlite3\"\n"), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte("listen = \"127.0.0.1:7447\"\ndatabase = \"state/factory.sqlite3\"\ndefault_build_runtime = \"PI\"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	config, err = loadServerBootstrapConfig(dataRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if config.Listen != "127.0.0.1:7447" || config.Database != filepath.Join(dataRoot, "state", "factory.sqlite3") {
+	if config.Listen != "127.0.0.1:7447" || config.Database != filepath.Join(dataRoot, "state", "factory.sqlite3") || config.DefaultBuildRuntime != "pi" {
 		t.Fatalf("loaded config = %#v", config)
 	}
 }

--- a/docs/local.md
+++ b/docs/local.md
@@ -31,6 +31,7 @@ needed before SQLite opens:
 ```toml
 listen = "127.0.0.1:7337"
 database = "server/factory.sqlite3"
+default_build_runtime = "codex"
 ```
 
 Relative database paths resolve from the config file directory. Unknown fields,
@@ -148,6 +149,30 @@ Add the global `--json` option for one JSON value on stdout. Set
 `FACTORY_SERVER=http://127.0.0.1:PORT` or pass `--server URL` when the operator
 API does not use the default port. These commands never open SQLite or Worker
 directories.
+
+Admit one or more work items with one command:
+
+```sh
+~/.factory/bin/factory build \
+  https://github.com/OWNER/REPOSITORY/issues/123 \
+  https://github.com/OWNER/REPOSITORY/issues/124
+
+~/.factory/bin/factory build \
+  --repo github.com/OWNER/REPOSITORY \
+  LINEAR-123 LINEAR-124
+```
+
+Use `--runtime`, `--request-key`, `--rebuild`, or `--wait` when needed. An
+opaque reference requires `--repo`. Without `--repo`, a GitHub-only batch may
+span several enabled managed repositories. The server admits the complete
+batch or none of it. `--wait` exits 2 when any Work needs input, 0 when every
+Work is ready, no-change, or legacy succeeded, and 1 when terminal Work includes
+a failure or cancellation.
+
+When `--request-key` is omitted, the CLI stores an uncertain admission under
+`~/.factory/operator/admissions` before sending. A lost response or failed
+output keeps that key for the next identical command. The journal uses
+owner-only permissions and retains at most 100 pending requests.
 
 Add a GitHub repository to the central fleet once:
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -2,6 +2,7 @@
 # Automations are created in the Factory UI and stored in SQLite.
 listen = "127.0.0.1:7337"
 database = "server/factory.sqlite3"
+default_build_runtime = "codex"
 
 # Optional remote VM Worker endpoint. Configure all three values together.
 # worker_listen = "0.0.0.0:7443"

--- a/internal/controlplane/build.go
+++ b/internal/controlplane/build.go
@@ -1,0 +1,326 @@
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+type resolvedBuildTarget struct {
+	reference   protocol.NormalizedBuildReference
+	repository  protocol.TaskRepository
+	targetKey   string
+	predecessor string
+}
+
+func (s *Store) AdmitBuild(ctx context.Context, input protocol.BuildRequest) (protocol.BuildAdmission, error) {
+	canonical, normalized, fingerprint, err := protocol.CanonicalBuildRequest(input)
+	if err != nil {
+		return protocol.BuildAdmission{}, invalid("invalid_build", err.Error())
+	}
+	if canonical.RequestKey == "" || len([]byte(canonical.RequestKey)) > 200 {
+		return protocol.BuildAdmission{}, invalid("invalid_request_key", "request_key is required and limited to 200 bytes")
+	}
+	if strings.HasPrefix(canonical.RequestKey, "schedule:") {
+		return protocol.BuildAdmission{}, invalid("reserved_request_key", "request_key uses a reserved internal prefix")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+	defer tx.Rollback()
+
+	// Request-key replay intentionally wins before repository, Procedure,
+	// runtime-default, duplicate, and rebuild-predecessor reads.
+	var existingRunID string
+	var existingFingerprint []byte
+	err = tx.QueryRowContext(ctx, `
+		SELECT id, request_digest FROM runs WHERE request_key = ?
+	`, canonical.RequestKey).Scan(&existingRunID, &existingFingerprint)
+	if err == nil {
+		if !bytes.Equal(existingFingerprint, fingerprint) {
+			return protocol.BuildAdmission{}, conflict(
+				"request_key_conflict",
+				"request_key was already used with different Build inputs",
+			)
+		}
+		if err := tx.Commit(); err != nil {
+			return protocol.BuildAdmission{}, unavailable(err)
+		}
+		detail, err := s.Run(ctx, existingRunID)
+		if err != nil {
+			return protocol.BuildAdmission{}, err
+		}
+		return protocol.BuildAdmission{
+			Result: protocol.AdmissionReplayed, RequestKey: canonical.RequestKey, Run: detail,
+		}, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+
+	runtime := normalized.Runtime
+	if !normalized.RuntimeSpecified {
+		runtime = s.defaultBuildRuntime
+	}
+	if !protocol.SupportedRuntime(runtime) {
+		return protocol.BuildAdmission{}, invalid(
+			"invalid_runtime",
+			fmt.Sprintf("runtime must be one of %s", strings.Join(protocol.SupportedRuntimes(), ", ")),
+		)
+	}
+
+	targets, err := resolveBuildTargets(ctx, tx, normalized)
+	if err != nil {
+		return protocol.BuildAdmission{}, err
+	}
+	if err := selectBuildPredecessors(ctx, tx, targets, normalized.Rebuild); err != nil {
+		return protocol.BuildAdmission{}, err
+	}
+
+	snapshot := protocol.TaskSnapshot{
+		ID:                 protocol.StandardBuildProcedureID,
+		Name:               protocol.StandardBuildProcedureName,
+		Prompt:             protocol.StandardBuildProcedurePrompt,
+		Runtime:            runtime,
+		TimeoutSeconds:     protocol.StandardBuildTimeoutSeconds,
+		ConcurrencyLimit:   protocol.StandardBuildConcurrencyLimit,
+		Generation:         protocol.StandardBuildProcedureGeneration,
+		OutcomeContract:    protocol.OutcomeAgentUpdate,
+		ExecutionProfileID: protocol.PersistentAutoProfileID,
+	}
+	seenRepositories := make(map[string]bool, len(targets))
+	for _, target := range targets {
+		if !seenRepositories[target.repository.ID] {
+			snapshot.Repositories = append(snapshot.Repositories, target.repository)
+			seenRepositories[target.repository.ID] = true
+		}
+	}
+	execution := protocol.ExecutionSnapshot{
+		ProfileID: protocol.PersistentAutoProfileID, ProfileVersion: 1,
+		Backend: protocol.BackendPersistent, Runtime: runtime,
+		Provider: "worker", Model: "worker-default",
+		TimeoutSeconds: protocol.StandardBuildTimeoutSeconds,
+		ResourceClass:  "worker", CommitResolutionPolicy: protocol.CommitResolvePerAttempt,
+	}
+	snapshotJSON, err := json.Marshal(snapshot)
+	if err != nil {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+	executionJSON, err := json.Marshal(execution)
+	if err != nil {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+	runID, err := newID()
+	if err != nil {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+	now := s.now().UnixMilli()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO runs(
+			id, request_key, request_digest, task_id, task_snapshot, source,
+			requested_execution_profile_id, execution_snapshot, outcome_contract,
+			admitted_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, 'manual', NULL, ?, ?, ?, ?)
+	`, runID, canonical.RequestKey, fingerprint, protocol.StandardBuildProcedureID,
+		snapshotJSON, executionJSON, protocol.OutcomeAgentUpdate, now, now); err != nil {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+
+	frozenTargets := make([]protocol.WorkTarget, 0, len(targets))
+	materialized := 0
+	for position, target := range targets {
+		workID, err := newID()
+		if err != nil {
+			return protocol.BuildAdmission{}, unavailable(err)
+		}
+		frozen := protocol.WorkTarget{
+			ID: workID, Position: position, TargetKey: target.targetKey,
+			TargetKind: "work_item", RepositoryID: target.repository.ID,
+			RepositoryIdentity: target.repository.RemoteIdentity,
+			SourceKind:         target.reference.SourceKind, SourceKey: target.reference.SourceKey,
+			SourceReference: target.reference.Reference,
+			PublishBranch:   workPublishBranch(workID),
+		}
+		resolvedPrompt := resolveStandardBuildPrompt(frozen)
+		if !protocol.AgentPromptFits(snapshot.Name, frozen.RepositoryIdentity, resolvedPrompt) {
+			return protocol.BuildAdmission{}, conflict(
+				"agent_prompt_too_large",
+				"the frozen standard-build Procedure and work-item context cannot fit the Worker request",
+			)
+		}
+		state, blockedReason := "blocked", taskConcurrencyBlockedReason
+		var assigned any
+		var selection runRouteCandidate
+		if materialized < snapshot.ConcurrencyLimit {
+			selection, err = s.selectSessionRoute(
+				ctx, tx, target.repository.ID, target.repository.RemoteIdentity, now, "", runtime,
+			)
+			blockedReason = "Waiting for a healthy compatible Worker with repository access."
+			if err == nil {
+				state, blockedReason, assigned = "queued", "", selection.workerID
+				materialized++
+			} else if !serviceErrorCode(err, "no_eligible_worker") {
+				return protocol.BuildAdmission{}, err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO sessions(
+				id, run_id, repository_id, repository_identity, resolved_prompt, required_runtime,
+				timeout_seconds, state, blocked_reason, assigned_worker_id, admitted_at,
+				execution_profile_id, execution_profile_version, execution_backend, execution_provider,
+				execution_model, resource_class, commit_resolution_policy,
+				target_position, target_key, target_kind, source_kind, source_key,
+				source_reference, context_snapshot, publish_branch, predecessor_work_id,
+				execution_owner, waiting_reason
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, workID, runID, target.repository.ID, target.repository.RemoteIdentity, resolvedPrompt, runtime,
+			execution.TimeoutSeconds, state, nullableString(blockedReason), assigned, now,
+			execution.ProfileID, execution.ProfileVersion, execution.Backend, execution.Provider,
+			execution.Model, execution.ResourceClass, execution.CommitResolutionPolicy,
+			frozen.Position, frozen.TargetKey, frozen.TargetKind, frozen.SourceKind, frozen.SourceKey,
+			frozen.SourceReference, frozen.ContextSnapshot, frozen.PublishBranch,
+			nullableString(target.predecessor), protocol.ExecutionOwnerNone,
+			boundedUTF8Bytes(blockedReason, protocol.MaxWaitingReasonBytes)); err != nil {
+			return protocol.BuildAdmission{}, unavailable(err)
+		}
+		if state == "queued" {
+			executionID, err := newID()
+			if err != nil {
+				return protocol.BuildAdmission{}, unavailable(err)
+			}
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO executions(
+					id, session_id, assigned_worker_id, required_runtime, state, created_at, updated_at
+				) VALUES (?, ?, ?, ?, 'queued', ?, ?)
+			`, executionID, workID, selection.workerID, runtime, now, now); err != nil {
+				return protocol.BuildAdmission{}, unavailable(err)
+			}
+		}
+		frozenTargets = append(frozenTargets, frozen)
+	}
+	targetsJSON, err := json.Marshal(frozenTargets)
+	if err != nil {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE runs SET targets_snapshot = ? WHERE id = ?`, targetsJSON, runID); err != nil {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+	if err := tx.Commit(); err != nil {
+		return protocol.BuildAdmission{}, unavailable(err)
+	}
+	detail, err := s.Run(ctx, runID)
+	if err != nil {
+		return protocol.BuildAdmission{}, err
+	}
+	return protocol.BuildAdmission{
+		Result: protocol.AdmissionAdmitted, RequestKey: canonical.RequestKey, Run: detail,
+	}, nil
+}
+
+func resolveBuildTargets(
+	ctx context.Context,
+	tx *sql.Tx,
+	input protocol.NormalizedBuildInput,
+) ([]*resolvedBuildTarget, error) {
+	targets := make([]*resolvedBuildTarget, 0, len(input.References))
+	seen := make(map[string]bool, len(input.References))
+	for _, reference := range input.References {
+		var repository protocol.TaskRepository
+		err := tx.QueryRowContext(ctx, `
+			SELECT id, remote_identity FROM repositories
+			WHERE lower(remote_identity) = lower(?) AND centrally_managed = 1 AND enabled = 1
+		`, reference.RepositoryIdentity).Scan(&repository.ID, &repository.RemoteIdentity)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, conflict(
+				"repository_not_managed",
+				fmt.Sprintf("repository %s is not enabled in the managed repository catalog", reference.RepositoryIdentity),
+			)
+		}
+		if err != nil {
+			return nil, unavailable(err)
+		}
+		targetKey := repository.ID + ":" + reference.SourceKind + ":" + reference.SourceKey
+		if seen[targetKey] {
+			return nil, conflict(
+				"duplicate_build_target",
+				fmt.Sprintf("reference %s appears more than once in this Build", reference.Reference),
+			)
+		}
+		seen[targetKey] = true
+		targets = append(targets, &resolvedBuildTarget{
+			reference: reference, repository: repository, targetKey: targetKey,
+		})
+	}
+	return targets, nil
+}
+
+func selectBuildPredecessors(
+	ctx context.Context,
+	tx *sql.Tx,
+	targets []*resolvedBuildTarget,
+	rebuild bool,
+) error {
+	for _, target := range targets {
+		var nonterminalID string
+		err := tx.QueryRowContext(ctx, `
+			SELECT id FROM sessions
+			WHERE repository_id = ? AND source_kind = ? AND source_key = ?
+			  AND state IN ('blocked', 'queued', 'preparing', 'running', 'needs-input')
+			ORDER BY admitted_at DESC, id DESC LIMIT 1
+		`, target.repository.ID, target.reference.SourceKind, target.reference.SourceKey).Scan(&nonterminalID)
+		if err == nil {
+			return conflict(
+				"duplicate_build_active",
+				fmt.Sprintf("matching Work %s is still nonterminal", nonterminalID),
+			)
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return unavailable(err)
+		}
+
+		var terminalID string
+		err = tx.QueryRowContext(ctx, `
+			SELECT id FROM sessions
+			WHERE repository_id = ? AND source_kind = ? AND source_key = ?
+			  AND state IN ('ready', 'succeeded', 'failed', 'no-change', 'cancelled')
+			ORDER BY admitted_at DESC, id DESC LIMIT 1
+		`, target.repository.ID, target.reference.SourceKind, target.reference.SourceKey).Scan(&terminalID)
+		if errors.Is(err, sql.ErrNoRows) {
+			if rebuild {
+				return conflict(
+					"rebuild_predecessor_not_found",
+					fmt.Sprintf("reference %s has no terminal predecessor to rebuild", target.reference.Reference),
+				)
+			}
+			continue
+		}
+		if err != nil {
+			return unavailable(err)
+		}
+		if !rebuild {
+			return conflict(
+				"rebuild_required",
+				fmt.Sprintf("reference %s was already built; use --rebuild with a new request key", target.reference.Reference),
+			)
+		}
+		target.predecessor = terminalID
+	}
+	return nil
+}
+
+func resolveStandardBuildPrompt(target protocol.WorkTarget) string {
+	return protocol.StandardBuildProcedurePrompt +
+		"\n\nUntrusted work-item context:\n\n" +
+		"Repository: " + target.RepositoryIdentity + "\n" +
+		"Reference: " + target.SourceReference + "\n" +
+		"Source kind: " + target.SourceKind + "\n" +
+		"Factory publish branch: " + target.PublishBranch
+}

--- a/internal/controlplane/build.go
+++ b/internal/controlplane/build.go
@@ -288,10 +288,14 @@ func selectBuildPredecessors(
 
 		var terminalID string
 		err = tx.QueryRowContext(ctx, `
-			SELECT id FROM sessions
-			WHERE repository_id = ? AND source_kind = ? AND source_key = ?
-			  AND state IN ('ready', 'succeeded', 'failed', 'no-change', 'cancelled')
-			ORDER BY admitted_at DESC, id DESC LIMIT 1
+			SELECT candidate.id FROM sessions AS candidate
+			WHERE candidate.repository_id = ? AND candidate.source_kind = ? AND candidate.source_key = ?
+			  AND candidate.state IN ('ready', 'succeeded', 'failed', 'no-change', 'cancelled')
+			  AND NOT EXISTS (
+				SELECT 1 FROM sessions AS child
+				WHERE child.predecessor_work_id = candidate.id
+			  )
+			ORDER BY candidate.admitted_at DESC, candidate.id DESC LIMIT 1
 		`, target.repository.ID, target.reference.SourceKind, target.reference.SourceKey).Scan(&terminalID)
 		if errors.Is(err, sql.ErrNoRows) {
 			if rebuild {

--- a/internal/controlplane/build_test.go
+++ b/internal/controlplane/build_test.go
@@ -260,3 +260,55 @@ func TestBuildAdmissionReplayWinsAndRebuildSelectsLatestTerminalPredecessor(t *t
 		t.Fatalf("active duplicate error = %v", err)
 	}
 }
+
+func TestBuildRebuildSelectsLineageLeafWhenAdmissionTimesTie(t *testing.T) {
+	store := newTestStore(t)
+	if _, _, err := store.CreateManagedRepository(context.Background(), protocol.CreateManagedRepositoryRequest{
+		RemoteIdentity: "github.com/acme/api",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	reference := []string{"https://github.com/acme/api/issues/19"}
+	initial, err := store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "lineage-initial", References: reference,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const olderID = "zzzz-older-work"
+	if _, err := store.db.Exec(`
+		UPDATE sessions
+		SET id = ?, state = 'failed', admitted_at = 1000, terminal_at = 1000,
+		    terminal_message = 'failed'
+		WHERE id = ?
+	`, olderID, initial.Run.Sessions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	firstRebuild, err := store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "lineage-first-rebuild", References: reference, Rebuild: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstRebuildID := firstRebuild.Run.Sessions[0].ID
+	if firstRebuild.Run.Sessions[0].PredecessorWorkID != olderID {
+		t.Fatalf("first rebuild predecessor = %q, want %q", firstRebuild.Run.Sessions[0].PredecessorWorkID, olderID)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions
+		SET state = 'failed', admitted_at = 1000, terminal_at = 1000,
+		    terminal_message = 'failed'
+		WHERE id = ?
+	`, firstRebuildID); err != nil {
+		t.Fatal(err)
+	}
+	secondRebuild, err := store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "lineage-second-rebuild", References: reference, Rebuild: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := secondRebuild.Run.Sessions[0].PredecessorWorkID; got != firstRebuildID {
+		t.Fatalf("second rebuild predecessor = %q, want lineage leaf %q", got, firstRebuildID)
+	}
+}

--- a/internal/controlplane/build_test.go
+++ b/internal/controlplane/build_test.go
@@ -1,0 +1,262 @@
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestBuildAdmissionHTTPReturnsTypedCommitStatus(t *testing.T) {
+	store := newTestStore(t)
+	if _, _, err := store.CreateManagedRepository(context.Background(), protocol.CreateManagedRepositoryRequest{
+		RemoteIdentity: "github.com/acme/api",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(NewHandler(store, slog.New(slog.NewTextHandler(io.Discard, nil))))
+	t.Cleanup(server.Close)
+	post := func(request protocol.BuildRequest) (*http.Response, []byte) {
+		t.Helper()
+		body, err := json.Marshal(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := http.Post(server.URL+"/api/v1/builds", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		encoded, err := io.ReadAll(response.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return response, encoded
+	}
+	request := protocol.BuildRequest{
+		RequestKey: "http-build", RepositorySpecified: true, Repository: "github.com/acme/api",
+		References: []string{"https://github.com/acme/api/issues/1", "LINEAR-2"},
+	}
+	response, encoded := post(request)
+	var admission protocol.BuildAdmission
+	if response.StatusCode != http.StatusCreated || json.Unmarshal(encoded, &admission) != nil ||
+		admission.Result != protocol.AdmissionAdmitted || admission.Run.Run.SessionCount != 2 {
+		t.Fatalf("created HTTP response = %d %s", response.StatusCode, encoded)
+	}
+	response, encoded = post(request)
+	if response.StatusCode != http.StatusOK || json.Unmarshal(encoded, &admission) != nil ||
+		admission.Result != protocol.AdmissionReplayed {
+		t.Fatalf("replayed HTTP response = %d %s", response.StatusCode, encoded)
+	}
+	request.Rebuild = true
+	response, encoded = post(request)
+	var failure protocol.ErrorBody
+	if response.StatusCode != http.StatusConflict || json.Unmarshal(encoded, &failure) != nil ||
+		failure.Error.AdmissionResult != protocol.AdmissionRejectedBeforeCommit ||
+		failure.Error.RequestKey != request.RequestKey {
+		t.Fatalf("rejected HTTP response = %d %s", response.StatusCode, encoded)
+	}
+	mismatch := protocol.BuildRequest{
+		RequestKey: "http-mismatch", RepositorySpecified: true, Repository: "github.com/acme/api",
+		References: []string{"https://github.com/acme/other/issues/3"},
+	}
+	response, encoded = post(mismatch)
+	if response.StatusCode != http.StatusBadRequest || json.Unmarshal(encoded, &failure) != nil ||
+		failure.Error.AdmissionResult != protocol.AdmissionRejectedBeforeCommit {
+		t.Fatalf("mismatched HTTP response = %d %s", response.StatusCode, encoded)
+	}
+}
+
+func TestStandardBuildBackingProcedureDoesNotCollideWithExistingTaskName(t *testing.T) {
+	store := newTestStore(t)
+	if _, err := store.db.Exec(`DELETE FROM tasks WHERE id = ?`, protocol.StandardBuildProcedureID); err != nil {
+		t.Fatal(err)
+	}
+	userTask, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "__factory_builtin_standard_build__", Prompt: "User-owned prompt.",
+		Runtime: protocol.RuntimeCodex,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ensureStandardBuildProcedure(context.Background()); err != nil {
+		t.Fatalf("install built-in beside existing Task: %v", err)
+	}
+	var userPrompt, userKey, builtInKey string
+	if err := store.db.QueryRow(`SELECT prompt, name_key FROM tasks WHERE id = ?`, userTask.ID).Scan(&userPrompt, &userKey); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.db.QueryRow(`SELECT name_key FROM tasks WHERE id = ?`, protocol.StandardBuildProcedureID).Scan(&builtInKey); err != nil {
+		t.Fatal(err)
+	}
+	if userPrompt != "User-owned prompt." || userKey != "__factory_builtin_standard_build__" ||
+		builtInKey == userKey {
+		t.Fatalf("user prompt %q, user key %q, built-in key %q", userPrompt, userKey, builtInKey)
+	}
+}
+
+func TestBuildAdmissionCreatesIndependentAtomicWorkAndSchedulerClaimsIt(t *testing.T) {
+	store := newTestStore(t)
+	repository, _, err := store.CreateManagedRepository(context.Background(), protocol.CreateManagedRepositoryRequest{
+		RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := registerTestWorker(t, store, workerA, 10, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: repository.RemoteIdentity,
+	})
+	admission, err := store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "mixed-build", RepositorySpecified: true,
+		Repository: repository.RemoteIdentity,
+		References: []string{
+			"https://github.com/OWAINLEWIS/FACTORY/issues/341",
+			"LINEAR-123",
+			"LINEAR-124",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admission.Result != protocol.AdmissionAdmitted || admission.Run.Run.SessionCount != 3 ||
+		admission.Run.Run.Task.ID != protocol.StandardBuildProcedureID ||
+		admission.Run.Run.Task.Generation != protocol.StandardBuildProcedureGeneration ||
+		admission.Run.Run.Task.Runtime != protocol.RuntimeCodex ||
+		admission.Run.Run.OutcomeContract != protocol.OutcomeAgentUpdate {
+		t.Fatalf("admission = %#v", admission)
+	}
+	seenBranches := map[string]bool{}
+	for index, work := range admission.Run.Sessions {
+		if work.Target.Position != index || work.Target.TargetKind != "work_item" ||
+			work.Target.RepositoryID != repository.ID || work.Target.PublishBranch == "" ||
+			!strings.Contains(work.ResolvedPrompt, "Untrusted work-item context:") ||
+			!strings.Contains(work.ResolvedPrompt, protocol.StandardBuildProcedurePrompt) {
+			t.Fatalf("Work %d = %#v", index, work)
+		}
+		if seenBranches[work.Target.PublishBranch] {
+			t.Fatalf("duplicate publish branch %q", work.Target.PublishBranch)
+		}
+		seenBranches[work.Target.PublishBranch] = true
+	}
+	if got := admission.Run.Sessions[0].Target.SourceKey; got != "github:owainlewis/factory:issue:341" {
+		t.Fatalf("GitHub source key = %q", got)
+	}
+	claim, err := store.Claim(context.Background(), worker.ID, protocol.ClaimRequest{
+		RequestID: "build-claim", LeaseToken: tokenA,
+	})
+	if err != nil || claim == nil {
+		t.Fatalf("claim = %#v, error %v", claim, err)
+	}
+	if claim.Session.RunID != admission.Run.Run.ID || claim.Session.Target.TargetKind != "work_item" ||
+		claim.Session.OutcomeContract != protocol.OutcomeAgentUpdate {
+		t.Fatalf("claimed Build Work = %#v", claim.Session)
+	}
+}
+
+func TestBuildAdmissionRejectsWholeInvalidBatchAndDuplicates(t *testing.T) {
+	store := newTestStore(t)
+	first, _, err := store.CreateManagedRepository(context.Background(), protocol.CreateManagedRepositoryRequest{
+		RemoteIdentity: "github.com/acme/api",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := store.CreateManagedRepository(context.Background(), protocol.CreateManagedRepositoryRequest{
+		RemoteIdentity: "github.com/acme/web",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "mismatch", RepositorySpecified: true, Repository: first.RemoteIdentity,
+		References: []string{"LINEAR-1", "https://github.com/acme/web/issues/2"},
+	})
+	if !serviceErrorCode(err, "invalid_build") {
+		t.Fatalf("repository mismatch error = %v", err)
+	}
+	var runs int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM runs WHERE request_key = 'mismatch'`).Scan(&runs); err != nil || runs != 0 {
+		t.Fatalf("mismatch Runs = %d, error %v", runs, err)
+	}
+	_, err = store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "duplicate", References: []string{
+			"https://github.com/acme/api/issues/7",
+			"https://github.com/ACME/API/issues/007",
+		},
+	})
+	if !serviceErrorCode(err, "duplicate_build_target") {
+		t.Fatalf("duplicate target error = %v", err)
+	}
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM runs WHERE request_key = 'duplicate'`).Scan(&runs); err != nil || runs != 0 {
+		t.Fatalf("duplicate Runs = %d, error %v", runs, err)
+	}
+}
+
+func TestBuildAdmissionReplayWinsAndRebuildSelectsLatestTerminalPredecessor(t *testing.T) {
+	store := newTestStore(t)
+	repository, _, err := store.CreateManagedRepository(context.Background(), protocol.CreateManagedRepositoryRequest{
+		RemoteIdentity: "github.com/acme/api",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := protocol.BuildRequest{
+		RequestKey: "initial", References: []string{"https://github.com/acme/api/issues/9"},
+	}
+	initial, err := store.AdmitBuild(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions SET state = 'failed', terminal_at = admitted_at, terminal_message = 'failed'
+		WHERE id = ?
+	`, initial.Run.Sessions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE repositories SET enabled = 0 WHERE id = ?`, repository.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetDefaultBuildRuntime(protocol.RuntimePi); err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := store.AdmitBuild(context.Background(), request)
+	if err != nil || replayed.Result != protocol.AdmissionReplayed || replayed.Run.Run.ID != initial.Run.Run.ID ||
+		replayed.Run.Run.Task.Runtime != protocol.RuntimeCodex {
+		t.Fatalf("replay = %#v, error %v", replayed, err)
+	}
+	request.Runtime, request.RuntimeSpecified = protocol.RuntimePi, true
+	if _, err := store.AdmitBuild(context.Background(), request); !serviceErrorCode(err, "request_key_conflict") {
+		t.Fatalf("fingerprint conflict = %v", err)
+	}
+	if _, err := store.db.Exec(`UPDATE repositories SET enabled = 1 WHERE id = ?`, repository.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "without-rebuild", References: []string{"https://github.com/acme/api/issues/9"},
+	}); !serviceErrorCode(err, "rebuild_required") {
+		t.Fatalf("missing rebuild error = %v", err)
+	}
+	rebuilt, err := store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "rebuilt", Rebuild: true,
+		References: []string{"https://github.com/acme/api/issues/9"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rebuilt.Run.Sessions[0].PredecessorWorkID != initial.Run.Sessions[0].ID ||
+		rebuilt.Run.Run.Task.Runtime != protocol.RuntimePi {
+		t.Fatalf("rebuilt = %#v", rebuilt)
+	}
+	if _, err := store.AdmitBuild(context.Background(), protocol.BuildRequest{
+		RequestKey: "duplicate-active", Rebuild: true,
+		References: []string{"https://github.com/acme/api/issues/9"},
+	}); !serviceErrorCode(err, "duplicate_build_active") {
+		t.Fatalf("active duplicate error = %v", err)
+	}
+}

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -93,6 +93,7 @@ func NewHandler(store *Store, logger *slog.Logger) http.Handler {
 	mux.HandleFunc("PUT /api/v1/tasks/{task_id}/archived", api.setTaskArchived)
 	mux.HandleFunc("POST /api/v1/tasks/{task_id}/run", api.runTask)
 	mux.HandleFunc("POST /api/v1/tasks/{task_id}/discard-occurrence", api.discardTaskOccurrence)
+	mux.HandleFunc("POST /api/v1/builds", api.admitBuild)
 	mux.HandleFunc("GET /api/v1/runs", api.listRuns)
 	mux.HandleFunc("GET /api/v1/runs/{run_id}", api.getRun)
 	mux.HandleFunc("POST /api/v1/runs/{run_id}/cancel", api.cancelRun)

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -49,9 +49,10 @@ func invalid(code, message string) error {
 }
 
 type Store struct {
-	db         *sql.DB
-	now        func() time.Time
-	sweepEvery time.Duration
+	db                  *sql.DB
+	now                 func() time.Time
+	sweepEvery          time.Duration
+	defaultBuildRuntime string
 }
 
 func Open(ctx context.Context, path string) (*Store, error) {
@@ -107,7 +108,10 @@ func openStore(ctx context.Context, path string, existingOnly bool) (*Store, err
 		return nil, fmt.Errorf("open sqlite: %w", err)
 	}
 	db.SetMaxOpenConns(8)
-	store := &Store{db: db, now: time.Now, sweepEvery: 5 * time.Second}
+	store := &Store{
+		db: db, now: time.Now, sweepEvery: 5 * time.Second,
+		defaultBuildRuntime: protocol.RuntimeCodex,
+	}
 	if err := db.PingContext(ctx); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("ping sqlite: %w", err)
@@ -116,6 +120,12 @@ func openStore(ctx context.Context, path string, existingOnly bool) (*Store, err
 		db.Close()
 		return nil, err
 	}
+	if !existingOnly {
+		if err := store.ensureStandardBuildProcedure(ctx); err != nil {
+			db.Close()
+			return nil, err
+		}
+	}
 	if path != ":memory:" {
 		if err := restrictDatabaseFilePermissions(path); err != nil {
 			db.Close()
@@ -123,6 +133,63 @@ func openStore(ctx context.Context, path string, existingOnly bool) (*Store, err
 		}
 	}
 	return store, nil
+}
+
+func (s *Store) SetDefaultBuildRuntime(value string) error {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if !protocol.SupportedRuntime(value) {
+		return fmt.Errorf("default Build runtime must be one of %s", strings.Join(protocol.SupportedRuntimes(), ", "))
+	}
+	s.defaultBuildRuntime = value
+	return nil
+}
+
+func (s *Store) ensureStandardBuildProcedure(ctx context.Context) error {
+	now := s.now().UnixMilli()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("install built-in standard-build Procedure: %w", err)
+	}
+	defer tx.Rollback()
+	var exists int
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS(SELECT 1 FROM tasks WHERE id = ?)
+	`, protocol.StandardBuildProcedureID).Scan(&exists); err != nil {
+		return fmt.Errorf("install built-in standard-build Procedure: %w", err)
+	}
+	if exists == 0 {
+		suffix, err := newID()
+		if err != nil {
+			return fmt.Errorf("install built-in standard-build Procedure: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO tasks(
+				id, name, name_key, prompt, runtime, timeout_seconds, concurrency_limit,
+				generation, outcome_contract, archived, migration_only, read_only,
+				schedule_enabled, schedule_health_status, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 1, 1, 0, 'disabled', ?, ?)
+		`, protocol.StandardBuildProcedureID, protocol.StandardBuildProcedureName,
+			"__factory_builtin_standard_build__:"+suffix,
+			protocol.StandardBuildProcedurePrompt, protocol.RuntimeCodex,
+			protocol.StandardBuildTimeoutSeconds, protocol.StandardBuildConcurrencyLimit,
+			protocol.StandardBuildProcedureGeneration, protocol.OutcomeAgentUpdate, now, now); err != nil {
+			return fmt.Errorf("install built-in standard-build Procedure: %w", err)
+		}
+	} else if _, err := tx.ExecContext(ctx, `
+		UPDATE tasks SET
+			prompt = ?, timeout_seconds = ?, concurrency_limit = ?, generation = ?,
+			outcome_contract = ?, archived = 1, migration_only = 1, read_only = 1,
+			schedule_enabled = 0, updated_at = ?
+		WHERE id = ?
+	`, protocol.StandardBuildProcedurePrompt, protocol.StandardBuildTimeoutSeconds,
+		protocol.StandardBuildConcurrencyLimit, protocol.StandardBuildProcedureGeneration,
+		protocol.OutcomeAgentUpdate, now, protocol.StandardBuildProcedureID); err != nil {
+		return fmt.Errorf("install built-in standard-build Procedure: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("install built-in standard-build Procedure: %w", err)
+	}
+	return nil
 }
 
 func prepareDatabasePath(path string) (string, error) {

--- a/internal/controlplane/tasks_http.go
+++ b/internal/controlplane/tasks_http.go
@@ -1,11 +1,42 @@
 package controlplane
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/owainlewis/factory/internal/protocol"
 )
+
+func (a *API) admitBuild(w http.ResponseWriter, r *http.Request) {
+	if !prepareMutation(w, r, protocol.MaxBodyBytes) {
+		return
+	}
+	var input protocol.BuildRequest
+	if !decodeJSON(w, r, &input) {
+		return
+	}
+	admission, err := a.store.AdmitBuild(r.Context(), input)
+	if err != nil {
+		var service *ServiceError
+		if errors.As(err, &service) && service.Status < http.StatusInternalServerError {
+			writeJSON(w, service.Status, protocol.ErrorBody{Error: protocol.APIError{
+				Code: service.Code, Message: service.Message,
+				AdmissionResult: protocol.AdmissionRejectedBeforeCommit,
+				RequestKey:      input.RequestKey,
+			}})
+			return
+		}
+		writeError(w, err)
+		return
+	}
+	if admission.Result == protocol.AdmissionAdmitted {
+		a.logStateChange("run", admission.Run.Run.ID, string(admission.Run.Run.State))
+		writeJSON(w, http.StatusCreated, admission)
+		return
+	}
+	writeJSON(w, http.StatusOK, admission)
+}
 
 func (a *API) listTasks(w http.ResponseWriter, r *http.Request) {
 	limit, err := pageLimit(r, defaultTaskPageSize, maxTaskPageSize)

--- a/internal/factorycli/admission_journal.go
+++ b/internal/factorycli/admission_journal.go
@@ -1,0 +1,298 @@
+package factorycli
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const maxPendingAdmissions = 100
+
+type pendingAdmissionEntry struct {
+	Scope       string    `json:"scope"`
+	Endpoint    string    `json:"endpoint"`
+	Fingerprint string    `json:"fingerprint"`
+	RequestKey  string    `json:"request_key"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type admissionJournal struct {
+	Version int                     `json:"version"`
+	Entries []pendingAdmissionEntry `json:"entries"`
+}
+
+type admissionLease struct {
+	directory  string
+	scope      string
+	requestKey string
+	lock       *os.File
+	journalled bool
+}
+
+func (c command) admissionStateDirectory() (string, error) {
+	root := c.getenv("FACTORY_DATA_HOME")
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve Factory data directory: %w", err)
+		}
+		root = filepath.Join(home, ".factory")
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve Factory data directory: %w", err)
+	}
+	return filepath.Join(absolute, "operator", "admissions"), nil
+}
+
+func (c command) prepareImplicitAdmission(endpoint string, fingerprint []byte) (*admissionLease, error) {
+	directory, err := c.admissionStateDirectory()
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureAdmissionDirectory(directory); err != nil {
+		return nil, err
+	}
+	fingerprintText := hex.EncodeToString(fingerprint)
+	scopeDigest := sha256.Sum256([]byte(endpoint + "\x00" + fingerprintText))
+	scope := hex.EncodeToString(scopeDigest[:])
+	lockPath := filepath.Join(directory, "scope-"+scope+".lock")
+	lock, err := openAdmissionLock(lockPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockAdmissionFile(lock, true); err != nil {
+		lock.Close()
+		if errors.Is(err, errAdmissionLockBusy) {
+			return nil, fmt.Errorf("an identical Build admission is already in progress; retry after it finishes")
+		}
+		return nil, fmt.Errorf("lock Build admission: %w", err)
+	}
+	lease := &admissionLease{directory: directory, scope: scope, lock: lock, journalled: true}
+	entry, found, err := loadOrCreatePendingAdmission(directory, pendingAdmissionEntry{
+		Scope: scope, Endpoint: endpoint, Fingerprint: fingerprintText,
+	})
+	if err != nil {
+		lease.Release()
+		return nil, err
+	}
+	lease.requestKey = entry.RequestKey
+	if found {
+		return lease, nil
+	}
+	return lease, nil
+}
+
+func explicitAdmissionLease(requestKey string) *admissionLease {
+	return &admissionLease{requestKey: requestKey}
+}
+
+func (lease *admissionLease) RequestKey() string { return lease.requestKey }
+
+func (lease *admissionLease) Complete() error {
+	if lease == nil || !lease.journalled {
+		return nil
+	}
+	if err := removePendingAdmission(lease.directory, lease.scope, lease.requestKey); err != nil {
+		return err
+	}
+	lease.journalled = false
+	return nil
+}
+
+func (lease *admissionLease) Release() error {
+	if lease == nil || lease.lock == nil {
+		return nil
+	}
+	unlockErr := unlockAdmissionFile(lease.lock)
+	closeErr := lease.lock.Close()
+	lease.lock = nil
+	return errors.Join(unlockErr, closeErr)
+}
+
+func ensureAdmissionDirectory(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return fmt.Errorf("create Build admission journal directory: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect Build admission journal directory: %w", err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("Build admission journal path is not a real directory: %s", path)
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		return fmt.Errorf("secure Build admission journal directory: %w", err)
+	}
+	return nil
+}
+
+func openAdmissionLock(path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open Build admission lock %s: %w", path, err)
+	}
+	if err := file.Chmod(0o600); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("secure Build admission lock %s: %w", path, err)
+	}
+	return file, nil
+}
+
+func withJournalLock(directory string, operation func(string) error) error {
+	lock, err := openAdmissionLock(filepath.Join(directory, "journal.lock"))
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	if err := lockAdmissionFile(lock, false); err != nil {
+		return fmt.Errorf("lock Build admission journal: %w", err)
+	}
+	defer unlockAdmissionFile(lock)
+	return operation(filepath.Join(directory, "pending.json"))
+}
+
+func loadOrCreatePendingAdmission(directory string, candidate pendingAdmissionEntry) (pendingAdmissionEntry, bool, error) {
+	var result pendingAdmissionEntry
+	var found bool
+	err := withJournalLock(directory, func(path string) error {
+		journal, err := readAdmissionJournal(path)
+		if err != nil {
+			return err
+		}
+		for _, entry := range journal.Entries {
+			if entry.Scope == candidate.Scope {
+				if entry.Endpoint != candidate.Endpoint || entry.Fingerprint != candidate.Fingerprint || entry.RequestKey == "" {
+					return errors.New("Build admission journal contains a conflicting scope entry")
+				}
+				result, found = entry, true
+				return nil
+			}
+		}
+		if len(journal.Entries) >= maxPendingAdmissions {
+			return fmt.Errorf(
+				"Build admission journal %s contains %d uncertain requests; recover them or provide --request-key",
+				path,
+				maxPendingAdmissions,
+			)
+		}
+		requestKey, err := randomRequestKey()
+		if err != nil {
+			return err
+		}
+		candidate.RequestKey = requestKey
+		candidate.CreatedAt = time.Now().UTC()
+		journal.Entries = append(journal.Entries, candidate)
+		if err := writeAdmissionJournal(directory, path, journal); err != nil {
+			return err
+		}
+		result = candidate
+		return nil
+	})
+	return result, found, err
+}
+
+func removePendingAdmission(directory, scope, requestKey string) error {
+	return withJournalLock(directory, func(path string) error {
+		journal, err := readAdmissionJournal(path)
+		if err != nil {
+			return err
+		}
+		filtered := journal.Entries[:0]
+		removed := false
+		for _, entry := range journal.Entries {
+			if entry.Scope == scope && entry.RequestKey == requestKey {
+				removed = true
+				continue
+			}
+			filtered = append(filtered, entry)
+		}
+		if !removed {
+			return errors.New("pending Build admission disappeared before authoritative output was flushed")
+		}
+		journal.Entries = filtered
+		return writeAdmissionJournal(directory, path, journal)
+	})
+}
+
+func readAdmissionJournal(path string) (admissionJournal, error) {
+	journal := admissionJournal{Version: 1, Entries: []pendingAdmissionEntry{}}
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return journal, nil
+	}
+	if err != nil {
+		return journal, fmt.Errorf("open Build admission journal: %w", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return journal, fmt.Errorf("inspect Build admission journal: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return journal, fmt.Errorf("Build admission journal must be a regular owner-only file: %s", path)
+	}
+	decoder := json.NewDecoder(io.LimitReader(file, 1<<20))
+	if err := decoder.Decode(&journal); err != nil {
+		return journal, fmt.Errorf("decode Build admission journal: %w", err)
+	}
+	if journal.Version != 1 || len(journal.Entries) > maxPendingAdmissions {
+		return journal, errors.New("Build admission journal has an unsupported or invalid shape")
+	}
+	return journal, nil
+}
+
+func writeAdmissionJournal(directory, path string, journal admissionJournal) error {
+	suffix, err := randomRequestKey()
+	if err != nil {
+		return err
+	}
+	temporary := filepath.Join(directory, ".pending-"+suffix+".tmp")
+	file, err := os.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create Build admission journal: %w", err)
+	}
+	removeTemporary := true
+	defer func() {
+		file.Close()
+		if removeTemporary {
+			_ = os.Remove(temporary)
+		}
+	}()
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(journal); err != nil {
+		return fmt.Errorf("encode Build admission journal: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync Build admission journal: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close Build admission journal: %w", err)
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		return fmt.Errorf("install Build admission journal: %w", err)
+	}
+	removeTemporary = false
+	if err := syncAdmissionDirectory(directory); err != nil {
+		return fmt.Errorf("sync Build admission journal directory: %w", err)
+	}
+	return nil
+}
+
+func randomRequestKey() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate Build request key: %w", err)
+	}
+	value[6] = value[6]&0x0f | 0x40
+	value[8] = value[8]&0x3f | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", value[0:4], value[4:6], value[6:8], value[8:10], value[10:16]), nil
+}

--- a/internal/factorycli/admission_journal.go
+++ b/internal/factorycli/admission_journal.go
@@ -69,7 +69,7 @@ func (c command) prepareImplicitAdmission(endpoint string, fingerprint []byte) (
 		return nil, err
 	}
 	if err := lockAdmissionFile(lock, true); err != nil {
-		lock.Close()
+		_ = lock.Close()
 		if errors.Is(err, errAdmissionLockBusy) {
 			return nil, fmt.Errorf("an identical Build admission is already in progress; retry after it finishes")
 		}
@@ -80,7 +80,7 @@ func (c command) prepareImplicitAdmission(endpoint string, fingerprint []byte) (
 		Scope: scope, Endpoint: endpoint, Fingerprint: fingerprintText,
 	})
 	if err != nil {
-		lease.Release()
+		_ = lease.Release()
 		return nil, err
 	}
 	lease.requestKey = entry.RequestKey
@@ -140,22 +140,22 @@ func openAdmissionLock(path string) (*os.File, error) {
 		return nil, fmt.Errorf("open Build admission lock %s: %w", path, err)
 	}
 	if err := file.Chmod(0o600); err != nil {
-		file.Close()
+		_ = file.Close()
 		return nil, fmt.Errorf("secure Build admission lock %s: %w", path, err)
 	}
 	return file, nil
 }
 
-func withJournalLock(directory string, operation func(string) error) error {
+func withJournalLock(directory string, operation func(string) error) (resultErr error) {
 	lock, err := openAdmissionLock(filepath.Join(directory, "journal.lock"))
 	if err != nil {
 		return err
 	}
-	defer lock.Close()
+	defer func() { resultErr = errors.Join(resultErr, lock.Close()) }()
 	if err := lockAdmissionFile(lock, false); err != nil {
 		return fmt.Errorf("lock Build admission journal: %w", err)
 	}
-	defer unlockAdmissionFile(lock)
+	defer func() { resultErr = errors.Join(resultErr, unlockAdmissionFile(lock)) }()
 	return operation(filepath.Join(directory, "pending.json"))
 }
 
@@ -231,7 +231,7 @@ func readAdmissionJournal(path string) (admissionJournal, error) {
 	if err != nil {
 		return journal, fmt.Errorf("open Build admission journal: %w", err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	info, err := file.Stat()
 	if err != nil {
 		return journal, fmt.Errorf("inspect Build admission journal: %w", err)
@@ -261,7 +261,7 @@ func writeAdmissionJournal(directory, path string, journal admissionJournal) err
 	}
 	removeTemporary := true
 	defer func() {
-		file.Close()
+		_ = file.Close()
 		if removeTemporary {
 			_ = os.Remove(temporary)
 		}

--- a/internal/factorycli/admission_lock_unix.go
+++ b/internal/factorycli/admission_lock_unix.go
@@ -34,6 +34,5 @@ func syncAdmissionDirectory(path string) error {
 	if err != nil {
 		return err
 	}
-	defer directory.Close()
-	return directory.Sync()
+	return errors.Join(directory.Sync(), directory.Close())
 }

--- a/internal/factorycli/admission_lock_unix.go
+++ b/internal/factorycli/admission_lock_unix.go
@@ -1,0 +1,39 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package factorycli
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+var errAdmissionLockBusy = errors.New("admission is already in progress")
+
+func lockAdmissionFile(file *os.File, nonblocking bool) error {
+	operation := unix.LOCK_EX
+	if nonblocking {
+		operation |= unix.LOCK_NB
+	}
+	if err := unix.Flock(int(file.Fd()), operation); err != nil {
+		if nonblocking && (errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN)) {
+			return errAdmissionLockBusy
+		}
+		return err
+	}
+	return nil
+}
+
+func unlockAdmissionFile(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}
+
+func syncAdmissionDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}

--- a/internal/factorycli/admission_lock_unsupported.go
+++ b/internal/factorycli/admission_lock_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !(darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
+
+package factorycli
+
+import (
+	"errors"
+	"os"
+)
+
+var errAdmissionLockBusy = errors.New("admission is already in progress")
+
+func lockAdmissionFile(*os.File, bool) error {
+	return errors.New("durable implicit Build request keys require a Unix platform")
+}
+
+func unlockAdmissionFile(*os.File) error { return nil }
+
+func syncAdmissionDirectory(string) error {
+	return errors.New("durable implicit Build request keys require a Unix platform")
+}

--- a/internal/factorycli/build.go
+++ b/internal/factorycli/build.go
@@ -1,0 +1,257 @@
+package factorycli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func (c command) runBuild(server string, jsonOutput bool, arguments []string) error {
+	flags := flag.NewFlagSet("factory build", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	repository := flags.String("repo", "", "scope every reference to one managed GitHub repository")
+	runtime := flags.String("runtime", "", "override the configured Build runtime")
+	requestKey := flags.String("request-key", "", "use an explicit idempotency key")
+	rebuild := flags.Bool("rebuild", false, "replace each target's latest terminal Work")
+	wait := flags.Bool("wait", false, "wait for a terminal or needs-input result")
+	orderedArguments, err := interspersedBuildArguments(arguments)
+	if err != nil {
+		return &usageError{message: err.Error()}
+	}
+	if err := flags.Parse(orderedArguments); err != nil {
+		return &usageError{message: err.Error()}
+	}
+	explicit := make(map[string]bool)
+	flags.Visit(func(value *flag.Flag) { explicit[value.Name] = true })
+	if flags.NArg() == 0 {
+		return &usageError{message: "build requires at least one work-item reference"}
+	}
+	if explicit["repo"] && strings.TrimSpace(*repository) == "" {
+		return &usageError{message: "--repo requires a non-empty value"}
+	}
+	if explicit["runtime"] && strings.TrimSpace(*runtime) == "" {
+		return &usageError{message: "--runtime requires a non-empty value"}
+	}
+	if explicit["request-key"] && strings.TrimSpace(*requestKey) == "" {
+		return &usageError{message: "--request-key requires a non-empty value"}
+	}
+	input := protocol.BuildRequest{
+		RequestKey: strings.TrimSpace(*requestKey), References: flags.Args(),
+		Repository: strings.TrimSpace(*repository), RepositorySpecified: explicit["repo"],
+		Runtime: strings.TrimSpace(*runtime), RuntimeSpecified: explicit["runtime"],
+		Rebuild: *rebuild,
+	}
+	canonical, _, fingerprint, err := protocol.CanonicalBuildRequest(input)
+	if err != nil {
+		return &usageError{message: err.Error()}
+	}
+	if explicit["request-key"] && len([]byte(canonical.RequestKey)) > 200 {
+		return &usageError{message: "--request-key is limited to 200 bytes"}
+	}
+
+	clientContext, cancelClient := context.WithTimeout(context.Background(), 10*time.Second)
+	client, err := newAPIClient(clientContext, server, c.client)
+	cancelClient()
+	if err != nil {
+		return err
+	}
+	var lease *admissionLease
+	if explicit["request-key"] {
+		lease = explicitAdmissionLease(canonical.RequestKey)
+	} else {
+		lease, err = c.prepareImplicitAdmission(client.endpoint.String(), fingerprint)
+		if err != nil {
+			return err
+		}
+	}
+	defer lease.Release()
+	canonical.RequestKey = lease.RequestKey()
+
+	var admission protocol.BuildAdmission
+	err = client.post(context.Background(), "/api/v1/builds", canonical, &admission, maxDetailResponseBytes)
+	if err != nil {
+		var failure *apiFailure
+		if !errors.As(err, &failure) || failure.APIError.AdmissionResult != protocol.AdmissionRejectedBeforeCommit {
+			return err
+		}
+		if failure.APIError.RequestKey == "" {
+			failure.APIError.RequestKey = canonical.RequestKey
+		}
+		if err := c.writeBuildFailure(jsonOutput, failure.APIError); err != nil {
+			return err
+		}
+		if err := flushAuthoritativeOutput(c.stdout); err != nil {
+			return fmt.Errorf("flush Build result: %w", err)
+		}
+		if err := lease.Complete(); err != nil {
+			return fmt.Errorf("clear completed Build admission: %w", err)
+		}
+		return failure
+	}
+	if admission.RequestKey != canonical.RequestKey || admission.Run.Run.ID == "" ||
+		(admission.Result != protocol.AdmissionAdmitted && admission.Result != protocol.AdmissionReplayed) {
+		return errors.New("server returned a malformed Build admission")
+	}
+
+	exitCode := 0
+	if *wait {
+		for {
+			code, done := buildWaitResult(admission.Run.Run)
+			if done {
+				exitCode = code
+				break
+			}
+			timer := time.NewTimer(time.Second)
+			<-timer.C
+			var detail protocol.RunDetail
+			path := "/api/v1/runs/" + url.PathEscape(admission.Run.Run.ID)
+			if err := client.get(context.Background(), path, &detail, maxDetailResponseBytes); err != nil {
+				return err
+			}
+			admission.Run = detail
+		}
+	}
+	if err := c.writeBuildAdmission(jsonOutput, admission); err != nil {
+		return err
+	}
+	if err := flushAuthoritativeOutput(c.stdout); err != nil {
+		return fmt.Errorf("flush Build result: %w", err)
+	}
+	if err := lease.Complete(); err != nil {
+		return fmt.Errorf("clear completed Build admission: %w", err)
+	}
+	if exitCode != 0 {
+		return &commandExit{code: exitCode}
+	}
+	return nil
+}
+
+func buildWaitResult(run protocol.Run) (int, bool) {
+	if run.NeedsInputCount > 0 {
+		return 2, true
+	}
+	if run.SessionCount > 0 && run.ReadyCount+run.NoChangeCount+run.SucceededCount == run.SessionCount {
+		return 0, true
+	}
+	if run.SessionCount > 0 && run.ReadyCount+run.NoChangeCount+run.SucceededCount+
+		run.FailedCount+run.CancelledCount == run.SessionCount {
+		return 1, true
+	}
+	return 0, false
+}
+
+func (c command) writeBuildAdmission(jsonOutput bool, admission protocol.BuildAdmission) error {
+	if jsonOutput {
+		if err := writeJSON(c.stdout, admission); err != nil {
+			return fmt.Errorf("write Build JSON: %w", err)
+		}
+		return nil
+	}
+	run := admission.Run.Run
+	if _, err := fmt.Fprintf(c.stdout,
+		"Request key: %s\nAdmission: %s\nRun: %s\nWork: %d total, %d active, %d ready, %d succeeded, %d needs input, %d no change, %d failed, %d cancelled\n",
+		oneLine(admission.RequestKey), oneLine(string(admission.Result)), oneLine(run.ID),
+		run.SessionCount, run.ActiveCount, run.ReadyCount, run.SucceededCount, run.NeedsInputCount,
+		run.NoChangeCount, run.FailedCount, run.CancelledCount,
+	); err != nil {
+		return fmt.Errorf("write Build output: %w", err)
+	}
+	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(writer, "WORK ID\tREPOSITORY\tREFERENCE\tSTATE"); err != nil {
+		return fmt.Errorf("write Build output: %w", err)
+	}
+	for _, work := range admission.Run.Sessions {
+		if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n",
+			oneLine(work.ID), oneLine(work.RepositoryIdentity),
+			oneLine(work.Target.SourceReference), oneLine(string(work.State))); err != nil {
+			return fmt.Errorf("write Build output: %w", err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write Build output: %w", err)
+	}
+	return nil
+}
+
+func interspersedBuildArguments(arguments []string) ([]string, error) {
+	options := make([]string, 0, len(arguments))
+	references := make([]string, 0, len(arguments))
+	terminated := false
+	for index := 0; index < len(arguments); index++ {
+		argument := arguments[index]
+		if argument == "--" {
+			terminated = true
+			references = append(references, arguments[index+1:]...)
+			break
+		}
+		if !strings.HasPrefix(argument, "-") || argument == "-" {
+			references = append(references, argument)
+			continue
+		}
+		options = append(options, argument)
+		name := strings.TrimLeft(argument, "-")
+		if separator := strings.IndexByte(name, '='); separator >= 0 {
+			continue
+		}
+		switch name {
+		case "repo", "runtime", "request-key":
+			if index+1 >= len(arguments) {
+				return nil, fmt.Errorf("flag needs an argument: --%s", name)
+			}
+			index++
+			options = append(options, arguments[index])
+		}
+	}
+	if terminated {
+		options = append(options, "--")
+	}
+	return append(options, references...), nil
+}
+
+func (c command) writeBuildFailure(jsonOutput bool, failure protocol.APIError) error {
+	result := struct {
+		Result     protocol.AdmissionResult `json:"result"`
+		RequestKey string                   `json:"request_key"`
+		Error      protocol.APIError        `json:"error"`
+	}{failure.AdmissionResult, failure.RequestKey, failure}
+	if jsonOutput {
+		if err := writeJSON(c.stdout, result); err != nil {
+			return fmt.Errorf("write Build rejection JSON: %w", err)
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(c.stdout, "Request key: %s\nAdmission: %s\nRejected: %s\n",
+		oneLine(failure.RequestKey), oneLine(string(failure.AdmissionResult)), oneLine(failure.Message)); err != nil {
+		return fmt.Errorf("write Build rejection: %w", err)
+	}
+	return nil
+}
+
+func flushAuthoritativeOutput(output io.Writer) error {
+	if flusher, ok := output.(interface{ Flush() error }); ok {
+		if err := flusher.Flush(); err != nil {
+			return err
+		}
+	}
+	file, ok := output.(*os.File)
+	if !ok {
+		return nil
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if info.Mode().IsRegular() {
+		return file.Sync()
+	}
+	return nil
+}

--- a/internal/factorycli/build.go
+++ b/internal/factorycli/build.go
@@ -68,12 +68,12 @@ func (c command) runBuild(server string, jsonOutput bool, arguments []string) er
 	if explicit["request-key"] {
 		lease = explicitAdmissionLease(canonical.RequestKey)
 	} else {
-		lease, err = c.prepareImplicitAdmission(client.endpoint.String(), fingerprint)
+		lease, err = c.prepareImplicitAdmission(client.admissionEndpoint, fingerprint)
 		if err != nil {
 			return err
 		}
 	}
-	defer lease.Release()
+	defer func() { _ = lease.Release() }()
 	canonical.RequestKey = lease.RequestKey()
 
 	var admission protocol.BuildAdmission

--- a/internal/factorycli/build_test.go
+++ b/internal/factorycli/build_test.go
@@ -1,0 +1,270 @@
+package factorycli
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestBuildReusesDurableImplicitKeyAfterLostResponseAcrossProcesses(t *testing.T) {
+	dataHome := t.TempDir()
+	requests := make(chan protocol.BuildRequest, 2)
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		var input protocol.BuildRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Error(err)
+			return
+		}
+		requests <- input
+		requestCount++
+		if requestCount == 1 {
+			hijacker, ok := output.(http.Hijacker)
+			if !ok {
+				t.Error("response does not support hijacking")
+				return
+			}
+			connection, _, err := hijacker.Hijack()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			connection.Close()
+			return
+		}
+		output.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(output).Encode(testBuildAdmission(input.RequestKey, protocol.RunQueued)); err != nil {
+			t.Error(err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	getenv := func(key string) string {
+		if key == "FACTORY_DATA_HOME" {
+			return dataHome
+		}
+		return ""
+	}
+	arguments := []string{"--server", server.URL, "build", "LINEAR-1", "--repo", "github.com/acme/api"}
+	var firstError bytes.Buffer
+	if code := Run(Options{Arguments: arguments, Stderr: &firstError, Getenv: getenv}); code != 1 ||
+		!strings.Contains(firstError.String(), "connect") {
+		t.Fatalf("lost response = code %d, stderr %q", code, firstError.String())
+	}
+	first := <-requests
+	if len(first.References) != 1 || first.References[0] != "LINEAR-1" || first.Repository != "github.com/acme/api" {
+		t.Fatalf("interspersed Build request = %#v", first)
+	}
+	journalPath := filepath.Join(dataHome, "operator", "admissions", "pending.json")
+	journal := readJournalForTest(t, journalPath)
+	if len(journal.Entries) != 1 || journal.Entries[0].RequestKey != first.RequestKey {
+		t.Fatalf("pending journal = %#v, first request %#v", journal, first)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run(Options{Arguments: arguments, Stdout: &stdout, Stderr: &stderr, Getenv: getenv}); code != 0 {
+		t.Fatalf("replay = code %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
+	}
+	second := <-requests
+	if second.RequestKey == "" || second.RequestKey != first.RequestKey {
+		t.Fatalf("request keys = first %q, second %q", first.RequestKey, second.RequestKey)
+	}
+	if !strings.Contains(stdout.String(), "Request key: "+first.RequestKey) ||
+		!strings.Contains(stdout.String(), "LINEAR-1") {
+		t.Fatalf("replay output = %q", stdout.String())
+	}
+	journal = readJournalForTest(t, journalPath)
+	if len(journal.Entries) != 0 {
+		t.Fatalf("completed journal = %#v", journal)
+	}
+	assertFileMode(t, filepath.Dir(journalPath), 0o700)
+	assertFileMode(t, journalPath, 0o600)
+}
+
+func TestBuildTypedRejectionClearsImplicitJournalAndWaitUsesDesignedExitCodes(t *testing.T) {
+	dataHome := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		var input protocol.BuildRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Error(err)
+			return
+		}
+		output.Header().Set("Content-Type", "application/json")
+		if input.References[0] == "REJECT" {
+			output.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(output).Encode(protocol.ErrorBody{Error: protocol.APIError{
+				Code: "duplicate_build_active", Message: "matching Work is active",
+				AdmissionResult: protocol.AdmissionRejectedBeforeCommit, RequestKey: input.RequestKey,
+			}})
+			return
+		}
+		state := protocol.RunSucceeded
+		if input.References[0] == "QUESTION" {
+			state = protocol.RunBlocked
+		}
+		_ = json.NewEncoder(output).Encode(testBuildAdmission(input.RequestKey, state))
+	}))
+	t.Cleanup(server.Close)
+	getenv := func(key string) string {
+		if key == "FACTORY_DATA_HOME" {
+			return dataHome
+		}
+		return ""
+	}
+	var stdout, stderr bytes.Buffer
+	arguments := []string{"--server", server.URL, "--json", "build", "--repo", "github.com/acme/api", "REJECT"}
+	if code := Run(Options{Arguments: arguments, Stdout: &stdout, Stderr: &stderr, Getenv: getenv}); code != 1 {
+		t.Fatalf("rejection = code %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
+	}
+	var rejected struct {
+		Result protocol.AdmissionResult `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &rejected); err != nil || rejected.Result != protocol.AdmissionRejectedBeforeCommit {
+		t.Fatalf("rejection JSON = %#v, error %v", rejected, err)
+	}
+	journal := readJournalForTest(t, filepath.Join(dataHome, "operator", "admissions", "pending.json"))
+	if len(journal.Entries) != 0 {
+		t.Fatalf("rejected journal = %#v", journal)
+	}
+
+	for _, test := range []struct {
+		reference string
+		wantCode  int
+	}{{"DONE", 0}, {"QUESTION", 2}} {
+		stdout.Reset()
+		stderr.Reset()
+		code := Run(Options{Arguments: []string{
+			"--server", server.URL, "build", "--repo", "github.com/acme/api",
+			"--request-key", "wait-" + strings.ToLower(test.reference), "--wait", test.reference,
+		}, Stdout: &stdout, Stderr: &stderr, Getenv: getenv})
+		if code != test.wantCode || !strings.Contains(stdout.String(), "Work: 1 total") || stderr.Len() != 0 {
+			t.Fatalf("wait %s = code %d, stdout %q, stderr %q", test.reference, code, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestBuildRetainsPendingKeyWhenAuthoritativeOutputFails(t *testing.T) {
+	dataHome := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		var input protocol.BuildRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Error(err)
+			return
+		}
+		_ = json.NewEncoder(output).Encode(testBuildAdmission(input.RequestKey, protocol.RunQueued))
+	}))
+	t.Cleanup(server.Close)
+	getenv := func(key string) string {
+		if key == "FACTORY_DATA_HOME" {
+			return dataHome
+		}
+		return ""
+	}
+	var stderr bytes.Buffer
+	code := Run(Options{
+		Arguments: []string{"--server", server.URL, "build", "--repo", "github.com/acme/api", "PENDING"},
+		Stdout:    failingWriter{}, Stderr: &stderr, Getenv: getenv,
+	})
+	if code != 1 || !strings.Contains(stderr.String(), "write Build output") {
+		t.Fatalf("failed output = code %d, stderr %q", code, stderr.String())
+	}
+	journal := readJournalForTest(t, filepath.Join(dataHome, "operator", "admissions", "pending.json"))
+	if len(journal.Entries) != 1 {
+		t.Fatalf("failed-output journal = %#v", journal)
+	}
+}
+
+func TestBuildScopeLockRejectsConcurrentDuplicateBeforeSending(t *testing.T) {
+	dataHome := t.TempDir()
+	command := newCommand(Options{Getenv: func(key string) string {
+		if key == "FACTORY_DATA_HOME" {
+			return dataHome
+		}
+		return ""
+	}})
+	fingerprint := sha256.Sum256([]byte("same Build"))
+	first, err := command.prepareImplicitAdmission("http://127.0.0.1:7337", fingerprint[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Release()
+	if _, err := command.prepareImplicitAdmission("http://127.0.0.1:7337", fingerprint[:]); err == nil ||
+		!strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("concurrent lock error = %v", err)
+	}
+}
+
+func TestBuildTerminatorKeepsOptionShapedReferencesLiteral(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests++
+	}))
+	t.Cleanup(server.Close)
+	var stderr bytes.Buffer
+	code := Run(Options{
+		Arguments: []string{
+			"--server", server.URL, "build", "--", "--repo=github.com/acme/api", "LINEAR-1",
+		},
+		Stderr: &stderr,
+	})
+	if code != 2 || !strings.Contains(stderr.String(), "invalid work-item reference") || requests != 0 {
+		t.Fatalf("terminated reference = code %d, stderr %q, requests %d", code, stderr.String(), requests)
+	}
+}
+
+func testBuildAdmission(requestKey string, state protocol.RunState) protocol.BuildAdmission {
+	run := protocol.Run{
+		ID: "run-1", Task: protocol.TaskSnapshot{Name: protocol.StandardBuildProcedureName},
+		State: state, SessionCount: 1,
+	}
+	workState := protocol.WorkQueued
+	switch state {
+	case protocol.RunSucceeded:
+		run.ReadyCount = 1
+		workState = protocol.WorkReady
+	case protocol.RunBlocked:
+		run.NeedsInputCount = 1
+		workState = protocol.WorkNeedsInput
+	default:
+		run.ActiveCount = 1
+	}
+	return protocol.BuildAdmission{
+		Result: protocol.AdmissionAdmitted, RequestKey: requestKey,
+		Run: protocol.RunDetail{Run: run, Sessions: []protocol.Session{{
+			ID: "work-1", RepositoryIdentity: "github.com/acme/api", State: workState,
+			Target: protocol.WorkTarget{SourceReference: "LINEAR-1"},
+		}}},
+	}
+}
+
+func readJournalForTest(t *testing.T, path string) admissionJournal {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	var journal admissionJournal
+	if err := json.NewDecoder(bufio.NewReader(file)).Decode(&journal); err != nil {
+		t.Fatal(err)
+	}
+	return journal
+}
+
+func assertFileMode(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("%s mode = %o, want %o", path, got, want)
+	}
+}

--- a/internal/factorycli/build_test.go
+++ b/internal/factorycli/build_test.go
@@ -3,6 +3,7 @@ package factorycli
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/owainlewis/factory/internal/protocol"
@@ -18,7 +20,7 @@ import (
 func TestBuildReusesDurableImplicitKeyAfterLostResponseAcrossProcesses(t *testing.T) {
 	dataHome := t.TempDir()
 	requests := make(chan protocol.BuildRequest, 2)
-	requestCount := 0
+	var requestCount atomic.Int64
 	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
 		var input protocol.BuildRequest
 		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
@@ -26,8 +28,7 @@ func TestBuildReusesDurableImplicitKeyAfterLostResponseAcrossProcesses(t *testin
 			return
 		}
 		requests <- input
-		requestCount++
-		if requestCount == 1 {
+		if requestCount.Add(1) == 1 {
 			hijacker, ok := output.(http.Hijacker)
 			if !ok {
 				t.Error("response does not support hijacking")
@@ -38,7 +39,7 @@ func TestBuildReusesDurableImplicitKeyAfterLostResponseAcrossProcesses(t *testin
 				t.Error(err)
 				return
 			}
-			connection.Close()
+			_ = connection.Close()
 			return
 		}
 		output.Header().Set("Content-Type", "application/json")
@@ -194,10 +195,23 @@ func TestBuildScopeLockRejectsConcurrentDuplicateBeforeSending(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer first.Release()
+	defer func() { _ = first.Release() }()
 	if _, err := command.prepareImplicitAdmission("http://127.0.0.1:7337", fingerprint[:]); err == nil ||
 		!strings.Contains(err.Error(), "already in progress") {
 		t.Fatalf("concurrent lock error = %v", err)
+	}
+}
+
+func TestBuildAdmissionScopeUsesStableNormalizedServerURL(t *testing.T) {
+	client, err := newAPIClient(context.Background(), "http://LOCALHOST:07337/", http.DefaultClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := client.admissionEndpoint, "http://localhost:7337"; got != want {
+		t.Fatalf("admission endpoint = %q, want %q", got, want)
+	}
+	if client.endpoint.Hostname() == "localhost" {
+		t.Fatalf("transport endpoint was not pinned: %q", client.endpoint)
 	}
 }
 

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -26,8 +26,9 @@ const (
 )
 
 type apiClient struct {
-	endpoint *url.URL
-	client   *http.Client
+	endpoint          *url.URL
+	admissionEndpoint string
+	client            *http.Client
 }
 
 type workerPage struct {
@@ -66,6 +67,14 @@ func newAPIClient(ctx context.Context, value string, client *http.Client) (apiCl
 	if err != nil {
 		return apiClient{}, err
 	}
+	stableHost := strings.ToLower(host)
+	if address := net.ParseIP(host); address != nil {
+		stableHost = address.String()
+	}
+	admissionEndpoint := (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(stableHost, strconv.FormatUint(port, 10)),
+	}).String()
 	// Use the validated literal address so proxies and a second DNS lookup
 	// cannot move a loopback-only command away from the local machine.
 	parsed.Host = net.JoinHostPort(pinnedAddresses[0].String(), parsed.Port())
@@ -77,7 +86,7 @@ func newAPIClient(ctx context.Context, value string, client *http.Client) (apiCl
 	clientCopy.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-	return apiClient{endpoint: parsed, client: &clientCopy}, nil
+	return apiClient{endpoint: parsed, admissionEndpoint: admissionEndpoint, client: &clientCopy}, nil
 }
 
 func validateLoopbackHost(ctx context.Context, host string) ([]net.IP, error) {

--- a/internal/factorycli/client.go
+++ b/internal/factorycli/client.go
@@ -34,6 +34,18 @@ type workerPage struct {
 	Workers []protocol.Worker `json:"workers"`
 }
 
+type apiFailure struct {
+	Status   string
+	APIError protocol.APIError
+}
+
+func (failure *apiFailure) Error() string {
+	if failure.APIError.Message != "" {
+		return fmt.Sprintf("server returned %s: %s", oneLine(failure.Status), oneLine(failure.APIError.Message))
+	}
+	return fmt.Sprintf("server returned %s", oneLine(failure.Status))
+}
+
 func newAPIClient(ctx context.Context, value string, client *http.Client) (apiClient, error) {
 	parsed, err := url.Parse(value)
 	if err != nil {
@@ -130,6 +142,18 @@ func pinLoopbackTransport(client *http.Client, addresses []net.IP) error {
 }
 
 func (c apiClient) get(ctx context.Context, path string, target any, responseLimit int64) error {
+	return c.request(ctx, http.MethodGet, path, nil, target, responseLimit)
+}
+
+func (c apiClient) post(ctx context.Context, path string, input, target any, responseLimit int64) error {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return fmt.Errorf("encode request: %w", err)
+	}
+	return c.request(ctx, http.MethodPost, path, body, target, responseLimit)
+}
+
+func (c apiClient) request(ctx context.Context, method, path string, requestBody []byte, target any, responseLimit int64) error {
 	requestURL := *c.endpoint
 	reference, err := url.Parse(path)
 	if err != nil {
@@ -137,11 +161,14 @@ func (c apiClient) get(ctx context.Context, path string, target any, responseLim
 	}
 	requestURL.Path = reference.Path
 	requestURL.RawQuery = reference.RawQuery
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL.String(), nil)
+	request, err := http.NewRequestWithContext(ctx, method, requestURL.String(), bytes.NewReader(requestBody))
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
 	request.Header.Set("Accept", "application/json")
+	if requestBody != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
 	response, err := c.client.Do(request)
 	if err != nil {
 		return fmt.Errorf("connect to %s: %w", c.endpoint.String(), err)
@@ -166,9 +193,9 @@ func (c apiClient) get(ctx context.Context, path string, target any, responseLim
 		status := oneLine(response.Status)
 		var failure protocol.ErrorBody
 		if err := json.Unmarshal(body, &failure); err == nil && failure.Error.Message != "" {
-			return fmt.Errorf("server returned %s: %s", status, oneLine(failure.Error.Message))
+			return &apiFailure{Status: status, APIError: failure.Error}
 		}
-		return fmt.Errorf("server returned %s", status)
+		return &apiFailure{Status: status}
 	}
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	if err := decoder.Decode(target); err != nil {

--- a/internal/factorycli/command.go
+++ b/internal/factorycli/command.go
@@ -47,9 +47,19 @@ type usageError struct {
 
 func (e *usageError) Error() string { return e.message }
 
+type commandExit struct {
+	code int
+}
+
+func (e *commandExit) Error() string { return "" }
+
 func Run(options Options) int {
 	operation := newCommand(options)
 	if err := operation.run(options.Arguments); err != nil {
+		var exit *commandExit
+		if errors.As(err, &exit) {
+			return exit.code
+		}
 		fmt.Fprintf(operation.stderr, "factory: %s\n", err)
 		var usage *usageError
 		if errors.As(err, &usage) {
@@ -144,6 +154,8 @@ func (c command) run(arguments []string) error {
 			return err
 		}
 		return c.status(ctx, client, *jsonOutput, *cursor)
+	case "build":
+		return c.runBuild(*server, *jsonOutput, remaining[1:])
 	case "show":
 		if len(remaining) != 2 || strings.TrimSpace(remaining[1]) == "" {
 			return &usageError{message: "show requires exactly one Run ID"}
@@ -184,7 +196,7 @@ func (c command) run(arguments []string) error {
 		return c.agentUpdate(*status, *message, *pullRequest, *jsonOutput)
 	case "server", "worker":
 		if *jsonOutput {
-			return &usageError{message: "--json is available only for status, show, and workers"}
+			return &usageError{message: "--json is available only for build, status, show, and workers"}
 		}
 		return c.startProcess(remaining[0], remaining[1:])
 	default:
@@ -276,6 +288,7 @@ func (c command) writeHelp() error {
 	_, err := fmt.Fprint(c.stdout, `Factory controls the local server and Workers and reads current operations.
 
 Usage:
+  factory [--server URL] [--json] build [options] REFERENCE...
   factory [--server URL] [--json] status [--cursor CURSOR]
   factory [--server URL] [--json] show RUN_ID
   factory [--server URL] [--json] workers
@@ -290,7 +303,8 @@ Options:
   --cursor      Continue status from a cursor printed by the previous page.
 
 Environment:
-  FACTORY_SERVER  Overrides the endpoint used by finite commands.
+  FACTORY_SERVER     Overrides the endpoint used by finite commands.
+  FACTORY_DATA_HOME  Stores durable pending Build request keys.
 `)
 	return err
 }

--- a/internal/factorycli/command_test.go
+++ b/internal/factorycli/command_test.go
@@ -485,17 +485,17 @@ func TestStartCommandsReturnUsefulUsageAndLookupErrors(t *testing.T) {
 	}
 }
 
-func TestHelpIsConciseAndDoesNotAdvertiseFutureCommands(t *testing.T) {
+func TestHelpIsConciseAndAdvertisesImplementedCommandsOnly(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	if code := Run(Options{Arguments: []string{"help"}, Stdout: &stdout, Stderr: &stderr}); code != 0 {
 		t.Fatalf("help = %d, stderr %q", code, stderr.String())
 	}
-	for _, want := range []string{"factory server start", "factory worker start", "factory [--server URL] [--json] status [--cursor CURSOR]", "FACTORY_SERVER"} {
+	for _, want := range []string{"factory server start", "factory worker start", "factory [--server URL] [--json] build", "factory [--server URL] [--json] status [--cursor CURSOR]", "FACTORY_SERVER"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("help %q does not contain %q", stdout.String(), want)
 		}
 	}
-	for _, forbidden := range []string{"factory build", "factory run", "factory update", "factory answer"} {
+	for _, forbidden := range []string{"factory run", "factory update", "factory answer"} {
 		if strings.Contains(stdout.String(), forbidden) {
 			t.Fatalf("help advertises %q: %q", forbidden, stdout.String())
 		}

--- a/internal/protocol/build.go
+++ b/internal/protocol/build.go
@@ -1,0 +1,274 @@
+package protocol
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	StandardBuildProcedureID         = "00000000-0000-4341-8000-000000000341"
+	StandardBuildProcedureName       = "standard-build"
+	StandardBuildProcedureGeneration = 1
+	StandardBuildTimeoutSeconds      = 2 * 60 * 60
+	StandardBuildConcurrencyLimit    = 10
+)
+
+const StandardBuildProcedurePrompt = `Complete the assigned software work item in this repository.
+
+Follow every repository instruction. Read the live work item with the tools available on this Worker, refine the requested outcome, implement it completely, and verify it with the relevant tests, linters, builds, or application checks. Preserve unrelated changes.
+
+Use a fresh review subagent that did not write the code. Fix every valid finding and repeat the relevant checks and review. Create or update one pull request, handle its CI and review findings, and push the final committed work to the immutable Factory publish branch supplied for this Work.
+
+This Work is unfinished until you report an outcome with factory update. Allowed statuses are running, ready, needs-input, failed, and no-change. Use running updates only when they help the operator. Ready requires the pull-request URL and delivery evidence. Needs-input ends the current Attempt, so commit and push all partial work first and explain exactly what the operator must answer. Failed and no-change require a concise explanation.`
+
+type BuildRequest struct {
+	RequestKey          string   `json:"request_key"`
+	References          []string `json:"references"`
+	Repository          string   `json:"repository,omitempty"`
+	RepositorySpecified bool     `json:"repository_specified"`
+	Runtime             string   `json:"runtime,omitempty"`
+	RuntimeSpecified    bool     `json:"runtime_specified"`
+	Rebuild             bool     `json:"rebuild"`
+}
+
+type AdmissionResult string
+
+const (
+	AdmissionAdmitted             AdmissionResult = "admitted"
+	AdmissionReplayed             AdmissionResult = "replayed"
+	AdmissionRejectedBeforeCommit AdmissionResult = "rejected_before_commit"
+)
+
+type BuildAdmission struct {
+	Result     AdmissionResult `json:"result"`
+	RequestKey string          `json:"request_key"`
+	Run        RunDetail       `json:"run"`
+}
+
+type NormalizedBuildReference struct {
+	Reference          string
+	SourceKind         string
+	SourceKey          string
+	RepositoryIdentity string
+}
+
+type NormalizedBuildInput struct {
+	References          []NormalizedBuildReference
+	Repository          string
+	RepositorySpecified bool
+	Runtime             string
+	RuntimeSpecified    bool
+	Rebuild             bool
+}
+
+func NormalizeBuildRequest(input BuildRequest) (NormalizedBuildInput, error) {
+	if len(input.References) < 1 || len(input.References) > MaxWorkTargets {
+		return NormalizedBuildInput{}, fmt.Errorf("build requires between 1 and %d references", MaxWorkTargets)
+	}
+	value := NormalizedBuildInput{
+		RepositorySpecified: input.RepositorySpecified,
+		RuntimeSpecified:    input.RuntimeSpecified,
+		Rebuild:             input.Rebuild,
+	}
+	if input.RepositorySpecified {
+		repository, err := NormalizeGitHubRepository(input.Repository)
+		if err != nil {
+			return NormalizedBuildInput{}, fmt.Errorf("invalid repository: %w", err)
+		}
+		value.Repository = repository
+	} else if strings.TrimSpace(input.Repository) != "" {
+		return NormalizedBuildInput{}, errors.New("repository_specified must be true when repository is provided")
+	}
+	if input.RuntimeSpecified {
+		value.Runtime = strings.ToLower(strings.TrimSpace(input.Runtime))
+		if value.Runtime == "" {
+			return NormalizedBuildInput{}, errors.New("runtime must not be empty")
+		}
+	} else if strings.TrimSpace(input.Runtime) != "" {
+		return NormalizedBuildInput{}, errors.New("runtime_specified must be true when runtime is provided")
+	}
+	value.References = make([]NormalizedBuildReference, 0, len(input.References))
+	for _, raw := range input.References {
+		reference, err := NormalizeBuildReference(raw)
+		if err != nil {
+			return NormalizedBuildInput{}, err
+		}
+		if reference.SourceKind == "opaque" {
+			if !value.RepositorySpecified {
+				return NormalizedBuildInput{}, fmt.Errorf("opaque reference %q requires --repo", reference.Reference)
+			}
+			reference.RepositoryIdentity = value.Repository
+		} else if value.RepositorySpecified && reference.RepositoryIdentity != value.Repository {
+			return NormalizedBuildInput{}, fmt.Errorf(
+				"GitHub reference %q does not match --repo %s",
+				reference.Reference,
+				value.Repository,
+			)
+		}
+		value.References = append(value.References, reference)
+	}
+	return value, nil
+}
+
+func NormalizeBuildReference(raw string) (NormalizedBuildReference, error) {
+	reference := strings.TrimSpace(raw)
+	if reference != raw {
+		return NormalizedBuildReference{}, errors.New("build references must not contain leading or trailing whitespace")
+	}
+	if reference == "" {
+		return NormalizedBuildReference{}, errors.New("build references must not be empty")
+	}
+	if len([]byte(reference)) > 2048 {
+		return NormalizedBuildReference{}, errors.New("build reference exceeds 2048 bytes")
+	}
+	if strings.Contains(reference, "://") {
+		return normalizeGitHubIssueURL(reference)
+	}
+	if len(reference) > 64 || !validOpaqueReference(reference) {
+		return NormalizedBuildReference{}, fmt.Errorf(
+			"invalid work-item reference %q: use an HTTPS GitHub issue URL or 1 to 64 ASCII letters, digits, dots, underscores, or hyphens",
+			reference,
+		)
+	}
+	return NormalizedBuildReference{
+		Reference:  reference,
+		SourceKind: "opaque",
+		SourceKey:  reference,
+	}, nil
+}
+
+func normalizeGitHubIssueURL(raw string) (NormalizedBuildReference, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme != "https" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || !strings.EqualFold(parsed.Host, "github.com") {
+		return NormalizedBuildReference{}, fmt.Errorf("invalid GitHub issue URL %q", raw)
+	}
+	parts := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(parts) != 4 || parts[2] != "issues" {
+		return NormalizedBuildReference{}, fmt.Errorf("invalid GitHub issue URL %q", raw)
+	}
+	owner, err := url.PathUnescape(parts[0])
+	if err != nil {
+		return NormalizedBuildReference{}, fmt.Errorf("invalid GitHub issue URL %q", raw)
+	}
+	repository, err := url.PathUnescape(parts[1])
+	if err != nil {
+		return NormalizedBuildReference{}, fmt.Errorf("invalid GitHub issue URL %q", raw)
+	}
+	identity, err := NormalizeGitHubRepository("github.com/" + owner + "/" + repository)
+	if err != nil {
+		return NormalizedBuildReference{}, fmt.Errorf("invalid GitHub issue URL %q", raw)
+	}
+	number, err := strconv.ParseUint(parts[3], 10, 64)
+	if err != nil || number == 0 {
+		return NormalizedBuildReference{}, fmt.Errorf("invalid GitHub issue URL %q", raw)
+	}
+	repositoryPath := strings.TrimPrefix(identity, "github.com/")
+	canonical := "https://github.com/" + repositoryPath + "/issues/" + strconv.FormatUint(number, 10)
+	return NormalizedBuildReference{
+		Reference:          canonical,
+		SourceKind:         "github_issue",
+		SourceKey:          "github:" + repositoryPath + ":issue:" + strconv.FormatUint(number, 10),
+		RepositoryIdentity: identity,
+	}, nil
+}
+
+func NormalizeGitHubRepository(raw string) (string, error) {
+	value := strings.TrimSuffix(strings.TrimSpace(raw), ".git")
+	parts := strings.Split(value, "/")
+	if len(parts) != 3 || !strings.EqualFold(parts[0], "github.com") || !validGitHubOwner(parts[1]) || !validGitHubRepository(parts[2]) {
+		return "", errors.New("repository must use github.com/owner/repository")
+	}
+	return strings.ToLower(strings.Join(parts, "/")), nil
+}
+
+func BuildCallerFingerprint(input NormalizedBuildInput) ([]byte, error) {
+	references := make([]string, 0, len(input.References))
+	for _, reference := range input.References {
+		references = append(references, reference.Reference)
+	}
+	encoded, err := json.Marshal(struct {
+		Operation           string   `json:"operation"`
+		References          []string `json:"references"`
+		RepositorySpecified bool     `json:"repository_specified"`
+		Repository          string   `json:"repository"`
+		RuntimeSpecified    bool     `json:"runtime_specified"`
+		Runtime             string   `json:"runtime"`
+		Rebuild             bool     `json:"rebuild"`
+	}{
+		Operation: "build", References: references,
+		RepositorySpecified: input.RepositorySpecified, Repository: input.Repository,
+		RuntimeSpecified: input.RuntimeSpecified, Runtime: input.Runtime, Rebuild: input.Rebuild,
+	})
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(encoded)
+	return digest[:], nil
+}
+
+func CanonicalBuildRequest(input BuildRequest) (BuildRequest, NormalizedBuildInput, []byte, error) {
+	normalized, err := NormalizeBuildRequest(input)
+	if err != nil {
+		return BuildRequest{}, NormalizedBuildInput{}, nil, err
+	}
+	request := BuildRequest{
+		RequestKey:          strings.TrimSpace(input.RequestKey),
+		Repository:          normalized.Repository,
+		RepositorySpecified: normalized.RepositorySpecified,
+		Runtime:             normalized.Runtime,
+		RuntimeSpecified:    normalized.RuntimeSpecified,
+		Rebuild:             normalized.Rebuild,
+		References:          make([]string, 0, len(normalized.References)),
+	}
+	for _, reference := range normalized.References {
+		request.References = append(request.References, reference.Reference)
+	}
+	fingerprint, err := BuildCallerFingerprint(normalized)
+	if err != nil {
+		return BuildRequest{}, NormalizedBuildInput{}, nil, err
+	}
+	return request, normalized, fingerprint, nil
+}
+
+func validOpaqueReference(value string) bool {
+	for index := 0; index < len(value); index++ {
+		character := value[index]
+		valid := character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' || index > 0 && (character == '.' || character == '_' || character == '-')
+		if !valid {
+			return false
+		}
+	}
+	return len(value) > 0
+}
+
+func validGitHubOwner(value string) bool {
+	if len(value) < 1 || len(value) > 39 || value[0] == '-' || value[len(value)-1] == '-' || strings.Contains(value, "--") {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func validGitHubRepository(value string) bool {
+	if len(value) < 1 || len(value) > 100 || value == "." || value == ".." {
+		return false
+	}
+	for _, character := range value {
+		if (character < 'a' || character > 'z') && (character < 'A' || character > 'Z') &&
+			(character < '0' || character > '9') && character != '-' && character != '_' && character != '.' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/protocol/build_test.go
+++ b/internal/protocol/build_test.go
@@ -1,0 +1,64 @@
+package protocol
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestNormalizeBuildRequestCanonicalizesCallerFingerprintInputs(t *testing.T) {
+	request := BuildRequest{
+		References:          []string{"https://github.com/Acme/API/issues/00042/", "LINEAR-7"},
+		RepositorySpecified: true, Repository: "GITHUB.COM/ACME/API.git",
+		RuntimeSpecified: true, Runtime: " CODEX ", Rebuild: true,
+	}
+	canonical, normalized, fingerprint, err := CanonicalBuildRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canonical.Repository != "github.com/acme/api" || canonical.Runtime != RuntimeCodex ||
+		canonical.References[0] != "https://github.com/acme/api/issues/42" ||
+		normalized.References[1].SourceKind != "opaque" || normalized.References[1].SourceKey != "LINEAR-7" {
+		t.Fatalf("canonical request = %#v, normalized = %#v", canonical, normalized)
+	}
+	request.References[0] = canonical.References[0]
+	request.Repository = canonical.Repository
+	request.Runtime = canonical.Runtime
+	_, _, repeated, err := CanonicalBuildRequest(request)
+	if err != nil || !bytes.Equal(fingerprint, repeated) {
+		t.Fatalf("repeated fingerprint = %x, error %v, want %x", repeated, err, fingerprint)
+	}
+	request.References = []string{"LINEAR-7", canonical.References[0]}
+	_, _, reordered, err := CanonicalBuildRequest(request)
+	if err != nil || bytes.Equal(fingerprint, reordered) {
+		t.Fatalf("ordered fingerprint = %x, error %v", reordered, err)
+	}
+}
+
+func TestNormalizeBuildRequestEnforcesReferenceAndBatchLimits(t *testing.T) {
+	invalid := []BuildRequest{
+		{},
+		{References: []string{"opaque-without-repo"}},
+		{References: []string{"has space"}, RepositorySpecified: true, Repository: "github.com/acme/api"},
+		{References: []string{"https://example.com/acme/api/issues/1"}},
+		{References: []string{"https://github.com/acme/api/pulls/1"}},
+		{References: []string{"https://github.com/acme/api/issues/0"}},
+		{References: []string{" LINEAR-1 "}, RepositorySpecified: true, Repository: "github.com/acme/api"},
+		{References: []string{" https://github.com/acme/api/issues/1"}},
+		{References: []string{"https://github.com/acme/web/issues/1"}, RepositorySpecified: true, Repository: "github.com/acme/api"},
+	}
+	for _, request := range invalid {
+		if _, err := NormalizeBuildRequest(request); err == nil {
+			t.Fatalf("accepted invalid request %#v", request)
+		}
+	}
+	references := make([]string, MaxWorkTargets+1)
+	for index := range references {
+		references[index] = fmt.Sprintf("ITEM-%d", index)
+	}
+	if _, err := NormalizeBuildRequest(BuildRequest{
+		References: references, RepositorySpecified: true, Repository: "github.com/acme/api",
+	}); err == nil {
+		t.Fatal("accepted more than 100 references")
+	}
+}

--- a/internal/protocol/types.go
+++ b/internal/protocol/types.go
@@ -282,6 +282,8 @@ type ErrorBody struct {
 }
 
 type APIError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code            string          `json:"code"`
+	Message         string          `json:"message"`
+	AdmissionResult AdmissionResult `json:"admission_result,omitempty"`
+	RequestKey      string          `json:"request_key,omitempty"`
 }


### PR DESCRIPTION
## Summary

- add atomic multi-reference build admission with immutable standard-build snapshots and scheduler-ready Work
- add strict reference normalization, replay and rebuild guards, and typed API admission results
- add durable CLI request journaling, cross-process locking, wait behavior, and human/JSON output
- document the admission flow, configuration, and operational behavior

## Verification

- go test ./cmd/factory ./internal/controlplane ./internal/protocol
- just format-check
- just vet
- just boundary
- just staticcheck
- just test
- git diff --check
- fresh agent review: approved with no findings after three regression fixes

Closes #341
Parent: #338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `factory build` for admitting up to 100 GitHub, Linear, or repository-scoped work-item references in one run.
  * Added batch validation, duplicate detection, replay protection, rebuild support, runtime selection, and optional wait mode.
  * Added JSON and tabular output with meaningful exit statuses.
  * Added a build API endpoint and configurable default runtime.

* **Documentation**
  * Updated quick-start, architecture, and local configuration guides with build usage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->