### PR TITLE
fix: classify build admission rejections

### DIFF
--- a/internal/controlplane/build_test.go
+++ b/internal/controlplane/build_test.go
@@ -74,6 +74,28 @@ func TestBuildAdmissionHTTPReturnsTypedCommitStatus(t *testing.T) {
 	}
 }
 
+func TestBuildAdmissionHTTPLogsTypedRejectionClass(t *testing.T) {
+	store := newTestStore(t)
+	var logs bytes.Buffer
+	handler := NewHandler(store, slog.New(slog.NewTextHandler(&logs, nil)))
+	body := strings.NewReader(`{
+		"request_key":"unmanaged-build",
+		"references":["https://github.com/acme/missing/issues/1"]
+	}`)
+	request := httptest.NewRequest(http.MethodPost, "http://localhost/api/v1/builds", body)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+
+	handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body %s", response.Code, response.Body.Bytes())
+	}
+	if !strings.Contains(logs.String(), "error_class=repository_not_managed") {
+		t.Fatalf("request log omitted Build rejection class: %q", logs.String())
+	}
+}
+
 func TestStandardBuildBackingProcedureDoesNotCollideWithExistingTaskName(t *testing.T) {
 	store := newTestStore(t)
 	if _, err := store.db.Exec(`DELETE FROM tasks WHERE id = ?`, protocol.StandardBuildProcedureID); err != nil {

--- a/internal/controlplane/tasks_http.go
+++ b/internal/controlplane/tasks_http.go
@@ -20,6 +20,9 @@ func (a *API) admitBuild(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		var service *ServiceError
 		if errors.As(err, &service) && service.Status < http.StatusInternalServerError {
+			if recorder, ok := w.(*responseRecorder); ok {
+				recorder.errorClass = service.Code
+			}
 			writeJSON(w, service.Status, protocol.ErrorBody{Error: protocol.APIError{
 				Code: service.Code, Message: service.Message,
 				AdmissionResult: protocol.AdmissionRejectedBeforeCommit,


### PR DESCRIPTION
## Summary

- record typed Build admission failures on the shared HTTP request log recorder
- preserve the existing pre-commit rejection response body
- add regression coverage for the missing `error_class` field

## Bug evidence

Commit `e3d9171` added a typed Build rejection path that called `writeJSON` directly. Unlike `writeError`, that path did not populate `responseRecorder.errorClass`, so 4xx Build failures lost their operational classification. The regression test fails against the parent implementation and passes with this fix.

## Verification

- `go test ./internal/controlplane -run ^TestBuildAdmissionHTTPLogsTypedRejectionClass$ -count=1`
- `go test ./internal/controlplane -count=1`
- `just format-check`
- `just vet`
- `go test -timeout 5m ./...`
- three-stage Factory Pipeline: prove and fix, independent verify and repair, final review
- independent reviews: no findings