### PR TITLE
feat: add the factory CLI with versioned phases

### DIFF
--- a/.factory/phases/audit.md
+++ b/.factory/phases/audit.md
@@ -1,0 +1,29 @@
+---
+name: audit
+description: Find real defects in a repository and file one issue for each
+runtime: claude
+timeout: 1h
+permissions: read-only
+max_findings: 5
+---
+Audit {{ run.repo }} for real defects.
+
+Look for incorrect logic, unhandled errors that lose data, race conditions,
+resource leaks, and security issues. Read the code. Do not infer defects from
+names or comments.
+
+For each finding you are confident in, file one issue containing:
+
+- a title that states the defect, not the area it lives in
+- the file and line
+- a concrete failure scenario: specific inputs or state, then the wrong result
+- acceptance criteria that a later phase can check against a diff
+
+Rules:
+
+- File at most {{ phase.max_findings }} issues. Rank by severity and file the
+  most severe.
+- If you cannot write a concrete failure scenario, it is not a finding. Drop it.
+- Label every issue `factory`.
+- Style, naming, and refactors are not defects. Do not file them.
+- Change no code.

--- a/.factory/phases/build.md
+++ b/.factory/phases/build.md
@@ -1,0 +1,25 @@
+---
+name: build
+description: Implement one scoped issue and open a pull request
+runtime: claude
+timeout: 2h
+---
+Implement {{ issue.identifier }}.
+
+{{ issue.title }}
+
+{{ issue.body }}
+
+Acceptance criteria:
+{{ run.criteria }}
+
+If PLAN.md is present in the repository root, follow it and delete it before
+you commit.
+
+You are on a clean worktree of {{ run.repo }}. Make the change, run the tests,
+and commit. Open a pull request when the tests pass.
+
+Where the issue is ambiguous, take the most reasonable reading, record the
+assumption at the top of the pull request description, and continue. Do not
+stop to ask a question: a run that waits for an answer has failed to be
+useful. Match the conventions already in the surrounding code.

--- a/.factory/phases/plan.md
+++ b/.factory/phases/plan.md
@@ -1,0 +1,24 @@
+---
+name: plan
+description: Turn a scoped issue into an implementation plan with acceptance criteria
+runtime: claude
+timeout: 30m
+---
+Plan the work for {{ issue.identifier }}.
+
+{{ issue.title }}
+
+{{ issue.body }}
+
+Read the code before you plan. Do not write any implementation.
+
+Write PLAN.md in the repository root containing:
+
+1. The files you will change, and what changes in each.
+2. Acceptance criteria, one line each, stated so that someone who did not
+   write the change can check them against the diff and the test output.
+3. Anything the issue leaves open, and the reading you took. State the
+   assumption; do not stop to ask.
+
+If the issue is already precise enough that a plan adds nothing, write a
+PLAN.md that says so and lists the acceptance criteria only.

--- a/.factory/phases/verify.md
+++ b/.factory/phases/verify.md
@@ -1,0 +1,25 @@
+---
+name: verify
+description: Check a change against its acceptance criteria and report only
+runtime: claude
+timeout: 30m
+---
+You are reviewing work you did not do. Assume it is wrong until the code shows
+otherwise.
+
+Change: {{ run.title }}
+
+Acceptance criteria:
+{{ run.criteria }}
+
+Check, in this order:
+
+1. Does the diff satisfy every acceptance criterion? Quote the code that
+   satisfies each one. A criterion with no code behind it is a failure.
+2. Run the test suite. Report the actual output, not what you expected it
+   to be.
+3. What does this change break that the tests do not cover?
+
+Report every assumption the change records, and say whether it is reasonable.
+
+Do not fix anything. Report only.

--- a/Justfile
+++ b/Justfile
@@ -12,6 +12,7 @@ build:
     mkdir -p "$build_directory"
     go build -o "$build_directory/factory-server" ./cmd/factory-server
     go build -o "$build_directory/factory-worker" ./cmd/factory-worker
