### PR TITLE
feat: run procedures across repository fleets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,10 +8,11 @@
 
 Factory is a local-first control plane for repeatable software-engineering
 agents. An operator can save a prompt and execution settings as a Task, or use
-`factory build` to admit up to 100 existing work-item references in one Run.
-Each target becomes independent Session-backed Work. A persistent Worker claims
-the Work, prepares an isolated Git worktree, runs Pi, Codex, or Claude Code,
-streams events, and reports one terminal result.
+`factory build` to admit up to 100 existing work-item references in one Run, or
+run one saved Procedure across up to 100 enabled managed repositories. Each
+target becomes independent Session-backed Work. A persistent Worker claims the
+Work, prepares an isolated Git worktree, runs Pi, Codex, or Claude Code, streams
+events, and reports one terminal result.
 
 The implementation has four main parts:
 
@@ -43,7 +44,7 @@ Operator browser or `factory` CLI
       | loopback HTTP and JSON
       v
 factory-server
-  |-- Task scheduler, Build admission, and Run admission
+  |-- Task scheduler, Build admission, and Procedure fleet admission
   |-- routing and lease state machine
   |-- embedded React UI
   `-- SQLite
@@ -87,7 +88,7 @@ control-plane or Worker state directly.
 
 ### Task
 
-A Task is a reusable definition containing:
+A Task is the stored form of a saved Procedure. It contains:
 
 - name and prompt;
 - runtime: `pi`, `codex`, or `claude-code`;
@@ -134,8 +135,10 @@ most 2 KiB and outcome messages are at most 8 KiB.
 
 A Session starts blocked when no eligible Worker can currently accept it. A
 later claim can route it when a healthy Worker advertises the runtime and
-repository access. Task concurrency limits how many sibling Sessions may be
-queued or active at once.
+repository access. Procedure concurrency limits how many sibling Sessions may
+be queued or active at once. Claim ordering uses each Run's prior Attempt count,
+then admission order, so a large Run yields to an older compatible Run that has
+received less service.
 
 ### Build admission
 
@@ -157,6 +160,22 @@ comparison happen before repository, runtime-default, duplicate, or predecessor
 reads. Matching replay returns the original Run. Active matching Work blocks a
 duplicate. A rebuild requires a new key and the latest terminal predecessor for
 every target, selected in the same transaction.
+
+### Procedure fleet admission
+
+`factory procedures` reads saved Procedures, including archived entries, from
+the bounded local API. `factory run PROCEDURE --repos ...|all` selects explicit
+enabled managed repositories in command order or freezes all enabled managed
+repositories in repository-identity order. The server snapshots the current
+Procedure generation, prompt, runtime, timeout, concurrency, outcome contract,
+execution choice, and ordered targets in one transaction.
+
+The caller fingerprint covers the normalized Procedure name, ordered repository
+selectors or `all`, and the rebuild flag. Request-key replay happens before
+Procedure, repository, execution-profile, or predecessor reads. A rebuild uses
+a new key and records the latest terminal predecessor for the exact Procedure
+and repository. Existing scheduled Tasks continue to use their saved repository
+selection and schedule snapshot.
 
 ### Execution and Attempt
 
@@ -216,29 +235,31 @@ static repository paths remain readable through Worker configuration.
     endpoint and read current state through bounded API routes.
 12. Claim protocol version 3 gates every persistent Worker claim. Older Workers
     receive `worker_upgrade_required`, including for process-exit Work.
-13. Build admission is all-or-none. Exact request-key replay wins before mutable
-    configuration reads, and one Run cannot contain a duplicate target.
-14. An implicit Build key is written durably before HTTP submission and is not
-    removed until an authoritative admitted, replayed, or pre-commit rejection
-    result has been written and flushed.
+13. Build and Procedure fleet admission are all-or-none. Exact request-key
+    replay wins before mutable configuration reads, and one Run cannot contain
+    a duplicate target.
+14. An implicit admission key is written durably before HTTP submission and is
+    not removed until an authoritative admitted, replayed, or pre-commit
+    rejection result has been written and flushed.
 
 ## Components
 
 ### Operator CLI
 
 `cmd/factory` delegates parsing and finite HTTP work to `internal/factorycli`.
-The `build`, `status`, `show`, and `workers` commands use typed protocol
-resources and write either stable tabular output or one JSON value. They do not
-import SQLite or Worker packages. Build syntax normalization is local, but
-managed-state resolution belongs to the server. An injected `factory update`
-command instead connects only to a private Attempt-scoped Unix socket using the
-Work ID, Attempt ID, and update token supplied by the Worker.
+The `build`, `run`, `procedures`, `status`, `show`, and `workers` commands use
+typed protocol resources and write either stable tabular output or one JSON
+value. They do not import SQLite or Worker packages. Build and Procedure Run
+syntax normalization is local, but managed-state resolution belongs to the
+server. An injected `factory update` command instead connects only to a private
+Attempt-scoped Unix socket using the Work ID, Attempt ID, and update token
+supplied by the Worker.
 
-When no Build key is supplied, the CLI journals a random key under the private
-operator data directory before sending. A nonblocking OS lock scopes concurrent
-submissions by endpoint and caller fingerprint. Lost responses retain the key
-for replay by a later CLI process. The journal holds at most 100 uncertain
-requests and never evicts one silently.
+When no Build or Procedure Run key is supplied, the CLI journals a random key
+under the private operator data directory before sending. A nonblocking OS lock
+scopes concurrent submissions by endpoint and caller fingerprint. Lost
+responses retain the key for replay by a later CLI process. The journal holds
+at most 100 uncertain requests and never evicts one silently.
 
 The `server start` and `worker start` commands replace the CLI process with the
 matching compatibility executable beside it or on `PATH`. An explicit config
@@ -347,13 +368,30 @@ security headers. Node.js is needed only when UI source changes.
    replayed, or typed pre-commit rejection result. Transport, server, malformed
    response, timeout, interruption, and output errors leave the key pending.
 
+### Procedure fleet admission
+
+1. The CLI normalizes the Procedure name and ordered repository selectors, or
+   the `all` selector, then computes a caller fingerprint.
+2. Explicit and generated request keys use the same lock, durable journal,
+   replay, typed rejection, output flush, and cleanup contract as Build.
+3. The server checks the key and fingerprint before any mutable read. Exact
+   replay returns the frozen Run even after Procedure or repository changes.
+4. For a new key, one transaction loads the active Procedure, resolves the
+   explicit enabled repositories or complete enabled set, validates the frozen
+   execution backend, and selects exact Procedure-and-repository predecessors
+   for a rebuild.
+5. The transaction inserts one Run and one ordered repository Work target per
+   selection. Each target keeps independent scheduling, Attempts, cancellation,
+   retries, updates, and outcomes.
+
 ### Claim and execution
 
 1. A healthy Worker registers capabilities and polls with a fresh claim request
    ID and lease token.
 2. In one transaction, the server may materialize a blocked route or reroute a
-   queued Session, checks capacity and Task concurrency, creates an Attempt,
-   and moves Execution and Session to `preparing`.
+   queued Session, checks capacity and Procedure concurrency, applies run-aware
+   fair ordering, creates an Attempt, and moves Execution and Session to
+   `preparing`.
 3. The Worker acquires or refreshes the repository, resolves its base commit,
    creates a branch and worktree, writes a manifest, then starts the supervisor.
 4. The Worker reports process identity and the server moves the lifecycle to
@@ -438,6 +476,7 @@ admission path.
 | --- | --- |
 | Operator CLI | `cmd/factory/main.go`, `internal/factorycli/command.go`, `internal/factorycli/client.go` |
 | Build admission and journal | `internal/controlplane/build.go`, `internal/factorycli/build.go`, `internal/factorycli/admission_journal.go`, `internal/protocol/build.go` |
+| Procedure fleet admission | `internal/controlplane/procedures.go`, `internal/factorycli/procedures.go`, `internal/protocol/procedures.go` |
 | Server startup and config | `cmd/factory-server/main.go`, `cmd/factory-server/config.go` |
 | HTTP routes and auth | `internal/controlplane/http.go`, `internal/controlplane/worker_auth.go` |
 | Task, Run, and Work model | `internal/controlplane/tasks.go`, `internal/controlplane/work.go`, `internal/protocol/tasks.go` |
@@ -461,6 +500,11 @@ admission path.
   normalization, replay ordering, runtime freezing, duplicate and rebuild
   guards, scheduler claim, typed commit status, journal recovery, locking, and
   wait exit codes.
+- `internal/controlplane/procedures_test.go`,
+  `internal/protocol/procedures_test.go`, and
+  `internal/factorycli/procedures_test.go` prove Procedure listing, explicit and
+  all-repository selection, atomic freezing, replay before mutable reads,
+  rebuild lineage, journal recovery, and fair cross-Run claims.
 - `internal/controlplane/tasks_migration_test.go` opens populated historical
   databases and proves identity, lifecycle, scheduled process-exit completion,
   and foreign-key preservation.

--- a/internal/controlplane/fake_cloud.go
+++ b/internal/controlplane/fake_cloud.go
@@ -156,7 +156,13 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 		      WHERE active_attempt.worker_id = 'cloud-run-' || session.execution_profile_id
 		        AND active_attempt.state IN ('preparing','running')
 		  ) < version.max_concurrent
-		ORDER BY session.admitted_at, session.id LIMIT 1
+		ORDER BY (
+			SELECT COUNT(*)
+			FROM attempts previous_attempt
+			JOIN executions previous_execution ON previous_execution.id = previous_attempt.execution_id
+			JOIN sessions previous_session ON previous_session.id = previous_execution.session_id
+			WHERE previous_session.run_id = session.run_id
+		), run.admitted_at, session.admitted_at, session.id LIMIT 1
 	`).Scan(&blockedSession, &blockedProfile, &blockedRuntime)
 	if err == nil {
 		executionID, idErr := newID()
@@ -200,6 +206,7 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 		       version.fake_outcome, version.fake_result, version.fake_error
 		FROM executions execution
 		JOIN sessions session ON session.id = execution.session_id
+		JOIN runs run ON run.id = session.run_id
 		JOIN execution_profiles profile ON profile.id = session.execution_profile_id
 		JOIN execution_profile_versions version
 		  ON version.profile_id = session.execution_profile_id
@@ -212,7 +219,13 @@ func (s *Store) dispatchOneFakeCloud(ctx context.Context) (bool, error) {
 		      WHERE active_attempt.worker_id = execution.assigned_worker_id
 		        AND active_attempt.state IN ('preparing','running')
 		  ) < version.max_concurrent
-		ORDER BY execution.created_at, execution.id LIMIT 1
+		ORDER BY (
+			SELECT COUNT(*)
+			FROM attempts previous_attempt
+			JOIN executions previous_execution ON previous_execution.id = previous_attempt.execution_id
+			JOIN sessions previous_session ON previous_session.id = previous_execution.session_id
+			WHERE previous_session.run_id = session.run_id
+		), run.admitted_at, execution.created_at, execution.id LIMIT 1
 	`).Scan(&executionID, &sessionID, &workerID, &outcome, &result, &failure)
 	if errors.Is(err, sql.ErrNoRows) {
 		if err := tx.Commit(); err != nil {

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -93,6 +93,8 @@ func NewHandler(store *Store, logger *slog.Logger) http.Handler {
 	mux.HandleFunc("PUT /api/v1/tasks/{task_id}/archived", api.setTaskArchived)
 	mux.HandleFunc("POST /api/v1/tasks/{task_id}/run", api.runTask)
 	mux.HandleFunc("POST /api/v1/tasks/{task_id}/discard-occurrence", api.discardTaskOccurrence)
+	mux.HandleFunc("GET /api/v1/procedures", api.listProcedures)
+	mux.HandleFunc("POST /api/v1/procedure-runs", api.admitProcedureRun)
 	mux.HandleFunc("POST /api/v1/builds", api.admitBuild)
 	mux.HandleFunc("GET /api/v1/runs", api.listRuns)
 	mux.HandleFunc("GET /api/v1/runs/{run_id}", api.getRun)

--- a/internal/controlplane/procedures.go
+++ b/internal/controlplane/procedures.go
@@ -1,0 +1,363 @@
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const procedureConcurrencyBlockedReason = "Waiting for an available Procedure concurrency slot."
+
+type resolvedProcedureTarget struct {
+	repository  protocol.TaskRepository
+	predecessor string
+}
+
+func (s *Store) AdmitProcedureRun(
+	ctx context.Context,
+	input protocol.ProcedureRunRequest,
+) (protocol.ProcedureRunAdmission, error) {
+	canonical, normalized, fingerprint, err := protocol.CanonicalProcedureRunRequest(input)
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, invalid("invalid_procedure_run", err.Error())
+	}
+	if canonical.RequestKey == "" || len([]byte(canonical.RequestKey)) > 200 {
+		return protocol.ProcedureRunAdmission{}, invalid("invalid_request_key", "request_key is required and limited to 200 bytes")
+	}
+	if strings.HasPrefix(canonical.RequestKey, "schedule:") {
+		return protocol.ProcedureRunAdmission{}, invalid("reserved_request_key", "request_key uses a reserved internal prefix")
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+	defer tx.Rollback()
+
+	// Replay intentionally wins before Procedure, repository, execution-profile,
+	// duplicate, and rebuild-predecessor reads.
+	var existingRunID string
+	var existingFingerprint []byte
+	err = tx.QueryRowContext(ctx, `
+		SELECT id, request_digest FROM runs WHERE request_key = ?
+	`, canonical.RequestKey).Scan(&existingRunID, &existingFingerprint)
+	if err == nil {
+		if !bytes.Equal(existingFingerprint, fingerprint) {
+			return protocol.ProcedureRunAdmission{}, conflict(
+				"request_key_conflict",
+				"request_key was already used with different Procedure Run inputs",
+			)
+		}
+		if err := tx.Commit(); err != nil {
+			return protocol.ProcedureRunAdmission{}, unavailable(err)
+		}
+		detail, err := s.Run(ctx, existingRunID)
+		if err != nil {
+			return protocol.ProcedureRunAdmission{}, err
+		}
+		return protocol.ProcedureRunAdmission{
+			Result: protocol.AdmissionReplayed, RequestKey: canonical.RequestKey, Run: detail,
+		}, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+
+	snapshot, err := loadProcedureSnapshot(ctx, tx, normalized.Procedure)
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, err
+	}
+	if snapshot.ConcurrencyLimit < 1 || snapshot.ConcurrencyLimit > protocol.MaxWorkTargets {
+		return protocol.ProcedureRunAdmission{}, conflict(
+			"invalid_procedure_concurrency", "the Procedure concurrency limit must be between 1 and 100",
+		)
+	}
+	targets, err := resolveProcedureTargets(ctx, tx, normalized)
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, err
+	}
+	if err := selectProcedurePredecessors(ctx, tx, snapshot.ID, targets, normalized.Rebuild); err != nil {
+		return protocol.ProcedureRunAdmission{}, err
+	}
+	snapshot.Repositories = make([]protocol.TaskRepository, 0, len(targets))
+	for _, target := range targets {
+		snapshot.Repositories = append(snapshot.Repositories, target.repository)
+	}
+
+	execution, profileReady, profileBlockedReason, err := loadExecutionSnapshot(ctx, tx, snapshot, "")
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, err
+	}
+	if snapshot.OutcomeContract == protocol.OutcomeAgentUpdate && execution.Backend != protocol.BackendPersistent {
+		return protocol.ProcedureRunAdmission{}, conflict(
+			"agent_update_backend_unsupported",
+			"agent_update requires the persistent execution backend",
+		)
+	}
+	if len([]byte(snapshot.Prompt)) > protocol.MaxResolvedPromptBytes {
+		return protocol.ProcedureRunAdmission{}, conflict(
+			"resolved_prompt_too_large", "the frozen Procedure prompt exceeds 64 KiB",
+		)
+	}
+
+	snapshotJSON, err := json.Marshal(snapshot)
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+	executionJSON, err := json.Marshal(execution)
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+	runID, err := newID()
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+	now := s.now().UnixMilli()
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO runs(
+			id, request_key, request_digest, task_id, task_snapshot, source,
+			requested_execution_profile_id, execution_snapshot, outcome_contract,
+			admitted_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, 'manual', NULL, ?, ?, ?, ?)
+	`, runID, canonical.RequestKey, fingerprint, snapshot.ID, snapshotJSON,
+		executionJSON, snapshot.OutcomeContract, now, now); err != nil {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+
+	frozenTargets := make([]protocol.WorkTarget, 0, len(targets))
+	materialized := 0
+	for position, target := range targets {
+		if !protocol.AgentPromptFits(snapshot.Name, target.repository.RemoteIdentity, snapshot.Prompt) {
+			return protocol.ProcedureRunAdmission{}, conflict(
+				"agent_prompt_too_large", "the frozen Procedure prompt cannot fit the Worker request",
+			)
+		}
+		workID, err := newID()
+		if err != nil {
+			return protocol.ProcedureRunAdmission{}, unavailable(err)
+		}
+		frozen := protocol.WorkTarget{
+			ID: workID, Position: position, TargetKey: "repository:" + target.repository.ID,
+			TargetKind: "repository", RepositoryID: target.repository.ID,
+			RepositoryIdentity: target.repository.RemoteIdentity, SourceKind: "repository",
+			SourceKey: target.repository.ID, SourceReference: target.repository.RemoteIdentity,
+			PublishBranch: workPublishBranch(workID),
+		}
+		state, blockedReason := "blocked", procedureConcurrencyBlockedReason
+		var assigned any
+		var selection runRouteCandidate
+		if !profileReady {
+			blockedReason = profileBlockedReason
+		} else if materialized < snapshot.ConcurrencyLimit {
+			if execution.Backend == protocol.BackendPersistent {
+				selection, err = s.selectSessionRoute(
+					ctx, tx, target.repository.ID, target.repository.RemoteIdentity, now, "", snapshot.Runtime,
+				)
+				blockedReason = "Waiting for a healthy compatible Worker with repository access."
+				if err == nil {
+					state, blockedReason, assigned = "queued", "", selection.workerID
+					materialized++
+				} else if !serviceErrorCode(err, "no_eligible_worker") {
+					return protocol.ProcedureRunAdmission{}, err
+				}
+			} else {
+				state, blockedReason, assigned = "queued", "", syntheticWorkerID(execution.ProfileID)
+				selection.workerID = assigned.(string)
+				materialized++
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO sessions(
+				id, run_id, repository_id, repository_identity, resolved_prompt, required_runtime,
+				timeout_seconds, state, blocked_reason, assigned_worker_id, admitted_at,
+				execution_profile_id, execution_profile_version, execution_backend, execution_provider,
+				execution_model, resource_class, commit_resolution_policy,
+				target_position, target_key, target_kind, source_kind, source_key,
+				source_reference, context_snapshot, publish_branch, predecessor_work_id,
+				execution_owner, waiting_reason
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, workID, runID, target.repository.ID, target.repository.RemoteIdentity, snapshot.Prompt, snapshot.Runtime,
+			execution.TimeoutSeconds, state, nullableString(blockedReason), assigned, now,
+			execution.ProfileID, execution.ProfileVersion, execution.Backend, execution.Provider,
+			execution.Model, execution.ResourceClass, execution.CommitResolutionPolicy,
+			frozen.Position, frozen.TargetKey, frozen.TargetKind, frozen.SourceKind, frozen.SourceKey,
+			frozen.SourceReference, frozen.ContextSnapshot, frozen.PublishBranch,
+			nullableString(target.predecessor), protocol.ExecutionOwnerNone,
+			boundedUTF8Bytes(blockedReason, protocol.MaxWaitingReasonBytes)); err != nil {
+			return protocol.ProcedureRunAdmission{}, unavailable(err)
+		}
+		if state == "queued" {
+			executionID, err := newID()
+			if err != nil {
+				return protocol.ProcedureRunAdmission{}, unavailable(err)
+			}
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO executions(
+					id, session_id, assigned_worker_id, required_runtime, state, created_at, updated_at
+				) VALUES (?, ?, ?, ?, 'queued', ?, ?)
+			`, executionID, workID, selection.workerID, snapshot.Runtime, now, now); err != nil {
+				return protocol.ProcedureRunAdmission{}, unavailable(err)
+			}
+		}
+		frozenTargets = append(frozenTargets, frozen)
+	}
+	targetsJSON, err := json.Marshal(frozenTargets)
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE runs SET targets_snapshot = ? WHERE id = ?`, targetsJSON, runID); err != nil {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+	if err := tx.Commit(); err != nil {
+		return protocol.ProcedureRunAdmission{}, unavailable(err)
+	}
+	detail, err := s.Run(ctx, runID)
+	if err != nil {
+		return protocol.ProcedureRunAdmission{}, err
+	}
+	return protocol.ProcedureRunAdmission{
+		Result: protocol.AdmissionAdmitted, RequestKey: canonical.RequestKey, Run: detail,
+	}, nil
+}
+
+func loadProcedureSnapshot(ctx context.Context, tx *sql.Tx, nameKey string) (protocol.TaskSnapshot, error) {
+	var snapshot protocol.TaskSnapshot
+	var archived, migrationOnly, readOnly int
+	err := tx.QueryRowContext(ctx, `
+		SELECT id, name, prompt, runtime, COALESCE(execution_profile_id, ''),
+		       timeout_seconds, concurrency_limit, generation, outcome_contract,
+		       archived, migration_only, read_only
+		FROM tasks WHERE name_key = ?
+	`, nameKey).Scan(&snapshot.ID, &snapshot.Name, &snapshot.Prompt, &snapshot.Runtime,
+		&snapshot.ExecutionProfileID, &snapshot.TimeoutSeconds, &snapshot.ConcurrencyLimit,
+		&snapshot.Generation, &snapshot.OutcomeContract, &archived, &migrationOnly, &readOnly)
+	if errors.Is(err, sql.ErrNoRows) {
+		return snapshot, invalid("procedure_not_found", fmt.Sprintf("Procedure %s does not exist", nameKey))
+	}
+	if err != nil {
+		return snapshot, unavailable(err)
+	}
+	if migrationOnly != 0 || readOnly != 0 {
+		return snapshot, conflict("procedure_read_only", "read-only Procedures cannot start fleet Runs")
+	}
+	if archived != 0 {
+		return snapshot, conflict("procedure_archived", "archived Procedures cannot start Runs")
+	}
+	return snapshot, nil
+}
+
+func resolveProcedureTargets(
+	ctx context.Context,
+	tx *sql.Tx,
+	input protocol.NormalizedProcedureRunInput,
+) ([]*resolvedProcedureTarget, error) {
+	var rows *sql.Rows
+	var err error
+	if input.AllRepositories {
+		rows, err = tx.QueryContext(ctx, `
+			SELECT id, remote_identity FROM repositories
+			WHERE centrally_managed = 1 AND enabled = 1
+			ORDER BY lower(remote_identity), id
+		`)
+		if err != nil {
+			return nil, unavailable(err)
+		}
+		defer rows.Close()
+		var targets []*resolvedProcedureTarget
+		for rows.Next() {
+			var repository protocol.TaskRepository
+			if err := rows.Scan(&repository.ID, &repository.RemoteIdentity); err != nil {
+				return nil, unavailable(err)
+			}
+			targets = append(targets, &resolvedProcedureTarget{repository: repository})
+			if len(targets) > protocol.MaxWorkTargets {
+				return nil, conflict("too_many_procedure_targets", "a Procedure Run is limited to 100 repositories")
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, unavailable(err)
+		}
+		if len(targets) == 0 {
+			return nil, conflict("procedure_repositories_empty", "no enabled managed repositories are available")
+		}
+		return targets, nil
+	}
+	targets := make([]*resolvedProcedureTarget, 0, len(input.Repositories))
+	for _, identity := range input.Repositories {
+		var repository protocol.TaskRepository
+		err := tx.QueryRowContext(ctx, `
+			SELECT id, remote_identity FROM repositories
+			WHERE lower(remote_identity) = lower(?) AND centrally_managed = 1 AND enabled = 1
+		`, identity).Scan(&repository.ID, &repository.RemoteIdentity)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, conflict(
+				"repository_not_managed",
+				fmt.Sprintf("repository %s is not enabled in the managed repository catalog", identity),
+			)
+		}
+		if err != nil {
+			return nil, unavailable(err)
+		}
+		targets = append(targets, &resolvedProcedureTarget{repository: repository})
+	}
+	return targets, nil
+}
+
+func selectProcedurePredecessors(
+	ctx context.Context,
+	tx *sql.Tx,
+	procedureID string,
+	targets []*resolvedProcedureTarget,
+	rebuild bool,
+) error {
+	if !rebuild {
+		return nil
+	}
+	for _, target := range targets {
+		var nonterminalID string
+		err := tx.QueryRowContext(ctx, `
+			SELECT session.id
+			FROM sessions session JOIN runs run ON run.id = session.run_id
+			WHERE run.task_id = ? AND session.repository_id = ? AND session.target_kind = 'repository'
+			  AND session.state IN ('blocked', 'queued', 'preparing', 'running', 'needs-input')
+			ORDER BY session.admitted_at DESC, session.id DESC LIMIT 1
+		`, procedureID, target.repository.ID).Scan(&nonterminalID)
+		if err == nil {
+			return conflict(
+				"procedure_rebuild_active",
+				fmt.Sprintf("matching Work %s is still nonterminal", nonterminalID),
+			)
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return unavailable(err)
+		}
+		var terminalID string
+		err = tx.QueryRowContext(ctx, `
+			SELECT session.id
+			FROM sessions session JOIN runs run ON run.id = session.run_id
+			WHERE run.task_id = ? AND session.repository_id = ? AND session.target_kind = 'repository'
+			  AND session.state IN ('ready', 'succeeded', 'failed', 'no-change', 'cancelled')
+			  AND NOT EXISTS (
+				SELECT 1 FROM sessions child WHERE child.predecessor_work_id = session.id
+			  )
+			ORDER BY session.admitted_at DESC, session.id DESC LIMIT 1
+		`, procedureID, target.repository.ID).Scan(&terminalID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return conflict(
+				"rebuild_predecessor_not_found",
+				fmt.Sprintf("repository %s has no terminal predecessor for Procedure rebuild", target.repository.RemoteIdentity),
+			)
+		}
+		if err != nil {
+			return unavailable(err)
+		}
+		target.predecessor = terminalID
+	}
+	return nil
+}

--- a/internal/controlplane/procedures_test.go
+++ b/internal/controlplane/procedures_test.go
@@ -1,0 +1,321 @@
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestProcedureRunFreezesAllEnabledRepositoriesAndReplaysBeforeChanges(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	web := createManagedRepositoryForProcedure(t, store, "github.com/acme/web")
+	api := createManagedRepositoryForProcedure(t, store, "github.com/acme/api")
+	disabled := createManagedRepositoryForProcedure(t, store, "github.com/acme/disabled")
+	if _, err := store.SetManagedRepositoryEnabled(ctx, disabled.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	procedure, err := store.CreateTask(ctx, protocol.SaveTaskRequest{
+		Name: "Bug-Fix", Prompt: "Find and fix one concrete bug.", Runtime: protocol.RuntimeCodex,
+		TimeoutSeconds: 900, ConcurrencyLimit: 2, OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := protocol.ProcedureRunRequest{
+		RequestKey: "fleet-all", Procedure: "bug-fix", AllRepositories: true,
+	}
+	admission, err := store.AdmitProcedureRun(ctx, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admission.Result != protocol.AdmissionAdmitted || admission.Run.Run.SessionCount != 2 ||
+		admission.Run.Run.Task.Generation != procedure.Generation ||
+		admission.Run.Run.Task.Prompt != "Find and fix one concrete bug." ||
+		admission.Run.Run.Task.TimeoutSeconds != 900 || admission.Run.Run.Task.ConcurrencyLimit != 2 ||
+		admission.Run.Run.OutcomeContract != protocol.OutcomeAgentUpdate {
+		t.Fatalf("admission = %#v", admission)
+	}
+	if got := []string{
+		admission.Run.Sessions[0].RepositoryIdentity,
+		admission.Run.Sessions[1].RepositoryIdentity,
+	}; got[0] != api.RemoteIdentity || got[1] != web.RemoteIdentity {
+		t.Fatalf("frozen all order = %#v", got)
+	}
+	for index, work := range admission.Run.Sessions {
+		if work.Target.Position != index || work.Target.TargetKind != "repository" ||
+			work.Target.TargetKey != "repository:"+work.RepositoryID ||
+			work.Target.SourceReference != work.RepositoryIdentity || work.Target.PublishBranch == "" {
+			t.Fatalf("Work %d = %#v", index, work)
+		}
+	}
+	if _, err := store.UpdateTask(ctx, procedure.ID, protocol.SaveTaskRequest{
+		Name: procedure.Name, Prompt: "Changed instructions.", Runtime: protocol.RuntimePi,
+		TimeoutSeconds: 1200, ConcurrencyLimit: 1, ExpectedGeneration: procedure.Generation,
+		OutcomeContract: protocol.OutcomeAgentUpdate,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.SetManagedRepositoryEnabled(ctx, api.ID, false); err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := store.AdmitProcedureRun(ctx, request)
+	if err != nil || replayed.Result != protocol.AdmissionReplayed ||
+		replayed.Run.Run.ID != admission.Run.Run.ID || replayed.Run.Run.Task.Runtime != protocol.RuntimeCodex ||
+		len(replayed.Run.Run.Targets) != 2 {
+		t.Fatalf("replay = %#v, err %v", replayed, err)
+	}
+	request.Repositories, request.AllRepositories = []string{web.RemoteIdentity}, false
+	if _, err := store.AdmitProcedureRun(ctx, request); !serviceErrorCode(err, "request_key_conflict") {
+		t.Fatalf("changed fingerprint error = %v", err)
+	}
+}
+
+func TestProcedureRunPreservesExplicitOrderAndIsAtomic(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	api := createManagedRepositoryForProcedure(t, store, "github.com/acme/api")
+	web := createManagedRepositoryForProcedure(t, store, "github.com/acme/web")
+	procedure, err := store.CreateTask(ctx, protocol.SaveTaskRequest{
+		Name: "Review", Prompt: "Review this repository.", Runtime: protocol.RuntimeCodex,
+		OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	admission, err := store.AdmitProcedureRun(ctx, protocol.ProcedureRunRequest{
+		RequestKey: "explicit-fleet", Procedure: procedure.Name,
+		Repositories: []string{web.RemoteIdentity, api.RemoteIdentity},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admission.Run.Sessions[0].RepositoryID != web.ID || admission.Run.Sessions[1].RepositoryID != api.ID {
+		t.Fatalf("explicit order = %#v", admission.Run.Sessions)
+	}
+	if _, err := store.AdmitProcedureRun(ctx, protocol.ProcedureRunRequest{
+		RequestKey: "invalid-fleet", Procedure: procedure.Name,
+		Repositories: []string{api.RemoteIdentity, "github.com/acme/missing"},
+	}); !serviceErrorCode(err, "repository_not_managed") {
+		t.Fatalf("invalid fleet error = %v", err)
+	}
+	var count int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM runs WHERE request_key = 'invalid-fleet'`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("partial invalid fleet count = %d, err %v", count, err)
+	}
+}
+
+func TestProcedureRunRebuildUsesLatestExactProcedureRepositoryPredecessor(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	repository := createManagedRepositoryForProcedure(t, store, "github.com/acme/api")
+	first := createProcedureForTest(t, store, "Bug fix")
+	other := createProcedureForTest(t, store, "Documentation")
+	terminalRun := admitProcedureForTest(t, store, "terminal", first.Name, repository.RemoteIdentity, false)
+	otherRun := admitProcedureForTest(t, store, "other", other.Name, repository.RemoteIdentity, false)
+	const terminalID = "zzzz-terminal-work"
+	if _, err := store.db.Exec(`UPDATE sessions SET id = ? WHERE id = ?`, terminalID, terminalRun.Run.Sessions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	for _, workID := range []string{terminalID, otherRun.Run.Sessions[0].ID} {
+		if _, err := store.db.Exec(`
+			UPDATE sessions SET state = 'failed', terminal_at = admitted_at, terminal_message = 'failed'
+			WHERE id = ?
+		`, workID); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rebuilt := admitProcedureForTest(t, store, "rebuilt", first.Name, repository.RemoteIdentity, true)
+	if got := rebuilt.Run.Sessions[0].PredecessorWorkID; got != terminalID {
+		t.Fatalf("predecessor = %q, want %q", got, terminalID)
+	}
+	if _, err := store.AdmitProcedureRun(ctx, protocol.ProcedureRunRequest{
+		RequestKey: "active-rebuild", Procedure: first.Name,
+		Repositories: []string{repository.RemoteIdentity}, Rebuild: true,
+	}); !serviceErrorCode(err, "procedure_rebuild_active") {
+		t.Fatalf("active rebuild error = %v", err)
+	}
+	const rebuiltID = "aaaa-rebuilt-work"
+	if _, err := store.db.Exec(`
+		UPDATE sessions SET id = ?, state = 'failed', admitted_at = 1000,
+		       terminal_at = 1000, terminal_message = 'failed'
+		WHERE id = ?
+	`, rebuiltID, rebuilt.Run.Sessions[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`UPDATE sessions SET admitted_at = 1000, terminal_at = 1000 WHERE id = ?`, terminalID); err != nil {
+		t.Fatal(err)
+	}
+	newest := admitProcedureForTest(t, store, "newest", first.Name, repository.RemoteIdentity, true)
+	if got := newest.Run.Sessions[0].PredecessorWorkID; got != rebuiltID {
+		t.Fatalf("latest predecessor = %q, want %q", got, rebuiltID)
+	}
+}
+
+func TestClaimSchedulingAlternatesEligibleRuns(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 23, 9, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+	api := createManagedRepositoryForProcedure(t, store, "github.com/acme/api")
+	web := createManagedRepositoryForProcedure(t, store, "github.com/acme/web")
+	worker := registerTestWorker(t, store, workerA, 10,
+		protocol.RepositoryRegistration{Key: "api", RemoteIdentity: api.RemoteIdentity},
+		protocol.RepositoryRegistration{Key: "web", RemoteIdentity: web.RemoteIdentity},
+	)
+	large := createProcedureForTest(t, store, "Large fleet")
+	small := createProcedureForTest(t, store, "Small fleet")
+	largeRun, err := store.AdmitProcedureRun(ctx, protocol.ProcedureRunRequest{
+		RequestKey: "large", Procedure: large.Name,
+		Repositories: []string{api.RemoteIdentity, web.RemoteIdentity},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Second)
+	smallRun := admitProcedureForTest(t, store, "small", small.Name, api.RemoteIdentity, false)
+	now = now.Add(time.Second)
+	first, err := store.Claim(ctx, worker.ID, protocol.ClaimRequest{
+		RequestID: "fair-1", LeaseToken: strings.Repeat("a", 64),
+	})
+	if err != nil || first == nil || first.Session.RunID != largeRun.Run.Run.ID {
+		t.Fatalf("first claim = %#v, err %v", first, err)
+	}
+	now = now.Add(time.Second)
+	second, err := store.Claim(ctx, worker.ID, protocol.ClaimRequest{
+		RequestID: "fair-2", LeaseToken: strings.Repeat("b", 64),
+	})
+	if err != nil || second == nil || second.Session.RunID != smallRun.Run.Run.ID {
+		t.Fatalf("second claim = %#v, err %v", second, err)
+	}
+}
+
+func TestFakeCloudSchedulingAlternatesEligibleRuns(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 23, 10, 0, 0, 0, time.UTC)
+	store.now = func() time.Time { return now }
+	api := createManagedRepositoryForProcedure(t, store, "github.com/acme/api")
+	web := createManagedRepositoryForProcedure(t, store, "github.com/acme/web")
+	profile := createFakeProfile(t, store, "Fleet cloud", protocol.RuntimeCodex, "succeeded")
+	createCloudProcedure := func(name string) protocol.Task {
+		procedure, err := store.CreateTask(ctx, protocol.SaveTaskRequest{
+			Name: name, Prompt: "Review this repository.", Runtime: protocol.RuntimeCodex,
+			ExecutionProfileID: profile.ID, OutcomeContract: protocol.OutcomeProcessExit,
+			ConcurrencyLimit: 10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return procedure
+	}
+	large := createCloudProcedure("Large cloud fleet")
+	small := createCloudProcedure("Small cloud fleet")
+	largeRun, err := store.AdmitProcedureRun(ctx, protocol.ProcedureRunRequest{
+		RequestKey: "large-cloud", Procedure: large.Name,
+		Repositories: []string{api.RemoteIdentity, web.RemoteIdentity},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Second)
+	smallRun := admitProcedureForTest(t, store, "small-cloud", small.Name, api.RemoteIdentity, false)
+	for iteration := 0; iteration < 2; iteration++ {
+		now = now.Add(time.Second)
+		if processed, err := store.DispatchFakeCloud(ctx, 1); err != nil || processed != 1 {
+			t.Fatalf("dispatch %d = %d, err %v", iteration, processed, err)
+		}
+	}
+	largeDetail, err := store.Run(ctx, largeRun.Run.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	smallDetail, err := store.Run(ctx, smallRun.Run.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	largeAttempts := len(largeDetail.Sessions[0].Attempts) + len(largeDetail.Sessions[1].Attempts)
+	if largeAttempts != 1 || len(smallDetail.Sessions[0].Attempts) != 1 {
+		t.Fatalf("fair fake-cloud attempts = large %d, small %d", largeAttempts, len(smallDetail.Sessions[0].Attempts))
+	}
+}
+
+func TestProcedureRunHTTPReturnsTypedAdmissionAndProcedures(t *testing.T) {
+	store := newTestStore(t)
+	repository := createManagedRepositoryForProcedure(t, store, "github.com/acme/api")
+	procedure := createProcedureForTest(t, store, "Bug fix")
+	server := httptest.NewServer(NewHandler(store, slog.New(slog.NewTextHandler(io.Discard, nil))))
+	t.Cleanup(server.Close)
+	response, err := http.Get(server.URL + "/api/v1/procedures?limit=200")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	var page protocol.ProcedurePage
+	if response.StatusCode != http.StatusOK || json.NewDecoder(response.Body).Decode(&page) != nil ||
+		len(page.Procedures) != 1 || page.Procedures[0].Name != procedure.Name {
+		t.Fatalf("Procedure page = %d %#v", response.StatusCode, page)
+	}
+	body, _ := json.Marshal(protocol.ProcedureRunRequest{
+		RequestKey: "http-fleet", Procedure: procedure.Name,
+		Repositories: []string{repository.RemoteIdentity},
+	})
+	response, err = http.Post(server.URL+"/api/v1/procedure-runs", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	var admission protocol.ProcedureRunAdmission
+	if response.StatusCode != http.StatusCreated || json.NewDecoder(response.Body).Decode(&admission) != nil ||
+		admission.Result != protocol.AdmissionAdmitted || admission.Run.Run.SessionCount != 1 {
+		t.Fatalf("Procedure admission = %d %#v", response.StatusCode, admission)
+	}
+}
+
+func createManagedRepositoryForProcedure(t *testing.T, store *Store, identity string) protocol.ManagedRepository {
+	t.Helper()
+	repository, _, err := store.CreateManagedRepository(context.Background(), protocol.CreateManagedRepositoryRequest{
+		RemoteIdentity: identity,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repository
+}
+
+func createProcedureForTest(t *testing.T, store *Store, name string) protocol.Task {
+	t.Helper()
+	procedure, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: name, Prompt: "Complete one repository review.", Runtime: protocol.RuntimeCodex,
+		OutcomeContract: protocol.OutcomeAgentUpdate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return procedure
+}
+
+func admitProcedureForTest(
+	t *testing.T,
+	store *Store,
+	requestKey, procedure, repository string,
+	rebuild bool,
+) protocol.ProcedureRunAdmission {
+	t.Helper()
+	admission, err := store.AdmitProcedureRun(context.Background(), protocol.ProcedureRunRequest{
+		RequestKey: requestKey, Procedure: procedure, Repositories: []string{repository}, Rebuild: rebuild,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return admission
+}

--- a/internal/controlplane/procedures_test.go
+++ b/internal/controlplane/procedures_test.go
@@ -251,11 +251,18 @@ func TestFakeCloudSchedulingAlternatesEligibleRuns(t *testing.T) {
 
 func TestProcedureRunHTTPReturnsTypedAdmissionAndProcedures(t *testing.T) {
 	store := newTestStore(t)
+	ctx := context.Background()
 	repository := createManagedRepositoryForProcedure(t, store, "github.com/acme/api")
 	procedure := createProcedureForTest(t, store, "Bug fix")
 	server := httptest.NewServer(NewHandler(store, slog.New(slog.NewTextHandler(io.Discard, nil))))
 	t.Cleanup(server.Close)
-	response, err := http.Get(server.URL + "/api/v1/procedures?limit=200")
+	listRequest, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, server.URL+"/api/v1/procedures?limit=200", nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := http.DefaultClient.Do(listRequest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +276,14 @@ func TestProcedureRunHTTPReturnsTypedAdmissionAndProcedures(t *testing.T) {
 		RequestKey: "http-fleet", Procedure: procedure.Name,
 		Repositories: []string{repository.RemoteIdentity},
 	})
-	response, err = http.Post(server.URL+"/api/v1/procedure-runs", "application/json", bytes.NewReader(body))
+	runRequest, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, server.URL+"/api/v1/procedure-runs", bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runRequest.Header.Set("Content-Type", "application/json")
+	response, err = http.DefaultClient.Do(runRequest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/controlplane/state.go
+++ b/internal/controlplane/state.go
@@ -167,7 +167,13 @@ func (s *Store) Claim(ctx context.Context, workerID string, input protocol.Claim
 		        AND terminal_attempt.state IN ('succeeded', 'failed', 'cancelled', 'lost')
 		        AND terminal_attempt.capacity_acknowledged = 0
 		  ) < ?
-		ORDER BY e.created_at, e.id
+		ORDER BY (
+			SELECT COUNT(*)
+			FROM attempts previous_attempt
+			JOIN executions previous_execution ON previous_execution.id = previous_attempt.execution_id
+			JOIN sessions previous_session ON previous_session.id = previous_execution.session_id
+			WHERE previous_session.run_id = session.run_id
+		), run.admitted_at, e.created_at, e.id
 		LIMIT 1
 	`, workerID, workerID, workerID, protocol.MaxRetainedPerRepo).Scan(&executionID)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/controlplane/task_claim.go
+++ b/internal/controlplane/task_claim.go
@@ -14,34 +14,54 @@ func (s *Store) materializeBlockedSessionForWorker(
 ) error {
 	type candidate struct {
 		id, repositoryID, identity, runtime string
-		admittedAt                          int64
+		fairCount, runAdmitted, admittedAt  int64
 	}
-	var cursorAdmitted int64
+	var cursorFair, cursorRunAdmitted, cursorAdmitted int64
 	var cursorID string
 	for {
 		rows, err := tx.QueryContext(ctx, `
-			SELECT session.id, session.repository_id, session.repository_identity,
-			       session.required_runtime, session.admitted_at
-			FROM sessions session
-			JOIN runs run ON run.id = session.run_id
-			JOIN repositories repository ON repository.id = session.repository_id
-			WHERE session.state = 'blocked'
-			  AND session.execution_backend = 'persistent'
-			  AND (repository.centrally_managed = 0 OR repository.enabled = 1)
-			  AND (? = '' OR session.admitted_at > ? OR (session.admitted_at = ? AND session.id > ?))
-			  AND (
-			      SELECT COUNT(*) FROM sessions active
-			      WHERE active.run_id = session.run_id AND active.state IN ('queued', 'preparing', 'running')
-			  ) < json_extract(run.task_snapshot, '$.concurrency_limit')
-			ORDER BY session.admitted_at, session.id LIMIT 50
-		`, cursorID, cursorAdmitted, cursorAdmitted, cursorID)
+			SELECT candidate.id, candidate.repository_id, candidate.repository_identity,
+			       candidate.required_runtime, candidate.fair_count,
+			       candidate.run_admitted_at, candidate.admitted_at
+			FROM (
+				SELECT session.id, session.repository_id, session.repository_identity,
+				       session.required_runtime, session.admitted_at,
+				       run.admitted_at AS run_admitted_at,
+				       (
+						SELECT COUNT(*)
+						FROM attempts previous_attempt
+						JOIN executions previous_execution ON previous_execution.id = previous_attempt.execution_id
+						JOIN sessions previous_session ON previous_session.id = previous_execution.session_id
+						WHERE previous_session.run_id = session.run_id
+				       ) AS fair_count
+				FROM sessions session
+				JOIN runs run ON run.id = session.run_id
+				JOIN repositories repository ON repository.id = session.repository_id
+				WHERE session.state = 'blocked'
+				  AND session.execution_backend = 'persistent'
+				  AND (repository.centrally_managed = 0 OR repository.enabled = 1)
+				  AND (
+				      SELECT COUNT(*) FROM sessions active
+				      WHERE active.run_id = session.run_id AND active.state IN ('queued', 'preparing', 'running')
+				  ) < json_extract(run.task_snapshot, '$.concurrency_limit')
+			) candidate
+			WHERE (? = '' OR candidate.fair_count > ?
+			  OR (candidate.fair_count = ? AND (candidate.run_admitted_at > ?
+			      OR (candidate.run_admitted_at = ? AND (candidate.admitted_at > ?
+			          OR (candidate.admitted_at = ? AND candidate.id > ?))))))
+			ORDER BY candidate.fair_count, candidate.run_admitted_at, candidate.admitted_at, candidate.id LIMIT 50
+		`, cursorID, cursorFair, cursorFair, cursorRunAdmitted, cursorRunAdmitted,
+			cursorAdmitted, cursorAdmitted, cursorID)
 		if err != nil {
 			return unavailable(err)
 		}
 		var candidates []candidate
 		for rows.Next() {
 			var value candidate
-			if err := rows.Scan(&value.id, &value.repositoryID, &value.identity, &value.runtime, &value.admittedAt); err != nil {
+			if err := rows.Scan(
+				&value.id, &value.repositoryID, &value.identity, &value.runtime,
+				&value.fairCount, &value.runAdmitted, &value.admittedAt,
+			); err != nil {
 				rows.Close()
 				return unavailable(err)
 			}
@@ -91,7 +111,8 @@ func (s *Store) materializeBlockedSessionForWorker(
 			return nil
 		}
 		last := candidates[len(candidates)-1]
-		cursorAdmitted, cursorID = last.admittedAt, last.id
+		cursorFair, cursorRunAdmitted, cursorAdmitted, cursorID =
+			last.fairCount, last.runAdmitted, last.admittedAt, last.id
 	}
 }
 

--- a/internal/controlplane/tasks_http.go
+++ b/internal/controlplane/tasks_http.go
@@ -38,6 +38,53 @@ func (a *API) admitBuild(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, admission)
 }
 
+func (a *API) admitProcedureRun(w http.ResponseWriter, r *http.Request) {
+	if !prepareMutation(w, r, protocol.MaxBodyBytes) {
+		return
+	}
+	var input protocol.ProcedureRunRequest
+	if !decodeJSON(w, r, &input) {
+		return
+	}
+	admission, err := a.store.AdmitProcedureRun(r.Context(), input)
+	if err != nil {
+		var service *ServiceError
+		if errors.As(err, &service) && service.Status < http.StatusInternalServerError {
+			writeJSON(w, service.Status, protocol.ErrorBody{Error: protocol.APIError{
+				Code: service.Code, Message: service.Message,
+				AdmissionResult: protocol.AdmissionRejectedBeforeCommit,
+				RequestKey:      input.RequestKey,
+			}})
+			return
+		}
+		writeError(w, err)
+		return
+	}
+	if admission.Result == protocol.AdmissionAdmitted {
+		a.logStateChange("run", admission.Run.Run.ID, string(admission.Run.Run.State))
+		writeJSON(w, http.StatusCreated, admission)
+		return
+	}
+	writeJSON(w, http.StatusOK, admission)
+}
+
+func (a *API) listProcedures(w http.ResponseWriter, r *http.Request) {
+	limit, err := pageLimit(r, defaultTaskPageSize, maxTaskPageSize)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	page, err := a.store.Tasks(r.Context(), true, limit, r.URL.Query().Get("cursor"))
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, protocol.ProcedurePage{
+		Procedures: page.Tasks,
+		NextCursor: page.NextCursor,
+	})
+}
+
 func (a *API) listTasks(w http.ResponseWriter, r *http.Request) {
 	limit, err := pageLimit(r, defaultTaskPageSize, maxTaskPageSize)
 	if err != nil {

--- a/internal/factorycli/command.go
+++ b/internal/factorycli/command.go
@@ -156,6 +156,19 @@ func (c command) run(arguments []string) error {
 		return c.status(ctx, client, *jsonOutput, *cursor)
 	case "build":
 		return c.runBuild(*server, *jsonOutput, remaining[1:])
+	case "run":
+		return c.runProcedure(*server, *jsonOutput, remaining[1:])
+	case "procedures":
+		if len(remaining) != 1 {
+			return &usageError{message: "procedures does not accept arguments"}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		client, err := newAPIClient(ctx, *server, c.client)
+		if err != nil {
+			return err
+		}
+		return c.procedures(ctx, client, *jsonOutput)
 	case "show":
 		if len(remaining) != 2 || strings.TrimSpace(remaining[1]) == "" {
 			return &usageError{message: "show requires exactly one Run ID"}
@@ -196,7 +209,7 @@ func (c command) run(arguments []string) error {
 		return c.agentUpdate(*status, *message, *pullRequest, *jsonOutput)
 	case "server", "worker":
 		if *jsonOutput {
-			return &usageError{message: "--json is available only for build, status, show, and workers"}
+			return &usageError{message: "--json is available only for build, run, procedures, status, show, and workers"}
 		}
 		return c.startProcess(remaining[0], remaining[1:])
 	default:
@@ -289,6 +302,8 @@ func (c command) writeHelp() error {
 
 Usage:
   factory [--server URL] [--json] build [options] REFERENCE...
+  factory [--server URL] [--json] run PROCEDURE --repos REPOSITORY...|all [options]
+  factory [--server URL] [--json] procedures
   factory [--server URL] [--json] status [--cursor CURSOR]
   factory [--server URL] [--json] show RUN_ID
   factory [--server URL] [--json] workers
@@ -304,7 +319,7 @@ Options:
 
 Environment:
   FACTORY_SERVER     Overrides the endpoint used by finite commands.
-  FACTORY_DATA_HOME  Stores durable pending Build request keys.
+  FACTORY_DATA_HOME  Stores durable pending admission request keys.
 `)
 	return err
 }

--- a/internal/factorycli/procedures.go
+++ b/internal/factorycli/procedures.go
@@ -1,0 +1,266 @@
+package factorycli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func (c command) procedures(ctx context.Context, client apiClient, jsonOutput bool) error {
+	page := protocol.ProcedurePage{Procedures: []protocol.Procedure{}}
+	cursor := ""
+	for {
+		query := url.Values{"limit": []string{"200"}}
+		if cursor != "" {
+			query.Set("cursor", cursor)
+		}
+		var next protocol.ProcedurePage
+		if err := client.get(ctx, "/api/v1/procedures?"+query.Encode(), &next, maxResponseBytes); err != nil {
+			return err
+		}
+		page.Procedures = append(page.Procedures, next.Procedures...)
+		if next.NextCursor == "" {
+			break
+		}
+		cursor = next.NextCursor
+	}
+	if jsonOutput {
+		if err := writeJSON(c.stdout, page); err != nil {
+			return fmt.Errorf("write Procedures JSON: %w", err)
+		}
+		return nil
+	}
+	if len(page.Procedures) == 0 {
+		_, err := fmt.Fprintln(c.stdout, "No Procedures.")
+		return err
+	}
+	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(writer, "NAME\tGENERATION\tRUNTIME\tTIMEOUT\tCONCURRENCY\tARCHIVED"); err != nil {
+		return fmt.Errorf("write Procedures output: %w", err)
+	}
+	for _, procedure := range page.Procedures {
+		if _, err := fmt.Fprintf(writer, "%s\t%d\t%s\t%s\t%d\t%t\n",
+			oneLine(procedure.Name), procedure.Generation, oneLine(procedure.Runtime),
+			(time.Duration(procedure.TimeoutSeconds) * time.Second).String(),
+			procedure.ConcurrencyLimit, procedure.Archived); err != nil {
+			return fmt.Errorf("write Procedures output: %w", err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write Procedures output: %w", err)
+	}
+	return nil
+}
+
+func (c command) runProcedure(server string, jsonOutput bool, arguments []string) error {
+	input, wait, explicitKey, err := parseProcedureRunArguments(arguments)
+	if err != nil {
+		return &usageError{message: err.Error()}
+	}
+	canonical, _, fingerprint, err := protocol.CanonicalProcedureRunRequest(input)
+	if err != nil {
+		return &usageError{message: err.Error()}
+	}
+	if explicitKey && len([]byte(canonical.RequestKey)) > 200 {
+		return &usageError{message: "--request-key is limited to 200 bytes"}
+	}
+	clientContext, cancelClient := context.WithTimeout(context.Background(), 10*time.Second)
+	client, err := newAPIClient(clientContext, server, c.client)
+	cancelClient()
+	if err != nil {
+		return err
+	}
+	var lease *admissionLease
+	if explicitKey {
+		lease = explicitAdmissionLease(canonical.RequestKey)
+	} else {
+		lease, err = c.prepareImplicitAdmission(client.admissionEndpoint, fingerprint)
+		if err != nil {
+			return err
+		}
+	}
+	defer func() { _ = lease.Release() }()
+	canonical.RequestKey = lease.RequestKey()
+
+	var admission protocol.ProcedureRunAdmission
+	err = client.post(context.Background(), "/api/v1/procedure-runs", canonical, &admission, maxDetailResponseBytes)
+	if err != nil {
+		var failure *apiFailure
+		if !errors.As(err, &failure) || failure.APIError.AdmissionResult != protocol.AdmissionRejectedBeforeCommit {
+			return err
+		}
+		if failure.APIError.RequestKey == "" {
+			failure.APIError.RequestKey = canonical.RequestKey
+		}
+		if err := c.writeProcedureRunFailure(jsonOutput, failure.APIError); err != nil {
+			return err
+		}
+		if err := flushAuthoritativeOutput(c.stdout); err != nil {
+			return fmt.Errorf("flush Procedure Run result: %w", err)
+		}
+		if err := lease.Complete(); err != nil {
+			return fmt.Errorf("clear completed Procedure Run admission: %w", err)
+		}
+		return failure
+	}
+	if admission.RequestKey != canonical.RequestKey || admission.Run.Run.ID == "" ||
+		(admission.Result != protocol.AdmissionAdmitted && admission.Result != protocol.AdmissionReplayed) {
+		return errors.New("server returned a malformed Procedure Run admission")
+	}
+	exitCode := 0
+	if wait {
+		for {
+			code, done := buildWaitResult(admission.Run.Run)
+			if done {
+				exitCode = code
+				break
+			}
+			timer := time.NewTimer(time.Second)
+			<-timer.C
+			var detail protocol.RunDetail
+			path := "/api/v1/runs/" + url.PathEscape(admission.Run.Run.ID)
+			if err := client.get(context.Background(), path, &detail, maxDetailResponseBytes); err != nil {
+				return err
+			}
+			admission.Run = detail
+		}
+	}
+	if err := c.writeProcedureRunAdmission(jsonOutput, admission); err != nil {
+		return err
+	}
+	if err := flushAuthoritativeOutput(c.stdout); err != nil {
+		return fmt.Errorf("flush Procedure Run result: %w", err)
+	}
+	if err := lease.Complete(); err != nil {
+		return fmt.Errorf("clear completed Procedure Run admission: %w", err)
+	}
+	if exitCode != 0 {
+		return &commandExit{code: exitCode}
+	}
+	return nil
+}
+
+func parseProcedureRunArguments(arguments []string) (protocol.ProcedureRunRequest, bool, bool, error) {
+	if len(arguments) == 0 || strings.TrimSpace(arguments[0]) == "" {
+		return protocol.ProcedureRunRequest{}, false, false, errors.New("run requires a Procedure name followed by --repos")
+	}
+	input := protocol.ProcedureRunRequest{Procedure: arguments[0]}
+	wait, reposSeen, explicitKey := false, false, false
+	for index := 1; index < len(arguments); index++ {
+		argument := arguments[index]
+		switch {
+		case argument == "--repos":
+			if reposSeen {
+				return input, wait, explicitKey, errors.New("--repos may be provided only once")
+			}
+			reposSeen = true
+			for index+1 < len(arguments) && !strings.HasPrefix(arguments[index+1], "-") {
+				index++
+				input.Repositories = append(input.Repositories, arguments[index])
+			}
+			if len(input.Repositories) == 0 {
+				return input, wait, explicitKey, errors.New("--repos requires one or more repositories or all")
+			}
+		case strings.HasPrefix(argument, "--repos="):
+			if reposSeen {
+				return input, wait, explicitKey, errors.New("--repos may be provided only once")
+			}
+			reposSeen = true
+			input.Repositories = []string{strings.TrimPrefix(argument, "--repos=")}
+		case argument == "--request-key":
+			if explicitKey || index+1 >= len(arguments) {
+				return input, wait, explicitKey, errors.New("--request-key requires one non-empty value")
+			}
+			index++
+			input.RequestKey, explicitKey = strings.TrimSpace(arguments[index]), true
+			if input.RequestKey == "" {
+				return input, wait, explicitKey, errors.New("--request-key requires one non-empty value")
+			}
+		case strings.HasPrefix(argument, "--request-key="):
+			if explicitKey {
+				return input, wait, explicitKey, errors.New("--request-key may be provided only once")
+			}
+			input.RequestKey, explicitKey = strings.TrimSpace(strings.TrimPrefix(argument, "--request-key=")), true
+			if input.RequestKey == "" {
+				return input, wait, explicitKey, errors.New("--request-key requires one non-empty value")
+			}
+		case argument == "--rebuild":
+			if input.Rebuild {
+				return input, wait, explicitKey, errors.New("--rebuild may be provided only once")
+			}
+			input.Rebuild = true
+		case argument == "--wait":
+			if wait {
+				return input, wait, explicitKey, errors.New("--wait may be provided only once")
+			}
+			wait = true
+		default:
+			return input, wait, explicitKey, fmt.Errorf("unexpected run argument %q", argument)
+		}
+	}
+	if !reposSeen {
+		return input, wait, explicitKey, errors.New("run requires --repos")
+	}
+	if len(input.Repositories) == 1 && strings.EqualFold(strings.TrimSpace(input.Repositories[0]), "all") {
+		input.Repositories = nil
+		input.AllRepositories = true
+	}
+	return input, wait, explicitKey, nil
+}
+
+func (c command) writeProcedureRunAdmission(jsonOutput bool, admission protocol.ProcedureRunAdmission) error {
+	if jsonOutput {
+		if err := writeJSON(c.stdout, admission); err != nil {
+			return fmt.Errorf("write Procedure Run JSON: %w", err)
+		}
+		return nil
+	}
+	run := admission.Run.Run
+	if _, err := fmt.Fprintf(c.stdout,
+		"Request key: %s\nAdmission: %s\nProcedure: %s generation %d\nRun: %s\nWork: %d total, %d active, %d ready, %d succeeded, %d needs input, %d no change, %d failed, %d cancelled\n",
+		oneLine(admission.RequestKey), oneLine(string(admission.Result)), oneLine(run.Task.Name), run.Task.Generation,
+		oneLine(run.ID), run.SessionCount, run.ActiveCount, run.ReadyCount, run.SucceededCount,
+		run.NeedsInputCount, run.NoChangeCount, run.FailedCount, run.CancelledCount,
+	); err != nil {
+		return fmt.Errorf("write Procedure Run output: %w", err)
+	}
+	writer := tabwriter.NewWriter(c.stdout, 0, 4, 2, ' ', 0)
+	if _, err := fmt.Fprintln(writer, "WORK ID\tREPOSITORY\tSTATE"); err != nil {
+		return fmt.Errorf("write Procedure Run output: %w", err)
+	}
+	for _, work := range admission.Run.Sessions {
+		if _, err := fmt.Fprintf(writer, "%s\t%s\t%s\n",
+			oneLine(work.ID), oneLine(work.RepositoryIdentity), oneLine(string(work.State))); err != nil {
+			return fmt.Errorf("write Procedure Run output: %w", err)
+		}
+	}
+	if err := writer.Flush(); err != nil {
+		return fmt.Errorf("write Procedure Run output: %w", err)
+	}
+	return nil
+}
+
+func (c command) writeProcedureRunFailure(jsonOutput bool, failure protocol.APIError) error {
+	result := struct {
+		Result     protocol.AdmissionResult `json:"result"`
+		RequestKey string                   `json:"request_key"`
+		Error      protocol.APIError        `json:"error"`
+	}{failure.AdmissionResult, failure.RequestKey, failure}
+	if jsonOutput {
+		if err := writeJSON(c.stdout, result); err != nil {
+			return fmt.Errorf("write Procedure Run rejection JSON: %w", err)
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(c.stdout, "Request key: %s\nAdmission: %s\nRejected: %s\n",
+		oneLine(failure.RequestKey), oneLine(string(failure.AdmissionResult)), oneLine(failure.Message)); err != nil {
+		return fmt.Errorf("write Procedure Run rejection: %w", err)
+	}
+	return nil
+}

--- a/internal/factorycli/procedures_test.go
+++ b/internal/factorycli/procedures_test.go
@@ -1,0 +1,202 @@
+package factorycli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestProcedureRunReusesImplicitKeyAndPreservesRepositoryOrder(t *testing.T) {
+	dataHome := t.TempDir()
+	requests := make(chan protocol.ProcedureRunRequest, 2)
+	var requestCount atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/procedure-runs" {
+			http.NotFound(output, request)
+			return
+		}
+		var input protocol.ProcedureRunRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Error(err)
+			return
+		}
+		requests <- input
+		if requestCount.Add(1) == 1 {
+			connection, _, err := output.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			_ = connection.Close()
+			return
+		}
+		_ = json.NewEncoder(output).Encode(testProcedureRunAdmission(input.RequestKey, protocol.RunQueued))
+	}))
+	t.Cleanup(server.Close)
+	getenv := func(key string) string {
+		if key == "FACTORY_DATA_HOME" {
+			return dataHome
+		}
+		return ""
+	}
+	arguments := []string{
+		"--server", server.URL, "run", "Bug-Fix", "--repos",
+		"github.com/Acme/Web", "github.com/acme/API", "--rebuild",
+	}
+	var stderr bytes.Buffer
+	if code := Run(Options{Arguments: arguments, Stderr: &stderr, Getenv: getenv}); code != 1 ||
+		!strings.Contains(stderr.String(), "connect") {
+		t.Fatalf("lost response = code %d, stderr %q", code, stderr.String())
+	}
+	first := <-requests
+	if first.Procedure != "bug-fix" || !first.Rebuild || first.AllRepositories ||
+		len(first.Repositories) != 2 || first.Repositories[0] != "github.com/acme/web" ||
+		first.Repositories[1] != "github.com/acme/api" {
+		t.Fatalf("first request = %#v", first)
+	}
+	journalPath := filepath.Join(dataHome, "operator", "admissions", "pending.json")
+	journal := readJournalForTest(t, journalPath)
+	if len(journal.Entries) != 1 || journal.Entries[0].RequestKey != first.RequestKey {
+		t.Fatalf("pending journal = %#v", journal)
+	}
+	var stdout bytes.Buffer
+	stderr.Reset()
+	if code := Run(Options{Arguments: arguments, Stdout: &stdout, Stderr: &stderr, Getenv: getenv}); code != 0 {
+		t.Fatalf("replay = code %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
+	}
+	second := <-requests
+	if second.RequestKey == "" || second.RequestKey != first.RequestKey ||
+		!strings.Contains(stdout.String(), "Procedure: Bug-Fix generation 3") ||
+		!strings.Contains(stdout.String(), "github.com/acme/web") {
+		t.Fatalf("second request = %#v, output %q", second, stdout.String())
+	}
+	if journal = readJournalForTest(t, journalPath); len(journal.Entries) != 0 {
+		t.Fatalf("completed journal = %#v", journal)
+	}
+}
+
+func TestProcedureRunAllAndTypedRejection(t *testing.T) {
+	dataHome := t.TempDir()
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		var input protocol.ProcedureRunRequest
+		if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+			t.Error(err)
+			return
+		}
+		if !input.AllRepositories || len(input.Repositories) != 0 {
+			t.Errorf("all request = %#v", input)
+		}
+		output.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(output).Encode(protocol.ErrorBody{Error: protocol.APIError{
+			Code: "procedure_rebuild_active", Message: "matching Work is active",
+			AdmissionResult: protocol.AdmissionRejectedBeforeCommit, RequestKey: input.RequestKey,
+		}})
+	}))
+	t.Cleanup(server.Close)
+	getenv := func(key string) string {
+		if key == "FACTORY_DATA_HOME" {
+			return dataHome
+		}
+		return ""
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run(Options{
+		Arguments: []string{"--server", server.URL, "--json", "run", "bug-fix", "--repos", "all"},
+		Stdout:    &stdout, Stderr: &stderr, Getenv: getenv,
+	})
+	if code != 1 || !strings.Contains(stdout.String(), `"result":"rejected_before_commit"`) {
+		t.Fatalf("rejection = code %d, stdout %q, stderr %q", code, stdout.String(), stderr.String())
+	}
+	journal := readJournalForTest(t, filepath.Join(dataHome, "operator", "admissions", "pending.json"))
+	if len(journal.Entries) != 0 {
+		t.Fatalf("rejected journal = %#v", journal)
+	}
+}
+
+func TestProceduresListsEveryPageWithRequiredFields(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(output http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/procedures" || request.URL.Query().Get("limit") != "200" {
+			http.NotFound(output, request)
+			return
+		}
+		requests++
+		page := protocol.ProcedurePage{}
+		if request.URL.Query().Get("cursor") == "" {
+			page.Procedures = []protocol.Procedure{{
+				Name: "Bug fix", Generation: 4, Runtime: protocol.RuntimeCodex,
+				TimeoutSeconds: 7200, ConcurrencyLimit: 12,
+			}}
+			page.NextCursor = "next"
+		} else {
+			page.Procedures = []protocol.Procedure{{
+				Name: "Archived review", Generation: 2, Runtime: protocol.RuntimePi,
+				TimeoutSeconds: 300, ConcurrencyLimit: 1, Archived: true,
+			}}
+		}
+		_ = json.NewEncoder(output).Encode(page)
+	}))
+	t.Cleanup(server.Close)
+	var stdout, stderr bytes.Buffer
+	if code := Run(Options{
+		Arguments: []string{"--server", server.URL, "procedures"}, Stdout: &stdout, Stderr: &stderr,
+	}); code != 0 || requests != 2 || !strings.Contains(stdout.String(), "GENERATION") ||
+		!strings.Contains(stdout.String(), "Bug fix") || !strings.Contains(stdout.String(), "2h0m0s") ||
+		!strings.Contains(stdout.String(), "Archived review") || !strings.Contains(stdout.String(), "true") {
+		t.Fatalf("human Procedures = code %d, requests %d, stdout %q, stderr %q", code, requests, stdout.String(), stderr.String())
+	}
+	requests = 0
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run(Options{
+		Arguments: []string{"--server", server.URL, "--json", "procedures"}, Stdout: &stdout, Stderr: &stderr,
+	}); code != 0 {
+		t.Fatalf("JSON Procedures = code %d, stderr %q", code, stderr.String())
+	}
+	var page protocol.ProcedurePage
+	if err := json.Unmarshal(stdout.Bytes(), &page); err != nil || len(page.Procedures) != 2 || page.NextCursor != "" {
+		t.Fatalf("JSON Procedures = %#v, err %v", page, err)
+	}
+}
+
+func TestProcedureRunUsageValidation(t *testing.T) {
+	input, _, _, err := parseProcedureRunArguments([]string{
+		"-audit", "--repos", "github.com/acme/api",
+	})
+	if err != nil || input.Procedure != "-audit" {
+		t.Fatalf("leading-hyphen Procedure = %#v, err %v", input, err)
+	}
+	for _, arguments := range [][]string{
+		{"run"},
+		{"run", "bug-fix"},
+		{"run", "bug-fix", "--repos"},
+		{"run", "bug-fix", "--repos", "all", "github.com/acme/api"},
+		{"run", "bug-fix", "--repos", "github.com/acme/api", "--repos", "github.com/acme/web"},
+	} {
+		var stderr bytes.Buffer
+		if code := Run(Options{Arguments: arguments, Stderr: &stderr}); code != 2 {
+			t.Fatalf("Run(%#v) = %d, stderr %q", arguments, code, stderr.String())
+		}
+	}
+}
+
+func testProcedureRunAdmission(requestKey string, state protocol.RunState) protocol.ProcedureRunAdmission {
+	run := protocol.Run{
+		ID: "run-1", Task: protocol.TaskSnapshot{Name: "Bug-Fix", Generation: 3},
+		State: state, SessionCount: 2, ActiveCount: 2,
+	}
+	return protocol.ProcedureRunAdmission{
+		Result: protocol.AdmissionReplayed, RequestKey: requestKey,
+		Run: protocol.RunDetail{Run: run, Sessions: []protocol.Session{
+			{ID: "work-1", RepositoryIdentity: "github.com/acme/web", State: protocol.WorkQueued},
+			{ID: "work-2", RepositoryIdentity: "github.com/acme/api", State: protocol.WorkQueued},
+		}},
+	}
+}

--- a/internal/protocol/procedures.go
+++ b/internal/protocol/procedures.go
@@ -1,0 +1,114 @@
+package protocol
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Procedure is the product name for a saved Task. The alias keeps the current
+// API and storage model compatible while operator surfaces adopt Procedure.
+type Procedure = Task
+
+type ProcedurePage struct {
+	Procedures []Procedure `json:"procedures"`
+	NextCursor string      `json:"next_cursor,omitempty"`
+}
+
+type ProcedureRunRequest struct {
+	RequestKey      string   `json:"request_key"`
+	Procedure       string   `json:"procedure"`
+	Repositories    []string `json:"repositories,omitempty"`
+	AllRepositories bool     `json:"all_repositories"`
+	Rebuild         bool     `json:"rebuild"`
+}
+
+type ProcedureRunAdmission struct {
+	Result     AdmissionResult `json:"result"`
+	RequestKey string          `json:"request_key"`
+	Run        RunDetail       `json:"run"`
+}
+
+type NormalizedProcedureRunInput struct {
+	Procedure       string
+	Repositories    []string
+	AllRepositories bool
+	Rebuild         bool
+}
+
+func NormalizeProcedureRunRequest(input ProcedureRunRequest) (NormalizedProcedureRunInput, error) {
+	procedure := strings.TrimSpace(input.Procedure)
+	if procedure == "" || utf8.RuneCountInString(procedure) > 200 {
+		return NormalizedProcedureRunInput{}, errors.New("procedure is required and limited to 200 characters")
+	}
+	value := NormalizedProcedureRunInput{
+		Procedure: strings.ToLower(procedure), AllRepositories: input.AllRepositories,
+		Rebuild: input.Rebuild,
+	}
+	if input.AllRepositories {
+		if len(input.Repositories) != 0 {
+			return NormalizedProcedureRunInput{}, errors.New("--repos all cannot be combined with explicit repositories")
+		}
+		return value, nil
+	}
+	if len(input.Repositories) < 1 || len(input.Repositories) > MaxWorkTargets {
+		return NormalizedProcedureRunInput{}, fmt.Errorf("run requires between 1 and %d repositories", MaxWorkTargets)
+	}
+	seen := make(map[string]bool, len(input.Repositories))
+	for _, raw := range input.Repositories {
+		repository, err := NormalizeGitHubRepository(raw)
+		if err != nil {
+			return NormalizedProcedureRunInput{}, fmt.Errorf("invalid repository %q: %w", raw, err)
+		}
+		if seen[repository] {
+			return NormalizedProcedureRunInput{}, fmt.Errorf("repository %s appears more than once", repository)
+		}
+		seen[repository] = true
+		value.Repositories = append(value.Repositories, repository)
+	}
+	return value, nil
+}
+
+func ProcedureRunCallerFingerprint(input NormalizedProcedureRunInput) ([]byte, error) {
+	encoded, err := json.Marshal(struct {
+		Operation       string   `json:"operation"`
+		Procedure       string   `json:"procedure"`
+		Repositories    []string `json:"repositories"`
+		AllRepositories bool     `json:"all_repositories"`
+		Rebuild         bool     `json:"rebuild"`
+	}{
+		Operation: "run_procedure", Procedure: input.Procedure,
+		Repositories: input.Repositories, AllRepositories: input.AllRepositories,
+		Rebuild: input.Rebuild,
+	})
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256(encoded)
+	return digest[:], nil
+}
+
+func CanonicalProcedureRunRequest(input ProcedureRunRequest) (
+	ProcedureRunRequest,
+	NormalizedProcedureRunInput,
+	[]byte,
+	error,
+) {
+	normalized, err := NormalizeProcedureRunRequest(input)
+	if err != nil {
+		return ProcedureRunRequest{}, NormalizedProcedureRunInput{}, nil, err
+	}
+	request := ProcedureRunRequest{
+		RequestKey: strings.TrimSpace(input.RequestKey), Procedure: normalized.Procedure,
+		Repositories:    append([]string(nil), normalized.Repositories...),
+		AllRepositories: normalized.AllRepositories, Rebuild: normalized.Rebuild,
+	}
+	fingerprint, err := ProcedureRunCallerFingerprint(normalized)
+	if err != nil {
+		return ProcedureRunRequest{}, NormalizedProcedureRunInput{}, nil, err
+	}
+	return request, normalized, fingerprint, nil
+}

--- a/internal/protocol/procedures_test.go
+++ b/internal/protocol/procedures_test.go
@@ -1,0 +1,45 @@
+package protocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCanonicalProcedureRunRequestPreservesOrderedSelectors(t *testing.T) {
+	canonical, normalized, fingerprint, err := CanonicalProcedureRunRequest(ProcedureRunRequest{
+		RequestKey: " key ", Procedure: " Bug-Fix ",
+		Repositories: []string{"github.com/Acme/Web.git", "github.com/acme/API"},
+		Rebuild:      true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canonical.RequestKey != "key" || canonical.Procedure != "bug-fix" ||
+		len(canonical.Repositories) != 2 || canonical.Repositories[0] != "github.com/acme/web" ||
+		canonical.Repositories[1] != "github.com/acme/api" || !normalized.Rebuild {
+		t.Fatalf("canonical request = %#v, normalized = %#v", canonical, normalized)
+	}
+	reordered, _, otherFingerprint, err := CanonicalProcedureRunRequest(ProcedureRunRequest{
+		Procedure: "bug-fix", Repositories: []string{"github.com/acme/api", "github.com/acme/web"}, Rebuild: true,
+	})
+	if err != nil || reordered.Repositories[0] != "github.com/acme/api" || bytes.Equal(fingerprint, otherFingerprint) {
+		t.Fatalf("reordered request = %#v, fingerprint changed = %v, err %v", reordered, !bytes.Equal(fingerprint, otherFingerprint), err)
+	}
+}
+
+func TestNormalizeProcedureRunRequestValidatesRepositorySelection(t *testing.T) {
+	for _, input := range []ProcedureRunRequest{
+		{Procedure: "bug-fix"},
+		{Procedure: "bug-fix", AllRepositories: true, Repositories: []string{"github.com/acme/api"}},
+		{Procedure: "bug-fix", Repositories: []string{"github.com/acme/api", "github.com/ACME/API"}},
+		{Procedure: " ", AllRepositories: true},
+	} {
+		if _, err := NormalizeProcedureRunRequest(input); err == nil {
+			t.Fatalf("NormalizeProcedureRunRequest(%#v) succeeded", input)
+		}
+	}
+	all, err := NormalizeProcedureRunRequest(ProcedureRunRequest{Procedure: "bug-fix", AllRepositories: true})
+	if err != nil || !all.AllRepositories || len(all.Repositories) != 0 {
+		t.Fatalf("all selection = %#v, err %v", all, err)
+	}
+}


### PR DESCRIPTION
Closes #344

Parent: #338

## Summary
- add saved Procedure listing and transactional fleet Run admission for explicit repositories or the frozen enabled set
- reuse Build idempotency and journal semantics, including deterministic Procedure/repository rebuild predecessors
- add run-aware fairness across persistent and fake-cloud schedulers
- document the implemented Procedure fleet contract

## Verification
- `go test ./cmd/factory ./internal/controlplane ./internal/protocol`
- `go test ./internal/protocol ./internal/factorycli ./internal/controlplane`
- `just format-check`
- `just vet`
- `just boundary`
- `just test`
- fresh final `/review`: Approve, no actionable findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added procedure listing and procedure-run admission through the API.
  - Added `factory procedures` and `factory run` commands with table or JSON output.
  - Supports selecting specific repositories or all repositories, rebuilding runs, and optionally waiting for completion.
  - Added request validation, replay protection, and clear rejection reporting.
- **Improvements**
  - Preserves repository ordering and frozen run targets for consistent execution.
  - Improved scheduling fairness across procedure runs.
- **Documentation**
  - Expanded architecture and CLI guidance for procedure workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->