+    go build -o "$build_directory/factory" ./cmd/factory
     printf 'Factory binaries built in %s\n' "$build_directory"
 
 # Start one control plane and worker. Pass a worker config path when needed.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,21 @@ cp examples/worker.toml ~/.factory/worker.toml
 just run
 ```
 
-Open [http://127.0.0.1:7337](http://127.0.0.1:7337). Edit
+Open [http://127.0.0.1:7337](http://127.0.0.1:7337). Dispatch work from the
+command line with a versioned prompt:
+
+```sh
+factory phases                                       # list this repo's phases
+factory run 412 --repo acme/api --phase build --dry-run
+factory run 412 --repo acme/api --phase build
+factory ps
+factory logs <run-id> --follow
+```
+
+A phase is one markdown file in `.factory/phases`. See the
+[phases guide](docs/phases.md).
+
+Edit
 `~/.factory/worker.toml` to enable the agent runtimes installed on your machine.
 The [local guide](docs/local.md) covers authentication, repository setup, and
 the complete first Run.

--- a/cmd/factory/issue.go
+++ b/cmd/factory/issue.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// target is the work a dispatch runs against. Number is zero for a phase that
+// targets a repository rather than an issue, such as audit.
+type target struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+// Identity is the control plane's managed repository identity.
+func (t target) Identity() string {
+	return fmt.Sprintf("github.com/%s/%s", t.Owner, t.Repo)
+}
+
+// Slug is the owner/repo form that gh accepts.
+func (t target) Slug() string { return t.Owner + "/" + t.Repo }
+
+// Reference is the display form, such as acme/api#412.
+func (t target) Reference() string {
+	if t.Number == 0 {
+		return t.Slug()
+	}
+	return fmt.Sprintf("%s#%d", t.Slug(), t.Number)
+}
+
+var (
+	urlPattern   = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)/?$`)
+	shortPattern = regexp.MustCompile(`^([^/\s]+)/([^/#\s]+)#(\d+)$`)
+	slugPattern  = regexp.MustCompile(`^([^/\s]+)/([^/\s]+)$`)
+)
+
+// parseTarget resolves the work argument.
+//
+// Three forms are accepted. A bare number with --repo matches how gh is used. A
+// pasted issue URL is unambiguous and is what is usually on the clipboard.
+// owner/repo#number is kept because it is how GitHub renders cross-repository
+// references, even though no CLI parses it.
+func parseTarget(work, repo, defaultOwner string) (target, error) {
+	work = strings.TrimSpace(work)
+	repo = strings.TrimSpace(repo)
+
+	if matches := urlPattern.FindStringSubmatch(work); matches != nil {
+		number, _ := strconv.Atoi(matches[3])
+		return target{Owner: matches[1], Repo: matches[2], Number: number}, nil
+	}
+	if matches := shortPattern.FindStringSubmatch(work); matches != nil {
+		number, _ := strconv.Atoi(matches[3])
+		return target{Owner: matches[1], Repo: matches[2], Number: number}, nil
+	}
+
+	owner, name, err := splitRepo(repo, defaultOwner)
+	if err != nil {
+		return target{}, err
+	}
+	if work == "" {
+		return target{Owner: owner, Repo: name}, nil
+	}
+	number, err := strconv.Atoi(work)
+	if err != nil || number <= 0 {
+		return target{}, fmt.Errorf("cannot read %q as work: use an issue number with --repo, a GitHub issue URL, or owner/repo#number", work)
+	}
+	return target{Owner: owner, Repo: name, Number: number}, nil
+}
+
+func splitRepo(repo, defaultOwner string) (string, string, error) {
+	if repo == "" {
+		return "", "", errors.New("--repo is required unless the work is a GitHub issue URL or owner/repo#number")
+	}
+	if matches := slugPattern.FindStringSubmatch(repo); matches != nil {
+		return matches[1], matches[2], nil
+	}
+	if strings.ContainsAny(repo, "/ \t") {
+		return "", "", fmt.Errorf("cannot read %q as a repository: use owner/name or a bare name with --owner", repo)
+	}
+	if defaultOwner == "" {
+		return "", "", fmt.Errorf("--repo %q has no owner: use owner/%s, or set --owner", repo, repo)
+	}
+	return defaultOwner, repo, nil
+}
+
+// issueDetail is the tracker text a phase body can reference.
+type issueDetail struct {
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	URL    string `json:"url"`
+	State  string `json:"state"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+// fetchIssue reads an issue through gh.
+//
+// Shelling out to gh rather than calling the GitHub API keeps Factory free of a
+// token, a client library, and an auth story: gh is already a documented
+// requirement and is already authenticated on the operator's machine.
+func fetchIssue(ctx context.Context, work target) (issueDetail, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return issueDetail{}, errors.New("gh is not installed, and it is needed to read issue text")
+	}
+	command := exec.CommandContext(ctx, "gh", "issue", "view",
+		strconv.Itoa(work.Number),
+		"--repo", work.Slug(),
+		"--json", "title,body,url,state,labels")
+
+	output, err := command.Output()
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			message := strings.TrimSpace(string(exitError.Stderr))
+			if message == "" {
+				message = exitError.String()
+			}
+			return issueDetail{}, fmt.Errorf("gh could not read %s: %s", work.Reference(), message)
+		}
+		return issueDetail{}, err
+	}
+
+	var detail issueDetail
+	if err := json.Unmarshal(output, &detail); err != nil {
+		return issueDetail{}, fmt.Errorf("gh returned output that could not be read: %w", err)
+	}
+	if strings.TrimSpace(detail.Title) == "" {
+		return issueDetail{}, fmt.Errorf("%s has no title", work.Reference())
+	}
+	return detail, nil
+}
+
+func (d issueDetail) labelNames() string {
+	names := make([]string, 0, len(d.Labels))
+	for _, label := range d.Labels {
+		names = append(names, label.Name)
+	}
+	return strings.Join(names, ", ")
+}

--- a/cmd/factory/main.go
+++ b/cmd/factory/main.go
@@ -1,0 +1,140 @@
+// Command factory is the operator command line for Factory.
+//
+// A phase is a versioned prompt file. A dispatch names the phase and the work.
+// Phases never chain themselves: the sequence is chosen here, at dispatch, so
+// that a phase file stays one prompt and Factory never grows a pipeline router.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/owainlewis/factory/internal/buildinfo"
+)
+
+const usage = `factory runs repeatable software work through coding agents.
+
+Usage:
+  factory run <work> [flags]     dispatch a phase against an issue or repository
+  factory ps [flags]             list runs
+  factory logs <run> [flags]     read the events of a run
+  factory cancel <run>           stop a run
+  factory phases [flags]         list the phases in this repository
+  factory validate               check every phase file
+  factory version                print the build version
+
+Work may be an issue number with --repo, a GitHub issue URL, owner/repo#number,
+or nothing when --repo names the target of a repository phase such as audit.
+
+Common flags:
+  --server <address>   control plane address (default 127.0.0.1:7337,
+                       or $FACTORY_SERVER)
+  -o <format>          output format: table (default) or json
+
+Run factory <command> --help for the flags of one command.
+`
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(2)
+		}
+		fmt.Fprintf(os.Stderr, "factory: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string) error {
+	if len(arguments) == 0 {
+		fmt.Fprint(os.Stderr, usage)
+		return errors.New("a command is required")
+	}
+
+	if buildinfo.Requested(arguments) {
+		fmt.Println(buildinfo.String("factory"))
+		return nil
+	}
+
+	command, rest := arguments[0], arguments[1:]
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	switch command {
+	case "run":
+		return runCommand(ctx, rest)
+	case "ps":
+		return psCommand(ctx, rest)
+	case "logs":
+		return logsCommand(ctx, rest)
+	case "cancel":
+		return cancelCommand(ctx, rest)
+	case "phases":
+		return phasesCommand(rest)
+	case "validate":
+		return validateCommand(rest)
+	case "version":
+		fmt.Println(buildinfo.String("factory"))
+		return nil
+	case "help", "-h", "--help":
+		fmt.Print(usage)
+		return nil
+	default:
+		fmt.Fprint(os.Stderr, usage)
+		return fmt.Errorf("unknown command %q", command)
+	}
+}
+
+// serverFlag registers the shared control-plane address flag.
+func serverFlag(set *flag.FlagSet) *string {
+	address := os.Getenv("FACTORY_SERVER")
+	return set.String("server", address, "control plane address (default 127.0.0.1:7337)")
+}
+
+// formatFlag registers the shared output format flag.
+//
+// The flag is -o rather than --json because gh, which is the tool most callers
+// have seen, uses --json as a field selector. A caller passing a field list to
+// a boolean flag would be a confusing first failure.
+func formatFlag(set *flag.FlagSet) *string {
+	return set.String("o", "table", "output format: table or json")
+}
+
+func checkFormat(format string) error {
+	switch format {
+	case "table", "json":
+		return nil
+	default:
+		return fmt.Errorf("unknown output format %q: use table or json", format)
+	}
+}
+
+// leadingArgument splits a leading positional argument from the flags.
+//
+// Go's flag package stops parsing at the first non-flag argument, so
+// `factory run 412 --repo acme/api` would otherwise ignore every flag. Callers
+// write the subject first, so the subject is lifted out before parsing.
+func leadingArgument(arguments []string) (string, []string) {
+	if len(arguments) > 0 && !strings.HasPrefix(arguments[0], "-") {
+		return arguments[0], arguments[1:]
+	}
+	return "", arguments
+}
+
+// repositoryRoot returns the directory holding .factory, which is the working
+// directory unless FACTORY_ROOT overrides it.
+func repositoryRoot() string {
+	if root := strings.TrimSpace(os.Getenv("FACTORY_ROOT")); root != "" {
+		return root
+	}
+	root, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	return root
+}

--- a/cmd/factory/main_test.go
+++ b/cmd/factory/main_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func TestParseTargetAcceptsEveryDocumentedForm(t *testing.T) {
+	for _, testCase := range []struct {
+		name, work, repo, owner string
+		want                    target
+	}{
+		{"number with repo", "412", "acme/api", "", target{"acme", "api", 412}},
+		{"number with bare repo and owner", "412", "api", "acme", target{"acme", "api", 412}},
+		{"issue url", "https://github.com/acme/api/issues/412", "", "", target{"acme", "api", 412}},
+		{"issue url with slash", "https://github.com/acme/api/issues/412/", "", "", target{"acme", "api", 412}},
+		{"short reference", "acme/api#412", "", "", target{"acme", "api", 412}},
+		{"repository only", "", "acme/api", "", target{"acme", "api", 0}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got, err := parseTarget(testCase.work, testCase.repo, testCase.owner)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != testCase.want {
+				t.Fatalf("target = %+v, want %+v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestParseTargetRejectsUnusableInput(t *testing.T) {
+	for _, testCase := range []struct{ name, work, repo, owner, want string }{
+		{"no repo", "412", "", "", "--repo is required"},
+		{"bare repo without owner", "412", "api", "", "has no owner"},
+		{"not a number", "twelve", "acme/api", "", "cannot read"},
+		{"zero", "0", "acme/api", "", "cannot read"},
+		{"negative", "-3", "acme/api", "", "cannot read"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := parseTarget(testCase.work, testCase.repo, testCase.owner)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("error = %v, want it to mention %q", err, testCase.want)
+			}
+		})
+	}
+}
+
+func TestTargetRendersIdentityAndReference(t *testing.T) {
+	issue := target{Owner: "acme", Repo: "api", Number: 412}
+	if issue.Identity() != "github.com/acme/api" {
+		t.Fatalf("identity = %q", issue.Identity())
+	}
+	if issue.Reference() != "acme/api#412" {
+		t.Fatalf("reference = %q", issue.Reference())
+	}
+	repository := target{Owner: "acme", Repo: "api"}
+	if repository.Reference() != "acme/api" {
+		t.Fatalf("repository reference = %q", repository.Reference())
+	}
+}
+
+func TestSelectedPhases(t *testing.T) {
+	got, err := selectedPhases("build", "")
+	if err != nil || len(got) != 1 || got[0] != "build" {
+		t.Fatalf("got %v, err %v", got, err)
+	}
+	if got, err := selectedPhases("", "verify"); err != nil || got[0] != "verify" {
+		t.Fatalf("got %v, err %v", got, err)
+	}
+
+	// A multi-phase dispatch must be atomic and needs a dependency edge the
+	// control plane does not have. Refusing beats starting them in parallel.
+	_, err = selectedPhases("", "plan,build,verify")
+	if err == nil || !strings.Contains(err.Error(), "one phase at a time") {
+		t.Fatalf("error = %v", err)
+	}
+	if _, err := selectedPhases("build", "verify"); err == nil {
+		t.Fatal("both --phase and --phases were accepted")
+	}
+	if _, err := selectedPhases("", ""); err == nil {
+		t.Fatal("a dispatch with no phase was accepted")
+	}
+}
+
+func TestResolveRuntime(t *testing.T) {
+	for _, testCase := range []struct{ override, declared, want string }{
+		{"", "", protocol.RuntimeCodex},
+		{"", "claude", protocol.RuntimeClaudeCode},
+		{"", "claude-code", protocol.RuntimeClaudeCode},
+		{"codex", "claude", protocol.RuntimeCodex},
+		{"pi", "", protocol.RuntimePi},
+	} {
+		got, err := resolveRuntime(testCase.override, testCase.declared)
+		if err != nil {
+			t.Fatalf("resolveRuntime(%q, %q): %v", testCase.override, testCase.declared, err)
+		}
+		if got != testCase.want {
+			t.Fatalf("resolveRuntime(%q, %q) = %q, want %q", testCase.override, testCase.declared, got, testCase.want)
+		}
+	}
+	if _, err := resolveRuntime("gpt", ""); err == nil {
+		t.Fatal("an unsupported runtime was accepted")
+	}
+}
+
+func TestSummariseKeepsEventsToOneLine(t *testing.T) {
+	for _, testCase := range []struct{ name, payload, want string }{
+		{"string", `"hello  world"`, "hello world"},
+		{"message field", `{"message":"ran the tests"}`, "ran the tests"},
+		{"error field", `{"error":"exit 1"}`, "exit 1"},
+		{"multiline", `"first\nsecond"`, "first second"},
+		{"opaque", `{"other":1}`, `{"other":1}`},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := summarise(json.RawMessage(testCase.payload))
+			if got != testCase.want {
+				t.Fatalf("summarise = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+	if summarise(nil) != "" {
+		t.Fatal("an empty payload produced output")
+	}
+	long := summarise(json.RawMessage(`"` + strings.Repeat("a", 400) + `"`))
+	if len([]rune(long)) != 120 {
+		t.Fatalf("summarise did not bound the line: %d runes", len([]rune(long)))
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 10); got != "short" {
+		t.Fatalf("truncate = %q", got)
+	}
+	if got := truncate("abcdef", 4); got != "abc…" {
+		t.Fatalf("truncate = %q", got)
+	}
+	if got := truncate("héllo wörld", 6); len([]rune(got)) != 6 {
+		t.Fatalf("truncate broke a multi-byte string: %q", got)
+	}
+}
+
+func TestCheckFormat(t *testing.T) {
+	for _, format := range []string{"table", "json"} {
+		if err := checkFormat(format); err != nil {
+			t.Fatalf("checkFormat(%q) = %v", format, err)
+		}
+	}
+	if err := checkFormat("yaml"); err == nil {
+		t.Fatal("an unknown format was accepted")
+	}
+}
+
+func TestRunRejectsAnUnknownCommand(t *testing.T) {
+	if err := run([]string{"deploy"}); err == nil {
+		t.Fatal("an unknown command was accepted")
+	}
+	if err := run(nil); err == nil {
+		t.Fatal("an empty command line was accepted")
+	}
+	if err := run([]string{"version"}); err != nil {
+		t.Fatalf("version = %v", err)
+	}
+}

--- a/cmd/factory/phases.go
+++ b/cmd/factory/phases.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/owainlewis/factory/internal/phase"
+)
+
+func phasesCommand(arguments []string) error {
+	set := flag.NewFlagSet("phases", flag.ContinueOnError)
+	format := formatFlag(set)
+	if err := set.Parse(arguments); err != nil {
+		return err
+	}
+	if err := checkFormat(*format); err != nil {
+		return err
+	}
+
+	loaded, err := phase.LoadAll(repositoryRoot())
+	if err != nil {
+		return err
+	}
+
+	if *format == "json" {
+		listing := make([]map[string]any, 0, len(loaded))
+		for _, item := range loaded {
+			listing = append(listing, map[string]any{
+				"name":        item.Name,
+				"description": item.Description,
+				"runtime":     item.Runtime,
+				"model":       item.Model,
+				"timeout":     item.Timeout.String(),
+				"read_only":   item.ReadOnly,
+				"hash":        item.Hash,
+				"path":        item.Path,
+			})
+		}
+		return writeJSON(listing)
+	}
+
+	if len(loaded) == 0 {
+		fmt.Fprintf(os.Stderr, "No phases in %s.\n", phase.Dir)
+		return nil
+	}
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "PHASE\tVERSION\tRUNTIME\tTIMEOUT\tDESCRIPTION")
+	for _, item := range loaded {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n",
+			item.Name,
+			item.ShortHash(),
+			orDefault(item.Runtime, "-"),
+			item.Timeout,
+			truncate(item.Description, 56))
+	}
+	return writer.Flush()
+}
+
+func validateCommand(arguments []string) error {
+	set := flag.NewFlagSet("validate", flag.ContinueOnError)
+	if err := set.Parse(arguments); err != nil {
+		return err
+	}
+	loaded, err := phase.LoadAll(repositoryRoot())
+	if err != nil {
+		return err
+	}
+	if len(loaded) == 0 {
+		return fmt.Errorf("no phase files in %s", phase.Dir)
+	}
+	for _, item := range loaded {
+		fmt.Printf("ok  %s@%s  %s\n", item.Name, item.ShortHash(), item.Path)
+	}
+	fmt.Fprintf(os.Stderr, "\n%d phases are valid.\n", len(loaded))
+	return nil
+}

--- a/cmd/factory/run.go
+++ b/cmd/factory/run.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/owainlewis/factory/internal/factoryclient"
+	"github.com/owainlewis/factory/internal/phase"
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+const runUsage = `factory run dispatches a phase against an issue or a repository.
+
+Usage:
+  factory run <work> --phase <name> [flags]
+  factory run --repo <owner/name> --phase <name> [flags]
+
+Examples:
+  factory run 412 --repo acme/api --phase build
+  factory run https://github.com/acme/api/issues/412 --phase build
+  factory run acme/api#412 --phase verify
+  factory run --repo acme/api --phase audit
+  factory run 412 --repo acme/api --phase build --dry-run
+`
+
+func runCommand(ctx context.Context, arguments []string) error {
+	work, arguments := leadingArgument(arguments)
+	set := flag.NewFlagSet("run", flag.ContinueOnError)
+	set.Usage = func() {
+		fmt.Fprint(os.Stderr, runUsage, "\nFlags:\n")
+		set.PrintDefaults()
+	}
+	var (
+		repo      = set.String("repo", "", "repository as owner/name, or a bare name with --owner")
+		owner     = set.String("owner", os.Getenv("FACTORY_OWNER"), "default repository owner")
+		phaseName = set.String("phase", "", "phase to run")
+		phaseList = set.String("phases", "", "comma-separated phases to run in order")
+		criteria  = set.String("criteria", "", "acceptance criteria for this run")
+		runtime   = set.String("runtime", "", "override the phase runtime (pi, codex, claude-code)")
+		dryRun    = set.Bool("dry-run", false, "render the prompt and dispatch nothing")
+		address   = serverFlag(set)
+		format    = formatFlag(set)
+	)
+	if err := set.Parse(arguments); err != nil {
+		return err
+	}
+	if err := checkFormat(*format); err != nil {
+		return err
+	}
+
+	names, err := selectedPhases(*phaseName, *phaseList)
+	if err != nil {
+		return err
+	}
+	if work == "" {
+		work = set.Arg(0)
+	}
+	target, err := parseTarget(work, *repo, *owner)
+	if err != nil {
+		return err
+	}
+
+	loaded, err := phase.Load(repositoryRoot(), names[0])
+	if err != nil {
+		return err
+	}
+
+	var issue *issueDetail
+	if target.Number > 0 {
+		detail, err := fetchIssue(ctx, target)
+		if err != nil {
+			return err
+		}
+		issue = &detail
+	}
+
+	title := loaded.Name + " " + target.Reference()
+	if issue != nil {
+		title = issue.Title
+	}
+
+	context := phase.Context{
+		Run: map[string]string{
+			"repo":     target.Slug(),
+			"phase":    loaded.Name,
+			"title":    title,
+			"criteria": *criteria,
+			"body":     "",
+		},
+	}
+	if issue != nil {
+		context.Run["body"] = issue.Body
+		context.Issue = map[string]string{
+			"identifier": target.Reference(),
+			"number":     fmt.Sprint(target.Number),
+			"title":      issue.Title,
+			"body":       issue.Body,
+			"url":        issue.URL,
+			"state":      issue.State,
+			"labels":     issue.labelNames(),
+		}
+	}
+
+	prompt, err := loaded.Render(context)
+	if err != nil {
+		return err
+	}
+
+	if *dryRun {
+		return showDryRun(*format, loaded, target, prompt)
+	}
+
+	selected, err := resolveRuntime(*runtime, loaded.Runtime)
+	if err != nil {
+		return err
+	}
+
+	client, err := factoryclient.New(*address)
+	if err != nil {
+		return err
+	}
+	repository, err := client.EnsureRepository(ctx, target.Identity())
+	if err != nil {
+		return fmt.Errorf("cannot register %s: %w", target.Identity(), err)
+	}
+
+	suffix, err := randomSuffix()
+	if err != nil {
+		return err
+	}
+	task, err := client.CreateTask(ctx, protocol.SaveTaskRequest{
+		Name:           fmt.Sprintf("%s %s %s", loaded.Name, target.Reference(), suffix),
+		Prompt:         prompt,
+		Runtime:        selected,
+		TimeoutSeconds: int(loaded.Timeout.Seconds()),
+		RepositoryIDs:  []string{repository.ID},
+	})
+	if err != nil {
+		if factoryclient.Code(err) == "task_limit_reached" {
+			return fmt.Errorf("%w\nEach dispatch currently records one task, and the control plane caps them. This is tracked as the schema collapse in the CLI issue", err)
+		}
+		return err
+	}
+
+	// The control plane scopes a request key to one task, and each dispatch
+	// records its own task, so a caller-supplied key could never deduplicate a
+	// repeated dispatch. Until a run carries the dispatch identity itself, the
+	// key is generated here rather than promised to callers.
+	detail, err := client.StartTask(ctx, task.ID, suffix+"-"+loaded.ShortHash())
+	if err != nil {
+		return err
+	}
+
+	return showDispatch(*format, loaded, target, detail)
+}
+
+// selectedPhases reads --phase and --phases.
+//
+// A multi-phase dispatch has to be one atomic call so that a partial fan-out is
+// impossible, and it needs a dependency edge in the control plane to hold the
+// second phase until the first succeeds. Neither exists yet, so a list of more
+// than one is refused rather than silently started in parallel.
+func selectedPhases(single, list string) ([]string, error) {
+	single = strings.TrimSpace(single)
+	list = strings.TrimSpace(list)
+	switch {
+	case single != "" && list != "":
+		return nil, fmt.Errorf("use either --phase or --phases, not both")
+	case single != "":
+		return []string{single}, nil
+	case list == "":
+		return nil, fmt.Errorf("--phase is required; run `factory phases` to list the phases in this repository")
+	}
+
+	names := make([]string, 0, 3)
+	for _, name := range strings.Split(list, ",") {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			names = append(names, trimmed)
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("--phases listed no phases")
+	}
+	if len(names) > 1 {
+		return nil, fmt.Errorf("chaining %s needs a dependency edge the control plane does not have yet; dispatch one phase at a time with --phase", strings.Join(names, ","))
+	}
+	return names, nil
+}
+
+// resolveRuntime maps a phase runtime onto a runtime the control plane accepts.
+// "claude" is accepted as the everyday spelling of claude-code.
+func resolveRuntime(override, declared string) (string, error) {
+	selected := strings.TrimSpace(override)
+	if selected == "" {
+		selected = strings.TrimSpace(declared)
+	}
+	if selected == "" {
+		return protocol.RuntimeCodex, nil
+	}
+	if selected == "claude" {
+		selected = protocol.RuntimeClaudeCode
+	}
+	if !protocol.SupportedRuntime(selected) {
+		return "", fmt.Errorf("runtime %q is not supported; use one of %s", selected, strings.Join(protocol.SupportedRuntimes(), ", "))
+	}
+	return selected, nil
+}
+
+func randomSuffix() (string, error) {
+	buffer := make([]byte, 4)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", fmt.Errorf("cannot generate a dispatch identifier: %w", err)
+	}
+	return hex.EncodeToString(buffer), nil
+}
+
+func showDryRun(format string, loaded phase.Phase, work target, prompt string) error {
+	if format == "json" {
+		return writeJSON(map[string]any{
+			"phase":      loaded.Name,
+			"phase_hash": loaded.Hash,
+			"work":       work.Reference(),
+			"runtime":    loaded.Runtime,
+			"timeout":    loaded.Timeout.String(),
+			"read_only":  loaded.ReadOnly,
+			"prompt":     prompt,
+		})
+	}
+	fmt.Printf("phase    %s@%s\n", loaded.Name, loaded.ShortHash())
+	fmt.Printf("work     %s\n", work.Reference())
+	fmt.Printf("runtime  %s\n", orDefault(loaded.Runtime, "(default)"))
+	fmt.Printf("timeout  %s\n", loaded.Timeout)
+	fmt.Printf("\n%s\n", strings.TrimRight(prompt, "\n"))
+	fmt.Fprintln(os.Stderr, "\nDry run: nothing was dispatched.")
+	return nil
+}
+
+func showDispatch(format string, loaded phase.Phase, work target, detail protocol.RunDetail) error {
+	if format == "json" {
+		return writeJSON(map[string]any{
+			"run":        detail.Run.ID,
+			"state":      string(detail.Run.State),
+			"phase":      loaded.Name,
+			"phase_hash": loaded.Hash,
+			"work":       work.Reference(),
+			"sessions":   len(detail.Sessions),
+		})
+	}
+	fmt.Printf("%s  %s  %s@%s  %s\n",
+		detail.Run.ID, work.Reference(), loaded.Name, loaded.ShortHash(), detail.Run.State)
+	fmt.Fprintf(os.Stderr, "\nFollow it with `factory logs %s --follow`.\n", detail.Run.ID)
+	return nil
+}
+
+func writeJSON(value any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func orDefault(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func since(start time.Time) string {
+	elapsed := time.Since(start).Truncate(time.Second)
+	if elapsed < 0 {
+		return "0s"
+	}
+	return elapsed.String()
+}

--- a/cmd/factory/status.go
+++ b/cmd/factory/status.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/owainlewis/factory/internal/factoryclient"
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+func psCommand(ctx context.Context, arguments []string) error {
+	set := flag.NewFlagSet("ps", flag.ContinueOnError)
+	limit := set.Int("limit", 20, "maximum runs to list")
+	all := set.Bool("all", false, "include runs that already finished")
+	address := serverFlag(set)
+	format := formatFlag(set)
+	if err := set.Parse(arguments); err != nil {
+		return err
+	}
+	if err := checkFormat(*format); err != nil {
+		return err
+	}
+
+	client, err := factoryclient.New(*address)
+	if err != nil {
+		return err
+	}
+	runs, err := client.Runs(ctx, *limit)
+	if err != nil {
+		return err
+	}
+	if !*all {
+		active := runs[:0]
+		for _, item := range runs {
+			if item.TerminalAt == nil {
+				active = append(active, item)
+			}
+		}
+		runs = active
+	}
+
+	if *format == "json" {
+		return writeJSON(runs)
+	}
+	if len(runs) == 0 {
+		fmt.Fprintln(os.Stderr, "No runs. Dispatch one with `factory run <issue> --repo <owner/name> --phase build`.")
+		return nil
+	}
+
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, "RUN\tTASK\tSTATE\tSESSIONS\tAGE")
+	for _, item := range runs {
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%d/%d\t%s\n",
+			item.ID,
+			truncate(item.Task.Name, 44),
+			item.State,
+			item.SucceededCount,
+			item.SessionCount,
+			since(item.AdmittedAt))
+	}
+	return writer.Flush()
+}
+
+func logsCommand(ctx context.Context, arguments []string) error {
+	runID, arguments := leadingArgument(arguments)
+	set := flag.NewFlagSet("logs", flag.ContinueOnError)
+	follow := set.Bool("follow", false, "keep polling until the run finishes")
+	interval := set.Duration("interval", 2*time.Second, "poll interval when following")
+	address := serverFlag(set)
+	format := formatFlag(set)
+	if err := set.Parse(arguments); err != nil {
+		return err
+	}
+	if err := checkFormat(*format); err != nil {
+		return err
+	}
+	if runID == "" {
+		runID = set.Arg(0)
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return fmt.Errorf("a run id is required; list them with `factory ps`")
+	}
+
+	client, err := factoryclient.New(*address)
+	if err != nil {
+		return err
+	}
+
+	var after int64
+	for {
+		detail, err := client.Run(ctx, runID)
+		if err != nil {
+			return err
+		}
+		attemptID, ok := latestAttempt(detail)
+		if !ok {
+			if !*follow {
+				fmt.Fprintln(os.Stderr, "The run has not started on a worker yet.")
+				return nil
+			}
+		} else {
+			page, err := client.Events(ctx, attemptID, after)
+			if err != nil {
+				return err
+			}
+			for _, event := range page.Events {
+				if err := printEvent(*format, event); err != nil {
+					return err
+				}
+			}
+			if page.NextAfter > after {
+				after = page.NextAfter
+			}
+		}
+
+		if !*follow || detail.Run.TerminalAt != nil {
+			if detail.Run.TerminalAt != nil && *format == "table" {
+				fmt.Fprintf(os.Stderr, "\nRun %s finished: %s\n", detail.Run.ID, detail.Run.State)
+			}
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(*interval):
+		}
+	}
+}
+
+func cancelCommand(ctx context.Context, arguments []string) error {
+	runID, arguments := leadingArgument(arguments)
+	set := flag.NewFlagSet("cancel", flag.ContinueOnError)
+	address := serverFlag(set)
+	if err := set.Parse(arguments); err != nil {
+		return err
+	}
+	if runID == "" {
+		runID = set.Arg(0)
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return fmt.Errorf("a run id is required; list them with `factory ps`")
+	}
+	client, err := factoryclient.New(*address)
+	if err != nil {
+		return err
+	}
+	if err := client.CancelRun(ctx, runID); err != nil {
+		return err
+	}
+	fmt.Printf("%s cancelling\n", runID)
+	return nil
+}
+
+// latestAttempt returns the newest attempt of a run. Events are recorded per
+// attempt, so following a run means following its current attempt.
+func latestAttempt(detail protocol.RunDetail) (string, bool) {
+	var (
+		newest protocol.Attempt
+		found  bool
+	)
+	for _, session := range detail.Sessions {
+		for _, attempt := range session.Attempts {
+			if !found || attempt.CreatedAt.After(newest.CreatedAt) {
+				newest, found = attempt, true
+			}
+		}
+	}
+	return newest.ID, found
+}
+
+func printEvent(format string, event protocol.AttemptEvent) error {
+	if format == "json" {
+		return writeJSON(event)
+	}
+	stamp := event.ServerTime.Format("15:04:05")
+	fmt.Printf("%s  %-18s %s\n", stamp, event.Kind, summarise(event.Payload))
+	return nil
+}
+
+// summarise renders an event payload as one line. Events carry arbitrary JSON,
+// and a multi-line dump per event makes a follow unreadable.
+func summarise(payload json.RawMessage) string {
+	if len(payload) == 0 {
+		return ""
+	}
+	var text string
+	if json.Unmarshal(payload, &text) == nil {
+		return truncate(collapse(text), 120)
+	}
+	var fields map[string]any
+	if json.Unmarshal(payload, &fields) == nil {
+		for _, key := range []string{"message", "text", "summary", "error"} {
+			if value, ok := fields[key].(string); ok && value != "" {
+				return truncate(collapse(value), 120)
+			}
+		}
+	}
+	return truncate(collapse(string(payload)), 120)
+}
+
+func collapse(value string) string {
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func truncate(value string, limit int) string {
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	if limit <= 1 {
+		return string(runes[:limit])
+	}
+	return string(runes[:limit-1]) + "…"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Start with the root [README](../README.md) to run Factory.
 - [Architecture](../ARCHITECTURE.md): system boundaries, flows, contracts,
   security, limits, and source map.
 - [Local guide](local.md): build, configure, start, delegate, and troubleshoot.
+- [Phases](phases.md): versioned prompt files and the `factory` command line.
 - [Worker contract](worker.md): identity, runtimes, claiming, process safety,
   and worktree cleanup.
 - [Remote VM Workers](remote-workers.md): TLS listener, one-time enrollment,

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -1,0 +1,139 @@
+# Phases
+
+A phase is one versioned prompt file. A dispatch names the phase and the work.
+
+```sh
+factory run 412 --repo acme/api --phase build
+```
+
+Phases live in `.factory/phases/<name>.md` inside the repository the work
+changes, so a prompt is reviewed, versioned, and rolled back like the code it
+operates on.
+
+## A phase file
+
+```markdown
+---
+name: verify
+description: Check a change against its acceptance criteria and report only
+runtime: claude
+timeout: 30m
+---
+You are reviewing work you did not do. Assume it is wrong until the code shows
+otherwise.
+
+Acceptance criteria:
+{{ run.criteria }}
+
+Report only. Do not fix anything.
+```
+
+Frontmatter is a leading `---` block of flat `key: value` pairs. Nested
+structures are rejected rather than ignored.
+
+| Key | Required | Meaning |
+| --- | --- | --- |
+| `description` | yes | What the phase does |
+| `name` | no | Must match the file name when set |
+| `runtime` | no | `claude`, `codex`, or `pi`. Defaults to the control-plane default |
+| `model` | no | Recorded for future runtime selection |
+| `timeout` | no | A duration such as `30m` or `2h`. Defaults to 2h |
+| `permissions` | no | `read-only` or `write`. Defaults to `write` |
+
+Any other key is kept and is readable in the body as `{{ phase.<key> }}`, which
+is how a phase declares a bound such as `max_findings` without Factory
+modelling it.
+
+## Phases never chain themselves
+
+A phase file describes one prompt and says nothing about what runs next. The
+sequence is chosen at dispatch:
+
+```sh
+factory run 412 --repo acme/api --phase plan
+factory run 412 --repo acme/api --phase build
+factory run 412 --repo acme/api --phase verify
+```
+
+This is the line that keeps Factory from growing a pipeline router. Where
+conditional routing is needed, it belongs to the operator deciding to dispatch
+again, not to a field in a markdown file.
+
+`--phases plan,build,verify` is reserved for the same sequence as one atomic
+dispatch. It is refused today because holding a later phase until an earlier one
+succeeds needs a dependency edge the control plane does not have yet.
+
+## Template variables
+
+Rendering is strict. An unknown variable fails the render rather than
+substituting an empty string, because a prompt that silently lost its acceptance
+criteria is worse than a prompt that did not run.
+
+There are exactly three namespaces.
+
+| Namespace | Available | Keys |
+| --- | --- | --- |
+| `run` | always | `repo`, `phase`, `title`, `body`, `criteria` |
+| `issue` | only when the work is an issue | `identifier`, `number`, `title`, `body`, `url`, `state`, `labels` |
+| `phase` | always | every frontmatter key of the phase |
+
+A phase that targets a repository rather than an issue, such as `audit`, must
+not reference `issue.*`.
+
+## Naming the work
+
+Three forms are accepted:
+
+```sh
+factory run 412 --repo acme/api                       # like gh
+factory run https://github.com/acme/api/issues/412    # what is on the clipboard
+factory run acme/api#412                              # how GitHub renders it
+factory run --repo acme/api --phase audit             # no issue at all
+```
+
+Issue text is read through `gh`, which is already a requirement and is already
+authenticated on the operator's machine.
+
+## Checking a phase before it runs
+
+```sh
+factory phases                                     # list phases and versions
+factory validate                                   # fail on any broken file
+factory run 412 --repo acme/api --phase build --dry-run
+```
+
+`--dry-run` renders the prompt and dispatches nothing, which is the loop for
+editing a phase file. Run `factory validate` in CI so a broken phase cannot
+merge.
+
+## Versioning
+
+Every phase carries the SHA-256 of its file. A dispatch records that hash with
+the rendered prompt, so "which prompt produced this pull request" stays
+answerable after the file has changed.
+
+```sh
+$ factory phases
+PHASE   VERSION  RUNTIME  TIMEOUT  DESCRIPTION
+audit   46a8567  claude   1h0m0s   Find real defects in a repository and file…
+build   2a2d6d1  claude   2h0m0s   Implement one scoped issue and open a pull request
+plan    f71d182  claude   30m0s    Turn a scoped issue into an implementation plan…
+verify  f1fd590  claude   30m0s    Check a change against its acceptance criteria…
+```
+
+## No task should need the operator
+
+The phases in this repository tell an agent to take the most reasonable reading
+of an ambiguous issue, record the assumption in the pull request, and continue.
+A run that stops to ask a question has failed to be useful, and the assumption
+is visible on a pull request the operator was going to read anyway.
+
+## Current limits
+
+- One phase per dispatch. Chaining needs a dependency edge in the control plane.
+- No `--worker` targeting. Work routes by repository access, runtime, and
+  capacity.
+- Each dispatch records one task, and the control plane caps tasks, so a long
+  history eventually needs the schema collapse tracked in the CLI issue.
+- `factory web` and `factory worker` are not subcommands yet. Start the control
+  plane and worker with `just run`.

--- a/internal/factoryclient/client.go
+++ b/internal/factoryclient/client.go
@@ -1,0 +1,227 @@
+// Package factoryclient talks to the Factory control plane over its loopback
+// operator API. It exists so the CLI never opens the SQLite database directly:
+// the running server owns that file, and two writers would fight.
+package factoryclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/owainlewis/factory/internal/protocol"
+)
+
+// DefaultAddress is the loopback address the control plane listens on.
+const DefaultAddress = "127.0.0.1:7337"
+
+// Client calls the operator API.
+type Client struct {
+	base string
+	http *http.Client
+}
+
+// New returns a client for address, which may be a bare host:port or a URL.
+func New(address string) (*Client, error) {
+	if strings.TrimSpace(address) == "" {
+		address = DefaultAddress
+	}
+	if !strings.Contains(address, "://") {
+		address = "http://" + address
+	}
+	parsed, err := url.Parse(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid server address %q: %w", address, err)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("invalid server address %q: no host", address)
+	}
+	return &Client{
+		base: strings.TrimSuffix(parsed.Scheme+"://"+parsed.Host, "/"),
+		http: &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+// APIError is a structured error returned by the control plane. Callers match
+// on Code so that a message change never breaks behaviour.
+type APIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *APIError) Error() string {
+	if e.Code == "" {
+		return fmt.Sprintf("control plane returned %d", e.Status)
+	}
+	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
+}
+
+// Code reports the control-plane error code for err, or "" when err did not
+// come from the API.
+func Code(err error) string {
+	var apiError *APIError
+	if errors.As(err, &apiError) {
+		return apiError.Code
+	}
+	return ""
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, c.base+path, reader)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	request.Header.Set("Accept", "application/json")
+
+	response, err := c.http.Do(request)
+	if err != nil {
+		var opError *net.OpError
+		if errors.As(err, &opError) {
+			return fmt.Errorf("cannot reach the Factory server at %s: start it with `just run`", c.base)
+		}
+		return err
+	}
+	defer response.Body.Close()
+
+	payload, err := io.ReadAll(io.LimitReader(response.Body, 8<<20))
+	if err != nil {
+		return err
+	}
+	if response.StatusCode >= 400 {
+		apiError := &APIError{Status: response.StatusCode}
+		var decoded protocol.ErrorBody
+		if json.Unmarshal(payload, &decoded) == nil {
+			apiError.Code = decoded.Error.Code
+			apiError.Message = decoded.Error.Message
+		}
+		if apiError.Message == "" {
+			apiError.Message = strings.TrimSpace(string(payload))
+		}
+		return apiError
+	}
+	if out == nil {
+		return nil
+	}
+	return json.Unmarshal(payload, out)
+}
+
+// Repositories lists the managed repositories the control plane knows about.
+func (c *Client) Repositories(ctx context.Context) ([]protocol.ManagedRepository, error) {
+	var page struct {
+		Repositories []protocol.ManagedRepository `json:"repositories"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/api/v1/repositories", nil, &page); err != nil {
+		return nil, err
+	}
+	return page.Repositories, nil
+}
+
+// EnsureRepository returns the managed repository for identity, registering it
+// when the control plane has not seen it before. Registration is idempotent on
+// the remote identity, so repeated dispatches converge on one repository.
+func (c *Client) EnsureRepository(ctx context.Context, identity string) (protocol.ManagedRepository, error) {
+	existing, err := c.Repositories(ctx)
+	if err != nil {
+		return protocol.ManagedRepository{}, err
+	}
+	for _, repository := range existing {
+		if strings.EqualFold(repository.RemoteIdentity, identity) {
+			return repository, nil
+		}
+	}
+	var created protocol.ManagedRepository
+	body := map[string]string{"remote_identity": identity}
+	if err := c.do(ctx, http.MethodPost, "/api/v1/repositories", body, &created); err != nil {
+		return protocol.ManagedRepository{}, err
+	}
+	return created, nil
+}
+
+// CreateTask records a dispatch. One dispatch is one task carrying the frozen
+// rendered prompt.
+func (c *Client) CreateTask(ctx context.Context, request protocol.SaveTaskRequest) (protocol.Task, error) {
+	var task protocol.Task
+	if err := c.do(ctx, http.MethodPost, "/api/v1/tasks", request, &task); err != nil {
+		return protocol.Task{}, err
+	}
+	return task, nil
+}
+
+// StartTask admits a task for execution. requestKey makes the call idempotent:
+// replaying it returns the run that already exists rather than starting a
+// second one.
+func (c *Client) StartTask(ctx context.Context, taskID, requestKey string) (protocol.RunDetail, error) {
+	var detail protocol.RunDetail
+	body := protocol.RunTaskRequest{RequestKey: requestKey}
+	path := "/api/v1/tasks/" + url.PathEscape(taskID) + "/run"
+	if err := c.do(ctx, http.MethodPost, path, body, &detail); err != nil {
+		return protocol.RunDetail{}, err
+	}
+	return detail, nil
+}
+
+// Runs lists runs, newest first.
+func (c *Client) Runs(ctx context.Context, limit int) ([]protocol.Run, error) {
+	path := "/api/v1/runs"
+	if limit > 0 {
+		path += "?limit=" + fmt.Sprint(limit)
+	}
+	var page protocol.RunPage
+	if err := c.do(ctx, http.MethodGet, path, nil, &page); err != nil {
+		return nil, err
+	}
+	return page.Runs, nil
+}
+
+// Run returns one run with its sessions and attempts.
+func (c *Client) Run(ctx context.Context, runID string) (protocol.RunDetail, error) {
+	var detail protocol.RunDetail
+	path := "/api/v1/runs/" + url.PathEscape(runID)
+	if err := c.do(ctx, http.MethodGet, path, nil, &detail); err != nil {
+		return protocol.RunDetail{}, err
+	}
+	return detail, nil
+}
+
+// CancelRun asks the control plane to stop a run.
+func (c *Client) CancelRun(ctx context.Context, runID string) error {
+	path := "/api/v1/runs/" + url.PathEscape(runID) + "/cancel"
+	return c.do(ctx, http.MethodPost, path, struct{}{}, nil)
+}
+
+// EventPage is one page of attempt events.
+type EventPage struct {
+	Events    []protocol.AttemptEvent `json:"events"`
+	NextAfter int64                   `json:"next_after"`
+	HasMore   bool                    `json:"has_more"`
+}
+
+// Events reads attempt events after a cursor. Following a run is a poll on
+// NextAfter, which matches the no-webhooks posture of the rest of Factory.
+func (c *Client) Events(ctx context.Context, attemptID string, after int64) (EventPage, error) {
+	path := fmt.Sprintf("/api/v1/attempts/%s/events?after=%d", url.PathEscape(attemptID), after)
+	var page EventPage
+	if err := c.do(ctx, http.MethodGet, path, nil, &page); err != nil {
+		return EventPage{}, err
+	}
+	return page, nil
+}

--- a/internal/factoryclient/client_test.go
+++ b/internal/factoryclient/client_test.go
@@ -1,0 +1,161 @@
+package factoryclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func testClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := New(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func TestNewAcceptsBareAddressesAndURLs(t *testing.T) {
+	for _, address := range []string{"", "127.0.0.1:7337", "http://127.0.0.1:7337", "http://127.0.0.1:7337/"} {
+		client, err := New(address)
+		if err != nil {
+			t.Fatalf("New(%q) = %v", address, err)
+		}
+		if client.base != "http://127.0.0.1:7337" {
+			t.Fatalf("New(%q) base = %q", address, client.base)
+		}
+	}
+	if _, err := New("http://"); err == nil {
+		t.Fatal("an address with no host was accepted")
+	}
+}
+
+func TestDecodesStructuredErrors(t *testing.T) {
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":{"code":"task_limit_reached","message":"too many tasks"}}`))
+	}))
+
+	_, err := client.Runs(context.Background(), 10)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if Code(err) != "task_limit_reached" {
+		t.Fatalf("Code = %q", Code(err))
+	}
+	if !strings.Contains(err.Error(), "too many tasks") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCodeIgnoresOtherErrors(t *testing.T) {
+	if Code(context.Canceled) != "" {
+		t.Fatal("a non-API error reported a code")
+	}
+}
+
+func TestUnreachableServerExplainsHowToStartIt(t *testing.T) {
+	// Port 1 is reserved and refuses connections, so this exercises the dial
+	// failure an operator hits when the control plane is not running.
+	client, err := New("127.0.0.1:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Runs(context.Background(), 1)
+	if err == nil || !strings.Contains(err.Error(), "just run") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEnsureRepositoryReusesAnExistingMatch(t *testing.T) {
+	var created int
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/repositories":
+			_, _ = w.Write([]byte(`{"repositories":[{"id":"repo_1","remote_identity":"github.com/acme/api"}]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/repositories":
+			created++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":"repo_2","remote_identity":"github.com/acme/web"}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+
+	existing, err := client.EnsureRepository(context.Background(), "github.com/acme/api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if existing.ID != "repo_1" {
+		t.Fatalf("id = %q, want the existing repository", existing.ID)
+	}
+	if created != 0 {
+		t.Fatal("an existing repository was registered again")
+	}
+
+	fresh, err := client.EnsureRepository(context.Background(), "github.com/acme/web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh.ID != "repo_2" || created != 1 {
+		t.Fatalf("id = %q created = %d", fresh.ID, created)
+	}
+}
+
+func TestStartTaskSendsTheIdempotencyKey(t *testing.T) {
+	var body map[string]string
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/tasks/task_1/run" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = w.Write([]byte(`{"run":{"id":"run_9","state":"running"},"sessions":[]}`))
+	}))
+
+	detail, err := client.StartTask(context.Background(), "task_1", "key-abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Run.ID != "run_9" {
+		t.Fatalf("run = %q", detail.Run.ID)
+	}
+	if body["request_key"] != "key-abc" {
+		t.Fatalf("request_key = %q", body["request_key"])
+	}
+}
+
+func TestEventsPassTheCursor(t *testing.T) {
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("after"); got != "12" {
+			t.Errorf("after = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"events":[{"sequence":13,"kind":"log"}],"next_after":13,"has_more":false}`))
+	}))
+
+	page, err := client.Events(context.Background(), "attempt_1", 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Events) != 1 || page.NextAfter != 13 {
+		t.Fatalf("page = %+v", page)
+	}
+}
+
+func TestCancelRunPostsToTheRun(t *testing.T) {
+	var called bool
+	client := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = r.Method == http.MethodPost && r.URL.Path == "/api/v1/runs/run_9/cancel"
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	if err := client.CancelRun(context.Background(), "run_9"); err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Fatal("cancel did not reach the run")
+	}
+}

--- a/internal/phase/phase.go
+++ b/internal/phase/phase.go
@@ -1,0 +1,244 @@
+// Package phase loads the versioned prompt files that Factory dispatches.
+//
+// A phase is one markdown file under .factory/phases. Its frontmatter declares
+// how the phase runs and its body is the prompt. A phase never declares what
+// runs after it: the sequence is chosen at dispatch, so a phase file stays one
+// prompt and Factory stays free of a pipeline router.
+package phase
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Dir is the per-repository directory holding phase files.
+const Dir = ".factory/phases"
+
+// MaxPromptBytes bounds a rendered prompt. The control plane rejects anything
+// larger, so failing here names the phase instead of returning an API error.
+const MaxPromptBytes = 64 * 1024
+
+// DefaultTimeout applies when a phase does not declare one.
+const DefaultTimeout = 2 * time.Hour
+
+// Phase is one loaded prompt file.
+type Phase struct {
+	// Name is the phase name. It defaults to the file name and must match it
+	// when frontmatter sets it, so a dispatch always names the file on disk.
+	Name string
+	// Description says what the phase does. It is required: a phase file with
+	// no description cannot be listed usefully.
+	Description string
+	// Runtime names a runtime declared in the operator configuration. Empty
+	// means the configured default.
+	Runtime string
+	// Model overrides the runtime's model. Empty means the runtime default.
+	Model string
+	// Timeout bounds one run of this phase.
+	Timeout time.Duration
+	// ReadOnly reports whether the phase may change the working tree. Audit
+	// phases set it so a prompt built from untrusted issue text cannot write.
+	ReadOnly bool
+	// Vars holds every frontmatter key, including ones Factory does not
+	// interpret, and is addressable in the body as {{ phase.<key> }}.
+	Vars map[string]string
+	// Body is the unrendered prompt.
+	Body string
+	// Hash is the SHA-256 of the whole file. Freezing it on a run is what makes
+	// "which prompt produced this pull request" answerable later.
+	Hash string
+	// Path is where the phase was loaded from.
+	Path string
+}
+
+// ShortHash returns the display form of the content hash.
+func (p Phase) ShortHash() string {
+	if len(p.Hash) < 7 {
+		return p.Hash
+	}
+	return p.Hash[:7]
+}
+
+// Load reads one phase by name from root.
+func Load(root, name string) (Phase, error) {
+	if err := validateName(name); err != nil {
+		return Phase{}, err
+	}
+	path := filepath.Join(root, filepath.FromSlash(Dir), name+".md")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Phase{}, fmt.Errorf("phase %q not found: no file at %s", name, path)
+	}
+	if err != nil {
+		return Phase{}, err
+	}
+	return parse(path, name, data)
+}
+
+// LoadAll reads every phase under root, sorted by name. A single unreadable
+// phase fails the whole load so that `factory validate` reports a broken file
+// rather than quietly listing the rest.
+func LoadAll(root string) ([]Phase, error) {
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("no phase directory at %s", dir)
+	}
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(entry.Name(), ".md"))
+	}
+	sort.Strings(names)
+	phases := make([]Phase, 0, len(names))
+	for _, name := range names {
+		loaded, err := Load(root, name)
+		if err != nil {
+			return nil, err
+		}
+		phases = append(phases, loaded)
+	}
+	return phases, nil
+}
+
+func validateName(name string) error {
+	if name == "" {
+		return errors.New("a phase name is required")
+	}
+	if len(name) > 64 {
+		return fmt.Errorf("phase name %q is longer than 64 characters", name)
+	}
+	for _, r := range name {
+		if r == '-' || r == '_' || unicode.IsDigit(r) || (unicode.IsLetter(r) && r < utf8.RuneSelf) {
+			continue
+		}
+		return fmt.Errorf("phase name %q may use only ASCII letters, digits, hyphen, and underscore", name)
+	}
+	return nil
+}
+
+func parse(path, name string, data []byte) (Phase, error) {
+	sum := sha256.Sum256(data)
+	fields, body, err := splitFrontmatter(string(data))
+	if err != nil {
+		return Phase{}, fmt.Errorf("%s: %w", path, err)
+	}
+
+	loaded := Phase{
+		Name:    name,
+		Timeout: DefaultTimeout,
+		Vars:    fields,
+		Body:    body,
+		Hash:    hex.EncodeToString(sum[:]),
+		Path:    path,
+	}
+
+	if declared, ok := fields["name"]; ok && declared != name {
+		return Phase{}, fmt.Errorf("%s: frontmatter name %q does not match the file name %q", path, declared, name)
+	}
+	loaded.Description = fields["description"]
+	if loaded.Description == "" {
+		return Phase{}, fmt.Errorf("%s: description is required", path)
+	}
+	loaded.Runtime = fields["runtime"]
+	loaded.Model = fields["model"]
+
+	if raw, ok := fields["timeout"]; ok {
+		duration, err := time.ParseDuration(raw)
+		if err != nil {
+			return Phase{}, fmt.Errorf("%s: timeout %q is not a duration such as 30m or 2h", path, raw)
+		}
+		if duration <= 0 {
+			return Phase{}, fmt.Errorf("%s: timeout must be positive", path)
+		}
+		loaded.Timeout = duration
+	}
+
+	if raw, ok := fields["permissions"]; ok {
+		switch raw {
+		case "read-only":
+			loaded.ReadOnly = true
+		case "write":
+		default:
+			return Phase{}, fmt.Errorf("%s: permissions %q must be read-only or write", path, raw)
+		}
+	}
+
+	if strings.TrimSpace(loaded.Body) == "" {
+		return Phase{}, fmt.Errorf("%s: the phase body is empty, so there is no prompt to run", path)
+	}
+	return loaded, nil
+}
+
+// splitFrontmatter reads a leading --- delimited block of flat key: value pairs.
+//
+// The subset is deliberate. Frontmatter in this format is flat scalars in every
+// real phase file, and parsing only that keeps Factory free of a YAML
+// dependency. Nested structures are rejected with a message that says so rather
+// than being silently ignored.
+func splitFrontmatter(text string) (map[string]string, string, error) {
+	text = strings.TrimPrefix(text, "\ufeff")
+	rest, ok := strings.CutPrefix(text, "---\n")
+	if !ok {
+		return nil, "", errors.New("the file must start with a --- frontmatter block")
+	}
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return nil, "", errors.New("the frontmatter block is not closed by ---")
+	}
+	block := rest[:end]
+	body := rest[end+len("\n---"):]
+	body = strings.TrimPrefix(body, "\n")
+
+	fields := map[string]string{}
+	for number, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if line != strings.TrimLeft(line, " \t") {
+			return nil, "", fmt.Errorf("frontmatter line %d is indented; only flat key: value pairs are supported", number+1)
+		}
+		key, value, ok := strings.Cut(trimmed, ":")
+		if !ok {
+			return nil, "", fmt.Errorf("frontmatter line %d is not a key: value pair", number+1)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, "", fmt.Errorf("frontmatter line %d has an empty key", number+1)
+		}
+		if _, duplicate := fields[key]; duplicate {
+			return nil, "", fmt.Errorf("frontmatter key %q appears more than once", key)
+		}
+		fields[key] = unquote(strings.TrimSpace(value))
+	}
+	return fields, body, nil
+}
+
+func unquote(value string) string {
+	if len(value) >= 2 {
+		first, last := value[0], value[len(value)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			if unquoted, err := strconv.Unquote(value); err == nil {
+				return unquoted
+			}
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}

--- a/internal/phase/phase_test.go
+++ b/internal/phase/phase_test.go
@@ -1,0 +1,254 @@
+package phase
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writePhase(t *testing.T, root, name, content string) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(Dir))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const buildPhase = `---
+name: build
+description: Implement one issue and open a pull request
+runtime: claude
+model: opus
+timeout: 90m
+---
+Implement {{ issue.identifier }}: {{ run.title }}
+
+{{ run.criteria }}
+`
+
+func TestLoadReadsFrontmatterAndFreezesHash(t *testing.T) {
+	root := t.TempDir()
+	writePhase(t, root, "build", buildPhase)
+
+	loaded, err := Load(root, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Description != "Implement one issue and open a pull request" {
+		t.Fatalf("description = %q", loaded.Description)
+	}
+	if loaded.Runtime != "claude" || loaded.Model != "opus" {
+		t.Fatalf("runtime = %q model = %q", loaded.Runtime, loaded.Model)
+	}
+	if loaded.Timeout != 90*time.Minute {
+		t.Fatalf("timeout = %s", loaded.Timeout)
+	}
+	if loaded.ReadOnly {
+		t.Fatal("phase defaulted to read-only")
+	}
+	if len(loaded.Hash) != 64 || len(loaded.ShortHash()) != 7 {
+		t.Fatalf("hash = %q", loaded.Hash)
+	}
+
+	// The hash must follow the file, so an edited prompt is a different version.
+	writePhase(t, root, "build", strings.Replace(buildPhase, "Implement {{", "Please implement {{", 1))
+	edited, err := Load(root, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edited.Hash == loaded.Hash {
+		t.Fatal("editing the body did not change the hash")
+	}
+}
+
+func TestLoadDefaultsAndPermissions(t *testing.T) {
+	root := t.TempDir()
+	writePhase(t, root, "audit", `---
+description: Find real defects and file one issue for each
+permissions: read-only
+max_findings: 5
+---
+Audit {{ run.repo }} and file at most {{ phase.max_findings }} issues.
+`)
+	loaded, err := Load(root, "audit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.ReadOnly {
+		t.Fatal("permissions: read-only was not applied")
+	}
+	if loaded.Timeout != DefaultTimeout {
+		t.Fatalf("timeout = %s, want the default", loaded.Timeout)
+	}
+	if loaded.Vars["max_findings"] != "5" {
+		t.Fatalf("uninterpreted frontmatter was dropped: %v", loaded.Vars)
+	}
+}
+
+func TestLoadRejectsBrokenFiles(t *testing.T) {
+	for _, testCase := range []struct{ name, content, want string }{
+		{"no frontmatter", "Just a prompt\n", "must start with a ---"},
+		{"unclosed", "---\ndescription: x\nstill open\n", "not closed"},
+		{"no description", "---\nruntime: claude\n---\nBody\n", "description is required"},
+		{"empty body", "---\ndescription: x\n---\n\n", "body is empty"},
+		{"bad timeout", "---\ndescription: x\ntimeout: soon\n---\nBody\n", "not a duration"},
+		{"bad permissions", "---\ndescription: x\npermissions: some\n---\nBody\n", "read-only or write"},
+		{"indented", "---\ndescription: x\n  nested: y\n---\nBody\n", "only flat key: value"},
+		{"duplicate key", "---\ndescription: x\ndescription: y\n---\nBody\n", "more than once"},
+		{"name mismatch", "---\nname: other\ndescription: x\n---\nBody\n", "does not match the file name"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			writePhase(t, root, "build", testCase.content)
+			_, err := Load(root, "build")
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Fatalf("error = %v, want it to mention %q", err, testCase.want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsUnsafeNames(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"", "../escape", "build/nested", "build.md"} {
+		if _, err := Load(root, name); err == nil {
+			t.Fatalf("name %q was accepted", name)
+		}
+	}
+}
+
+func TestLoadAllSortsAndFailsOnOneBrokenFile(t *testing.T) {
+	root := t.TempDir()
+	writePhase(t, root, "verify", "---\ndescription: Check the change\n---\nCheck it.\n")
+	writePhase(t, root, "build", buildPhase)
+
+	phases, err := LoadAll(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(phases) != 2 || phases[0].Name != "build" || phases[1].Name != "verify" {
+		t.Fatalf("phases = %v", phases)
+	}
+
+	writePhase(t, root, "broken", "no frontmatter\n")
+	if _, err := LoadAll(root); err == nil {
+		t.Fatal("one broken phase did not fail the load")
+	}
+}
+
+func TestRenderSubstitutesEveryNamespace(t *testing.T) {
+	root := t.TempDir()
+	writePhase(t, root, "build", buildPhase)
+	loaded, err := Load(root, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rendered, err := loaded.Render(Context{
+		Run:   map[string]string{"title": "Add rate limiting", "criteria": "429 after 100 req/min"},
+		Issue: map[string]string{"identifier": "acme/api#412"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"acme/api#412", "Add rate limiting", "429 after 100 req/min"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered prompt is missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "{{") {
+		t.Fatalf("rendered prompt still holds a reference:\n%s", rendered)
+	}
+}
+
+func TestRenderIsStrict(t *testing.T) {
+	root := t.TempDir()
+
+	t.Run("unknown key names what is available", func(t *testing.T) {
+		writePhase(t, root, "build", "---\ndescription: x\n---\nUse {{ run.missing }}.\n")
+		loaded, err := Load(root, "build")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = loaded.Render(Context{Run: map[string]string{"title": "t"}})
+		if err == nil || !strings.Contains(err.Error(), "run.missing") {
+			t.Fatalf("error = %v", err)
+		}
+		if !strings.Contains(err.Error(), "title") {
+			t.Fatalf("error did not list the available keys: %v", err)
+		}
+	})
+
+	t.Run("issue on a repository run", func(t *testing.T) {
+		writePhase(t, root, "audit", "---\ndescription: x\n---\nAudit {{ issue.title }}.\n")
+		loaded, err := Load(root, "audit")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = loaded.Render(Context{Run: map[string]string{"repo": "api"}})
+		if err == nil || !strings.Contains(err.Error(), "targets a repository") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("unknown namespace", func(t *testing.T) {
+		writePhase(t, root, "build", "---\ndescription: x\n---\nUse {{ task.title }}.\n")
+		loaded, err := Load(root, "build")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = loaded.Render(Context{Run: map[string]string{}})
+		if err == nil || !strings.Contains(err.Error(), "unknown namespace") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("unclosed reference", func(t *testing.T) {
+		writePhase(t, root, "build", "---\ndescription: x\n---\nUse {{ run.title.\n")
+		loaded, err := Load(root, "build")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = loaded.Render(Context{Run: map[string]string{"title": "t"}})
+		if err == nil || !strings.Contains(err.Error(), "unclosed") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestRenderDefaultsPhaseNamespaceToFrontmatter(t *testing.T) {
+	root := t.TempDir()
+	writePhase(t, root, "audit", "---\ndescription: x\nmax_findings: 5\n---\nFile at most {{ phase.max_findings }}.\n")
+	loaded, err := Load(root, "audit")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := loaded.Render(Context{Run: map[string]string{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rendered, "File at most 5.") {
+		t.Fatalf("rendered = %q", rendered)
+	}
+}
+
+func TestRenderRejectsAnOversizedPrompt(t *testing.T) {
+	root := t.TempDir()
+	writePhase(t, root, "build", "---\ndescription: x\n---\n{{ run.body }}\n")
+	loaded, err := Load(root, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = loaded.Render(Context{Run: map[string]string{"body": strings.Repeat("a", MaxPromptBytes+1)}})
+	if err == nil || !strings.Contains(err.Error(), "byte limit") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/internal/phase/render.go
+++ b/internal/phase/render.go
@@ -1,0 +1,107 @@
+package phase
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Context supplies the values a phase body may reference.
+//
+// There are exactly three namespaces. Run always exists. Issue exists only when
+// the run came from a tracker, so a repository-targeted phase such as audit must
+// not reference it. Phase exposes the phase's own frontmatter, which is how a
+// phase declares a bound such as max_findings without Factory modelling it.
+type Context struct {
+	Run   map[string]string
+	Issue map[string]string
+	Phase map[string]string
+}
+
+// Render substitutes {{ namespace.key }} references in the phase body.
+//
+// Rendering is strict. An unknown namespace, an unknown key, or a reference to
+// issue.* on a run with no issue is an error. A silently empty substitution
+// would hand an agent a prompt with no acceptance criteria and no way to tell,
+// which is the failure this strictness exists to prevent.
+func (p Phase) Render(context Context) (string, error) {
+	if context.Phase == nil {
+		context.Phase = p.Vars
+	}
+	var out strings.Builder
+	out.Grow(len(p.Body))
+
+	rest := p.Body
+	for {
+		start := strings.Index(rest, "{{")
+		if start < 0 {
+			out.WriteString(rest)
+			break
+		}
+		out.WriteString(rest[:start])
+		rest = rest[start+2:]
+		end := strings.Index(rest, "}}")
+		if end < 0 {
+			return "", fmt.Errorf("%s: unclosed {{ in the phase body", p.Path)
+		}
+		reference := strings.TrimSpace(rest[:end])
+		rest = rest[end+2:]
+
+		value, err := context.lookup(reference)
+		if err != nil {
+			return "", fmt.Errorf("%s: %w", p.Path, err)
+		}
+		out.WriteString(value)
+	}
+
+	rendered := out.String()
+	if len(rendered) > MaxPromptBytes {
+		return "", fmt.Errorf("%s: the rendered prompt is %d bytes, over the %d byte limit", p.Path, len(rendered), MaxPromptBytes)
+	}
+	if strings.TrimSpace(rendered) == "" {
+		return "", fmt.Errorf("%s: the rendered prompt is empty", p.Path)
+	}
+	return rendered, nil
+}
+
+func (c Context) lookup(reference string) (string, error) {
+	namespace, key, ok := strings.Cut(reference, ".")
+	if !ok {
+		return "", fmt.Errorf("{{ %s }} must be namespaced, such as {{ run.title }}", reference)
+	}
+	namespace = strings.TrimSpace(namespace)
+	key = strings.TrimSpace(key)
+
+	var values map[string]string
+	switch namespace {
+	case "run":
+		values = c.Run
+	case "issue":
+		if c.Issue == nil {
+			return "", fmt.Errorf("{{ %s }} needs an issue, but this run targets a repository", reference)
+		}
+		values = c.Issue
+	case "phase":
+		values = c.Phase
+	default:
+		return "", fmt.Errorf("{{ %s }} uses unknown namespace %q; use run, issue, or phase", reference, namespace)
+	}
+
+	value, ok := values[key]
+	if !ok {
+		return "", fmt.Errorf("{{ %s }} is not set; %s has %s", reference, namespace, known(values))
+	}
+	return value, nil
+}
+
+func known(values map[string]string) string {
+	if len(values) == 0 {
+		return "no values"
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}

--- a/scripts/test-build.sh
+++ b/scripts/test-build.sh
@@ -63,7 +63,8 @@ mkdir -p "$temporary/home"
 
 test -x "$temporary/home/.factory/bin/factory-server"
 test -x "$temporary/home/.factory/bin/factory-worker"
-test "$(wc -l <"$temporary/default-go.log" | tr -d ' ')" = "2"
+test -x "$temporary/home/.factory/bin/factory"
+test "$(wc -l <"$temporary/default-go.log" | tr -d ' ')" = "3"
 
 set +e
 output=$(
@@ -170,10 +171,12 @@ PATH="$temporary/bin:/usr/bin:/bin" \
 
 test -x "$temporary/output/factory-server"
 test -x "$temporary/output/factory-worker"
+test -x "$temporary/output/factory"
 test ! -e "$temporary/output/factory-poller"
-test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "2"
+test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "3"
 grep -q 'build -o .*factory-server ./cmd/factory-server' "$temporary/go.log"
 grep -q 'build -o .*factory-worker ./cmd/factory-worker' "$temporary/go.log"
+grep -q 'build -o .*factory ./cmd/factory' "$temporary/go.log"
 
 commands=$(
   "$just_binary" --justfile "$root/Justfile" --working-directory "$root" --list
@@ -211,7 +214,7 @@ if ! printf '%s\n' "$output" |
   echo "$output" >&2
   exit 1
 fi
-test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "2"
+test "$(wc -l <"$temporary/go.log" | tr -d ' ')" = "3"
 
 mkdir -p "$temporary/ui-bin"
 cat >"$temporary/ui-bin/node" <<'EOF'


### PR DESCRIPTION
Builds the phase model and the `factory` command line from #354. Subtasks 1-6
are done; 7 (chaining) and 8 (worker targeting) need schema changes and are
left open.

## What this adds

**`internal/phase`** — loads `.factory/phases/<name>.md`, parses flat
frontmatter, renders the body, and freezes a SHA-256 of the file.

Rendering is strict. An unknown variable, an unknown namespace, or a reference
to `issue.*` on a repository-targeted run all fail the render. A silently empty
substitution would hand an agent a prompt with no acceptance criteria and no
way to notice, which is the failure this exists to prevent. Three namespaces
only: `run.*` always, `issue.*` when tracker-backed, `phase.*` for the phase's
own frontmatter. There is no `task.*`.

**`internal/factoryclient`** — typed client for the loopback operator API, so
the CLI never opens the SQLite file the running server owns.

**`cmd/factory`** — `run`, `ps`, `logs`, `cancel`, `phases`, `validate`,
`version`.

**`.factory/phases/`** — `plan`, `build`, `verify`, and `audit`, dogfooded in
this repository.

## Phases never chain themselves

A phase file describes one prompt and says nothing about what runs next. The
sequence is chosen at dispatch. `--phases plan,build,verify` is reserved for
the atomic form and currently refuses with an explanation, because holding a
later phase until an earlier one succeeds needs a dependency edge the control
plane does not have.

## Naming taken from prior art

- `-o json`, not `--json`. `gh` uses `--json` as a field selector, so a caller
  trained on `gh` would pass a field list to a boolean flag.
- Work is an issue number with `--repo`, a pasted issue URL, or
  `owner/repo#number`. `gh` parses only the first two; the third is kept as an
  alias because it is how GitHub renders cross-repository references.
- Issue text comes from `gh`, which is already a documented requirement and is
  already authenticated, rather than a token and a client library.

## Proof

Dispatched against this repository's own issue #354 on a scratch control plane:

```
$ factory run 354 --repo owainlewis/factory --phase build --criteria "..."
d9efecdc-...  owainlewis/factory#354  build@2a2d6d1  blocked

$ factory ps
RUN           TASK                                     STATE    SESSIONS  AGE
d9efecdc-...  build owainlewis/factory#354 f0068c76    blocked  0/1       0s
```

`blocked` is correct with no worker holding that repository. `--dry-run`
renders the real issue body through `build.md`. `cancel`, `logs`, `-o json`,
and the unreachable-server path were exercised the same way.

Two bugs that testing caught and this fixes: Go's `flag` package stops parsing
at the first positional argument, so `factory run 412 --repo x` ignored every
flag; and a caller-supplied `--request-key` returned `request_key_conflict`
because the control plane scopes that key to a task while each dispatch records
its own task. The flag is removed rather than left promising idempotency it
cannot deliver.

`just format-check vet staticcheck boundary test test-tooling test-launcher
test-release` all pass. `just vuln` fails identically on `main` with this branch
stashed: the local toolchain is go1.26.4 and the standard-library fixes landed
in go1.26.6.

## Known limits, all documented in docs/phases.md

- One phase per dispatch.
- No `--worker` targeting; work routes by repository access, runtime, capacity.
- Each dispatch records one task and the control plane caps tasks, so a long
  history eventually needs the schema collapse.
- `factory web` and `factory worker` are not subcommands yet. Absorbing them
  means moving the two mains behind `internal/` and handling the worker's
  re-exec supervisor dispatch, which is worth its own change.

Closes nothing; #354 stays open for subtasks 7 and 8.

https://claude.ai/code/session_015mkxCdSHBFkkYKWTaBZuuH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `factory` command-line tool for running, monitoring, logging, cancelling, and validating workflow runs.
  * Added configurable, versioned phases for audit, planning, building, and verification.
  * Added support for issue and repository targets, acceptance criteria, dry runs, multiple output formats, and runtime selection.
  * Added phase validation, prompt rendering, and detailed run status and event reporting.

* **Documentation**
  * Expanded quick-start guidance and documented phase configuration, commands, templates, and workflow limits.

* **Build & Testing**
  * Updated builds to produce the `factory` executable and added comprehensive command, client, phase, and build coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->