### PR TITLE
feat: add runnable local Factory prototype

### DIFF
--- a/prototype/local-factory/README.md
+++ b/prototype/local-factory/README.md
@@ -1,0 +1,111 @@
+# Local Factory spike
+
+This folder is a runnable reset of Factory. It tests one product idea:
+
+> An always-on local control plane turns GitHub tickets into reviewed pull-request candidates, while one Foreman session owns the nuanced plan, build, verify loop.
+
+It deliberately does not reuse the current orchestration packages. That lets us test the product shape before migrating the main application.
+
+## Try it
+
+Build the spike as `factory`:
+
+```sh
+go build -o /tmp/factory ./prototype/local-factory
+```
+
+Create a Factory project for a local checkout:
+
+```sh
+/tmp/factory init ~/Code/my-factory \
+  --repo acme/payments \
+  --repo-path ~/Code/payments
+cd ~/Code/my-factory
+```
+
+This creates:
+
+```text
+my-factory/
+  factory.toml
+  agents/
+    foreman.md
+    planner.md
+    builder.md
+    verifier.md
+```
+
+Edit the TOML to select Claude, Codex, or a local command for each role. Edit the Markdown files to change the stable operating prompts.
+
+`factory init` records the remote default branch as `base_ref`; every Work starts from that ref rather than whichever branch happens to be checked out. Pass `--base-ref` only when the default cannot be detected or you intentionally want another base.
+
+Start the always-on process:
+
+```sh
+/tmp/factory web
+```
+
+Then open [http://127.0.0.1:7338](http://127.0.0.1:7338). The process remains in the foreground and owns:
+
+- the GitHub label poller;
+- admission and idempotency;
+- the local scheduler and concurrency limit;
+- embedded local workers;
+- durable files under `.state/`;
+- the monitoring UI;
+- the future webhook HTTP boundary.
+
+The poller admits every open issue with the configured `factory` label. An explicit run uses the same admission path:
+
+```sh
+/tmp/factory run acme/payments#123
+```
+
+`factory run` requires `factory web` to be running. It submits work to the control plane rather than starting a second runner.
+
+## What one work item does
+
+The scheduler claims the whole ticket once. It creates an isolated Git worktree and launches one Foreman session. The Foreman synchronously delegates to the configured agents:
+
+```text
+planner -> builder -> verifier
+               ^          |
+               +-- revise-+
+```
+
+The reports are normal Markdown. The verifier runs in a fresh detached worktree at the exact committed candidate revision. The Foreman interprets the report and either finishes, blocks, or asks the builder to revise. `max_revisions` bounds the loop.
+
+The local issue snapshot, plan, build report, verification report, Foreman report, events, and checkout remain under `.state/` for inspection. `factory status` returns the same state as JSON.
+
+## GitHub safety
+
+Dry run is the default. Factory's GitHub adapter reads issues and labels, changes only isolated local worktrees, and does not edit issues, push branches, or open pull requests.
+
+After proving a repository and its prompts locally, opt into writes explicitly:
+
+```sh
+/tmp/factory web --github-writes
+```
+
+In write mode, Factory publishes the plan to the issue, comments with the reason when work is blocked, pushes the candidate branch, and opens a draft pull request after verification.
+
+This is a trusted-local executor, not a security sandbox. A custom `command` runtime, or another local agent configured with broad shell access, runs with the operator's host permissions and could use host credentials outside Factory's adapter. Use only trusted prompts and runtimes. Credential isolation belongs in the remote-worker phase.
+
+## Current boundaries
+
+- The process must be kept alive by the terminal, launchd, systemd, or a container. Service installation is not part of this spike.
+- GitHub polling works now. `POST /webhooks/github` is reserved but returns `501` until signature verification and delivery deduplication are implemented.
+- A process interruption marks an active attempt failed on restart. Automatic session resume is intentionally deferred.
+- Running the same issue explicitly requeues failed or blocked Work as a new attempt. Polling never auto-retries terminal Work.
+- The UI is read-only and local-only. The config rejects non-loopback listen addresses.
+- Polling assumes that configured repositories and their trigger labels are controlled by trusted collaborators. Public-repository label-actor verification is not implemented yet.
+- CI follow-up, PR review events, cloud workers, authentication, and multi-host leases are later steps. The Work and agent interfaces leave room for them without changing the prompt loop.
+
+## Verify
+
+```sh
+go test ./prototype/local-factory
+go vet ./prototype/local-factory
+```
+
+The end-to-end test creates a temporary Git repository, runs the real Foreman subprocess protocol with fake agents, forces one verifier-to-builder revision, and asserts the final committed candidate and retained artifacts.

--- a/prototype/local-factory/README.md
+++ b/prototype/local-factory/README.md
@@ -35,7 +35,7 @@ my-factory/
     verifier.md
 ```
 
-Edit the TOML to select Claude, Codex, or a local command for each role. Edit the Markdown files to change the stable operating prompts.
+Edit the TOML to select Claude, Codex, or a local command for each role, and to set a deadline for every agent. The V1 Foreman must use Claude or a trusted command because Codex's read-only sandbox cannot reach the loopback control API; Codex remains supported for plan, build, and verify. Edit the Markdown files to change the stable operating prompts.
 
 `factory init` records the remote default branch as `base_ref`; every Work starts from that ref rather than whichever branch happens to be checked out. Pass `--base-ref` only when the default cannot be detected or you intentionally want another base.
 
@@ -87,7 +87,7 @@ After proving a repository and its prompts locally, opt into writes explicitly:
 /tmp/factory web --github-writes
 ```
 
-In write mode, Factory publishes the plan as a non-destructive issue comment, comments with the reason when work is blocked, pushes the candidate branch, and opens a draft pull request after verification. The durable local `plan.md` remains the authoritative plan because GitHub does not offer an atomic conditional update for issue bodies.
+In write mode, Factory publishes the plan as a non-destructive issue comment, comments with the reason when work is blocked, pushes the exact verified SHA to the candidate branch, and opens a draft pull request after verification. It validates `origin` against the configured GitHub repository and reconciles an existing open PR by exact branch and head SHA before creating another. The durable local `plan.md` remains the authoritative plan because GitHub does not offer an atomic conditional update for issue bodies.
 
 This is a trusted-local executor, not a security sandbox. A custom `command` runtime, or another local agent configured with broad shell access, runs with the operator's host permissions and could use host credentials outside Factory's adapter. Use only trusted prompts and runtimes. Credential isolation belongs in the remote-worker phase.
 
@@ -97,7 +97,7 @@ This is a trusted-local executor, not a security sandbox. A custom `command` run
 - GitHub polling works now. `POST /webhooks/github` is reserved but returns `501` until signature verification and delivery deduplication are implemented.
 - A process interruption marks an active attempt failed on restart. Automatic session resume is intentionally deferred.
 - Running the same issue explicitly requeues failed or blocked Work as a new attempt. Polling never auto-retries terminal Work.
-- The UI is read-only and local-only. The config rejects non-loopback listen addresses.
+- The UI is read-only and local-only. The config rejects non-loopback listen addresses, and the HTTP boundary rejects foreign Host and Origin values.
 - Polling assumes that configured repositories and their trigger labels are controlled by trusted collaborators. Public-repository label-actor verification is not implemented yet.
 - CI follow-up, PR review events, cloud workers, authentication, and multi-host leases are later steps. The Work and agent interfaces leave room for them without changing the prompt loop.
 

--- a/prototype/local-factory/README.md
+++ b/prototype/local-factory/README.md
@@ -87,7 +87,7 @@ After proving a repository and its prompts locally, opt into writes explicitly:
 /tmp/factory web --github-writes
 ```
 
-In write mode, Factory publishes the plan to the issue, comments with the reason when work is blocked, pushes the candidate branch, and opens a draft pull request after verification.
+In write mode, Factory publishes the plan as a non-destructive issue comment, comments with the reason when work is blocked, pushes the candidate branch, and opens a draft pull request after verification. The durable local `plan.md` remains the authoritative plan because GitHub does not offer an atomic conditional update for issue bodies.
 
 This is a trusted-local executor, not a security sandbox. A custom `command` runtime, or another local agent configured with broad shell access, runs with the operator's host permissions and could use host credentials outside Factory's adapter. Use only trusted prompts and runtimes. Credential isolation belongs in the remote-worker phase.
 

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -48,7 +51,7 @@ func (r *agentRunner) runWork(ctx context.Context, id string) error {
 
 	foremanName := r.config.Config.Roles.Foreman
 	prompt := r.config.Prompts[foremanName] + "\n\n" + r.foremanContext(item)
-	output, err := r.runAgent(ctx, foremanName, workspace, prompt, "foreman", id)
+	output, err := r.runAgent(ctx, foremanName, workspace, prompt, "foreman", id, r.workToken(item))
 	_ = r.store.artifact(id, "foreman.md", output)
 	if err != nil {
 		return err
@@ -115,7 +118,7 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 		return nil, err
 	}
 	prompt := r.config.Prompts[agentName] + "\n\n" + r.roleContext(item, role, directory)
-	output, runErr := r.runAgent(ctx, agentName, directory, prompt, role, id)
+	output, runErr := r.runAgent(ctx, agentName, directory, prompt, role, id, "")
 	if role == "verify" {
 		if verifyErr := ensureExactHead(ctx, directory, item.HeadSHA); verifyErr != nil && runErr == nil {
 			runErr = verifyErr
@@ -181,7 +184,7 @@ func verificationVerdict(output []byte) (string, error) {
 	}
 }
 
-func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, role, id string) ([]byte, error) {
+func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, role, id, workToken string) ([]byte, error) {
 	agent := r.config.Config.Agents[name]
 	var command *exec.Cmd
 	switch agent.Runtime {
@@ -225,7 +228,7 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 		"FACTORY_WORKSPACE="+directory,
 	)
 	if role == "foreman" {
-		command.Env = append(command.Env, "FACTORY_AUTH_TOKEN="+r.authToken)
+		command.Env = append(command.Env, "FACTORY_AUTH_TOKEN="+workToken)
 	}
 	var stdout, stderr bytes.Buffer
 	command.Stdout, command.Stderr = &stdout, &stderr
@@ -245,6 +248,12 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 		return stdout.Bytes(), fmt.Errorf("agent %q process cleanup: %w", name, cleanupErr)
 	}
 	return stdout.Bytes(), nil
+}
+
+func (r *agentRunner) workToken(item work) string {
+	mac := hmac.New(sha256.New, []byte(r.authToken))
+	_, _ = fmt.Fprintf(mac, "%s\x00%d", item.ID, item.Attempt)
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 func withoutFactoryEnvironment(environment []string) []string {

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -186,11 +186,21 @@ func verificationVerdict(output []byte) (string, error) {
 
 func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, role, id, workToken string) ([]byte, error) {
 	agent := r.config.Config.Agents[name]
+	timeout := 30 * time.Minute
+	if agent.Timeout != "" {
+		var err error
+		timeout, err = time.ParseDuration(agent.Timeout)
+		if err != nil || timeout <= 0 {
+			return nil, fmt.Errorf("agent %q has invalid timeout %q", name, agent.Timeout)
+		}
+	}
+	agentContext, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	var command *exec.Cmd
 	switch agent.Runtime {
 	case "command":
 		args := append([]string(nil), agent.Command[1:]...)
-		command = exec.CommandContext(ctx, agent.Command[0], args...)
+		command = exec.CommandContext(agentContext, agent.Command[0], args...)
 	case "codex":
 		args := []string{"exec", "-C", directory, "--ephemeral", "--color", "never", "--sandbox", "read-only"}
 		if role == "build" || role == "verify" {
@@ -200,7 +210,7 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 			args = append(args, "--model", agent.Model)
 		}
 		args = append(args, "-")
-		command = exec.CommandContext(ctx, "codex", args...)
+		command = exec.CommandContext(agentContext, "codex", args...)
 	case "claude":
 		args := []string{"--print", "--safe-mode", "--no-session-persistence", "--output-format", "text", "--permission-mode", "dontAsk"}
 		if role == "foreman" {
@@ -213,7 +223,7 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 		if agent.Model != "" {
 			args = append(args, "--model", agent.Model)
 		}
-		command = exec.CommandContext(ctx, "claude", args...)
+		command = exec.CommandContext(agentContext, "claude", args...)
 	default:
 		return nil, fmt.Errorf("unsupported runtime %q", agent.Runtime)
 	}
@@ -234,6 +244,13 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 	command.Stdout, command.Stderr = &stdout, &stderr
 	runErr := command.Run()
 	cleanupErr := cleanupAgentCommand(command)
+	if errors.Is(agentContext.Err(), context.DeadlineExceeded) {
+		message := fmt.Sprintf("agent %q timed out after %s", name, timeout)
+		if cleanupErr != nil {
+			message += "; process cleanup: " + cleanupErr.Error()
+		}
+		return stdout.Bytes(), errors.New(message)
+	}
 	if runErr != nil {
 		message := strings.TrimSpace(stderr.String())
 		if message == "" {
@@ -403,6 +420,9 @@ func (r *agentRunner) finish(ctx context.Context, id string) error {
 	if sha != item.VerifiedSHA {
 		return fmt.Errorf("candidate changed after verification: verified %s, current %s", item.VerifiedSHA, sha)
 	}
+	if err := ensureCandidateBranch(ctx, item.Workspace, item.Branch, item.VerifiedSHA); err != nil {
+		return err
+	}
 	prURL := ""
 	if r.githubWrites {
 		repository, err := repositoryFor(r.config, item.Issue.Repository)
@@ -410,13 +430,13 @@ func (r *agentRunner) finish(ctx context.Context, id string) error {
 			return err
 		}
 		baseBranch := strings.TrimPrefix(repository.BaseRef, "origin/")
-		if err := pushBranch(ctx, item.Workspace, item.Branch, item.Issue.Repository); err != nil {
+		if err := pushBranch(ctx, item.Workspace, item.Branch, item.VerifiedSHA, item.Issue.Repository); err != nil {
 			return err
 		}
 		plan, _ := r.store.readArtifact(id, "plan.md")
 		review, _ := r.store.readArtifact(id, "review.md")
 		body := fmt.Sprintf("Closes #%d\n\n## Plan\n\n%s\n\n## Verification\n\n%s", item.Issue.Number, plan, review)
-		prURL, err = r.github.OpenDraftPR(ctx, item.Issue, item.Branch, baseBranch, item.Issue.Title, body)
+		prURL, err = r.github.EnsureDraftPR(ctx, item.Issue, item.Branch, item.VerifiedSHA, baseBranch, item.Issue.Title, body)
 		if err != nil {
 			return err
 		}

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -1,0 +1,361 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type agentRunner struct {
+	config       loadedConfig
+	store        *store
+	github       githubClient
+	githubWrites bool
+	executable   string
+}
+
+func (r *agentRunner) runWork(ctx context.Context, id string) error {
+	item, err := r.store.get(id)
+	if err != nil {
+		return err
+	}
+	workspace, branch, err := prepareWorkspace(ctx, r.config, item)
+	if err != nil {
+		return err
+	}
+	item, err = r.store.update(id, func(item *work) error {
+		now := time.Now().UTC()
+		item.State = stateRunning
+		item.StartedAt = now
+		item.Workspace = workspace
+		item.Branch = branch
+		item.ActiveRole = "foreman"
+		item.Events = append(item.Events, event{At: now, Message: "foreman started"})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	foremanName := r.config.Config.Roles.Foreman
+	prompt := r.config.Prompts[foremanName] + "\n\n" + r.foremanContext(item)
+	output, err := r.runAgent(ctx, foremanName, workspace, prompt, "foreman", id)
+	_ = r.store.artifact(id, "foreman.md", output)
+	if err != nil {
+		return err
+	}
+	latest, err := r.store.get(id)
+	if err != nil {
+		return err
+	}
+	if latest.State == stateRunning {
+		return errors.New("foreman stopped without calling finish or block")
+	}
+	return nil
+}
+
+func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, error) {
+	item, err := r.store.get(id)
+	if err != nil {
+		return nil, err
+	}
+	if item.State != stateRunning {
+		return nil, fmt.Errorf("work is %s, not running", item.State)
+	}
+
+	var agentName, directory, artifact string
+	switch role {
+	case "plan":
+		agentName = r.config.Config.Roles.Plan
+		repository, err := repositoryFor(r.config, item.Issue.Repository)
+		if err != nil {
+			return nil, err
+		}
+		directory, artifact = repository.Path, "plan.md"
+	case "build":
+		agentName, directory, artifact = r.config.Config.Roles.Build, item.Workspace, "build.md"
+	case "verify":
+		if item.VerifyRuns >= r.config.Config.MaxRevisions+1 {
+			return nil, fmt.Errorf("verification limit reached after %d runs", item.VerifyRuns)
+		}
+		sha, err := checkpoint(ctx, item.Workspace, fmt.Sprintf("feat: address %s#%d", item.Issue.Repository, item.Issue.Number))
+		if err != nil {
+			return nil, fmt.Errorf("checkpoint build: %w", err)
+		}
+		directory, err = prepareVerificationWorkspace(ctx, r.config, item, sha)
+		if err != nil {
+			return nil, err
+		}
+		agentName, artifact = r.config.Config.Roles.Verify, "review.md"
+		item.HeadSHA = sha
+	default:
+		return nil, errors.New("role must be plan, build, or verify")
+	}
+
+	item, err = r.store.update(id, func(current *work) error {
+		current.ActiveRole = role
+		if role == "verify" {
+			current.HeadSHA = item.HeadSHA
+			current.VerifyRuns++
+		}
+		current.Events = append(current.Events, event{At: time.Now().UTC(), Message: role + " agent started"})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	prompt := r.config.Prompts[agentName] + "\n\n" + r.roleContext(item, role)
+	output, runErr := r.runAgent(ctx, agentName, directory, prompt, role, id)
+	if role == "verify" {
+		if verifyErr := ensureExactHead(ctx, directory, item.HeadSHA); verifyErr != nil && runErr == nil {
+			runErr = verifyErr
+		}
+	}
+	if artifactErr := r.store.artifact(id, artifact, output); artifactErr != nil && runErr == nil {
+		runErr = artifactErr
+	}
+	_, _ = r.store.update(id, func(current *work) error {
+		current.ActiveRole = "foreman"
+		message := role + " agent completed"
+		if runErr != nil {
+			message = role + " agent failed: " + runErr.Error()
+		} else if role == "verify" {
+			current.VerifiedSHA = current.HeadSHA
+		}
+		current.Events = append(current.Events, event{At: time.Now().UTC(), Message: message})
+		return nil
+	})
+	return output, runErr
+}
+
+func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, role, id string) ([]byte, error) {
+	agent := r.config.Config.Agents[name]
+	var command *exec.Cmd
+	switch agent.Runtime {
+	case "command":
+		args := append([]string(nil), agent.Command[1:]...)
+		command = exec.CommandContext(ctx, agent.Command[0], args...)
+	case "codex":
+		args := []string{"exec", "-C", directory, "--ephemeral", "--color", "never", "--sandbox", "read-only"}
+		if role == "build" || role == "verify" {
+			args[len(args)-1] = "workspace-write"
+		}
+		if agent.Model != "" {
+			args = append(args, "--model", agent.Model)
+		}
+		args = append(args, "-")
+		command = exec.CommandContext(ctx, "codex", args...)
+	case "claude":
+		args := []string{"--print", "--safe-mode", "--no-session-persistence", "--output-format", "text", "--permission-mode", "dontAsk"}
+		if role == "foreman" {
+			args = append(args, "--tools", "Bash", "--allowedTools", "Bash("+r.executable+" internal *)")
+		} else if role == "plan" {
+			args = append(args, "--tools", "Read,Glob,Grep")
+		} else {
+			args = append(args, "--tools", "Read,Edit,Write,Glob,Grep,Bash", "--allowedTools", "Read,Edit,Write,Glob,Grep,Bash")
+		}
+		if agent.Model != "" {
+			args = append(args, "--model", agent.Model)
+		}
+		command = exec.CommandContext(ctx, "claude", args...)
+	default:
+		return nil, fmt.Errorf("unsupported runtime %q", agent.Runtime)
+	}
+	command.Dir = directory
+	command.Stdin = strings.NewReader(prompt)
+	command.Env = append(os.Environ(),
+		"FACTORY_CONFIG="+r.config.Path,
+		"FACTORY_EXECUTABLE="+r.executable,
+		"FACTORY_WORK_ID="+id,
+		"FACTORY_ROLE="+role,
+		"FACTORY_WORKSPACE="+directory,
+		"FACTORY_GITHUB_WRITES="+strconv.FormatBool(r.githubWrites),
+	)
+	var stdout, stderr bytes.Buffer
+	command.Stdout, command.Stderr = &stdout, &stderr
+	if err := command.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return stdout.Bytes(), fmt.Errorf("agent %q: %s", name, message)
+	}
+	return stdout.Bytes(), nil
+}
+
+func (r *agentRunner) foremanContext(item work) string {
+	command := fmt.Sprintf("%s internal --config %s --work %s", r.executable, shellQuote(r.config.Path), shellQuote(item.ID))
+	return fmt.Sprintf(`## Assignment
+
+Work ID: %s
+Issue: %s#%d
+Title: %s
+
+You can act only by running these commands with Bash:
+
+  %s delegate plan
+  %s publish-plan
+  %s delegate build
+  %s delegate verify
+  %s finish
+  %s block "reason"
+
+The delegate commands are synchronous. Their stdout is the child's natural-language report. Read it and decide what to do next.`, item.ID, item.Issue.Repository, item.Issue.Number, item.Issue.Title, command, command, command, command, command, command)
+}
+
+func (r *agentRunner) roleContext(item work, role string) string {
+	parts := []string{renderIssue(item.Issue)}
+	if plan, err := r.store.readArtifact(item.ID, "plan.md"); err == nil && role != "plan" {
+		parts = append(parts, "# Current plan\n\n"+string(plan))
+	}
+	if review, err := r.store.readArtifact(item.ID, "review.md"); err == nil && role == "build" {
+		parts = append(parts, "# Latest verification report\n\n"+string(review))
+	}
+	parts = append(parts, "# Run context\n\nRole: "+role+"\nCheckout: "+item.Workspace+"\nVerification run: "+strconv.Itoa(item.VerifyRuns+1))
+	return strings.Join(parts, "\n\n")
+}
+
+func shellQuote(value string) string { return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'" }
+
+func (r *agentRunner) publishPlan(ctx context.Context, id string) error {
+	item, err := r.store.get(id)
+	if err != nil {
+		return err
+	}
+	if item.State != stateRunning {
+		return fmt.Errorf("work is %s, not running", item.State)
+	}
+	plan, err := r.store.readArtifact(id, "plan.md")
+	if err != nil {
+		return errors.New("planner has not produced plan.md")
+	}
+	if r.githubWrites {
+		currentIssue, err := r.github.Issue(ctx, item.Issue.Repository, item.Issue.Number)
+		if err != nil {
+			return fmt.Errorf("refresh issue before publishing plan: %w", err)
+		}
+		body := managedPlanBody(currentIssue.Body, string(plan))
+		if err := r.github.UpdateIssueBody(ctx, currentIssue, body); err != nil {
+			return err
+		}
+		_, err = r.store.event(id, "issue body updated with plan")
+		return err
+	}
+	_, err = r.store.event(id, "dry run: plan retained locally; issue was not changed")
+	return err
+}
+
+func (r *agentRunner) finish(ctx context.Context, id string) error {
+	item, err := r.store.get(id)
+	if err != nil {
+		return err
+	}
+	if item.State != stateRunning {
+		return fmt.Errorf("work is %s, not running", item.State)
+	}
+	if item.VerifyRuns == 0 || item.VerifiedSHA == "" {
+		return errors.New("cannot finish before a successful verification in this attempt")
+	}
+	if err := ensureClean(ctx, item.Workspace); err != nil {
+		return fmt.Errorf("candidate changed after verification: %w", err)
+	}
+	shaOutput, err := commandOutput(ctx, item.Workspace, nil, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	sha := strings.TrimSpace(string(shaOutput))
+	if sha != item.VerifiedSHA {
+		return fmt.Errorf("candidate changed after verification: verified %s, current %s", item.VerifiedSHA, sha)
+	}
+	prURL := ""
+	if r.githubWrites {
+		repository, err := repositoryFor(r.config, item.Issue.Repository)
+		if err != nil {
+			return err
+		}
+		baseBranch := strings.TrimPrefix(repository.BaseRef, "origin/")
+		if err := pushBranch(ctx, item.Workspace, item.Branch); err != nil {
+			return err
+		}
+		plan, _ := r.store.readArtifact(id, "plan.md")
+		review, _ := r.store.readArtifact(id, "review.md")
+		body := fmt.Sprintf("Closes #%d\n\n## Plan\n\n%s\n\n## Verification\n\n%s", item.Issue.Number, plan, review)
+		prURL, err = r.github.OpenDraftPR(ctx, item.Issue, item.Branch, baseBranch, item.Issue.Title, body)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = r.store.update(id, func(current *work) error {
+		now := time.Now().UTC()
+		current.State = stateReady
+		current.ActiveRole = ""
+		current.HeadSHA = sha
+		current.PRURL = prURL
+		current.CompletedAt = now
+		message := "dry run ready; local branch retained"
+		if r.githubWrites {
+			message = "draft pull request opened"
+		}
+		current.Events = append(current.Events, event{At: now, Message: message})
+		return nil
+	})
+	return err
+}
+
+func (r *agentRunner) block(ctx context.Context, id, reason string) error {
+	if strings.TrimSpace(reason) == "" {
+		return errors.New("block reason is required")
+	}
+	item, err := r.store.get(id)
+	if err != nil {
+		return err
+	}
+	if item.State != stateRunning {
+		return fmt.Errorf("work is %s, not running", item.State)
+	}
+	if r.githubWrites {
+		if err := r.github.CommentIssue(ctx, item.Issue, "Factory blocked this ticket:\n\n"+reason); err != nil {
+			return err
+		}
+	}
+	_, err = r.store.update(id, func(item *work) error {
+		now := time.Now().UTC()
+		item.State = stateBlocked
+		item.ActiveRole = ""
+		item.Failure = reason
+		item.CompletedAt = now
+		item.Events = append(item.Events, event{At: now, Message: "blocked: " + reason})
+		return nil
+	})
+	return err
+}
+
+func managedPlanBody(issueBody, plan string) string {
+	const start = "<!-- factory-plan:start -->"
+	const end = "<!-- factory-plan:end -->"
+	block := start + "\n## Factory plan\n\n" + strings.TrimSpace(plan) + "\n" + end
+	startIndex := strings.Index(issueBody, start)
+	if startIndex >= 0 {
+		endOffset := strings.Index(issueBody[startIndex:], end)
+		if endOffset >= 0 {
+			endIndex := startIndex + endOffset + len(end)
+			return strings.TrimSpace(issueBody[:startIndex]+block+issueBody[endIndex:]) + "\n"
+		}
+	}
+	return strings.TrimSpace(issueBody) + "\n\n" + block + "\n"
+}
+
+func executablePath() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(path)
+}

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -375,7 +375,10 @@ func (r *agentRunner) publishPlan(ctx context.Context, id string) error {
 		if err != nil {
 			return fmt.Errorf("refresh issue before publishing plan: %w", err)
 		}
-		body := managedPlanBody(currentIssue.Body, string(plan))
+		body, err := managedPlanBody(currentIssue.Body, string(plan))
+		if err != nil {
+			return fmt.Errorf("prepare managed issue plan: %w", err)
+		}
 		if err := r.github.UpdateIssueBody(ctx, currentIssue, body); err != nil {
 			return err
 		}
@@ -471,19 +474,35 @@ func (r *agentRunner) block(ctx context.Context, id, reason string) error {
 	return err
 }
 
-func managedPlanBody(issueBody, plan string) string {
+func managedPlanBody(issueBody, plan string) (string, error) {
 	const start = "<!-- factory-plan:start -->"
 	const end = "<!-- factory-plan:end -->"
-	block := start + "\n## Factory plan\n\n" + strings.TrimSpace(plan) + "\n" + end
-	startIndex := strings.Index(issueBody, start)
-	if startIndex >= 0 {
-		endOffset := strings.Index(issueBody[startIndex:], end)
-		if endOffset >= 0 {
-			endIndex := startIndex + endOffset + len(end)
-			return strings.TrimSpace(issueBody[:startIndex]+block+issueBody[endIndex:]) + "\n"
-		}
+	if strings.Contains(plan, start) || strings.Contains(plan, end) {
+		return "", errors.New("plan contains reserved Factory plan markers")
 	}
-	return strings.TrimSpace(issueBody) + "\n\n" + block + "\n"
+	block := start + "\n## Factory plan\n\n" + strings.TrimSpace(plan) + "\n" + end
+	startCount := strings.Count(issueBody, start)
+	endCount := strings.Count(issueBody, end)
+	if startCount == 0 && endCount == 0 {
+		separator := ""
+		if issueBody != "" && !strings.HasSuffix(issueBody, "\n\n") {
+			separator = "\n\n"
+			if strings.HasSuffix(issueBody, "\n") {
+				separator = "\n"
+			}
+		}
+		return issueBody + separator + block + "\n", nil
+	}
+	if startCount != 1 || endCount != 1 {
+		return "", errors.New("issue body has incomplete or duplicate Factory plan markers")
+	}
+	startIndex := strings.Index(issueBody, start)
+	endIndex := strings.Index(issueBody, end)
+	if endIndex < startIndex {
+		return "", errors.New("issue body has Factory plan markers in the wrong order")
+	}
+	endIndex += len(end)
+	return issueBody[:startIndex] + block + issueBody[endIndex:], nil
 }
 
 func executablePath() (string, error) {

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -371,18 +371,10 @@ func (r *agentRunner) publishPlan(ctx context.Context, id string) error {
 		return errors.New("planner has not produced plan.md")
 	}
 	if r.githubWrites {
-		currentIssue, err := r.github.Issue(ctx, item.Issue.Repository, item.Issue.Number)
-		if err != nil {
-			return fmt.Errorf("refresh issue before publishing plan: %w", err)
-		}
-		body, err := managedPlanBody(currentIssue.Body, string(plan))
-		if err != nil {
-			return fmt.Errorf("prepare managed issue plan: %w", err)
-		}
-		if err := r.github.UpdateIssueBody(ctx, currentIssue, body); err != nil {
+		if err := r.github.CommentIssue(ctx, item.Issue, managedPlanComment(string(plan))); err != nil {
 			return err
 		}
-		_, err = r.store.event(id, "issue body updated with plan")
+		_, err = r.store.event(id, "plan published as issue comment")
 		return err
 	}
 	_, err = r.store.event(id, "dry run: plan retained locally; issue was not changed")
@@ -474,35 +466,8 @@ func (r *agentRunner) block(ctx context.Context, id, reason string) error {
 	return err
 }
 
-func managedPlanBody(issueBody, plan string) (string, error) {
-	const start = "<!-- factory-plan:start -->"
-	const end = "<!-- factory-plan:end -->"
-	if strings.Contains(plan, start) || strings.Contains(plan, end) {
-		return "", errors.New("plan contains reserved Factory plan markers")
-	}
-	block := start + "\n## Factory plan\n\n" + strings.TrimSpace(plan) + "\n" + end
-	startCount := strings.Count(issueBody, start)
-	endCount := strings.Count(issueBody, end)
-	if startCount == 0 && endCount == 0 {
-		separator := ""
-		if issueBody != "" && !strings.HasSuffix(issueBody, "\n\n") {
-			separator = "\n\n"
-			if strings.HasSuffix(issueBody, "\n") {
-				separator = "\n"
-			}
-		}
-		return issueBody + separator + block + "\n", nil
-	}
-	if startCount != 1 || endCount != 1 {
-		return "", errors.New("issue body has incomplete or duplicate Factory plan markers")
-	}
-	startIndex := strings.Index(issueBody, start)
-	endIndex := strings.Index(issueBody, end)
-	if endIndex < startIndex {
-		return "", errors.New("issue body has Factory plan markers in the wrong order")
-	}
-	endIndex += len(end)
-	return issueBody[:startIndex] + block + issueBody[endIndex:], nil
+func managedPlanComment(plan string) string {
+	return "<!-- factory-plan -->\n## Factory plan\n\n" + strings.TrimSpace(plan)
 }
 
 func executablePath() (string, error) {

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -101,6 +101,7 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 		if role == "verify" {
 			current.HeadSHA = item.HeadSHA
 			current.VerifyRuns++
+			current.VerifiedSHA = ""
 		}
 		current.Events = append(current.Events, event{At: time.Now().UTC(), Message: role + " agent started"})
 		return nil
@@ -138,6 +139,9 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 		current.ActiveRole = "foreman"
 		message := role + " agent completed"
 		if runErr != nil {
+			if role == "verify" {
+				current.VerifiedSHA = ""
+			}
 			message = role + " agent failed: " + runErr.Error()
 		} else if role == "verify" {
 			verdict, _ := verificationVerdict(output)

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -20,6 +20,7 @@ type agentRunner struct {
 	github       githubClient
 	githubWrites bool
 	executable   string
+	authToken    string
 }
 
 func (r *agentRunner) runWork(ctx context.Context, id string) error {
@@ -74,12 +75,7 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 	var agentName, directory, artifact string
 	switch role {
 	case "plan":
-		agentName = r.config.Config.Roles.Plan
-		repository, err := repositoryFor(r.config, item.Issue.Repository)
-		if err != nil {
-			return nil, err
-		}
-		directory, artifact = repository.Path, "plan.md"
+		agentName, directory, artifact = r.config.Config.Roles.Plan, item.Workspace, "plan.md"
 	case "build":
 		agentName, directory, artifact = r.config.Config.Roles.Build, item.Workspace, "build.md"
 	case "verify":
@@ -110,9 +106,14 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 		return nil
 	})
 	if err != nil {
+		if role == "verify" {
+			cleanupContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_ = removeVerificationWorkspace(cleanupContext, r.config, item, directory)
+			cancel()
+		}
 		return nil, err
 	}
-	prompt := r.config.Prompts[agentName] + "\n\n" + r.roleContext(item, role)
+	prompt := r.config.Prompts[agentName] + "\n\n" + r.roleContext(item, role, directory)
 	output, runErr := r.runAgent(ctx, agentName, directory, prompt, role, id)
 	if role == "verify" {
 		if verifyErr := ensureExactHead(ctx, directory, item.HeadSHA); verifyErr != nil && runErr == nil {
@@ -122,6 +123,12 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 			if _, verdictErr := verificationVerdict(output); verdictErr != nil {
 				runErr = verdictErr
 			}
+		}
+		cleanupContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		cleanupErr := removeVerificationWorkspace(cleanupContext, r.config, item, directory)
+		cancel()
+		if cleanupErr != nil {
+			runErr = errors.Join(runErr, cleanupErr)
 		}
 	}
 	if artifactErr := r.store.artifact(id, artifact, output); artifactErr != nil && runErr == nil {
@@ -189,7 +196,7 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 		if role == "foreman" {
 			args = append(args, "--tools", "Bash", "--allowedTools", "Bash("+r.executable+" internal *)")
 		} else if role == "plan" {
-			args = append(args, "--tools", "Read,Glob,Grep")
+			args = append(args, "--tools", "Read,Glob,Grep", "--allowedTools", "Read,Glob,Grep")
 		} else {
 			args = append(args, "--tools", "Read,Edit,Write,Glob,Grep,Bash", "--allowedTools", "Read,Edit,Write,Glob,Grep,Bash")
 		}
@@ -203,24 +210,44 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 	command.Dir = directory
 	configureAgentCommand(command)
 	command.Stdin = strings.NewReader(prompt)
-	command.Env = append(os.Environ(),
+	command.Env = append(withoutFactoryEnvironment(os.Environ()),
 		"FACTORY_CONFIG="+r.config.Path,
 		"FACTORY_EXECUTABLE="+r.executable,
 		"FACTORY_WORK_ID="+id,
 		"FACTORY_ROLE="+role,
 		"FACTORY_WORKSPACE="+directory,
-		"FACTORY_GITHUB_WRITES="+strconv.FormatBool(r.githubWrites),
 	)
+	if role == "foreman" {
+		command.Env = append(command.Env, "FACTORY_AUTH_TOKEN="+r.authToken)
+	}
 	var stdout, stderr bytes.Buffer
 	command.Stdout, command.Stderr = &stdout, &stderr
-	if err := command.Run(); err != nil {
+	runErr := command.Run()
+	cleanupErr := cleanupAgentCommand(command)
+	if runErr != nil {
 		message := strings.TrimSpace(stderr.String())
 		if message == "" {
-			message = err.Error()
+			message = runErr.Error()
+		}
+		if cleanupErr != nil {
+			message += "; process cleanup: " + cleanupErr.Error()
 		}
 		return stdout.Bytes(), fmt.Errorf("agent %q: %s", name, message)
 	}
+	if cleanupErr != nil {
+		return stdout.Bytes(), fmt.Errorf("agent %q process cleanup: %w", name, cleanupErr)
+	}
 	return stdout.Bytes(), nil
+}
+
+func withoutFactoryEnvironment(environment []string) []string {
+	filtered := make([]string, 0, len(environment))
+	for _, value := range environment {
+		if !strings.HasPrefix(value, "FACTORY_") {
+			filtered = append(filtered, value)
+		}
+	}
+	return filtered
 }
 
 func configureAgentCommand(command *exec.Cmd) {
@@ -247,8 +274,38 @@ func configureAgentCommand(command *exec.Cmd) {
 	command.WaitDelay = 2 * time.Second
 }
 
+func cleanupAgentCommand(command *exec.Cmd) error {
+	if command.Process == nil {
+		return nil
+	}
+	processGroup := -command.Process.Pid
+	err := syscall.Kill(processGroup, syscall.SIGTERM)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		err = syscall.Kill(processGroup, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	err = syscall.Kill(processGroup, syscall.SIGKILL)
+	if errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
+}
+
 func (r *agentRunner) foremanContext(item work) string {
-	command := fmt.Sprintf("%s internal --config %s --work %s", r.executable, shellQuote(r.config.Path), shellQuote(item.ID))
+	command := fmt.Sprintf("%s internal --config %s --work %s", shellQuote(r.executable), shellQuote(r.config.Path), shellQuote(item.ID))
 	return fmt.Sprintf(`## Assignment
 
 Work ID: %s
@@ -267,7 +324,7 @@ You can act only by running these commands with Bash:
 The delegate commands are synchronous. Their stdout is the child's natural-language report. Read it and decide what to do next.`, item.ID, item.Issue.Repository, item.Issue.Number, item.Issue.Title, command, command, command, command, command, command)
 }
 
-func (r *agentRunner) roleContext(item work, role string) string {
+func (r *agentRunner) roleContext(item work, role, directory string) string {
 	parts := []string{renderIssue(item.Issue)}
 	if plan, err := r.store.readArtifact(item.ID, "plan.md"); err == nil && role != "plan" {
 		parts = append(parts, "# Current plan\n\n"+string(plan))
@@ -275,7 +332,7 @@ func (r *agentRunner) roleContext(item work, role string) string {
 	if review, err := r.store.readArtifact(item.ID, "review.md"); err == nil && role == "build" {
 		parts = append(parts, "# Latest verification report\n\n"+string(review))
 	}
-	parts = append(parts, "# Run context\n\nRole: "+role+"\nCheckout: "+item.Workspace+"\nVerification run: "+strconv.Itoa(item.VerifyRuns+1))
+	parts = append(parts, "# Run context\n\nRole: "+role+"\nCheckout: "+directory+"\nVerification run: "+strconv.Itoa(item.VerifyRuns+1))
 	return strings.Join(parts, "\n\n")
 }
 

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -135,7 +135,7 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 	if artifactErr := r.store.artifact(id, artifact, output); artifactErr != nil && runErr == nil {
 		runErr = artifactErr
 	}
-	_, _ = r.store.update(id, func(current *work) error {
+	_, stateErr := r.store.update(id, func(current *work) error {
 		current.ActiveRole = "foreman"
 		message := role + " agent completed"
 		if runErr != nil {
@@ -156,6 +156,9 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 		current.Events = append(current.Events, event{At: time.Now().UTC(), Message: message})
 		return nil
 	})
+	if stateErr != nil {
+		runErr = errors.Join(runErr, fmt.Errorf("persist %s completion: %w", role, stateErr))
+	}
 	return output, runErr
 }
 
@@ -336,7 +339,11 @@ func (r *agentRunner) roleContext(item work, role, directory string) string {
 	if review, err := r.store.readArtifact(item.ID, "review.md"); err == nil && role == "build" {
 		parts = append(parts, "# Latest verification report\n\n"+string(review))
 	}
-	parts = append(parts, "# Run context\n\nRole: "+role+"\nCheckout: "+directory+"\nVerification run: "+strconv.Itoa(item.VerifyRuns+1))
+	verificationRun := item.VerifyRuns
+	if role != "verify" {
+		verificationRun++
+	}
+	parts = append(parts, "# Run context\n\nRole: "+role+"\nCheckout: "+directory+"\nVerification run: "+strconv.Itoa(verificationRun))
 	return strings.Join(parts, "\n\n")
 }
 

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -415,7 +415,7 @@ func (r *agentRunner) finish(ctx context.Context, id string) error {
 			return err
 		}
 		baseBranch := strings.TrimPrefix(repository.BaseRef, "origin/")
-		if err := pushBranch(ctx, item.Workspace, item.Branch); err != nil {
+		if err := pushBranch(ctx, item.Workspace, item.Branch, item.Issue.Repository); err != nil {
 			return err
 		}
 		plan, _ := r.store.readArtifact(id, "plan.md")

--- a/prototype/local-factory/agents.go
+++ b/prototype/local-factory/agents.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -117,6 +118,11 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 		if verifyErr := ensureExactHead(ctx, directory, item.HeadSHA); verifyErr != nil && runErr == nil {
 			runErr = verifyErr
 		}
+		if runErr == nil {
+			if _, verdictErr := verificationVerdict(output); verdictErr != nil {
+				runErr = verdictErr
+			}
+		}
 	}
 	if artifactErr := r.store.artifact(id, artifact, output); artifactErr != nil && runErr == nil {
 		runErr = artifactErr
@@ -127,12 +133,38 @@ func (r *agentRunner) delegate(ctx context.Context, id, role string) ([]byte, er
 		if runErr != nil {
 			message = role + " agent failed: " + runErr.Error()
 		} else if role == "verify" {
-			current.VerifiedSHA = current.HeadSHA
+			verdict, _ := verificationVerdict(output)
+			if verdict == "PASS" {
+				current.VerifiedSHA = current.HeadSHA
+				message = "verify agent passed candidate"
+			} else {
+				current.VerifiedSHA = ""
+				message = "verify agent requested revision"
+			}
 		}
 		current.Events = append(current.Events, event{At: time.Now().UTC(), Message: message})
 		return nil
 	})
 	return output, runErr
+}
+
+func verificationVerdict(output []byte) (string, error) {
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return "", errors.New("verifier returned an empty report")
+	}
+	firstLine := trimmed
+	if newline := strings.IndexByte(firstLine, '\n'); newline >= 0 {
+		firstLine = firstLine[:newline]
+	}
+	switch strings.TrimSpace(firstLine) {
+	case "Verdict: PASS":
+		return "PASS", nil
+	case "Verdict: REVISE":
+		return "REVISE", nil
+	default:
+		return "", errors.New("verifier report must begin with Verdict: PASS or Verdict: REVISE")
+	}
 }
 
 func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, role, id string) ([]byte, error) {
@@ -169,6 +201,7 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 		return nil, fmt.Errorf("unsupported runtime %q", agent.Runtime)
 	}
 	command.Dir = directory
+	configureAgentCommand(command)
 	command.Stdin = strings.NewReader(prompt)
 	command.Env = append(os.Environ(),
 		"FACTORY_CONFIG="+r.config.Path,
@@ -188,6 +221,30 @@ func (r *agentRunner) runAgent(ctx context.Context, name, directory, prompt, rol
 		return stdout.Bytes(), fmt.Errorf("agent %q: %s", name, message)
 	}
 	return stdout.Bytes(), nil
+}
+
+func configureAgentCommand(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.Cancel = func() error {
+		if command.Process == nil {
+			return nil
+		}
+		processGroup := -command.Process.Pid
+		err := syscall.Kill(processGroup, syscall.SIGTERM)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		if err == nil {
+			go func() {
+				timer := time.NewTimer(time.Second)
+				defer timer.Stop()
+				<-timer.C
+				_ = syscall.Kill(processGroup, syscall.SIGKILL)
+			}()
+		}
+		return err
+	}
+	command.WaitDelay = 2 * time.Second
 }
 
 func (r *agentRunner) foremanContext(item work) string {

--- a/prototype/local-factory/config.go
+++ b/prototype/local-factory/config.go
@@ -39,6 +39,7 @@ type agentConfig struct {
 	Runtime string   `toml:"runtime"`
 	Model   string   `toml:"model"`
 	Prompt  string   `toml:"prompt"`
+	Timeout string   `toml:"timeout"`
 	Command []string `toml:"command"`
 }
 
@@ -180,6 +181,15 @@ func validateConfig(value config) error {
 		if agent.Prompt == "" {
 			return fmt.Errorf("agent %q prompt is required", name)
 		}
+		if agent.Timeout != "" {
+			timeout, err := time.ParseDuration(agent.Timeout)
+			if err != nil {
+				return fmt.Errorf("agent %q timeout: %w", name, err)
+			}
+			if timeout <= 0 {
+				return fmt.Errorf("agent %q timeout must be greater than zero", name)
+			}
+		}
 		switch agent.Runtime {
 		case "claude", "codex":
 			if len(agent.Command) != 0 {
@@ -192,6 +202,9 @@ func validateConfig(value config) error {
 		default:
 			return fmt.Errorf("agent %q runtime must be claude, codex, or command", name)
 		}
+	}
+	if value.Agents[value.Roles.Foreman].Runtime == "codex" {
+		return errors.New("roles.foreman cannot use runtime=codex in V1 because the read-only sandbox cannot reach Factory's loopback control API")
 	}
 	return nil
 }

--- a/prototype/local-factory/config.go
+++ b/prototype/local-factory/config.go
@@ -70,6 +70,9 @@ func loadConfig(path string) (loadedConfig, error) {
 	if undecoded := metadata.Undecoded(); len(undecoded) != 0 {
 		return loadedConfig{}, fmt.Errorf("decode config: unknown field %q", undecoded[0])
 	}
+	for index := range value.Repositories {
+		value.Repositories[index].GitHub = strings.TrimSpace(value.Repositories[index].GitHub)
+	}
 	if err := validateConfig(value); err != nil {
 		return loadedConfig{}, err
 	}
@@ -144,7 +147,6 @@ func validateConfig(value config) error {
 	}
 	seenRepositories := make(map[string]struct{}, len(value.Repositories))
 	for index, repository := range value.Repositories {
-		repository.GitHub = strings.TrimSpace(repository.GitHub)
 		if !validRepositoryName(repository.GitHub) {
 			return fmt.Errorf("repositories[%d].github must use owner/repository format", index)
 		}

--- a/prototype/local-factory/config.go
+++ b/prototype/local-factory/config.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+type config struct {
+	Version        int                    `toml:"version"`
+	StateDirectory string                 `toml:"state_directory"`
+	MaxRevisions   int                    `toml:"max_revisions"`
+	Server         serverConfig           `toml:"server"`
+	Repositories   []repositoryConfig     `toml:"repositories"`
+	Agents         map[string]agentConfig `toml:"agents"`
+	Roles          roleConfig             `toml:"roles"`
+}
+
+type serverConfig struct {
+	Listen        string `toml:"listen"`
+	PollEvery     string `toml:"poll_every"`
+	TriggerLabel  string `toml:"trigger_label"`
+	MaxConcurrent int    `toml:"max_concurrent"`
+}
+
+type repositoryConfig struct {
+	GitHub  string `toml:"github"`
+	Path    string `toml:"path"`
+	BaseRef string `toml:"base_ref"`
+}
+
+type agentConfig struct {
+	Runtime string   `toml:"runtime"`
+	Model   string   `toml:"model"`
+	Prompt  string   `toml:"prompt"`
+	Command []string `toml:"command"`
+}
+
+type roleConfig struct {
+	Foreman string `toml:"foreman"`
+	Plan    string `toml:"plan"`
+	Build   string `toml:"build"`
+	Verify  string `toml:"verify"`
+}
+
+type loadedConfig struct {
+	Path      string
+	Directory string
+	Config    config
+	Prompts   map[string]string
+}
+
+func loadConfig(path string) (loadedConfig, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return loadedConfig{}, fmt.Errorf("resolve config path: %w", err)
+	}
+
+	var value config
+	metadata, err := toml.DecodeFile(abs, &value)
+	if err != nil {
+		return loadedConfig{}, fmt.Errorf("decode config: %w", err)
+	}
+	if undecoded := metadata.Undecoded(); len(undecoded) != 0 {
+		return loadedConfig{}, fmt.Errorf("decode config: unknown field %q", undecoded[0])
+	}
+	if err := validateConfig(value); err != nil {
+		return loadedConfig{}, err
+	}
+
+	directory := filepath.Dir(abs)
+	prompts := make(map[string]string, len(value.Agents))
+	for name, agent := range value.Agents {
+		promptPath, err := resolveBeneath(directory, agent.Prompt)
+		if err != nil {
+			return loadedConfig{}, fmt.Errorf("agent %q prompt: %w", name, err)
+		}
+		body, err := os.ReadFile(promptPath)
+		if err != nil {
+			return loadedConfig{}, fmt.Errorf("read agent %q prompt: %w", name, err)
+		}
+		if strings.TrimSpace(string(body)) == "" {
+			return loadedConfig{}, fmt.Errorf("agent %q prompt is empty", name)
+		}
+		prompts[name] = string(body)
+	}
+
+	if value.StateDirectory == "" {
+		value.StateDirectory = filepath.Join(directory, ".state")
+	} else if !filepath.IsAbs(value.StateDirectory) {
+		value.StateDirectory = filepath.Join(directory, value.StateDirectory)
+	}
+	value.StateDirectory = filepath.Clean(value.StateDirectory)
+
+	return loadedConfig{
+		Path:      abs,
+		Directory: directory,
+		Config:    value,
+		Prompts:   prompts,
+	}, nil
+}
+
+func validateConfig(value config) error {
+	if value.Version != 1 {
+		return fmt.Errorf("config version must be 1, got %d", value.Version)
+	}
+	if value.MaxRevisions < 0 || value.MaxRevisions > 5 {
+		return errors.New("max_revisions must be between 0 and 5")
+	}
+	if value.Server.Listen == "" {
+		return errors.New("server.listen is required")
+	}
+	host, _, err := net.SplitHostPort(value.Server.Listen)
+	if err != nil {
+		return fmt.Errorf("server.listen: %w", err)
+	}
+	if host != "localhost" && host != "127.0.0.1" && host != "::1" {
+		return errors.New("server.listen must use localhost, 127.0.0.1, or ::1 in this local spike")
+	}
+	if value.Server.PollEvery == "" {
+		return errors.New("server.poll_every is required")
+	}
+	pollEvery, err := time.ParseDuration(value.Server.PollEvery)
+	if err != nil {
+		return fmt.Errorf("server.poll_every: %w", err)
+	}
+	if pollEvery <= 0 {
+		return errors.New("server.poll_every must be greater than zero")
+	}
+	if value.Server.TriggerLabel == "" {
+		return errors.New("server.trigger_label is required")
+	}
+	if value.Server.MaxConcurrent < 1 || value.Server.MaxConcurrent > 16 {
+		return errors.New("server.max_concurrent must be between 1 and 16")
+	}
+	if len(value.Repositories) == 0 {
+		return errors.New("at least one [[repositories]] entry is required")
+	}
+	seenRepositories := make(map[string]struct{}, len(value.Repositories))
+	for index, repository := range value.Repositories {
+		repository.GitHub = strings.TrimSpace(repository.GitHub)
+		if !validRepositoryName(repository.GitHub) {
+			return fmt.Errorf("repositories[%d].github must use owner/repository format", index)
+		}
+		if repository.Path == "" {
+			return fmt.Errorf("repositories[%d].path is required", index)
+		}
+		if strings.TrimSpace(repository.BaseRef) == "" || strings.HasPrefix(repository.BaseRef, "-") {
+			return fmt.Errorf("repositories[%d].base_ref is required and must be a Git ref", index)
+		}
+		key := strings.ToLower(repository.GitHub)
+		if _, exists := seenRepositories[key]; exists {
+			return fmt.Errorf("repository %q is configured more than once", repository.GitHub)
+		}
+		seenRepositories[key] = struct{}{}
+	}
+	roles := map[string]string{
+		"foreman": value.Roles.Foreman,
+		"plan":    value.Roles.Plan,
+		"build":   value.Roles.Build,
+		"verify":  value.Roles.Verify,
+	}
+	for role, name := range roles {
+		if name == "" {
+			return fmt.Errorf("roles.%s is required", role)
+		}
+		if _, ok := value.Agents[name]; !ok {
+			return fmt.Errorf("roles.%s references unknown agent %q", role, name)
+		}
+	}
+	for name, agent := range value.Agents {
+		if agent.Prompt == "" {
+			return fmt.Errorf("agent %q prompt is required", name)
+		}
+		switch agent.Runtime {
+		case "claude", "codex":
+			if len(agent.Command) != 0 {
+				return fmt.Errorf("agent %q command is allowed only for runtime=command", name)
+			}
+		case "command":
+			if len(agent.Command) == 0 || strings.TrimSpace(agent.Command[0]) == "" {
+				return fmt.Errorf("agent %q command is required for runtime=command", name)
+			}
+		default:
+			return fmt.Errorf("agent %q runtime must be claude, codex, or command", name)
+		}
+	}
+	return nil
+}
+
+func validRepositoryName(value string) bool {
+	parts := strings.Split(value, "/")
+	return len(parts) == 2 && parts[0] != "" && parts[1] != "" &&
+		!strings.ContainsAny(value, "#?\\")
+}
+
+func resolveBeneath(root, path string) (string, error) {
+	if path == "" {
+		return "", errors.New("path is required")
+	}
+	joined := path
+	if !filepath.IsAbs(joined) {
+		joined = filepath.Join(root, joined)
+	}
+	abs, err := filepath.Abs(joined)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(root, abs)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("path escapes the config directory")
+	}
+	return abs, nil
+}

--- a/prototype/local-factory/config.go
+++ b/prototype/local-factory/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -120,12 +121,16 @@ func validateConfig(value config) error {
 	if value.Server.Listen == "" {
 		return errors.New("server.listen is required")
 	}
-	host, _, err := net.SplitHostPort(value.Server.Listen)
+	host, port, err := net.SplitHostPort(value.Server.Listen)
 	if err != nil {
 		return fmt.Errorf("server.listen: %w", err)
 	}
 	if host != "localhost" && host != "127.0.0.1" && host != "::1" {
 		return errors.New("server.listen must use localhost, 127.0.0.1, or ::1 in this local spike")
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return errors.New("server.listen must use a numeric port between 1 and 65535")
 	}
 	if value.Server.PollEvery == "" {
 		return errors.New("server.poll_every is required")

--- a/prototype/local-factory/git.go
+++ b/prototype/local-factory/git.go
@@ -33,7 +33,21 @@ func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string,
 	}
 	workspace := filepath.Join(cfg.Config.StateDirectory, "checkouts", item.ID, fmt.Sprintf("attempt-%d", item.Attempt), "work")
 	branch := fmt.Sprintf("factory/%s-attempt-%d", item.ID, item.Attempt)
+	if strings.HasPrefix(repository.BaseRef, "origin/") {
+		remoteBranch := strings.TrimPrefix(repository.BaseRef, "origin/")
+		if _, err := commandOutput(ctx, repository.Path, nil, "git", "fetch", "origin", remoteBranch); err != nil {
+			return "", "", fmt.Errorf("fetch base branch: %w", err)
+		}
+	}
+	baseOutput, err := commandOutput(ctx, repository.Path, nil, "git", "rev-parse", "--verify", repository.BaseRef+"^{commit}")
+	if err != nil {
+		return "", "", fmt.Errorf("resolve base_ref %q: %w", repository.BaseRef, err)
+	}
+	baseSHA := strings.TrimSpace(string(baseOutput))
 	if _, err := os.Stat(workspace); err == nil {
+		if err := validateReusableWorkspace(ctx, workspace, branch, baseSHA); err != nil {
+			return "", "", fmt.Errorf("existing attempt workspace is not safe to reuse: %w", err)
+		}
 		return workspace, branch, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", "", err
@@ -41,19 +55,54 @@ func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string,
 	if err := os.MkdirAll(filepath.Dir(workspace), 0o755); err != nil {
 		return "", "", err
 	}
-	if strings.HasPrefix(repository.BaseRef, "origin/") {
-		remoteBranch := strings.TrimPrefix(repository.BaseRef, "origin/")
-		if _, err := commandOutput(ctx, repository.Path, nil, "git", "fetch", "origin", remoteBranch); err != nil {
-			return "", "", fmt.Errorf("fetch base branch: %w", err)
-		}
-	}
-	if _, err := commandOutput(ctx, repository.Path, nil, "git", "rev-parse", "--verify", repository.BaseRef+"^{commit}"); err != nil {
-		return "", "", fmt.Errorf("resolve base_ref %q: %w", repository.BaseRef, err)
-	}
-	if _, err := commandOutput(ctx, repository.Path, nil, "git", "worktree", "add", "-b", branch, workspace, repository.BaseRef); err != nil {
+	if _, err := commandOutput(ctx, repository.Path, nil, "git", "worktree", "add", "-b", branch, workspace, baseSHA); err != nil {
 		return "", "", fmt.Errorf("create worktree: %w", err)
 	}
 	return workspace, branch, nil
+}
+
+func validateReusableWorkspace(ctx context.Context, workspace, expectedBranch, expectedSHA string) error {
+	topLevel, err := commandOutput(ctx, workspace, nil, "git", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return err
+	}
+	actualTopLevel, err := filepath.Abs(strings.TrimSpace(string(topLevel)))
+	if err != nil {
+		return err
+	}
+	expectedTopLevel, err := filepath.Abs(workspace)
+	if err != nil {
+		return err
+	}
+	actualTopLevel, err = filepath.EvalSymlinks(actualTopLevel)
+	if err != nil {
+		return err
+	}
+	expectedTopLevel, err = filepath.EvalSymlinks(expectedTopLevel)
+	if err != nil {
+		return err
+	}
+	if filepath.Clean(actualTopLevel) != filepath.Clean(expectedTopLevel) {
+		return fmt.Errorf("checkout root is %q, expected %q", actualTopLevel, expectedTopLevel)
+	}
+	branch, err := commandOutput(ctx, workspace, nil, "git", "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		return err
+	}
+	if actualBranch := strings.TrimSpace(string(branch)); actualBranch != expectedBranch {
+		return fmt.Errorf("branch is %q, expected %q", actualBranch, expectedBranch)
+	}
+	head, err := commandOutput(ctx, workspace, nil, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	if actualSHA := strings.TrimSpace(string(head)); actualSHA != expectedSHA {
+		return fmt.Errorf("HEAD is %s, expected base %s", actualSHA, expectedSHA)
+	}
+	if err := ensureClean(ctx, workspace); err != nil {
+		return err
+	}
+	return nil
 }
 
 func checkpoint(ctx context.Context, workspace, message string) (string, error) {
@@ -86,6 +135,17 @@ func prepareVerificationWorkspace(ctx context.Context, cfg loadedConfig, item wo
 		return "", fmt.Errorf("create verification worktree: %w", err)
 	}
 	return workspace, nil
+}
+
+func removeVerificationWorkspace(ctx context.Context, cfg loadedConfig, item work, workspace string) error {
+	repository, err := repositoryFor(cfg, item.Issue.Repository)
+	if err != nil {
+		return err
+	}
+	if _, err := commandOutput(ctx, repository.Path, nil, "git", "worktree", "remove", "--force", workspace); err != nil {
+		return fmt.Errorf("remove verification worktree: %w", err)
+	}
+	return nil
 }
 
 func pushBranch(ctx context.Context, workspace, branch string) error {

--- a/prototype/local-factory/git.go
+++ b/prototype/local-factory/git.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func repositoryFor(cfg loadedConfig, name string) (repositoryConfig, error) {
+	for _, repository := range cfg.Config.Repositories {
+		if strings.EqualFold(repository.GitHub, name) {
+			path := repository.Path
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(cfg.Directory, path)
+			}
+			repository.Path = filepath.Clean(path)
+			return repository, nil
+		}
+	}
+	return repositoryConfig{}, fmt.Errorf("repository %q is not configured", name)
+}
+
+func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string, string, error) {
+	repository, err := repositoryFor(cfg, item.Issue.Repository)
+	if err != nil {
+		return "", "", err
+	}
+	if _, err := os.Stat(filepath.Join(repository.Path, ".git")); err != nil {
+		return "", "", fmt.Errorf("repository path %q is not a git checkout", repository.Path)
+	}
+	workspace := filepath.Join(cfg.Config.StateDirectory, "checkouts", item.ID, "work")
+	branch := "factory/" + item.ID
+	if _, err := os.Stat(workspace); err == nil {
+		return workspace, branch, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(workspace), 0o755); err != nil {
+		return "", "", err
+	}
+	if strings.HasPrefix(repository.BaseRef, "origin/") {
+		remoteBranch := strings.TrimPrefix(repository.BaseRef, "origin/")
+		if _, err := commandOutput(ctx, repository.Path, nil, "git", "fetch", "origin", remoteBranch); err != nil {
+			return "", "", fmt.Errorf("fetch base branch: %w", err)
+		}
+	}
+	if _, err := commandOutput(ctx, repository.Path, nil, "git", "rev-parse", "--verify", repository.BaseRef+"^{commit}"); err != nil {
+		return "", "", fmt.Errorf("resolve base_ref %q: %w", repository.BaseRef, err)
+	}
+	if _, err := commandOutput(ctx, repository.Path, nil, "git", "worktree", "add", "-b", branch, workspace, repository.BaseRef); err != nil {
+		return "", "", fmt.Errorf("create worktree: %w", err)
+	}
+	return workspace, branch, nil
+}
+
+func checkpoint(ctx context.Context, workspace, message string) (string, error) {
+	if _, err := commandOutput(ctx, workspace, nil, "git", "add", "--all"); err != nil {
+		return "", err
+	}
+	changed, err := commandOutput(ctx, workspace, nil, "git", "status", "--porcelain")
+	if err != nil {
+		return "", err
+	}
+	if len(changed) != 0 {
+		if _, err := commandOutput(ctx, workspace, nil, "git", "-c", "user.name=Factory", "-c", "user.email=factory@localhost", "commit", "-m", message); err != nil {
+			return "", err
+		}
+	}
+	sha, err := commandOutput(ctx, workspace, nil, "git", "rev-parse", "HEAD")
+	return strings.TrimSpace(string(sha)), err
+}
+
+func prepareVerificationWorkspace(ctx context.Context, cfg loadedConfig, item work, sha string) (string, error) {
+	repository, err := repositoryFor(cfg, item.Issue.Repository)
+	if err != nil {
+		return "", err
+	}
+	workspace := filepath.Join(cfg.Config.StateDirectory, "checkouts", item.ID, "verify", fmt.Sprintf("attempt-%d-run-%d", item.Attempt, item.VerifyRuns+1))
+	if err := os.MkdirAll(filepath.Dir(workspace), 0o755); err != nil {
+		return "", err
+	}
+	if _, err := commandOutput(ctx, repository.Path, nil, "git", "worktree", "add", "--detach", workspace, sha); err != nil {
+		return "", fmt.Errorf("create verification worktree: %w", err)
+	}
+	return workspace, nil
+}
+
+func pushBranch(ctx context.Context, workspace, branch string) error {
+	_, err := commandOutput(ctx, workspace, nil, "git", "push", "--set-upstream", "origin", branch)
+	return err
+}
+
+func ensureClean(ctx context.Context, workspace string) error {
+	output, err := commandOutput(ctx, workspace, nil, "git", "status", "--porcelain")
+	if err != nil {
+		return err
+	}
+	if len(output) != 0 {
+		return errors.New("verifier changed the checkout; verification agents must not modify product files")
+	}
+	return nil
+}
+
+func ensureExactHead(ctx context.Context, workspace, expectedSHA string) error {
+	if err := ensureClean(ctx, workspace); err != nil {
+		return err
+	}
+	output, err := commandOutput(ctx, workspace, nil, "git", "rev-parse", "HEAD")
+	if err != nil {
+		return err
+	}
+	actualSHA := strings.TrimSpace(string(output))
+	if actualSHA != expectedSHA {
+		return fmt.Errorf("checkout HEAD changed during verification: expected %s, got %s", expectedSHA, actualSHA)
+	}
+	return nil
+}

--- a/prototype/local-factory/git.go
+++ b/prototype/local-factory/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -174,9 +175,42 @@ func removeVerificationWorkspace(ctx context.Context, cfg loadedConfig, item wor
 	return nil
 }
 
-func pushBranch(ctx context.Context, workspace, branch string) error {
-	_, err := commandOutput(ctx, workspace, nil, "git", "push", "--set-upstream", "origin", branch)
+func pushBranch(ctx context.Context, workspace, branch, expectedRepository string) error {
+	remoteOutput, err := commandOutput(ctx, workspace, nil, "git", "remote", "get-url", "--push", "origin")
+	if err != nil {
+		return fmt.Errorf("resolve origin push URL: %w", err)
+	}
+	actualRepository, err := githubRepositoryFromRemote(strings.TrimSpace(string(remoteOutput)))
+	if err != nil {
+		return fmt.Errorf("validate origin push URL: %w", err)
+	}
+	if !strings.EqualFold(actualRepository, expectedRepository) {
+		return fmt.Errorf("origin points to GitHub repository %q, expected %q", actualRepository, expectedRepository)
+	}
+	remote := strings.TrimSpace(string(remoteOutput))
+	refspec := "refs/heads/" + branch + ":refs/heads/" + branch
+	_, err = commandOutput(ctx, workspace, nil, "git", "push", remote, refspec)
 	return err
+}
+
+func githubRepositoryFromRemote(remote string) (string, error) {
+	var repositoryPath string
+	const scpPrefix = "git@github.com:"
+	if len(remote) >= len(scpPrefix) && strings.EqualFold(remote[:len(scpPrefix)], scpPrefix) {
+		repositoryPath = remote[len(scpPrefix):]
+	} else {
+		remoteURL, err := url.Parse(remote)
+		if err != nil || !strings.EqualFold(remoteURL.Hostname(), "github.com") || remoteURL.RawQuery != "" || remoteURL.Fragment != "" {
+			return "", errors.New("origin push URL is not a GitHub repository")
+		}
+		repositoryPath = remoteURL.Path
+	}
+	repositoryPath = strings.TrimSuffix(strings.Trim(strings.TrimSpace(repositoryPath), "/"), ".git")
+	parts := strings.Split(repositoryPath, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", errors.New("origin push URL must identify one GitHub owner and repository")
+	}
+	return parts[0] + "/" + parts[1], nil
 }
 
 func ensureClean(ctx context.Context, workspace string) error {

--- a/prototype/local-factory/git.go
+++ b/prototype/local-factory/git.go
@@ -55,15 +55,82 @@ func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string,
 		return "", "", err
 	}
 	if _, err := commandOutput(ctx, repository.Path, nil, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err == nil {
-		return "", "", fmt.Errorf("candidate branch %q already exists without a reusable attempt workspace; refusing to delete it", branch)
+		if !workspaceIntentMatches(workspace, repository.Path, branch, baseSHA) {
+			return "", "", fmt.Errorf("candidate branch %q already exists without a reusable attempt workspace; refusing to delete it", branch)
+		}
+		branchOutput, err := commandOutput(ctx, repository.Path, nil, "git", "rev-parse", "refs/heads/"+branch)
+		if err != nil {
+			return "", "", fmt.Errorf("resolve recoverable candidate branch: %w", err)
+		}
+		if branchSHA := strings.TrimSpace(string(branchOutput)); branchSHA != baseSHA {
+			return "", "", fmt.Errorf("recoverable candidate branch %q points to %s, expected base %s", branch, branchSHA, baseSHA)
+		}
+		if _, err := commandOutput(ctx, repository.Path, nil, "git", "worktree", "add", workspace, branch); err != nil {
+			return "", "", fmt.Errorf("recover candidate worktree: %w", err)
+		}
+		return workspace, branch, nil
 	}
 	if err := os.MkdirAll(filepath.Dir(workspace), 0o755); err != nil {
+		return "", "", err
+	}
+	if err := writeWorkspaceIntent(workspace, repository.Path, branch, baseSHA); err != nil {
 		return "", "", err
 	}
 	if _, err := commandOutput(ctx, repository.Path, nil, "git", "worktree", "add", "-b", branch, workspace, baseSHA); err != nil {
 		return "", "", fmt.Errorf("create worktree: %w", err)
 	}
 	return workspace, branch, nil
+}
+
+func workspaceIntentBody(repository, workspace, branch, baseSHA string) []byte {
+	return []byte(strings.Join([]string{repository, workspace, branch, baseSHA}, "\n") + "\n")
+}
+
+func workspaceIntentPath(workspace string) string {
+	return filepath.Join(filepath.Dir(workspace), ".workspace-intent")
+}
+
+func workspaceIntentMatches(workspace, repository, branch, baseSHA string) bool {
+	body, err := os.ReadFile(workspaceIntentPath(workspace))
+	return err == nil && string(body) == string(workspaceIntentBody(repository, workspace, branch, baseSHA))
+}
+
+func writeWorkspaceIntent(workspace, repository, branch, baseSHA string) error {
+	path := workspaceIntentPath(workspace)
+	expected := workspaceIntentBody(repository, workspace, branch, baseSHA)
+	if body, err := os.ReadFile(path); err == nil {
+		if string(body) != string(expected) {
+			return fmt.Errorf("workspace intent %q does not match this attempt", path)
+		}
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".workspace-intent-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(expected); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return err
+	}
+	return nil
 }
 
 func validateReusableWorkspace(ctx context.Context, workspace, expectedBranch, expectedSHA string) error {

--- a/prototype/local-factory/git.go
+++ b/prototype/local-factory/git.go
@@ -153,7 +153,7 @@ func removeVerificationWorkspace(ctx context.Context, cfg loadedConfig, item wor
 	return nil
 }
 
-func pushBranch(ctx context.Context, workspace, branch, expectedRepository string) error {
+func pushBranch(ctx context.Context, workspace, branch, verifiedSHA, expectedRepository string) error {
 	remoteOutput, err := commandOutput(ctx, workspace, nil, "git", "remote", "get-url", "--push", "origin")
 	if err != nil {
 		return fmt.Errorf("resolve origin push URL: %w", err)
@@ -166,9 +166,27 @@ func pushBranch(ctx context.Context, workspace, branch, expectedRepository strin
 		return fmt.Errorf("origin points to GitHub repository %q, expected %q", actualRepository, expectedRepository)
 	}
 	remote := strings.TrimSpace(string(remoteOutput))
-	refspec := "refs/heads/" + branch + ":refs/heads/" + branch
+	refspec := verifiedSHA + ":refs/heads/" + branch
 	_, err = commandOutput(ctx, workspace, nil, "git", "push", remote, refspec)
 	return err
+}
+
+func ensureCandidateBranch(ctx context.Context, workspace, expectedBranch, expectedSHA string) error {
+	branchOutput, err := commandOutput(ctx, workspace, nil, "git", "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		return fmt.Errorf("candidate checkout must remain on Factory branch %q: %w", expectedBranch, err)
+	}
+	if actualBranch := strings.TrimSpace(string(branchOutput)); actualBranch != expectedBranch {
+		return fmt.Errorf("candidate checkout is on branch %q, expected Factory branch %q", actualBranch, expectedBranch)
+	}
+	branchSHAOutput, err := commandOutput(ctx, workspace, nil, "git", "rev-parse", "refs/heads/"+expectedBranch)
+	if err != nil {
+		return fmt.Errorf("resolve candidate branch: %w", err)
+	}
+	if branchSHA := strings.TrimSpace(string(branchSHAOutput)); branchSHA != expectedSHA {
+		return fmt.Errorf("candidate branch points to %s, expected verified SHA %s", branchSHA, expectedSHA)
+	}
+	return nil
 }
 
 func githubRepositoryFromRemote(remote string) (string, error) {

--- a/prototype/local-factory/git.go
+++ b/prototype/local-factory/git.go
@@ -45,12 +45,22 @@ func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string,
 	}
 	baseSHA := strings.TrimSpace(string(baseOutput))
 	if _, err := os.Stat(workspace); err == nil {
-		if err := validateReusableWorkspace(ctx, workspace, branch, baseSHA); err != nil {
-			return "", "", fmt.Errorf("existing attempt workspace is not safe to reuse: %w", err)
+		if validationErr := validateReusableWorkspace(ctx, workspace, branch, baseSHA); validationErr != nil {
+			if item.Workspace != "" || item.Branch != "" || item.HeadSHA != "" {
+				return "", "", fmt.Errorf("existing attempt workspace is not safe to reuse: %w", validationErr)
+			}
+			if err := cleanupPartialAttemptWorkspace(ctx, repository.Path, workspace, branch); err != nil {
+				return "", "", fmt.Errorf("recover partial attempt workspace: %w", err)
+			}
+		} else {
+			return workspace, branch, nil
 		}
-		return workspace, branch, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", "", err
+	} else if item.Workspace == "" && item.Branch == "" && item.HeadSHA == "" {
+		if err := cleanupPartialAttemptWorkspace(ctx, repository.Path, workspace, branch); err != nil {
+			return "", "", fmt.Errorf("recover partial attempt registration: %w", err)
+		}
 	}
 	if err := os.MkdirAll(filepath.Dir(workspace), 0o755); err != nil {
 		return "", "", err
@@ -59,6 +69,22 @@ func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string,
 		return "", "", fmt.Errorf("create worktree: %w", err)
 	}
 	return workspace, branch, nil
+}
+
+func cleanupPartialAttemptWorkspace(ctx context.Context, repositoryPath, workspace, branch string) error {
+	_, _ = commandOutput(ctx, repositoryPath, nil, "git", "worktree", "remove", "--force", workspace)
+	if err := os.RemoveAll(workspace); err != nil {
+		return err
+	}
+	if _, err := commandOutput(ctx, repositoryPath, nil, "git", "worktree", "prune"); err != nil {
+		return err
+	}
+	if _, err := commandOutput(ctx, repositoryPath, nil, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err == nil {
+		if _, err := commandOutput(ctx, repositoryPath, nil, "git", "branch", "-D", branch); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateReusableWorkspace(ctx context.Context, workspace, expectedBranch, expectedSHA string) error {

--- a/prototype/local-factory/git.go
+++ b/prototype/local-factory/git.go
@@ -47,21 +47,15 @@ func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string,
 	baseSHA := strings.TrimSpace(string(baseOutput))
 	if _, err := os.Stat(workspace); err == nil {
 		if validationErr := validateReusableWorkspace(ctx, workspace, branch, baseSHA); validationErr != nil {
-			if item.Workspace != "" || item.Branch != "" || item.HeadSHA != "" {
-				return "", "", fmt.Errorf("existing attempt workspace is not safe to reuse: %w", validationErr)
-			}
-			if err := cleanupPartialAttemptWorkspace(ctx, repository.Path, workspace, branch); err != nil {
-				return "", "", fmt.Errorf("recover partial attempt workspace: %w", err)
-			}
+			return "", "", fmt.Errorf("existing attempt workspace is not safe to reuse: %w", validationErr)
 		} else {
 			return workspace, branch, nil
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", "", err
-	} else if item.Workspace == "" && item.Branch == "" && item.HeadSHA == "" {
-		if err := cleanupPartialAttemptWorkspace(ctx, repository.Path, workspace, branch); err != nil {
-			return "", "", fmt.Errorf("recover partial attempt registration: %w", err)
-		}
+	}
+	if _, err := commandOutput(ctx, repository.Path, nil, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err == nil {
+		return "", "", fmt.Errorf("candidate branch %q already exists without a reusable attempt workspace; refusing to delete it", branch)
 	}
 	if err := os.MkdirAll(filepath.Dir(workspace), 0o755); err != nil {
 		return "", "", err
@@ -70,22 +64,6 @@ func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string,
 		return "", "", fmt.Errorf("create worktree: %w", err)
 	}
 	return workspace, branch, nil
-}
-
-func cleanupPartialAttemptWorkspace(ctx context.Context, repositoryPath, workspace, branch string) error {
-	_, _ = commandOutput(ctx, repositoryPath, nil, "git", "worktree", "remove", "--force", workspace)
-	if err := os.RemoveAll(workspace); err != nil {
-		return err
-	}
-	if _, err := commandOutput(ctx, repositoryPath, nil, "git", "worktree", "prune"); err != nil {
-		return err
-	}
-	if _, err := commandOutput(ctx, repositoryPath, nil, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err == nil {
-		if _, err := commandOutput(ctx, repositoryPath, nil, "git", "branch", "-D", branch); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func validateReusableWorkspace(ctx context.Context, workspace, expectedBranch, expectedSHA string) error {

--- a/prototype/local-factory/git.go
+++ b/prototype/local-factory/git.go
@@ -31,8 +31,8 @@ func prepareWorkspace(ctx context.Context, cfg loadedConfig, item work) (string,
 	if _, err := os.Stat(filepath.Join(repository.Path, ".git")); err != nil {
 		return "", "", fmt.Errorf("repository path %q is not a git checkout", repository.Path)
 	}
-	workspace := filepath.Join(cfg.Config.StateDirectory, "checkouts", item.ID, "work")
-	branch := "factory/" + item.ID
+	workspace := filepath.Join(cfg.Config.StateDirectory, "checkouts", item.ID, fmt.Sprintf("attempt-%d", item.Attempt), "work")
+	branch := fmt.Sprintf("factory/%s-attempt-%d", item.ID, item.Attempt)
 	if _, err := os.Stat(workspace); err == nil {
 		return workspace, branch, nil
 	} else if !errors.Is(err, os.ErrNotExist) {

--- a/prototype/local-factory/github.go
+++ b/prototype/local-factory/github.go
@@ -16,7 +16,8 @@ type githubClient interface {
 	Issue(context.Context, string, int) (issue, error)
 	LabeledIssues(context.Context, string, string) ([]issue, error)
 	CommentIssue(context.Context, issue, string) error
-	OpenDraftPR(context.Context, issue, string, string, string, string) (string, error)
+	FindOpenPR(context.Context, issue, string) (pullRequest, bool, error)
+	EnsureDraftPR(context.Context, issue, string, string, string, string, string) (string, error)
 }
 
 type ghClient struct{}
@@ -31,6 +32,14 @@ type ghIssue struct {
 	Labels      []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
+}
+
+type pullRequest struct {
+	URL               string `json:"url"`
+	HeadRefName       string `json:"headRefName"`
+	HeadSHA           string `json:"headRefOid"`
+	BaseRefName       string `json:"baseRefName"`
+	IsCrossRepository bool   `json:"isCrossRepository"`
 }
 
 func (ghClient) Issue(ctx context.Context, repository string, number int) (issue, error) {
@@ -71,12 +80,64 @@ func (ghClient) CommentIssue(ctx context.Context, value issue, body string) erro
 	return err
 }
 
-func (ghClient) OpenDraftPR(ctx context.Context, value issue, branch, base, title, body string) (string, error) {
+func (client ghClient) FindOpenPR(ctx context.Context, value issue, branch string) (pullRequest, bool, error) {
+	output, err := commandOutput(ctx, "", nil, "gh", "pr", "list", "--repo", value.Repository, "--head", branch, "--state", "open", "--limit", "10", "--json", "url,headRefName,headRefOid,baseRefName,isCrossRepository")
+	if err != nil {
+		return pullRequest{}, false, err
+	}
+	var candidates []pullRequest
+	if err := json.Unmarshal(output, &candidates); err != nil {
+		return pullRequest{}, false, fmt.Errorf("decode gh pull request list: %w", err)
+	}
+	var matches []pullRequest
+	for _, candidate := range candidates {
+		if candidate.HeadRefName == branch && !candidate.IsCrossRepository {
+			matches = append(matches, candidate)
+		}
+	}
+	if len(matches) > 1 {
+		return pullRequest{}, false, fmt.Errorf("found %d open pull requests for branch %q", len(matches), branch)
+	}
+	if len(matches) == 0 {
+		return pullRequest{}, false, nil
+	}
+	return matches[0], true, nil
+}
+
+func (client ghClient) EnsureDraftPR(ctx context.Context, value issue, branch, expectedSHA, base, title, body string) (string, error) {
+	if existing, found, err := client.FindOpenPR(ctx, value, branch); err != nil {
+		return "", err
+	} else if found {
+		return verifiedPRURL(existing, expectedSHA, base)
+	}
 	output, err := commandOutput(ctx, "", []byte(body), "gh", "pr", "create", "--repo", value.Repository, "--head", branch, "--base", base, "--title", title, "--body-file", "-", "--draft")
 	if err != nil {
+		if existing, found, reconcileErr := client.FindOpenPR(ctx, value, branch); reconcileErr == nil && found {
+			return verifiedPRURL(existing, expectedSHA, base)
+		} else if reconcileErr != nil {
+			return "", fmt.Errorf("create draft pull request: %v; reconcile outcome: %w", err, reconcileErr)
+		}
 		return "", err
 	}
-	return strings.TrimSpace(string(output)), nil
+	createdURL := strings.TrimSpace(string(output))
+	created, found, err := client.FindOpenPR(ctx, value, branch)
+	if err != nil {
+		return "", fmt.Errorf("draft pull request %s was created but could not be reconciled: %w", createdURL, err)
+	}
+	if !found {
+		return "", fmt.Errorf("draft pull request %s was created but was not found by its head branch", createdURL)
+	}
+	return verifiedPRURL(created, expectedSHA, base)
+}
+
+func verifiedPRURL(value pullRequest, expectedSHA, expectedBase string) (string, error) {
+	if value.HeadSHA != expectedSHA {
+		return "", fmt.Errorf("pull request %s head is %s, expected verified SHA %s", value.URL, value.HeadSHA, expectedSHA)
+	}
+	if value.BaseRefName != expectedBase {
+		return "", fmt.Errorf("pull request %s targets %s, expected base branch %s", value.URL, value.BaseRefName, expectedBase)
+	}
+	return value.URL, nil
 }
 
 func fromGHIssue(repository string, value ghIssue) issue {

--- a/prototype/local-factory/github.go
+++ b/prototype/local-factory/github.go
@@ -15,7 +15,6 @@ import (
 type githubClient interface {
 	Issue(context.Context, string, int) (issue, error)
 	LabeledIssues(context.Context, string, string) ([]issue, error)
-	UpdateIssueBody(context.Context, issue, string) error
 	CommentIssue(context.Context, issue, string) error
 	OpenDraftPR(context.Context, issue, string, string, string, string) (string, error)
 }
@@ -65,11 +64,6 @@ func (ghClient) LabeledIssues(ctx context.Context, repository, label string) ([]
 		}
 	}
 	return result, nil
-}
-
-func (ghClient) UpdateIssueBody(ctx context.Context, value issue, body string) error {
-	_, err := commandOutput(ctx, "", []byte(body), "gh", "issue", "edit", strconv.Itoa(value.Number), "--repo", value.Repository, "--body-file", "-")
-	return err
 }
 
 func (ghClient) CommentIssue(ctx context.Context, value issue, body string) error {

--- a/prototype/local-factory/github.go
+++ b/prototype/local-factory/github.go
@@ -23,11 +23,13 @@ type githubClient interface {
 type ghClient struct{}
 
 type ghIssue struct {
-	Number int    `json:"number"`
-	Title  string `json:"title"`
-	Body   string `json:"body"`
-	URL    string `json:"url"`
-	Labels []struct {
+	Number      int             `json:"number"`
+	Title       string          `json:"title"`
+	Body        string          `json:"body"`
+	URL         string          `json:"html_url"`
+	IssueURL    string          `json:"url"`
+	PullRequest json.RawMessage `json:"pull_request"`
+	Labels      []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
 }
@@ -45,17 +47,22 @@ func (ghClient) Issue(ctx context.Context, repository string, number int) (issue
 }
 
 func (ghClient) LabeledIssues(ctx context.Context, repository, label string) ([]issue, error) {
-	body, err := commandOutput(ctx, "", nil, "gh", "issue", "list", "--repo", repository, "--state", "open", "--label", label, "--limit", "100", "--json", "number,title,body,url,labels")
+	body, err := commandOutput(ctx, "", nil, "gh", "api", "--method", "GET", "--paginate", "--slurp", "repos/"+repository+"/issues", "-f", "state=open", "-f", "labels="+label, "-f", "per_page=100")
 	if err != nil {
 		return nil, err
 	}
-	var values []ghIssue
-	if err := json.Unmarshal(body, &values); err != nil {
+	var pages [][]ghIssue
+	if err := json.Unmarshal(body, &pages); err != nil {
 		return nil, fmt.Errorf("decode gh issue list response: %w", err)
 	}
-	result := make([]issue, 0, len(values))
-	for _, value := range values {
-		result = append(result, fromGHIssue(repository, value))
+	var result []issue
+	for _, page := range pages {
+		for _, value := range page {
+			if len(value.PullRequest) != 0 && string(value.PullRequest) != "null" {
+				continue
+			}
+			result = append(result, fromGHIssue(repository, value))
+		}
 	}
 	return result, nil
 }
@@ -83,7 +90,11 @@ func fromGHIssue(repository string, value ghIssue) issue {
 	for _, label := range value.Labels {
 		labels = append(labels, label.Name)
 	}
-	return issue{Repository: repository, Number: value.Number, Title: value.Title, Body: value.Body, URL: value.URL, Labels: labels}
+	url := value.URL
+	if url == "" {
+		url = value.IssueURL
+	}
+	return issue{Repository: repository, Number: value.Number, Title: value.Title, Body: value.Body, URL: url, Labels: labels}
 }
 
 var issueReferencePattern = regexp.MustCompile(`^(?:https://github\.com/)?([^/#\s]+/[^/#\s]+)(?:/issues/|#)([1-9][0-9]*)/?$`)

--- a/prototype/local-factory/github.go
+++ b/prototype/local-factory/github.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type githubClient interface {
+	Issue(context.Context, string, int) (issue, error)
+	LabeledIssues(context.Context, string, string) ([]issue, error)
+	UpdateIssueBody(context.Context, issue, string) error
+	CommentIssue(context.Context, issue, string) error
+	OpenDraftPR(context.Context, issue, string, string, string, string) (string, error)
+}
+
+type ghClient struct{}
+
+type ghIssue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	URL    string `json:"url"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+func (ghClient) Issue(ctx context.Context, repository string, number int) (issue, error) {
+	body, err := commandOutput(ctx, "", nil, "gh", "issue", "view", strconv.Itoa(number), "--repo", repository, "--json", "number,title,body,url,labels")
+	if err != nil {
+		return issue{}, err
+	}
+	var value ghIssue
+	if err := json.Unmarshal(body, &value); err != nil {
+		return issue{}, fmt.Errorf("decode gh issue response: %w", err)
+	}
+	return fromGHIssue(repository, value), nil
+}
+
+func (ghClient) LabeledIssues(ctx context.Context, repository, label string) ([]issue, error) {
+	body, err := commandOutput(ctx, "", nil, "gh", "issue", "list", "--repo", repository, "--state", "open", "--label", label, "--limit", "100", "--json", "number,title,body,url,labels")
+	if err != nil {
+		return nil, err
+	}
+	var values []ghIssue
+	if err := json.Unmarshal(body, &values); err != nil {
+		return nil, fmt.Errorf("decode gh issue list response: %w", err)
+	}
+	result := make([]issue, 0, len(values))
+	for _, value := range values {
+		result = append(result, fromGHIssue(repository, value))
+	}
+	return result, nil
+}
+
+func (ghClient) UpdateIssueBody(ctx context.Context, value issue, body string) error {
+	_, err := commandOutput(ctx, "", []byte(body), "gh", "issue", "edit", strconv.Itoa(value.Number), "--repo", value.Repository, "--body-file", "-")
+	return err
+}
+
+func (ghClient) CommentIssue(ctx context.Context, value issue, body string) error {
+	_, err := commandOutput(ctx, "", []byte(body), "gh", "issue", "comment", strconv.Itoa(value.Number), "--repo", value.Repository, "--body-file", "-")
+	return err
+}
+
+func (ghClient) OpenDraftPR(ctx context.Context, value issue, branch, base, title, body string) (string, error) {
+	output, err := commandOutput(ctx, "", []byte(body), "gh", "pr", "create", "--repo", value.Repository, "--head", branch, "--base", base, "--title", title, "--body-file", "-", "--draft")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func fromGHIssue(repository string, value ghIssue) issue {
+	labels := make([]string, 0, len(value.Labels))
+	for _, label := range value.Labels {
+		labels = append(labels, label.Name)
+	}
+	return issue{Repository: repository, Number: value.Number, Title: value.Title, Body: value.Body, URL: value.URL, Labels: labels}
+}
+
+var issueReferencePattern = regexp.MustCompile(`^(?:https://github\.com/)?([^/#\s]+/[^/#\s]+)(?:/issues/|#)([1-9][0-9]*)/?$`)
+
+func parseIssueReference(value string) (string, int, error) {
+	matches := issueReferencePattern.FindStringSubmatch(strings.TrimSpace(value))
+	if matches == nil {
+		return "", 0, errors.New("issue must be owner/repository#123 or a GitHub issue URL")
+	}
+	number, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return "", 0, err
+	}
+	return matches[1], number, nil
+}
+
+func commandOutput(ctx context.Context, directory string, stdin []byte, name string, args ...string) ([]byte, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	command.Dir = directory
+	if stdin != nil {
+		command.Stdin = bytes.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("%s: %s", name, message)
+	}
+	return stdout.Bytes(), nil
+}

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -36,8 +36,7 @@ func (f fakeGitHub) LabeledIssues(context.Context, string, string) ([]issue, err
 	return append([]issue(nil), f.issues...), nil
 }
 
-func (fakeGitHub) UpdateIssueBody(context.Context, issue, string) error { return nil }
-func (fakeGitHub) CommentIssue(context.Context, issue, string) error    { return nil }
+func (fakeGitHub) CommentIssue(context.Context, issue, string) error { return nil }
 func (fakeGitHub) OpenDraftPR(context.Context, issue, string, string, string, string) (string, error) {
 	return "https://github.com/acme/widgets/pull/2", nil
 }
@@ -348,66 +347,11 @@ func TestForemanCommandQuotesExecutable(t *testing.T) {
 	}
 }
 
-func TestManagedPlanBodyReplacesOnlyFactoryBlock(t *testing.T) {
+func TestManagedPlanComment(t *testing.T) {
 	t.Parallel()
-	first, err := managedPlanBody("User description", "First plan")
-	if err != nil {
-		t.Fatal(err)
-	}
-	second, err := managedPlanBody(first, "Second plan")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Count(second, "<!-- factory-plan:start -->") != 1 {
-		t.Fatalf("managed block duplicated:\n%s", second)
-	}
-	if !strings.Contains(second, "User description") || !strings.Contains(second, "Second plan") || strings.Contains(second, "First plan") {
-		t.Fatalf("managed plan replacement failed:\n%s", second)
-	}
-}
-
-func TestManagedPlanBodyRejectsMalformedMarkers(t *testing.T) {
-	t.Parallel()
-	const start = "<!-- factory-plan:start -->"
-	const end = "<!-- factory-plan:end -->"
-	for name, issueBody := range map[string]string{
-		"orphan start":    "Requirements\n" + start + "\nDo not delete this",
-		"orphan end":      "Requirements\n" + end,
-		"duplicate start": start + "\nRequirements\n" + start + "\n" + end,
-		"duplicate end":   start + "\n" + end + "\nRequirements\n" + end,
-		"wrong order":     end + "\nRequirements\n" + start,
-	} {
-		t.Run(name, func(t *testing.T) {
-			if _, err := managedPlanBody(issueBody, "Replacement plan"); err == nil {
-				t.Fatal("malformed markers were accepted")
-			}
-		})
-	}
-	if _, err := managedPlanBody("Requirements", "Plan with "+start); err == nil {
-		t.Fatal("reserved marker in plan was accepted")
-	}
-}
-
-func TestManagedPlanBodyPreservesUserTextExactly(t *testing.T) {
-	t.Parallel()
-	const start = "<!-- factory-plan:start -->"
-	const end = "<!-- factory-plan:end -->"
-	original := "    indented requirement\nline with a hard break  \n"
-	appended, err := managedPlanBody(original, "New plan")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasPrefix(appended, original) {
-		t.Fatalf("append changed user text:\nwant prefix %q\ngot %q", original, appended)
-	}
-	prefix := "    leading code block\nline with a hard break  \n\n"
-	suffix := "\n\nTrailing requirement  "
-	replaced, err := managedPlanBody(prefix+start+"\nOld plan\n"+end+suffix, "New plan")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.HasPrefix(replaced, prefix) || !strings.HasSuffix(replaced, suffix) {
-		t.Fatalf("replacement changed user text:\nwant prefix %q and suffix %q\ngot %q", prefix, suffix, replaced)
+	comment := managedPlanComment("\nPlan one\n")
+	if comment != "<!-- factory-plan -->\n## Factory plan\n\nPlan one" {
+		t.Fatalf("managed plan comment = %q", comment)
 	}
 }
 

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -101,6 +101,9 @@ func TestExplicitRetryOnlyRequeuesFailedOrBlockedWork(t *testing.T) {
 	if _, retried, err := state.retry(item.ID, originalIssue); err != nil || retried {
 		t.Fatalf("queued retry = %t, %v", retried, err)
 	}
+	if err := state.artifact(item.ID, "review.md", []byte("obsolete review\n")); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := state.update(item.ID, func(current *work) error {
 		current.State = stateFailed
 		current.Failure = "agent stopped"
@@ -111,6 +114,12 @@ func TestExplicitRetryOnlyRequeuesFailedOrBlockedWork(t *testing.T) {
 	}
 	refreshedIssue := originalIssue
 	refreshedIssue.Body = "New details from the user"
+	if err := state.archiveAttemptArtifactsUnlocked(item.ID, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWrite(filepath.Join(state.workDir(item.ID), "issue.md"), []byte(renderIssue(refreshedIssue)), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	retried, changed, err := state.retry(item.ID, refreshedIssue)
 	if err != nil {
 		t.Fatal(err)
@@ -124,6 +133,17 @@ func TestExplicitRetryOnlyRequeuesFailedOrBlockedWork(t *testing.T) {
 	snapshot, err := state.readArtifact(item.ID, "issue.md")
 	if err != nil || !strings.Contains(string(snapshot), refreshedIssue.Body) {
 		t.Fatalf("retry snapshot was not refreshed: %v\n%s", err, snapshot)
+	}
+	if _, err := state.readArtifact(item.ID, "review.md"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("retry retained prior review: %v", err)
+	}
+	archivedReview, err := os.ReadFile(filepath.Join(state.workDir(item.ID), "attempts", "attempt-1", "review.md"))
+	if err != nil || string(archivedReview) != "obsolete review\n" {
+		t.Fatalf("prior review was not archived: %v, %q", err, archivedReview)
+	}
+	archivedIssue, err := os.ReadFile(filepath.Join(state.workDir(item.ID), "attempts", "attempt-1", "issue.md"))
+	if err != nil || !strings.Contains(string(archivedIssue), originalIssue.Body) || strings.Contains(string(archivedIssue), refreshedIssue.Body) {
+		t.Fatalf("partial retry overwrote archived issue: %v\n%s", err, archivedIssue)
 	}
 }
 
@@ -221,18 +241,19 @@ func TestRuntimeAuthorityIsHeldByOneServer(t *testing.T) {
 	if err := state.activate("server-token"); err != nil {
 		t.Fatal(err)
 	}
-	if err := state.activate("second-token"); err == nil || !strings.Contains(err.Error(), "already running") {
+	secondState := newStore(state.root)
+	if err := secondState.activate("second-token"); err == nil || !strings.Contains(err.Error(), "already running") {
 		t.Fatalf("second server claimed authority: %v", err)
 	}
 	state.deactivate("invented-token")
-	if err := state.activate("second-token"); err == nil {
+	if err := secondState.activate("second-token"); err == nil {
 		t.Fatal("wrong token released runtime authority")
 	}
 	state.deactivate("server-token")
-	if err := state.activate("second-token"); err != nil {
+	if err := secondState.activate("second-token"); err != nil {
 		t.Fatalf("released authority could not be reclaimed: %v", err)
 	}
-	state.deactivate("second-token")
+	secondState.deactivate("second-token")
 }
 
 func TestInternalAPIRejectsInventedAuthority(t *testing.T) {
@@ -608,6 +629,34 @@ command = [%q]
 		if _, err := os.Stat(verificationPath); !os.IsNotExist(err) {
 			t.Fatalf("verification worktree %q was retained: %v", verificationPath, err)
 		}
+	}
+	if _, err := state.update(item.ID, func(current *work) error {
+		current.State = stateRunning
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeExecutable(t, agentScript, `#!/bin/sh
+set -eu
+printf 'Malformed verification report.\n'
+`)
+	if _, err := runner.delegate(context.Background(), item.ID, "verify"); err == nil || !strings.Contains(err.Error(), "must begin") {
+		t.Fatalf("malformed re-verification succeeded: %v", err)
+	}
+	afterFailedVerification, err := state.get(item.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterFailedVerification.VerifiedSHA != "" {
+		t.Fatalf("failed re-verification retained approval %q", afterFailedVerification.VerifiedSHA)
+	}
+	if _, err := state.update(item.ID, func(current *work) error {
+		current.State = stateReady
+		current.VerifyRuns = completed.VerifyRuns
+		current.VerifiedSHA = completed.VerifiedSHA
+		return nil
+	}); err != nil {
+		t.Fatal(err)
 	}
 	verificationWorkspace, err := prepareVerificationWorkspace(context.Background(), cfg, completed, completed.HeadSHA)
 	if err != nil {

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -425,6 +425,32 @@ func TestRunAPIDoesNotRetryWhileOldAttemptIsActive(t *testing.T) {
 	}
 }
 
+func TestAdmitRunReloadsWorkAfterWaitingForActiveAttempt(t *testing.T) {
+	t.Parallel()
+	state := newStore(t.TempDir())
+	value := issue{Repository: "acme/widgets", Number: 1, Title: "Retry concurrently"}
+	stale, _, err := state.create(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := state.update(stale.ID, func(item *work) error {
+		item.Attempt++
+		item.State = stateRunning
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := server{store: state, running: map[string]struct{}{stale.ID: {}}}
+	admitted, created, err := server.admitRun(stale, false, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created || admitted.Attempt != current.Attempt || admitted.State != stateRunning {
+		t.Fatalf("admitted stale work: %#v, created=%t; want attempt %d running", admitted, created, current.Attempt)
+	}
+}
+
 func TestGitHubWritesRequireRemoteBaseRef(t *testing.T) {
 	t.Parallel()
 	value := validTestConfig()
@@ -432,6 +458,40 @@ func TestGitHubWritesRequireRemoteBaseRef(t *testing.T) {
 	_, err := newServer(loadedConfig{Config: value}, fakeGitHub{}, true, log.New(io.Discard, "", 0))
 	if err == nil || !strings.Contains(err.Error(), "origin/<branch>") {
 		t.Fatalf("write mode accepted local base ref: %v", err)
+	}
+}
+
+func TestGitHubRepositoryFromRemote(t *testing.T) {
+	t.Parallel()
+	for _, remote := range []string{
+		"git@github.com:acme/widgets.git",
+		"https://github.com/acme/widgets.git",
+		"ssh://git@github.com/acme/widgets",
+	} {
+		repository, err := githubRepositoryFromRemote(remote)
+		if err != nil || repository != "acme/widgets" {
+			t.Errorf("githubRepositoryFromRemote(%q) = %q, %v", remote, repository, err)
+		}
+	}
+	for _, remote := range []string{
+		"https://example.com/acme/widgets.git",
+		"file:///tmp/widgets",
+		"https://github.com/acme/widgets/extra.git",
+	} {
+		if _, err := githubRepositoryFromRemote(remote); err == nil {
+			t.Errorf("githubRepositoryFromRemote(%q) unexpectedly succeeded", remote)
+		}
+	}
+}
+
+func TestPushBranchRejectsWrongOriginRepository(t *testing.T) {
+	t.Parallel()
+	repository := t.TempDir()
+	mustRun(t, repository, "git", "init")
+	mustRun(t, repository, "git", "remote", "add", "origin", "https://github.com/other/widgets.git")
+	err := pushBranch(t.Context(), repository, "factory/test", "acme/widgets")
+	if err == nil || !strings.Contains(err.Error(), `origin points to GitHub repository "other/widgets", expected "acme/widgets"`) {
+		t.Fatalf("push accepted wrong origin: %v", err)
 	}
 }
 

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -263,16 +263,60 @@ func TestRuntimeAuthorityIsHeldByOneServer(t *testing.T) {
 	secondState.deactivate("second-token")
 }
 
-func TestInternalAPIRejectsInventedAuthority(t *testing.T) {
+func TestInternalAPIRejectsWrongWorkAuthority(t *testing.T) {
 	t.Parallel()
-	server := server{runner: &agentRunner{authToken: "server-token"}}
-	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/internal", strings.NewReader(`{"work_id":"work-1","action":"finish"}`))
+	state := newStore(t.TempDir())
+	first, _, err := state.create(issue{Repository: "acme/widgets", Number: 1, Title: "First"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := state.create(issue{Repository: "acme/widgets", Number: 2, Title: "Second"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &agentRunner{store: state, authToken: "server-token"}
+	server := server{store: state, runner: runner}
+	for name, token := range map[string]string{
+		"invented token": "invented-token",
+		"other work":     runner.workToken(first),
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/internal", strings.NewReader(fmt.Sprintf(`{"work_id":%q,"action":"finish"}`, second.ID)))
+			request.Header.Set("Content-Type", "application/json")
+			request.Header.Set("Authorization", "Bearer "+token)
+			response := httptest.NewRecorder()
+			server.handleInternal(response, request)
+			if response.Code != http.StatusUnauthorized {
+				t.Fatalf("response status = %d, want %d", response.Code, http.StatusUnauthorized)
+			}
+		})
+	}
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/internal", strings.NewReader(fmt.Sprintf(`{"work_id":%q,"action":"finish"}`, first.ID)))
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", "Bearer invented-token")
+	request.Header.Set("Authorization", "Bearer "+runner.workToken(first))
 	response := httptest.NewRecorder()
 	server.handleInternal(response, request)
+	if response.Code == http.StatusUnauthorized {
+		t.Fatal("matching work capability was rejected")
+	}
+	oldToken := runner.workToken(first)
+	first, err = state.update(first.ID, func(current *work) error {
+		current.Attempt++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldToken == runner.workToken(first) {
+		t.Fatal("work capability did not change across attempts")
+	}
+	request = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/internal", strings.NewReader(fmt.Sprintf(`{"work_id":%q,"action":"finish"}`, first.ID)))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+oldToken)
+	response = httptest.NewRecorder()
+	server.handleInternal(response, request)
 	if response.Code != http.StatusUnauthorized {
-		t.Fatalf("response status = %d, want %d", response.Code, http.StatusUnauthorized)
+		t.Fatalf("old attempt response status = %d, want %d", response.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -602,6 +646,7 @@ command = [%q]
 		t.Fatal(err)
 	}
 	runner := agentRunner{config: cfg, store: state, github: fakeGitHub{issues: []issue{value}}, executable: binary, authToken: authToken}
+	internalServer.store = state
 	internalServer.runner = &runner
 	if err := runner.runWork(context.Background(), item.ID); err != nil {
 		t.Fatal(err)

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -108,6 +108,10 @@ func TestExplicitRetryOnlyRequeuesFailedOrBlockedWork(t *testing.T) {
 		current.State = stateFailed
 		current.Failure = "agent stopped"
 		current.VerifyRuns = 2
+		current.Branch = "factory/old-attempt"
+		current.Workspace = "/tmp/old-attempt"
+		current.HeadSHA = "old-head"
+		current.PRURL = "https://github.com/acme/widgets/pull/1"
 		return nil
 	}); err != nil {
 		t.Fatal(err)
@@ -126,6 +130,9 @@ func TestExplicitRetryOnlyRequeuesFailedOrBlockedWork(t *testing.T) {
 	}
 	if !changed || retried.State != stateQueued || retried.Attempt != 2 || retried.VerifyRuns != 0 || retried.Failure != "" {
 		t.Fatalf("unexpected retry: %#v, changed=%t", retried, changed)
+	}
+	if retried.Branch != "" || retried.Workspace != "" || retried.HeadSHA != "" || retried.PRURL != "" {
+		t.Fatalf("retry retained attempt-local checkout metadata: %#v", retried)
 	}
 	if retried.Issue.Body != refreshedIssue.Body {
 		t.Fatalf("retry retained stale issue body %q", retried.Issue.Body)
@@ -323,9 +330,9 @@ func TestConfigRejectsNonPositivePollInterval(t *testing.T) {
 func TestVerifierContextNamesDetachedCheckout(t *testing.T) {
 	t.Parallel()
 	runner := agentRunner{store: newStore(t.TempDir())}
-	item := work{ID: "work", Workspace: "/tmp/mutable-builder", Issue: issue{Repository: "acme/widgets", Number: 1}}
+	item := work{ID: "work", Workspace: "/tmp/mutable-builder", VerifyRuns: 1, Issue: issue{Repository: "acme/widgets", Number: 1}}
 	context := runner.roleContext(item, "verify", "/tmp/detached-verifier")
-	if !strings.Contains(context, "Checkout: /tmp/detached-verifier") || strings.Contains(context, item.Workspace) {
+	if !strings.Contains(context, "Checkout: /tmp/detached-verifier") || !strings.Contains(context, "Verification run: 1") || strings.Contains(context, item.Workspace) {
 		t.Fatalf("verifier context points at the wrong checkout:\n%s", context)
 	}
 }
@@ -704,12 +711,17 @@ printf 'Malformed verification report.\n'
 	if err != nil || !changed {
 		t.Fatalf("retry failed: changed=%t, err=%v", changed, err)
 	}
+	expectedRetryBranch := fmt.Sprintf("factory/%s-attempt-%d", retried.ID, retried.Attempt)
+	mustRun(t, repository, "git", "branch", expectedRetryBranch, "HEAD")
 	retryWorkspace, retryBranch, err := prepareWorkspace(context.Background(), cfg, retried)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if retryWorkspace == completed.Workspace || retryBranch == completed.Branch {
 		t.Fatalf("retry reused workspace %q or branch %q", retryWorkspace, retryBranch)
+	}
+	if retryBranch != expectedRetryBranch {
+		t.Fatalf("recovered branch = %q, want %q", retryBranch, expectedRetryBranch)
 	}
 	if _, err := os.Stat(filepath.Join(retryWorkspace, "result.txt")); !os.IsNotExist(err) {
 		t.Fatalf("retry inherited result.txt: %v", err)
@@ -720,7 +732,21 @@ printf 'Malformed verification report.\n'
 	if err := os.WriteFile(filepath.Join(retryWorkspace, "stale.txt"), []byte("stale attempt state\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := prepareWorkspace(context.Background(), cfg, retried); err == nil || !strings.Contains(err.Error(), "not safe to reuse") {
+	recoveredWorkspace, recoveredBranch, err := prepareWorkspace(context.Background(), cfg, retried)
+	if err != nil || recoveredWorkspace != retryWorkspace || recoveredBranch != retryBranch {
+		t.Fatalf("partial preparation was not recovered: %q, %q, %v", recoveredWorkspace, recoveredBranch, err)
+	}
+	if _, err := os.Stat(filepath.Join(recoveredWorkspace, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatalf("partial workspace content survived recovery: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(recoveredWorkspace, "stale.txt"), []byte("unsafe running state\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prepared := retried
+	prepared.Workspace = recoveredWorkspace
+	prepared.Branch = recoveredBranch
+	prepared.HeadSHA = mustOutput(t, recoveredWorkspace, "git", "rev-parse", "HEAD")
+	if _, _, err := prepareWorkspace(context.Background(), cfg, prepared); err == nil || !strings.Contains(err.Error(), "not safe to reuse") {
 		t.Fatalf("dirty attempt workspace was reused: %v", err)
 	}
 }
@@ -740,4 +766,15 @@ func mustRun(t *testing.T, directory, name string, args ...string) {
 	if err != nil {
 		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, output)
 	}
+}
+
+func mustOutput(t *testing.T, directory, name string, args ...string) string {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), name, args...)
+	command.Dir = directory
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("%s %s: %v", name, strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -567,6 +567,17 @@ func TestConfigRejectsCodexForemanAndInvalidTimeout(t *testing.T) {
 	}
 }
 
+func TestConfigRejectsUnreachableListenPort(t *testing.T) {
+	t.Parallel()
+	for _, listen := range []string{"127.0.0.1:0", "127.0.0.1:", "127.0.0.1:not-a-port", "127.0.0.1:65536"} {
+		value := validTestConfig()
+		value.Server.Listen = listen
+		if err := validateConfig(value); err == nil || !strings.Contains(err.Error(), "port") {
+			t.Fatalf("server.listen %q was accepted: %v", listen, err)
+		}
+	}
+}
+
 func TestLocalOnlyHandlerRejectsForeignAuthority(t *testing.T) {
 	t.Parallel()
 	handler := localOnlyHandler("127.0.0.1:7338", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -982,6 +993,15 @@ printf 'Malformed verification report.\n'
 		t.Fatalf("unowned branch changed from %s to %s", retainedBranchSHA, actualSHA)
 	}
 	mustRun(t, repository, "git", "branch", "-D", expectedRetryBranch)
+	retryWorkspacePath := filepath.Join(cfg.Config.StateDirectory, "checkouts", retried.ID, fmt.Sprintf("attempt-%d", retried.Attempt), "work")
+	retryBaseSHA := mustOutput(t, repository, "git", "rev-parse", "HEAD")
+	if err := os.MkdirAll(filepath.Dir(retryWorkspacePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWorkspaceIntent(retryWorkspacePath, repository, expectedRetryBranch, retryBaseSHA); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, repository, "git", "branch", expectedRetryBranch, retryBaseSHA)
 	retryWorkspace, retryBranch, err := prepareWorkspace(context.Background(), cfg, retried)
 	if err != nil {
 		t.Fatal(err)

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -70,8 +70,23 @@ func TestInitialiseWritesEditableProject(t *testing.T) {
 			t.Fatalf("%s is empty", name)
 		}
 	}
-	if _, err := loadConfig(filepath.Join(directory, "factory.toml")); err != nil {
+	configPath := filepath.Join(directory, "factory.toml")
+	if _, err := loadConfig(configPath); err != nil {
 		t.Fatalf("generated config does not load: %v", err)
+	}
+	body, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(strings.Replace(string(body), `"acme/widgets"`, `" acme/widgets "`, 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Config.Repositories[0].GitHub != "acme/widgets" {
+		t.Fatalf("repository name was not normalized: %q", loaded.Config.Repositories[0].GitHub)
 	}
 }
 
@@ -200,6 +215,67 @@ func TestVerificationVerdictUsesMinimalMarkdownContract(t *testing.T) {
 	}
 }
 
+func TestRuntimeAuthorityIsHeldByOneServer(t *testing.T) {
+	t.Parallel()
+	state := newStore(t.TempDir())
+	if err := state.activate("server-token"); err != nil {
+		t.Fatal(err)
+	}
+	if err := state.activate("second-token"); err == nil || !strings.Contains(err.Error(), "already running") {
+		t.Fatalf("second server claimed authority: %v", err)
+	}
+	state.deactivate("invented-token")
+	if err := state.activate("second-token"); err == nil {
+		t.Fatal("wrong token released runtime authority")
+	}
+	state.deactivate("server-token")
+	if err := state.activate("second-token"); err != nil {
+		t.Fatalf("released authority could not be reclaimed: %v", err)
+	}
+	state.deactivate("second-token")
+}
+
+func TestInternalAPIRejectsInventedAuthority(t *testing.T) {
+	t.Parallel()
+	server := server{runner: &agentRunner{authToken: "server-token"}}
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/internal", strings.NewReader(`{"work_id":"work-1","action":"finish"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer invented-token")
+	response := httptest.NewRecorder()
+	server.handleInternal(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("response status = %d, want %d", response.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestPositionalArgumentMustComeFirst(t *testing.T) {
+	t.Parallel()
+	if _, _, err := takeFirstArgument([]string{"--config", "ticket"}); err == nil {
+		t.Fatal("flag value was consumed as the positional argument")
+	}
+	value, remaining, err := takeFirstArgument([]string{"ticket", "--config", "factory.toml"})
+	if err != nil || value != "ticket" || len(remaining) != 2 {
+		t.Fatalf("positional parse = %q, %v, %v", value, remaining, err)
+	}
+}
+
+func TestFactoryEnvironmentDoesNotLeakCapabilities(t *testing.T) {
+	t.Parallel()
+	filtered := withoutFactoryEnvironment([]string{"PATH=/bin", "FACTORY_AUTH_TOKEN=attacker", "FACTORY_ROLE=stale"})
+	if len(filtered) != 1 || filtered[0] != "PATH=/bin" {
+		t.Fatalf("filtered environment = %v", filtered)
+	}
+}
+
+func TestForemanCommandQuotesExecutable(t *testing.T) {
+	t.Parallel()
+	runner := agentRunner{executable: "/tmp/factory tools/factory", config: loadedConfig{Path: "/tmp/factory.toml"}}
+	context := runner.foremanContext(work{ID: "work", Issue: issue{Repository: "acme/widgets", Number: 1}})
+	if !strings.Contains(context, `'/tmp/factory tools/factory' internal`) {
+		t.Fatalf("executable was not shell quoted:\n%s", context)
+	}
+}
+
 func TestManagedPlanBodyReplacesOnlyFactoryBlock(t *testing.T) {
 	t.Parallel()
 	first := managedPlanBody("User description", "First plan")
@@ -223,9 +299,19 @@ func TestConfigRejectsNonPositivePollInterval(t *testing.T) {
 	}
 }
 
+func TestVerifierContextNamesDetachedCheckout(t *testing.T) {
+	t.Parallel()
+	runner := agentRunner{store: newStore(t.TempDir())}
+	item := work{ID: "work", Workspace: "/tmp/mutable-builder", Issue: issue{Repository: "acme/widgets", Number: 1}}
+	context := runner.roleContext(item, "verify", "/tmp/detached-verifier")
+	if !strings.Contains(context, "Checkout: /tmp/detached-verifier") || strings.Contains(context, item.Workspace) {
+		t.Fatalf("verifier context points at the wrong checkout:\n%s", context)
+	}
+}
+
 func TestRunAPIRejectsSimpleCrossOriginContentType(t *testing.T) {
 	t.Parallel()
-	request := httptest.NewRequest(http.MethodPost, "/api/run", strings.NewReader(`{"issue":"acme/widgets#1"}`))
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/run", strings.NewReader(`{"issue":"acme/widgets#1"}`))
 	request.Header.Set("Content-Type", "text/plain")
 	response := httptest.NewRecorder()
 	server := server{config: loadedConfig{Config: validTestConfig()}, store: newStore(t.TempDir()), github: fakeGitHub{}}
@@ -251,7 +337,7 @@ func TestRunAPIDoesNotRetryWhileOldAttemptIsActive(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := server{config: cfg, store: state, github: fakeGitHub{issues: []issue{value}}, running: map[string]struct{}{item.ID: {}}}
-	request := httptest.NewRequest(http.MethodPost, "/api/run", strings.NewReader(`{"issue":"acme/widgets#1"}`))
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/run", strings.NewReader(`{"issue":"acme/widgets#1"}`))
 	request.Header.Set("Content-Type", "application/json")
 	response := httptest.NewRecorder()
 	server.handleRun(response, request)
@@ -308,6 +394,33 @@ func TestAgentCancellationKillsDescendantProcessGroup(t *testing.T) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("descendant process %d survived cancellation: %v", childPID, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestAgentExitKillsBackgroundDescendant(t *testing.T) {
+	command := exec.CommandContext(t.Context(), "sh", "-c", "sleep 30 >/dev/null 2>&1 & echo $!; exit 0")
+	configureAgentCommand(command)
+	output, err := command.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(output)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanupAgentCommand(command); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		err := syscall.Kill(childPID, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("background descendant %d survived leader exit: %v", childPID, err)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
@@ -442,17 +555,26 @@ command = [%q]
 	if err := os.WriteFile(configPath, []byte(configBody), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	internalServer := &server{}
+	internalHTTP := httptest.NewServer(http.HandlerFunc(internalServer.handleInternal))
+	t.Cleanup(internalHTTP.Close)
+	configBody = strings.Replace(configBody, `listen = "127.0.0.1:0"`, fmt.Sprintf("listen = %q", strings.TrimPrefix(internalHTTP.URL, "http://")), 1)
+	if err := os.WriteFile(configPath, []byte(configBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	cfg, err := loadConfig(configPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 	state := newStore(cfg.Config.StateDirectory)
+	const authToken = "test-runtime-authority"
 	value := issue{Repository: "acme/widgets", Number: 1, Title: "Produce the correct result", Body: "The result must be correct.", URL: "https://github.com/acme/widgets/issues/1"}
 	item, _, err := state.create(value)
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner := agentRunner{config: cfg, store: state, github: fakeGitHub{issues: []issue{value}}, executable: binary}
+	runner := agentRunner{config: cfg, store: state, github: fakeGitHub{issues: []issue{value}}, executable: binary, authToken: authToken}
+	internalServer.runner = &runner
 	if err := runner.runWork(context.Background(), item.ID); err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +603,16 @@ command = [%q]
 			t.Fatalf("missing %s: %v", artifact, err)
 		}
 	}
-	verificationWorkspace := filepath.Join(cfg.Config.StateDirectory, "checkouts", item.ID, "verify", "attempt-1-run-2")
+	for run := 1; run <= completed.VerifyRuns; run++ {
+		verificationPath := filepath.Join(cfg.Config.StateDirectory, "checkouts", item.ID, "verify", fmt.Sprintf("attempt-1-run-%d", run))
+		if _, err := os.Stat(verificationPath); !os.IsNotExist(err) {
+			t.Fatalf("verification worktree %q was retained: %v", verificationPath, err)
+		}
+	}
+	verificationWorkspace, err := prepareVerificationWorkspace(context.Background(), cfg, completed, completed.HeadSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(verificationWorkspace, "verifier-change.txt"), []byte("must not be accepted\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -489,6 +620,9 @@ command = [%q]
 	mustRun(t, verificationWorkspace, "git", "-c", "user.name=Verifier", "-c", "user.email=verifier@example.com", "commit", "-m", "bad verifier change")
 	if err := ensureExactHead(context.Background(), verificationWorkspace, completed.HeadSHA); err == nil || !strings.Contains(err.Error(), "HEAD changed") {
 		t.Fatalf("accepted verifier commit: %v", err)
+	}
+	if err := removeVerificationWorkspace(context.Background(), cfg, completed, verificationWorkspace); err != nil {
+		t.Fatal(err)
 	}
 	if _, err := state.update(item.ID, func(current *work) error {
 		current.State = stateRunning
@@ -531,6 +665,15 @@ command = [%q]
 	if _, err := os.Stat(filepath.Join(retryWorkspace, "result.txt")); !os.IsNotExist(err) {
 		t.Fatalf("retry inherited result.txt: %v", err)
 	}
+	if reusedWorkspace, reusedBranch, err := prepareWorkspace(context.Background(), cfg, retried); err != nil || reusedWorkspace != retryWorkspace || reusedBranch != retryBranch {
+		t.Fatalf("clean workspace was not safely reused: %q, %q, %v", reusedWorkspace, reusedBranch, err)
+	}
+	if err := os.WriteFile(filepath.Join(retryWorkspace, "stale.txt"), []byte("stale attempt state\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := prepareWorkspace(context.Background(), cfg, retried); err == nil || !strings.Contains(err.Error(), "not safe to reuse") {
+		t.Fatalf("dirty attempt workspace was reused: %v", err)
+	}
 }
 
 func writeExecutable(t *testing.T, path, body string) {
@@ -542,7 +685,7 @@ func writeExecutable(t *testing.T, path, body string) {
 
 func mustRun(t *testing.T, directory, name string, args ...string) {
 	t.Helper()
-	command := exec.Command(name, args...)
+	command := exec.CommandContext(t.Context(), name, args...)
 	command.Dir = directory
 	output, err := command.CombinedOutput()
 	if err != nil {

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -868,7 +868,16 @@ printf 'Malformed verification report.\n'
 		t.Fatalf("retry failed: changed=%t, err=%v", changed, err)
 	}
 	expectedRetryBranch := fmt.Sprintf("factory/%s-attempt-%d", retried.ID, retried.Attempt)
-	mustRun(t, repository, "git", "branch", expectedRetryBranch, "HEAD")
+	retainedCommit := mustOutput(t, repository, "git", "commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "retained candidate")
+	mustRun(t, repository, "git", "branch", expectedRetryBranch, retainedCommit)
+	retainedBranchSHA := mustOutput(t, repository, "git", "rev-parse", expectedRetryBranch)
+	if _, _, err := prepareWorkspace(context.Background(), cfg, retried); err == nil || !strings.Contains(err.Error(), "refusing to delete") {
+		t.Fatalf("unowned branch collision was accepted: %v", err)
+	}
+	if actualSHA := mustOutput(t, repository, "git", "rev-parse", expectedRetryBranch); actualSHA != retainedBranchSHA {
+		t.Fatalf("unowned branch changed from %s to %s", retainedBranchSHA, actualSHA)
+	}
+	mustRun(t, repository, "git", "branch", "-D", expectedRetryBranch)
 	retryWorkspace, retryBranch, err := prepareWorkspace(context.Background(), cfg, retried)
 	if err != nil {
 		t.Fatal(err)
@@ -888,20 +897,19 @@ printf 'Malformed verification report.\n'
 	if err := os.WriteFile(filepath.Join(retryWorkspace, "stale.txt"), []byte("stale attempt state\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	recoveredWorkspace, recoveredBranch, err := prepareWorkspace(context.Background(), cfg, retried)
-	if err != nil || recoveredWorkspace != retryWorkspace || recoveredBranch != retryBranch {
-		t.Fatalf("partial preparation was not recovered: %q, %q, %v", recoveredWorkspace, recoveredBranch, err)
+	if _, _, err := prepareWorkspace(context.Background(), cfg, retried); err == nil || !strings.Contains(err.Error(), "not safe to reuse") {
+		t.Fatalf("dirty unowned workspace was reused: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(recoveredWorkspace, "stale.txt")); !os.IsNotExist(err) {
-		t.Fatalf("partial workspace content survived recovery: %v", err)
+	if body, err := os.ReadFile(filepath.Join(retryWorkspace, "stale.txt")); err != nil || string(body) != "stale attempt state\n" {
+		t.Fatalf("dirty unowned workspace content was not preserved: %q, %v", body, err)
 	}
-	if err := os.WriteFile(filepath.Join(recoveredWorkspace, "stale.txt"), []byte("unsafe running state\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(retryWorkspace, "stale.txt"), []byte("unsafe running state\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	prepared := retried
-	prepared.Workspace = recoveredWorkspace
-	prepared.Branch = recoveredBranch
-	prepared.HeadSHA = mustOutput(t, recoveredWorkspace, "git", "rev-parse", "HEAD")
+	prepared.Workspace = retryWorkspace
+	prepared.Branch = retryBranch
+	prepared.HeadSHA = mustOutput(t, retryWorkspace, "git", "rev-parse", "HEAD")
 	if _, _, err := prepareWorkspace(context.Background(), cfg, prepared); err == nil || !strings.Contains(err.Error(), "not safe to reuse") {
 		t.Fatalf("dirty attempt workspace was reused: %v", err)
 	}

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -20,7 +20,8 @@ import (
 )
 
 type fakeGitHub struct {
-	issues []issue
+	issues      []issue
+	pullRequest pullRequest
 }
 
 func (f fakeGitHub) Issue(_ context.Context, repository string, number int) (issue, error) {
@@ -37,7 +38,13 @@ func (f fakeGitHub) LabeledIssues(context.Context, string, string) ([]issue, err
 }
 
 func (fakeGitHub) CommentIssue(context.Context, issue, string) error { return nil }
-func (fakeGitHub) OpenDraftPR(context.Context, issue, string, string, string, string) (string, error) {
+func (f fakeGitHub) FindOpenPR(context.Context, issue, string) (pullRequest, bool, error) {
+	return f.pullRequest, f.pullRequest.URL != "", nil
+}
+func (f fakeGitHub) EnsureDraftPR(_ context.Context, _ issue, _, expectedSHA, base, _, _ string) (string, error) {
+	if f.pullRequest.URL != "" {
+		return verifiedPRURL(f.pullRequest, expectedSHA, base)
+	}
 	return "https://github.com/acme/widgets/pull/2", nil
 }
 
@@ -437,12 +444,97 @@ func TestAdmitRunReloadsWorkAfterWaitingForActiveAttempt(t *testing.T) {
 		t.Fatal(err)
 	}
 	server := server{store: state, running: map[string]struct{}{stale.ID: {}}}
-	admitted, created, err := server.admitRun(stale, false, value)
+	admitted, created, err := server.admitRun(t.Context(), stale, false, value)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if created || admitted.Attempt != current.Attempt || admitted.State != stateRunning {
 		t.Fatalf("admitted stale work: %#v, created=%t; want attempt %d running", admitted, created, current.Attempt)
+	}
+}
+
+func TestAdmitRunRecoversExistingVerifiedPullRequest(t *testing.T) {
+	t.Parallel()
+	state := newStore(t.TempDir())
+	value := issue{Repository: "acme/widgets", Number: 4, Title: "Recover publication"}
+	item, _, err := state.create(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const verifiedSHA = "0123456789012345678901234567890123456789"
+	item, err = state.update(item.ID, func(current *work) error {
+		current.State = stateFailed
+		current.Branch = "factory/recovery-attempt-1"
+		current.VerifiedSHA = verifiedSHA
+		current.Failure = "factory web stopped before the attempt completed"
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	github := fakeGitHub{pullRequest: pullRequest{URL: "https://github.com/acme/widgets/pull/9", HeadRefName: item.Branch, HeadSHA: verifiedSHA, BaseRefName: "main"}}
+	server := server{config: loadedConfig{Config: validTestConfig()}, store: state, github: github, runner: &agentRunner{githubWrites: true}, running: make(map[string]struct{})}
+	recovered, created, err := server.admitRun(t.Context(), item, false, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created || recovered.Attempt != item.Attempt || recovered.State != stateReady || recovered.PRURL != github.pullRequest.URL || recovered.Failure != "" {
+		t.Fatalf("pull request was not recovered: %#v, created=%t", recovered, created)
+	}
+}
+
+func TestAdmitRunReturnsCompletedWorkWithoutReconciliation(t *testing.T) {
+	t.Parallel()
+	state := newStore(t.TempDir())
+	value := issue{Repository: "acme/widgets", Number: 5, Title: "Already complete"}
+	item, _, err := state.create(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	completedAt := time.Now().UTC().Add(-time.Hour)
+	item, err = state.update(item.ID, func(current *work) error {
+		current.State = stateReady
+		current.Branch = "factory/complete-attempt-1"
+		current.VerifiedSHA = "0123456789012345678901234567890123456789"
+		current.PRURL = "https://github.com/acme/widgets/pull/10"
+		current.CompletedAt = completedAt
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := server{config: loadedConfig{Config: validTestConfig()}, store: state, github: fakeGitHub{}, runner: &agentRunner{githubWrites: true}, running: make(map[string]struct{})}
+	admitted, created, err := server.admitRun(t.Context(), item, false, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created || admitted.State != stateReady || admitted.Attempt != item.Attempt || !admitted.CompletedAt.Equal(completedAt) || len(admitted.Events) != len(item.Events) {
+		t.Fatalf("completed work changed during admission: %#v, created=%t", admitted, created)
+	}
+}
+
+func TestAdmitRunRejectsRecoveredPullRequestWithWrongBase(t *testing.T) {
+	t.Parallel()
+	state := newStore(t.TempDir())
+	value := issue{Repository: "acme/widgets", Number: 6, Title: "Wrong base"}
+	item, _, err := state.create(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const verifiedSHA = "0123456789012345678901234567890123456789"
+	item, err = state.update(item.ID, func(current *work) error {
+		current.State = stateFailed
+		current.Branch = "factory/wrong-base-attempt-1"
+		current.VerifiedSHA = verifiedSHA
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	github := fakeGitHub{pullRequest: pullRequest{URL: "https://github.com/acme/widgets/pull/11", HeadRefName: item.Branch, HeadSHA: verifiedSHA, BaseRefName: "release"}}
+	server := server{config: loadedConfig{Config: validTestConfig()}, store: state, github: github, runner: &agentRunner{githubWrites: true}, running: make(map[string]struct{})}
+	if _, _, err := server.admitRun(t.Context(), item, false, value); err == nil || !strings.Contains(err.Error(), "expected base branch main") {
+		t.Fatalf("wrong PR base was accepted: %v", err)
 	}
 }
 
@@ -453,6 +545,55 @@ func TestGitHubWritesRequireRemoteBaseRef(t *testing.T) {
 	_, err := newServer(loadedConfig{Config: value}, fakeGitHub{}, true, log.New(io.Discard, "", 0))
 	if err == nil || !strings.Contains(err.Error(), "origin/<branch>") {
 		t.Fatalf("write mode accepted local base ref: %v", err)
+	}
+}
+
+func TestConfigRejectsCodexForemanAndInvalidTimeout(t *testing.T) {
+	t.Parallel()
+	value := validTestConfig()
+	foreman := value.Agents[value.Roles.Foreman]
+	foreman.Runtime = "codex"
+	foreman.Command = nil
+	value.Agents[value.Roles.Foreman] = foreman
+	if err := validateConfig(value); err == nil || !strings.Contains(err.Error(), "cannot use runtime=codex") {
+		t.Fatalf("Codex Foreman was accepted: %v", err)
+	}
+	value = validTestConfig()
+	planner := value.Agents[value.Roles.Plan]
+	planner.Timeout = "0s"
+	value.Agents[value.Roles.Plan] = planner
+	if err := validateConfig(value); err == nil || !strings.Contains(err.Error(), "greater than zero") {
+		t.Fatalf("zero agent timeout was accepted: %v", err)
+	}
+}
+
+func TestLocalOnlyHandlerRejectsForeignAuthority(t *testing.T) {
+	t.Parallel()
+	handler := localOnlyHandler("127.0.0.1:7338", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	for name, mutate := range map[string]func(*http.Request){
+		"foreign host": func(request *http.Request) { request.Host = "attacker.example:7338" },
+		"foreign origin": func(request *http.Request) {
+			request.Header.Set("Origin", "http://attacker.example:7338")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://127.0.0.1:7338/api/work", nil)
+			mutate(request)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
+			}
+		})
+	}
+	request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "http://127.0.0.1:7338/api/work", nil)
+	request.Header.Set("Origin", "http://127.0.0.1:7338")
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("same-origin status = %d, want %d", response.Code, http.StatusNoContent)
 	}
 }
 
@@ -484,7 +625,7 @@ func TestPushBranchRejectsWrongOriginRepository(t *testing.T) {
 	repository := t.TempDir()
 	mustRun(t, repository, "git", "init")
 	mustRun(t, repository, "git", "remote", "add", "origin", "https://github.com/other/widgets.git")
-	err := pushBranch(t.Context(), repository, "factory/test", "acme/widgets")
+	err := pushBranch(t.Context(), repository, "factory/test", strings.Repeat("a", 40), "acme/widgets")
 	if err == nil || !strings.Contains(err.Error(), `origin points to GitHub repository "other/widgets", expected "acme/widgets"`) {
 		t.Fatalf("push accepted wrong origin: %v", err)
 	}
@@ -523,6 +664,20 @@ func TestAgentCancellationKillsDescendantProcessGroup(t *testing.T) {
 			t.Fatalf("descendant process %d survived cancellation: %v", childPID, err)
 		}
 		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestAgentDeadlineStopsHungCommand(t *testing.T) {
+	runner := agentRunner{config: loadedConfig{Config: config{Agents: map[string]agentConfig{
+		"slow": {Runtime: "command", Command: []string{"sh", "-c", "sleep 30"}, Timeout: "50ms"},
+	}}}}
+	started := time.Now()
+	_, err := runner.runAgent(t.Context(), "slow", t.TempDir(), "wait", "plan", "work", "")
+	if err == nil || !strings.Contains(err.Error(), "timed out after 50ms") {
+		t.Fatalf("hung agent did not report timeout: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > 3*time.Second {
+		t.Fatalf("hung agent took %s to stop", elapsed)
 	}
 }
 
@@ -726,6 +881,11 @@ command = [%q]
 	if completed.PRURL != "" {
 		t.Fatalf("dry run unexpectedly opened PR %q", completed.PRURL)
 	}
+	mustRun(t, completed.Workspace, "git", "checkout", "--detach", completed.VerifiedSHA)
+	if err := ensureCandidateBranch(context.Background(), completed.Workspace, completed.Branch, completed.VerifiedSHA); err == nil || !strings.Contains(err.Error(), "must remain on Factory branch") {
+		t.Fatalf("detached verified checkout was accepted: %v", err)
+	}
+	mustRun(t, completed.Workspace, "git", "checkout", completed.Branch)
 	for _, artifact := range []string{"plan.md", "build.md", "review.md", "foreman.md"} {
 		if _, err := state.readArtifact(item.ID, artifact); err != nil {
 			t.Fatalf("missing %s: %v", artifact, err)

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -10,8 +12,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 type fakeGitHub struct {
@@ -73,11 +78,12 @@ func TestInitialiseWritesEditableProject(t *testing.T) {
 func TestExplicitRetryOnlyRequeuesFailedOrBlockedWork(t *testing.T) {
 	t.Parallel()
 	state := newStore(t.TempDir())
-	item, _, err := state.create(issue{Repository: "acme/widgets", Number: 7, Title: "Retry me"})
+	originalIssue := issue{Repository: "acme/widgets", Number: 7, Title: "Retry me", Body: "Old body"}
+	item, _, err := state.create(originalIssue)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, retried, err := state.retry(item.ID); err != nil || retried {
+	if _, retried, err := state.retry(item.ID, originalIssue); err != nil || retried {
 		t.Fatalf("queued retry = %t, %v", retried, err)
 	}
 	if _, err := state.update(item.ID, func(current *work) error {
@@ -88,12 +94,109 @@ func TestExplicitRetryOnlyRequeuesFailedOrBlockedWork(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	retried, changed, err := state.retry(item.ID)
+	refreshedIssue := originalIssue
+	refreshedIssue.Body = "New details from the user"
+	retried, changed, err := state.retry(item.ID, refreshedIssue)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !changed || retried.State != stateQueued || retried.Attempt != 2 || retried.VerifyRuns != 0 || retried.Failure != "" {
 		t.Fatalf("unexpected retry: %#v, changed=%t", retried, changed)
+	}
+	if retried.Issue.Body != refreshedIssue.Body {
+		t.Fatalf("retry retained stale issue body %q", retried.Issue.Body)
+	}
+	snapshot, err := state.readArtifact(item.ID, "issue.md")
+	if err != nil || !strings.Contains(string(snapshot), refreshedIssue.Body) {
+		t.Fatalf("retry snapshot was not refreshed: %v\n%s", err, snapshot)
+	}
+}
+
+func TestWorkIDPreservesRepositoryIdentity(t *testing.T) {
+	t.Parallel()
+	first := workID("acme/foo.bar", 1)
+	second := workID("acme/foo-bar", 1)
+	if first == second {
+		t.Fatalf("distinct repositories collided at %q", first)
+	}
+}
+
+func TestConcurrentRetryAdmitsOneFreshAttempt(t *testing.T) {
+	t.Parallel()
+	state := newStore(t.TempDir())
+	original := issue{Repository: "acme/widgets", Number: 8, Title: "Retry once", Body: "Old body"}
+	item, _, err := state.create(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.update(item.ID, func(current *work) error {
+		current.State = stateFailed
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	type result struct {
+		item    work
+		changed bool
+		err     error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	for _, body := range []string{"First refresh", "Second refresh"} {
+		refreshed := original
+		refreshed.Body = body
+		go func() {
+			<-start
+			value, changed, err := state.retry(item.ID, refreshed)
+			results <- result{item: value, changed: changed, err: err}
+		}()
+	}
+	close(start)
+	changedCount := 0
+	for range 2 {
+		result := <-results
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if result.changed {
+			changedCount++
+		}
+	}
+	if changedCount != 1 {
+		t.Fatalf("concurrent retries admitted %d attempts", changedCount)
+	}
+	stored, err := state.get(item.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Attempt != 2 {
+		t.Fatalf("attempt = %d, want 2", stored.Attempt)
+	}
+	snapshot, err := state.readArtifact(item.ID, "issue.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(snapshot), stored.Issue.Body) {
+		t.Fatalf("snapshot and stored issue diverged:\n%s\n%#v", snapshot, stored.Issue)
+	}
+}
+
+func TestVerificationVerdictUsesMinimalMarkdownContract(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		body    string
+		verdict string
+		valid   bool
+	}{
+		{"Verdict: PASS\n\nChecks passed.", "PASS", true},
+		{"Verdict: REVISE\n\nFix the bug.", "REVISE", true},
+		{"Everything looks good.", "", false},
+	} {
+		verdict, err := verificationVerdict([]byte(test.body))
+		if (err == nil) != test.valid || verdict != test.verdict {
+			t.Fatalf("verificationVerdict(%q) = %q, %v", test.body, verdict, err)
+		}
 	}
 }
 
@@ -171,6 +274,42 @@ func TestGitHubWritesRequireRemoteBaseRef(t *testing.T) {
 	_, err := newServer(loadedConfig{Config: value}, fakeGitHub{}, true, log.New(io.Discard, "", 0))
 	if err == nil || !strings.Contains(err.Error(), "origin/<branch>") {
 		t.Fatalf("write mode accepted local base ref: %v", err)
+	}
+}
+
+func TestAgentCancellationKillsDescendantProcessGroup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	command := exec.CommandContext(ctx, "sh", "-c", "sleep 30 & child=$!; echo $child; wait")
+	configureAgentCommand(command)
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	scanner := bufio.NewScanner(stdout)
+	if !scanner.Scan() {
+		t.Fatalf("read descendant PID: %v", scanner.Err())
+	}
+	childPID, err := strconv.Atoi(scanner.Text())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if err := command.Wait(); err == nil {
+		t.Fatal("cancelled command exited successfully")
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		err := syscall.Kill(childPID, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("descendant process %d survived cancellation: %v", childPID, err)
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 
@@ -371,6 +510,26 @@ command = [%q]
 	}
 	if err := runner.block(context.Background(), item.ID, "stale foreman"); err == nil || !strings.Contains(err.Error(), "not running") {
 		t.Fatalf("stale foreman changed queued work: %v", err)
+	}
+	if _, err := state.update(item.ID, func(current *work) error {
+		current.State = stateFailed
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	retried, changed, err := state.retry(item.ID, value)
+	if err != nil || !changed {
+		t.Fatalf("retry failed: changed=%t, err=%v", changed, err)
+	}
+	retryWorkspace, retryBranch, err := prepareWorkspace(context.Background(), cfg, retried)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retryWorkspace == completed.Workspace || retryBranch == completed.Branch {
+		t.Fatalf("retry reused workspace %q or branch %q", retryWorkspace, retryBranch)
+	}
+	if _, err := os.Stat(filepath.Join(retryWorkspace, "result.txt")); !os.IsNotExist(err) {
+		t.Fatalf("retry inherited result.txt: %v", err)
 	}
 }
 

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -350,13 +350,64 @@ func TestForemanCommandQuotesExecutable(t *testing.T) {
 
 func TestManagedPlanBodyReplacesOnlyFactoryBlock(t *testing.T) {
 	t.Parallel()
-	first := managedPlanBody("User description", "First plan")
-	second := managedPlanBody(first, "Second plan")
+	first, err := managedPlanBody("User description", "First plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := managedPlanBody(first, "Second plan")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if strings.Count(second, "<!-- factory-plan:start -->") != 1 {
 		t.Fatalf("managed block duplicated:\n%s", second)
 	}
 	if !strings.Contains(second, "User description") || !strings.Contains(second, "Second plan") || strings.Contains(second, "First plan") {
 		t.Fatalf("managed plan replacement failed:\n%s", second)
+	}
+}
+
+func TestManagedPlanBodyRejectsMalformedMarkers(t *testing.T) {
+	t.Parallel()
+	const start = "<!-- factory-plan:start -->"
+	const end = "<!-- factory-plan:end -->"
+	for name, issueBody := range map[string]string{
+		"orphan start":    "Requirements\n" + start + "\nDo not delete this",
+		"orphan end":      "Requirements\n" + end,
+		"duplicate start": start + "\nRequirements\n" + start + "\n" + end,
+		"duplicate end":   start + "\n" + end + "\nRequirements\n" + end,
+		"wrong order":     end + "\nRequirements\n" + start,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := managedPlanBody(issueBody, "Replacement plan"); err == nil {
+				t.Fatal("malformed markers were accepted")
+			}
+		})
+	}
+	if _, err := managedPlanBody("Requirements", "Plan with "+start); err == nil {
+		t.Fatal("reserved marker in plan was accepted")
+	}
+}
+
+func TestManagedPlanBodyPreservesUserTextExactly(t *testing.T) {
+	t.Parallel()
+	const start = "<!-- factory-plan:start -->"
+	const end = "<!-- factory-plan:end -->"
+	original := "    indented requirement\nline with a hard break  \n"
+	appended, err := managedPlanBody(original, "New plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(appended, original) {
+		t.Fatalf("append changed user text:\nwant prefix %q\ngot %q", original, appended)
+	}
+	prefix := "    leading code block\nline with a hard break  \n\n"
+	suffix := "\n\nTrailing requirement  "
+	replaced, err := managedPlanBody(prefix+start+"\nOld plan\n"+end+suffix, "New plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(replaced, prefix) || !strings.HasSuffix(replaced, suffix) {
+		t.Fatalf("replacement changed user text:\nwant prefix %q and suffix %q\ngot %q", prefix, suffix, replaced)
 	}
 }
 

--- a/prototype/local-factory/local_factory_test.go
+++ b/prototype/local-factory/local_factory_test.go
@@ -1,0 +1,392 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeGitHub struct {
+	issues []issue
+}
+
+func (f fakeGitHub) Issue(_ context.Context, repository string, number int) (issue, error) {
+	for _, value := range f.issues {
+		if value.Repository == repository && value.Number == number {
+			return value, nil
+		}
+	}
+	return issue{}, fmt.Errorf("issue not found")
+}
+
+func (f fakeGitHub) LabeledIssues(context.Context, string, string) ([]issue, error) {
+	return append([]issue(nil), f.issues...), nil
+}
+
+func (fakeGitHub) UpdateIssueBody(context.Context, issue, string) error { return nil }
+func (fakeGitHub) CommentIssue(context.Context, issue, string) error    { return nil }
+func (fakeGitHub) OpenDraftPR(context.Context, issue, string, string, string, string) (string, error) {
+	return "https://github.com/acme/widgets/pull/2", nil
+}
+
+func TestParseIssueReference(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{"acme/widgets#42", "https://github.com/acme/widgets/issues/42"} {
+		repository, number, err := parseIssueReference(value)
+		if err != nil || repository != "acme/widgets" || number != 42 {
+			t.Fatalf("parseIssueReference(%q) = %q, %d, %v", value, repository, number, err)
+		}
+	}
+	if _, _, err := parseIssueReference("widgets/42"); err == nil {
+		t.Fatal("expected invalid reference to fail")
+	}
+}
+
+func TestInitialiseWritesEditableProject(t *testing.T) {
+	t.Parallel()
+	directory := filepath.Join(t.TempDir(), "factory")
+	if err := initialise(directory, "acme/widgets", "/tmp/widgets", "origin/main"); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"factory.toml", "agents/foreman.md", "agents/planner.md", "agents/builder.md", "agents/verifier.md"} {
+		body, err := os.ReadFile(filepath.Join(directory, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if len(strings.TrimSpace(string(body))) == 0 {
+			t.Fatalf("%s is empty", name)
+		}
+	}
+	if _, err := loadConfig(filepath.Join(directory, "factory.toml")); err != nil {
+		t.Fatalf("generated config does not load: %v", err)
+	}
+}
+
+func TestExplicitRetryOnlyRequeuesFailedOrBlockedWork(t *testing.T) {
+	t.Parallel()
+	state := newStore(t.TempDir())
+	item, _, err := state.create(issue{Repository: "acme/widgets", Number: 7, Title: "Retry me"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, retried, err := state.retry(item.ID); err != nil || retried {
+		t.Fatalf("queued retry = %t, %v", retried, err)
+	}
+	if _, err := state.update(item.ID, func(current *work) error {
+		current.State = stateFailed
+		current.Failure = "agent stopped"
+		current.VerifyRuns = 2
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	retried, changed, err := state.retry(item.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed || retried.State != stateQueued || retried.Attempt != 2 || retried.VerifyRuns != 0 || retried.Failure != "" {
+		t.Fatalf("unexpected retry: %#v, changed=%t", retried, changed)
+	}
+}
+
+func TestManagedPlanBodyReplacesOnlyFactoryBlock(t *testing.T) {
+	t.Parallel()
+	first := managedPlanBody("User description", "First plan")
+	second := managedPlanBody(first, "Second plan")
+	if strings.Count(second, "<!-- factory-plan:start -->") != 1 {
+		t.Fatalf("managed block duplicated:\n%s", second)
+	}
+	if !strings.Contains(second, "User description") || !strings.Contains(second, "Second plan") || strings.Contains(second, "First plan") {
+		t.Fatalf("managed plan replacement failed:\n%s", second)
+	}
+}
+
+func TestConfigRejectsNonPositivePollInterval(t *testing.T) {
+	t.Parallel()
+	value := validTestConfig()
+	for _, interval := range []string{"0s", "-1s"} {
+		value.Server.PollEvery = interval
+		if err := validateConfig(value); err == nil || !strings.Contains(err.Error(), "greater than zero") {
+			t.Fatalf("poll interval %q was accepted: %v", interval, err)
+		}
+	}
+}
+
+func TestRunAPIRejectsSimpleCrossOriginContentType(t *testing.T) {
+	t.Parallel()
+	request := httptest.NewRequest(http.MethodPost, "/api/run", strings.NewReader(`{"issue":"acme/widgets#1"}`))
+	request.Header.Set("Content-Type", "text/plain")
+	response := httptest.NewRecorder()
+	server := server{config: loadedConfig{Config: validTestConfig()}, store: newStore(t.TempDir()), github: fakeGitHub{}}
+	server.handleRun(response, request)
+	if response.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("response status = %d, want %d", response.Code, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestRunAPIDoesNotRetryWhileOldAttemptIsActive(t *testing.T) {
+	t.Parallel()
+	cfg := loadedConfig{Config: validTestConfig()}
+	state := newStore(t.TempDir())
+	value := issue{Repository: "acme/widgets", Number: 1, Title: "Blocked but still unwinding"}
+	item, _, err := state.create(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := state.update(item.ID, func(current *work) error {
+		current.State = stateBlocked
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	server := server{config: cfg, store: state, github: fakeGitHub{issues: []issue{value}}, running: map[string]struct{}{item.ID: {}}}
+	request := httptest.NewRequest(http.MethodPost, "/api/run", strings.NewReader(`{"issue":"acme/widgets#1"}`))
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	server.handleRun(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("response status = %d, want %d", response.Code, http.StatusOK)
+	}
+	current, err := state.get(item.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.Attempt != 1 || current.State != stateBlocked {
+		t.Fatalf("active attempt was retried: %#v", current)
+	}
+}
+
+func TestGitHubWritesRequireRemoteBaseRef(t *testing.T) {
+	t.Parallel()
+	value := validTestConfig()
+	value.Repositories[0].BaseRef = "HEAD"
+	_, err := newServer(loadedConfig{Config: value}, fakeGitHub{}, true, log.New(io.Discard, "", 0))
+	if err == nil || !strings.Contains(err.Error(), "origin/<branch>") {
+		t.Fatalf("write mode accepted local base ref: %v", err)
+	}
+}
+
+func validTestConfig() config {
+	return config{
+		Version:      1,
+		MaxRevisions: 2,
+		Server: serverConfig{
+			Listen:        "127.0.0.1:7338",
+			PollEvery:     "1m",
+			TriggerLabel:  "factory",
+			MaxConcurrent: 1,
+		},
+		Repositories: []repositoryConfig{{GitHub: "acme/widgets", Path: "/tmp/widgets", BaseRef: "origin/main"}},
+		Agents: map[string]agentConfig{
+			"foreman":  {Runtime: "command", Prompt: "foreman.md", Command: []string{"true"}},
+			"planner":  {Runtime: "command", Prompt: "planner.md", Command: []string{"true"}},
+			"builder":  {Runtime: "command", Prompt: "builder.md", Command: []string{"true"}},
+			"verifier": {Runtime: "command", Prompt: "verifier.md", Command: []string{"true"}},
+		},
+		Roles: roleConfig{Foreman: "foreman", Plan: "planner", Build: "builder", Verify: "verifier"},
+	}
+}
+
+func TestRunnerCompletesRevisionLoop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds the local factory binary")
+	}
+	root := t.TempDir()
+	repository := filepath.Join(root, "repository")
+	mustRun(t, "", "git", "init", repository)
+	mustRun(t, repository, "git", "config", "user.name", "Test")
+	mustRun(t, repository, "git", "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(repository, "README.md"), []byte("fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, repository, "git", "add", "README.md")
+	mustRun(t, repository, "git", "commit", "-m", "chore: initial")
+
+	packageDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	binary := filepath.Join(root, "factory")
+	mustRun(t, packageDirectory, "go", "build", "-o", binary, ".")
+
+	project := filepath.Join(root, "project")
+	if err := os.MkdirAll(filepath.Join(project, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentScript := filepath.Join(root, "agent.sh")
+	coordinatorScript := filepath.Join(root, "foreman.sh")
+	writeExecutable(t, agentScript, `#!/bin/sh
+set -eu
+case "$FACTORY_ROLE" in
+  plan)
+    printf 'Outcome: READY\n\nPlan: change result.txt and verify it.\n'
+    ;;
+  build)
+    if [ -f result.txt ]; then
+      printf 'correct\n' > result.txt
+      printf 'Revised result.txt after verifier feedback.\n'
+    else
+      printf 'first attempt\n' > result.txt
+      printf 'Created the first candidate.\n'
+    fi
+    ;;
+  verify)
+    if grep -q '^correct$' result.txt; then
+      printf 'Verdict: PASS\n\nThe exact candidate is correct.\n'
+    else
+      printf 'Verdict: REVISE\n\nresult.txt has the wrong value.\n'
+    fi
+    ;;
+esac
+`)
+	writeExecutable(t, coordinatorScript, `#!/bin/sh
+set -eu
+factory="$FACTORY_EXECUTABLE"
+base="$factory internal --config $FACTORY_CONFIG --work $FACTORY_WORK_ID"
+$base delegate plan
+$base publish-plan
+$base delegate build
+$base delegate verify
+$base delegate build
+$base delegate verify
+$base finish
+printf 'Foreman completed one revision loop.\n'
+`)
+	for _, name := range []string{"foreman", "planner", "builder", "verifier"} {
+		if err := os.WriteFile(filepath.Join(project, "agents", name+".md"), []byte("Test "+name+" prompt.\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	configPath := filepath.Join(project, "factory.toml")
+	configBody := fmt.Sprintf(`version = 1
+state_directory = ".state"
+max_revisions = 2
+[server]
+listen = "127.0.0.1:0"
+poll_every = "1h"
+trigger_label = "factory-test-never"
+max_concurrent = 1
+[[repositories]]
+github = "acme/widgets"
+path = %q
+base_ref = "HEAD"
+[roles]
+foreman = "foreman"
+plan = "planner"
+build = "builder"
+verify = "verifier"
+[agents.foreman]
+runtime = "command"
+prompt = "agents/foreman.md"
+command = [%q]
+[agents.planner]
+runtime = "command"
+prompt = "agents/planner.md"
+command = [%q]
+[agents.builder]
+runtime = "command"
+prompt = "agents/builder.md"
+command = [%q]
+[agents.verifier]
+runtime = "command"
+prompt = "agents/verifier.md"
+command = [%q]
+`, repository, coordinatorScript, agentScript, agentScript, agentScript)
+	if err := os.WriteFile(configPath, []byte(configBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := newStore(cfg.Config.StateDirectory)
+	value := issue{Repository: "acme/widgets", Number: 1, Title: "Produce the correct result", Body: "The result must be correct.", URL: "https://github.com/acme/widgets/issues/1"}
+	item, _, err := state.create(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := agentRunner{config: cfg, store: state, github: fakeGitHub{issues: []issue{value}}, executable: binary}
+	if err := runner.runWork(context.Background(), item.ID); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := state.get(item.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if completed.State != stateReady || completed.VerifyRuns != 2 {
+		t.Fatalf("completed work = state %q, verify runs %d", completed.State, completed.VerifyRuns)
+	}
+	if completed.VerifiedSHA == "" || completed.VerifiedSHA != completed.HeadSHA {
+		t.Fatalf("candidate SHA %q was not the verified SHA %q", completed.HeadSHA, completed.VerifiedSHA)
+	}
+	result, err := os.ReadFile(filepath.Join(completed.Workspace, "result.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(result) != "correct\n" {
+		t.Fatalf("result.txt = %q", result)
+	}
+	if completed.PRURL != "" {
+		t.Fatalf("dry run unexpectedly opened PR %q", completed.PRURL)
+	}
+	for _, artifact := range []string{"plan.md", "build.md", "review.md", "foreman.md"} {
+		if _, err := state.readArtifact(item.ID, artifact); err != nil {
+			t.Fatalf("missing %s: %v", artifact, err)
+		}
+	}
+	verificationWorkspace := filepath.Join(cfg.Config.StateDirectory, "checkouts", item.ID, "verify", "attempt-1-run-2")
+	if err := os.WriteFile(filepath.Join(verificationWorkspace, "verifier-change.txt"), []byte("must not be accepted\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, verificationWorkspace, "git", "add", "verifier-change.txt")
+	mustRun(t, verificationWorkspace, "git", "-c", "user.name=Verifier", "-c", "user.email=verifier@example.com", "commit", "-m", "bad verifier change")
+	if err := ensureExactHead(context.Background(), verificationWorkspace, completed.HeadSHA); err == nil || !strings.Contains(err.Error(), "HEAD changed") {
+		t.Fatalf("accepted verifier commit: %v", err)
+	}
+	if _, err := state.update(item.ID, func(current *work) error {
+		current.State = stateRunning
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(completed.Workspace, "unverified.txt"), []byte("late change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runner.finish(context.Background(), item.ID); err == nil || !strings.Contains(err.Error(), "changed after verification") {
+		t.Fatalf("finish accepted unverified worktree change: %v", err)
+	}
+	if _, err := state.update(item.ID, func(current *work) error {
+		current.State = stateQueued
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := runner.block(context.Background(), item.ID, "stale foreman"); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("stale foreman changed queued work: %v", err)
+	}
+}
+
+func writeExecutable(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustRun(t *testing.T, directory, name string, args ...string) {
+	t.Helper()
+	command := exec.Command(name, args...)
+	command.Dir = directory
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+}

--- a/prototype/local-factory/main.go
+++ b/prototype/local-factory/main.go
@@ -124,11 +124,16 @@ func submitCommand(args []string) error {
 	}
 	body, _ := json.Marshal(map[string]string{"issue": reference})
 	client := http.Client{Timeout: 30 * time.Second}
-	response, err := client.Post(serverURL(cfg.Config.Server.Listen)+"/api/run", "application/json", bytes.NewReader(body))
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, serverURL(cfg.Config.Server.Listen)+"/api/run", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := client.Do(request)
 	if err != nil {
 		return fmt.Errorf("connect to factory web: %w", err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	responseBody, _ := io.ReadAll(response.Body)
 	if response.StatusCode >= 300 {
 		return fmt.Errorf("factory web returned %s: %s", response.Status, strings.TrimSpace(string(responseBody)))
@@ -153,11 +158,15 @@ func statusCommand(args []string) error {
 		return err
 	}
 	client := http.Client{Timeout: 5 * time.Second}
-	response, err := client.Get(serverURL(cfg.Config.Server.Listen) + "/api/work")
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, serverURL(cfg.Config.Server.Listen)+"/api/work", nil)
+	if err != nil {
+		return err
+	}
+	response, err := client.Do(request)
 	if err != nil {
 		return fmt.Errorf("connect to factory web: %w", err)
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }()
 	if response.StatusCode >= 300 {
 		return fmt.Errorf("factory web returned %s", response.Status)
 	}
@@ -180,55 +189,66 @@ func internalCommand(args []string) error {
 	if err != nil {
 		return err
 	}
-	executable, err := executablePath()
-	if err != nil {
-		return err
+	authToken := os.Getenv("FACTORY_AUTH_TOKEN")
+	if authToken == "" {
+		return errors.New("internal command is not authorized by factory web")
 	}
-	writes, _ := strconvParseBool(os.Getenv("FACTORY_GITHUB_WRITES"))
-	runner := &agentRunner{config: cfg, store: newStore(cfg.Config.StateDirectory), github: ghClient{}, githubWrites: writes, executable: executable}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	action := flags.Arg(0)
+	actionArgs := flags.Args()[1:]
 	switch action {
 	case "delegate":
-		if flags.NArg() != 2 {
+		if len(actionArgs) != 1 {
 			return errors.New("delegate requires a role")
 		}
-		output, err := runner.delegate(ctx, *workID, flags.Arg(1))
-		if len(output) != 0 {
-			_, _ = os.Stdout.Write(output)
-		}
-		return err
 	case "publish-plan":
-		return runner.publishPlan(ctx, *workID)
+		if len(actionArgs) != 0 {
+			return errors.New("publish-plan does not accept arguments")
+		}
 	case "finish":
-		return runner.finish(ctx, *workID)
+		if len(actionArgs) != 0 {
+			return errors.New("finish does not accept arguments")
+		}
 	case "block":
-		if flags.NArg() < 2 {
+		if len(actionArgs) == 0 {
 			return errors.New("block requires a reason")
 		}
-		return runner.block(ctx, *workID, strings.Join(flags.Args()[1:], " "))
 	default:
 		return fmt.Errorf("unknown internal action %q", action)
 	}
+	payload, _ := json.Marshal(struct {
+		WorkID string   `json:"work_id"`
+		Action string   `json:"action"`
+		Args   []string `json:"args"`
+	}{WorkID: *workID, Action: action, Args: actionArgs})
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL(cfg.Config.Server.Listen)+"/api/internal", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer "+authToken)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("connect to factory web: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	responseBody, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		return readErr
+	}
+	if response.StatusCode >= 300 {
+		return fmt.Errorf("factory web returned %s: %s", response.Status, strings.TrimSpace(string(responseBody)))
+	}
+	if len(responseBody) != 0 {
+		_, _ = os.Stdout.Write(responseBody)
+	}
+	return nil
 }
 
 func takeFirstArgument(args []string) (string, []string, error) {
-	for index, value := range args {
-		if !strings.HasPrefix(value, "-") {
-			return value, append(append([]string(nil), args[:index]...), args[index+1:]...), nil
-		}
+	if len(args) == 0 || strings.HasPrefix(args[0], "-") {
+		return "", args, errors.New("argument not found")
 	}
-	return "", args, errors.New("argument not found")
-}
-
-func strconvParseBool(value string) (bool, error) {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "1", "true", "yes":
-		return true, nil
-	case "", "0", "false", "no":
-		return false, nil
-	default:
-		return false, fmt.Errorf("invalid boolean %q", value)
-	}
+	return args[0], args[1:], nil
 }

--- a/prototype/local-factory/main.go
+++ b/prototype/local-factory/main.go
@@ -186,7 +186,8 @@ func internalCommand(args []string) error {
 	}
 	writes, _ := strconvParseBool(os.Getenv("FACTORY_GITHUB_WRITES"))
 	runner := &agentRunner{config: cfg, store: newStore(cfg.Config.StateDirectory), github: ghClient{}, githubWrites: writes, executable: executable}
-	ctx := context.Background()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	action := flags.Arg(0)
 	switch action {
 	case "delegate":

--- a/prototype/local-factory/main.go
+++ b/prototype/local-factory/main.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+func main() {
+	if err := runCLI(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "factory:", err)
+		os.Exit(1)
+	}
+}
+
+func runCLI(args []string) error {
+	if len(args) == 0 {
+		return usageError()
+	}
+	switch args[0] {
+	case "init":
+		return initCommand(args[1:])
+	case "web":
+		return webCommand(args[1:])
+	case "run":
+		return submitCommand(args[1:])
+	case "status":
+		return statusCommand(args[1:])
+	case "internal":
+		return internalCommand(args[1:])
+	case "help", "-h", "--help":
+		fmt.Print(usage)
+		return nil
+	default:
+		return fmt.Errorf("unknown command %q\n\n%s", args[0], usage)
+	}
+}
+
+const usage = `Usage:
+  factory init DIRECTORY --repo OWNER/REPO --repo-path PATH [--base-ref REF]
+  factory web [--config factory.toml] [--github-writes]
+  factory run ISSUE [--config factory.toml]
+  factory status [--config factory.toml]
+
+factory web is the always-on process. It owns polling, scheduling, local
+workers, durable state, and the monitoring UI. GitHub writes are off unless
+--github-writes is explicitly supplied.
+`
+
+func usageError() error { return errors.New(strings.TrimSpace(usage)) }
+
+func initCommand(args []string) error {
+	directory, remaining, err := takeFirstArgument(args)
+	if err != nil {
+		return fmt.Errorf("init: directory is required")
+	}
+	flags := flag.NewFlagSet("init", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	repository := flags.String("repo", "", "GitHub owner/repository")
+	repositoryPath := flags.String("repo-path", "", "local repository checkout")
+	baseRef := flags.String("base-ref", "", "Git base ref; defaults to origin's default branch")
+	if err := flags.Parse(remaining); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return usageError()
+	}
+	if err := initialise(directory, *repository, *repositoryPath, *baseRef); err != nil {
+		return err
+	}
+	fmt.Printf("Created %s\nNext: cd %s && factory web\n", directory, directory)
+	return nil
+}
+
+func webCommand(args []string) error {
+	flags := flag.NewFlagSet("web", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	configPath := flags.String("config", "factory.toml", "config path")
+	githubWrites := flags.Bool("github-writes", false, "allow issue, branch, and PR writes")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return usageError()
+	}
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	server, err := newServer(cfg, ghClient{}, *githubWrites, log.New(os.Stderr, "", log.LstdFlags))
+	if err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return server.serve(ctx)
+}
+
+func submitCommand(args []string) error {
+	reference, remaining, err := takeFirstArgument(args)
+	if err != nil {
+		return fmt.Errorf("run: GitHub issue is required")
+	}
+	flags := flag.NewFlagSet("run", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	configPath := flags.String("config", "factory.toml", "config path")
+	if err := flags.Parse(remaining); err != nil {
+		return err
+	}
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	body, _ := json.Marshal(map[string]string{"issue": reference})
+	client := http.Client{Timeout: 30 * time.Second}
+	response, err := client.Post(serverURL(cfg.Config.Server.Listen)+"/api/run", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("connect to factory web: %w", err)
+	}
+	defer response.Body.Close()
+	responseBody, _ := io.ReadAll(response.Body)
+	if response.StatusCode >= 300 {
+		return fmt.Errorf("factory web returned %s: %s", response.Status, strings.TrimSpace(string(responseBody)))
+	}
+	var item work
+	if err := json.Unmarshal(responseBody, &item); err != nil {
+		return err
+	}
+	fmt.Printf("%s: %s\n%s\n", item.ID, item.State, serverURL(cfg.Config.Server.Listen))
+	return nil
+}
+
+func statusCommand(args []string) error {
+	flags := flag.NewFlagSet("status", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	configPath := flags.String("config", "factory.toml", "config path")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	client := http.Client{Timeout: 5 * time.Second}
+	response, err := client.Get(serverURL(cfg.Config.Server.Listen) + "/api/work")
+	if err != nil {
+		return fmt.Errorf("connect to factory web: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode >= 300 {
+		return fmt.Errorf("factory web returned %s", response.Status)
+	}
+	_, err = io.Copy(os.Stdout, response.Body)
+	return err
+}
+
+func internalCommand(args []string) error {
+	flags := flag.NewFlagSet("internal", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	configPath := flags.String("config", "", "config path")
+	workID := flags.String("work", "", "work ID")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if *configPath == "" || *workID == "" || flags.NArg() == 0 {
+		return errors.New("internal requires --config, --work, and an action")
+	}
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	executable, err := executablePath()
+	if err != nil {
+		return err
+	}
+	writes, _ := strconvParseBool(os.Getenv("FACTORY_GITHUB_WRITES"))
+	runner := &agentRunner{config: cfg, store: newStore(cfg.Config.StateDirectory), github: ghClient{}, githubWrites: writes, executable: executable}
+	ctx := context.Background()
+	action := flags.Arg(0)
+	switch action {
+	case "delegate":
+		if flags.NArg() != 2 {
+			return errors.New("delegate requires a role")
+		}
+		output, err := runner.delegate(ctx, *workID, flags.Arg(1))
+		if len(output) != 0 {
+			_, _ = os.Stdout.Write(output)
+		}
+		return err
+	case "publish-plan":
+		return runner.publishPlan(ctx, *workID)
+	case "finish":
+		return runner.finish(ctx, *workID)
+	case "block":
+		if flags.NArg() < 2 {
+			return errors.New("block requires a reason")
+		}
+		return runner.block(ctx, *workID, strings.Join(flags.Args()[1:], " "))
+	default:
+		return fmt.Errorf("unknown internal action %q", action)
+	}
+}
+
+func takeFirstArgument(args []string) (string, []string, error) {
+	for index, value := range args {
+		if !strings.HasPrefix(value, "-") {
+			return value, append(append([]string(nil), args[:index]...), args[index+1:]...), nil
+		}
+	}
+	return "", args, errors.New("argument not found")
+}
+
+func strconvParseBool(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes":
+		return true, nil
+	case "", "0", "false", "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean %q", value)
+	}
+}

--- a/prototype/local-factory/model.go
+++ b/prototype/local-factory/model.go
@@ -1,0 +1,45 @@
+package main
+
+import "time"
+
+type issue struct {
+	Repository string   `json:"repository"`
+	Number     int      `json:"number"`
+	Title      string   `json:"title"`
+	Body       string   `json:"body"`
+	URL        string   `json:"url"`
+	Labels     []string `json:"labels,omitempty"`
+}
+
+type event struct {
+	At      time.Time `json:"at"`
+	Message string    `json:"message"`
+}
+
+type work struct {
+	ID          string    `json:"id"`
+	Issue       issue     `json:"issue"`
+	State       string    `json:"state"`
+	Attempt     int       `json:"attempt"`
+	ActiveRole  string    `json:"active_role,omitempty"`
+	Branch      string    `json:"branch,omitempty"`
+	Workspace   string    `json:"workspace,omitempty"`
+	HeadSHA     string    `json:"head_sha,omitempty"`
+	VerifiedSHA string    `json:"verified_sha,omitempty"`
+	VerifyRuns  int       `json:"verify_runs,omitempty"`
+	PRURL       string    `json:"pr_url,omitempty"`
+	Failure     string    `json:"failure,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	StartedAt   time.Time `json:"started_at,omitempty"`
+	CompletedAt time.Time `json:"completed_at,omitempty"`
+	Events      []event   `json:"events"`
+}
+
+const (
+	stateQueued  = "queued"
+	stateRunning = "running"
+	stateBlocked = "blocked"
+	stateReady   = "ready"
+	stateFailed  = "failed"
+)

--- a/prototype/local-factory/server.go
+++ b/prototype/local-factory/server.go
@@ -324,16 +324,10 @@ func (s *server) handleRun(w http.ResponseWriter, request *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	unlock := s.lockWork(item.ID)
-	defer unlock()
-	if !created {
-		if !s.isRunning(item.ID) {
-			item, created, err = s.store.retry(item.ID, value)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-		}
+	item, created, err = s.admitRun(item, created, value)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	status := http.StatusAccepted
 	if !created {
@@ -342,6 +336,19 @@ func (s *server) handleRun(w http.ResponseWriter, request *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(item)
+}
+
+func (s *server) admitRun(item work, created bool, value issue) (work, bool, error) {
+	unlock := s.lockWork(item.ID)
+	defer unlock()
+	if created {
+		return item, true, nil
+	}
+	if !s.isRunning(item.ID) {
+		return s.store.retry(item.ID, value)
+	}
+	item, err := s.store.get(item.ID)
+	return item, false, err
 }
 
 func (s *server) lockWork(id string) func() {

--- a/prototype/local-factory/server.go
+++ b/prototype/local-factory/server.go
@@ -22,9 +22,10 @@ type server struct {
 	runner *agentRunner
 	log    *log.Logger
 
-	mu      sync.Mutex
-	running map[string]struct{}
-	workers sync.WaitGroup
+	mu        sync.Mutex
+	running   map[string]struct{}
+	workLocks map[string]*sync.Mutex
+	workers   sync.WaitGroup
 }
 
 func newServer(cfg loadedConfig, github githubClient, writes bool, logger *log.Logger) (*server, error) {
@@ -45,7 +46,7 @@ func newServer(cfg loadedConfig, github githubClient, writes bool, logger *log.L
 	}
 	state := newStore(cfg.Config.StateDirectory)
 	runner := &agentRunner{config: cfg, store: state, github: github, githubWrites: writes, executable: executable, authToken: authToken}
-	return &server{config: cfg, store: state, github: github, runner: runner, log: logger, running: make(map[string]struct{})}, nil
+	return &server{config: cfg, store: state, github: github, runner: runner, log: logger, running: make(map[string]struct{}), workLocks: make(map[string]*sync.Mutex)}, nil
 }
 
 func (s *server) serve(ctx context.Context) error {
@@ -112,12 +113,6 @@ func (s *server) serve(ctx context.Context) error {
 }
 
 func (s *server) handleInternal(w http.ResponseWriter, request *http.Request) {
-	expected := "Bearer " + s.runner.authToken
-	provided := request.Header.Get("Authorization")
-	if subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
-		http.Error(w, "unauthorized internal command", http.StatusUnauthorized)
-		return
-	}
 	mediaType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
 	if err != nil || mediaType != "application/json" {
 		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
@@ -131,6 +126,19 @@ func (s *server) handleInternal(w http.ResponseWriter, request *http.Request) {
 	}
 	if err := json.NewDecoder(request.Body).Decode(&input); err != nil || input.WorkID == "" {
 		http.Error(w, "invalid internal command", http.StatusBadRequest)
+		return
+	}
+	unlock := s.lockWork(input.WorkID)
+	defer unlock()
+	item, err := s.store.get(input.WorkID)
+	if err != nil {
+		http.Error(w, "unauthorized internal command", http.StatusUnauthorized)
+		return
+	}
+	expected := "Bearer " + s.runner.workToken(item)
+	provided := request.Header.Get("Authorization")
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+		http.Error(w, "unauthorized internal command", http.StatusUnauthorized)
 		return
 	}
 	var output []byte
@@ -316,6 +324,8 @@ func (s *server) handleRun(w http.ResponseWriter, request *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	unlock := s.lockWork(item.ID)
+	defer unlock()
 	if !created {
 		if !s.isRunning(item.ID) {
 			item, created, err = s.store.retry(item.ID, value)
@@ -332,6 +342,21 @@ func (s *server) handleRun(w http.ResponseWriter, request *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(item)
+}
+
+func (s *server) lockWork(id string) func() {
+	s.mu.Lock()
+	if s.workLocks == nil {
+		s.workLocks = make(map[string]*sync.Mutex)
+	}
+	lock := s.workLocks[id]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		s.workLocks[id] = lock
+	}
+	s.mu.Unlock()
+	lock.Lock()
+	return lock.Unlock
 }
 
 func (s *server) isRunning(id string) bool {

--- a/prototype/local-factory/server.go
+++ b/prototype/local-factory/server.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"log"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type server struct {
+	config loadedConfig
+	store  *store
+	github githubClient
+	runner *agentRunner
+	log    *log.Logger
+
+	mu      sync.Mutex
+	running map[string]struct{}
+}
+
+func newServer(cfg loadedConfig, github githubClient, writes bool, logger *log.Logger) (*server, error) {
+	if writes {
+		for _, repository := range cfg.Config.Repositories {
+			if !strings.HasPrefix(repository.BaseRef, "origin/") || strings.TrimPrefix(repository.BaseRef, "origin/") == "" {
+				return nil, fmt.Errorf("repository %s base_ref must use origin/<branch> when GitHub writes are enabled", repository.GitHub)
+			}
+		}
+	}
+	executable, err := executablePath()
+	if err != nil {
+		return nil, err
+	}
+	state := newStore(cfg.Config.StateDirectory)
+	runner := &agentRunner{config: cfg, store: state, github: github, githubWrites: writes, executable: executable}
+	return &server{config: cfg, store: state, github: github, runner: runner, log: logger, running: make(map[string]struct{})}, nil
+}
+
+func (s *server) serve(ctx context.Context) error {
+	if err := s.recoverInterrupted(); err != nil {
+		return err
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", s.handleHome)
+	mux.HandleFunc("GET /api/work", s.handleList)
+	mux.HandleFunc("POST /api/run", s.handleRun)
+	mux.HandleFunc("POST /webhooks/github", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "GitHub webhooks are not enabled in this local spike; use the poller", http.StatusNotImplemented)
+	})
+
+	httpServer := &http.Server{Addr: s.config.Config.Server.Listen, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	go s.schedule(ctx)
+	go s.poll(ctx)
+	go func() {
+		<-ctx.Done()
+		shutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = httpServer.Shutdown(shutdown)
+	}()
+	s.log.Printf("factory web listening on http://%s", displayAddress(s.config.Config.Server.Listen))
+	err := httpServer.ListenAndServe()
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
+}
+
+func (s *server) recoverInterrupted() error {
+	items, err := s.store.list()
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		if item.State != stateRunning {
+			continue
+		}
+		_, err := s.store.update(item.ID, func(current *work) error {
+			current.State = stateFailed
+			current.ActiveRole = ""
+			current.Failure = "factory web stopped while this attempt was running"
+			current.Events = append(current.Events, event{At: time.Now().UTC(), Message: "interrupted attempt marked failed on restart"})
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *server) poll(ctx context.Context) {
+	duration, _ := time.ParseDuration(s.config.Config.Server.PollEvery)
+	ticker := time.NewTicker(duration)
+	defer ticker.Stop()
+	s.pollOnce(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.pollOnce(ctx)
+		}
+	}
+}
+
+func (s *server) pollOnce(ctx context.Context) {
+	for _, repository := range s.config.Config.Repositories {
+		issues, err := s.github.LabeledIssues(ctx, repository.GitHub, s.config.Config.Server.TriggerLabel)
+		if err != nil {
+			s.log.Printf("poll %s: %v", repository.GitHub, err)
+			continue
+		}
+		for _, value := range issues {
+			if _, created, err := s.store.create(value); err != nil {
+				s.log.Printf("admit %s#%d: %v", value.Repository, value.Number, err)
+			} else if created {
+				s.log.Printf("queued %s#%d from label", value.Repository, value.Number)
+			}
+		}
+	}
+}
+
+func (s *server) schedule(ctx context.Context) {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.startQueued(ctx)
+		}
+	}
+}
+
+func (s *server) startQueued(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.running) >= s.config.Config.Server.MaxConcurrent {
+		return
+	}
+	items, err := s.store.list()
+	if err != nil {
+		s.log.Printf("schedule: %v", err)
+		return
+	}
+	for i := len(items) - 1; i >= 0 && len(s.running) < s.config.Config.Server.MaxConcurrent; i-- {
+		item := items[i]
+		if item.State != stateQueued {
+			continue
+		}
+		if _, active := s.running[item.ID]; active {
+			continue
+		}
+		s.running[item.ID] = struct{}{}
+		go s.execute(ctx, item.ID)
+	}
+}
+
+func (s *server) execute(ctx context.Context, id string) {
+	err := s.runner.runWork(ctx, id)
+	if err != nil {
+		_, _ = s.store.update(id, func(item *work) error {
+			if item.State == stateRunning || item.State == stateQueued {
+				item.State = stateFailed
+				item.ActiveRole = ""
+				item.Failure = err.Error()
+				item.CompletedAt = time.Now().UTC()
+				item.Events = append(item.Events, event{At: time.Now().UTC(), Message: "attempt failed: " + err.Error()})
+			}
+			return nil
+		})
+		s.log.Printf("work %s failed: %v", id, err)
+	}
+	s.mu.Lock()
+	delete(s.running, id)
+	s.mu.Unlock()
+}
+
+func (s *server) handleRun(w http.ResponseWriter, request *http.Request) {
+	mediaType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	request.Body = http.MaxBytesReader(w, request.Body, 16<<10)
+	var input struct {
+		Issue string `json:"issue"`
+	}
+	if err := json.NewDecoder(request.Body).Decode(&input); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	repository, number, err := parseIssueReference(input.Issue)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if _, err := repositoryFor(s.config, repository); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	value, err := s.github.Issue(request.Context(), repository, number)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	item, created, err := s.store.create(value)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !created {
+		if !s.isRunning(item.ID) {
+			item, created, err = s.store.retry(item.ID)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+	status := http.StatusAccepted
+	if !created {
+		status = http.StatusOK
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(item)
+}
+
+func (s *server) isRunning(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.running[id]
+	return ok
+}
+
+func (s *server) handleList(w http.ResponseWriter, _ *http.Request) {
+	items, err := s.store.list()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(items)
+}
+
+var homeTemplate = template.Must(template.New("home").Funcs(template.FuncMap{
+	"shortTime": func(value time.Time) string {
+		if value.IsZero() {
+			return ""
+		}
+		return value.Local().Format("2006-01-02 15:04:05")
+	},
+}).Parse(`<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><meta http-equiv="refresh" content="5"><title>Factory</title><style>
+body{font:15px system-ui,sans-serif;max-width:1100px;margin:40px auto;padding:0 20px;color:#18202a;background:#f6f7f9}h1{font-size:24px}p{color:#5c6773}.grid{display:grid;gap:14px}.card{background:white;border:1px solid #dde2e7;border-radius:10px;padding:16px}.top{display:flex;justify-content:space-between;gap:16px}.state{font:12px ui-monospace,monospace;text-transform:uppercase;padding:4px 8px;border-radius:999px;background:#edf1f5}.meta{font-size:13px;color:#66717d}.events{margin:12px 0 0;padding-left:20px;color:#48535e}a{color:#075bc7;text-decoration:none}code{font-size:12px}
+</style></head><body><h1>Factory</h1><p>Always-on local control plane. Polling every {{.PollEvery}} for <code>{{.Label}}</code>.</p><div class="grid">{{range .Work}}<section class="card"><div class="top"><div><a href="{{.Issue.URL}}"><strong>{{.Issue.Repository}}#{{.Issue.Number}} {{.Issue.Title}}</strong></a><div class="meta">Attempt {{.Attempt}} · updated {{shortTime .UpdatedAt}}{{if .ActiveRole}} · active: {{.ActiveRole}}{{end}}{{if .Branch}} · {{.Branch}}{{end}}</div></div><span class="state">{{.State}}</span></div>{{if .Failure}}<p>{{.Failure}}</p>{{end}}{{if .PRURL}}<p><a href="{{.PRURL}}">Open pull request</a></p>{{end}}<ul class="events">{{range .Events}}<li>{{shortTime .At}} · {{.Message}}</li>{{end}}</ul></section>{{else}}<section class="card">No work yet. Add the configured label or run <code>factory run owner/repo#123</code>.</section>{{end}}</div></body></html>`))
+
+func (s *server) handleHome(w http.ResponseWriter, _ *http.Request) {
+	items, err := s.store.list()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	data := struct {
+		PollEvery string
+		Label     string
+		Work      []work
+	}{s.config.Config.Server.PollEvery, s.config.Config.Server.TriggerLabel, items}
+	if err := homeTemplate.Execute(w, data); err != nil {
+		s.log.Printf("render home: %v", err)
+	}
+}
+
+func displayAddress(address string) string {
+	if strings.HasPrefix(address, ":") {
+		return "127.0.0.1" + address
+	}
+	return address
+}
+
+func serverURL(address string) string { return fmt.Sprintf("http://%s", displayAddress(address)) }

--- a/prototype/local-factory/server.go
+++ b/prototype/local-factory/server.go
@@ -10,6 +10,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -70,7 +71,7 @@ func (s *server) serve(ctx context.Context) error {
 
 	httpServer := &http.Server{
 		Addr:              s.config.Config.Server.Listen,
-		Handler:           mux,
+		Handler:           localOnlyHandler(s.config.Config.Server.Listen, mux),
 		ReadHeaderTimeout: 5 * time.Second,
 		BaseContext: func(net.Listener) context.Context {
 			return serverContext
@@ -110,6 +111,35 @@ func (s *server) serve(ctx context.Context) error {
 		return nil
 	}
 	return err
+}
+
+func localOnlyHandler(expectedAddress string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if !sameAuthority(request.Host, expectedAddress) {
+			http.Error(w, "forbidden request host", http.StatusForbidden)
+			return
+		}
+		if origin := request.Header.Get("Origin"); origin != "" {
+			originURL, err := url.Parse(origin)
+			if err != nil || originURL.Scheme != "http" || originURL.User != nil || originURL.Path != "" || originURL.RawQuery != "" || originURL.Fragment != "" || !sameAuthority(originURL.Host, expectedAddress) {
+				http.Error(w, "forbidden request origin", http.StatusForbidden)
+				return
+			}
+		}
+		next.ServeHTTP(w, request)
+	})
+}
+
+func sameAuthority(actual, expected string) bool {
+	actualHost, actualPort, err := net.SplitHostPort(actual)
+	if err != nil {
+		return false
+	}
+	expectedHost, expectedPort, err := net.SplitHostPort(expected)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(actualHost, expectedHost) && actualPort == expectedPort
 }
 
 func (s *server) handleInternal(w http.ResponseWriter, request *http.Request) {
@@ -324,7 +354,7 @@ func (s *server) handleRun(w http.ResponseWriter, request *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	item, created, err = s.admitRun(item, created, value)
+	item, created, err = s.admitRun(request.Context(), item, created, value)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -338,17 +368,51 @@ func (s *server) handleRun(w http.ResponseWriter, request *http.Request) {
 	_ = json.NewEncoder(w).Encode(item)
 }
 
-func (s *server) admitRun(item work, created bool, value issue) (work, bool, error) {
+func (s *server) admitRun(ctx context.Context, item work, created bool, value issue) (work, bool, error) {
 	unlock := s.lockWork(item.ID)
 	defer unlock()
 	if created {
 		return item, true, nil
 	}
-	if !s.isRunning(item.ID) {
-		return s.store.retry(item.ID, value)
-	}
 	item, err := s.store.get(item.ID)
-	return item, false, err
+	if err != nil {
+		return work{}, false, err
+	}
+	if !s.isRunning(item.ID) {
+		if item.State == stateFailed && s.runner != nil && s.runner.githubWrites && item.Branch != "" && item.VerifiedSHA != "" {
+			repository, err := repositoryFor(s.config, item.Issue.Repository)
+			if err != nil {
+				return work{}, false, err
+			}
+			baseBranch := strings.TrimPrefix(repository.BaseRef, "origin/")
+			candidate, found, err := s.github.FindOpenPR(ctx, item.Issue, item.Branch)
+			if err != nil {
+				return work{}, false, fmt.Errorf("reconcile prior pull request: %w", err)
+			}
+			if found {
+				prURL, err := verifiedPRURL(candidate, item.VerifiedSHA, baseBranch)
+				if err != nil {
+					return work{}, false, err
+				}
+				item, err = s.store.update(item.ID, func(current *work) error {
+					now := time.Now().UTC()
+					current.State = stateReady
+					current.ActiveRole = ""
+					current.PRURL = prURL
+					current.Failure = ""
+					current.CompletedAt = now
+					current.Events = append(current.Events, event{At: now, Message: "recovered existing draft pull request"})
+					return nil
+				})
+				return item, false, err
+			}
+		}
+		if item.State == stateFailed || item.State == stateBlocked {
+			return s.store.retry(item.ID, value)
+		}
+		return item, false, nil
+	}
+	return item, false, nil
 }
 
 func (s *server) lockWork(id string) func() {

--- a/prototype/local-factory/server.go
+++ b/prototype/local-factory/server.go
@@ -22,6 +22,7 @@ type server struct {
 
 	mu      sync.Mutex
 	running map[string]struct{}
+	workers sync.WaitGroup
 }
 
 func newServer(cfg loadedConfig, github githubClient, writes bool, logger *log.Logger) (*server, error) {
@@ -45,6 +46,8 @@ func (s *server) serve(ctx context.Context) error {
 	if err := s.recoverInterrupted(); err != nil {
 		return err
 	}
+	serverContext, cancel := context.WithCancel(ctx)
+	defer cancel()
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", s.handleHome)
 	mux.HandleFunc("GET /api/work", s.handleList)
@@ -54,16 +57,36 @@ func (s *server) serve(ctx context.Context) error {
 	})
 
 	httpServer := &http.Server{Addr: s.config.Config.Server.Listen, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
-	go s.schedule(ctx)
-	go s.poll(ctx)
+	var loops sync.WaitGroup
+	loops.Add(2)
 	go func() {
-		<-ctx.Done()
+		defer loops.Done()
+		s.schedule(serverContext)
+	}()
+	go func() {
+		defer loops.Done()
+		s.poll(serverContext)
+	}()
+	go func() {
+		<-serverContext.Done()
 		shutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = httpServer.Shutdown(shutdown)
 	}()
 	s.log.Printf("factory web listening on http://%s", displayAddress(s.config.Config.Server.Listen))
 	err := httpServer.ListenAndServe()
+	cancel()
+	loops.Wait()
+	workersDone := make(chan struct{})
+	go func() {
+		s.workers.Wait()
+		close(workersDone)
+	}()
+	select {
+	case <-workersDone:
+	case <-time.After(5 * time.Second):
+		return fmt.Errorf("timed out waiting for active agent processes to stop")
+	}
 	if err == http.ErrServerClosed {
 		return nil
 	}
@@ -158,11 +181,13 @@ func (s *server) startQueued(ctx context.Context) {
 			continue
 		}
 		s.running[item.ID] = struct{}{}
+		s.workers.Add(1)
 		go s.execute(ctx, item.ID)
 	}
 }
 
 func (s *server) execute(ctx context.Context, id string) {
+	defer s.workers.Done()
 	err := s.runner.runWork(ctx, id)
 	if err != nil {
 		_, _ = s.store.update(id, func(item *work) error {
@@ -217,7 +242,7 @@ func (s *server) handleRun(w http.ResponseWriter, request *http.Request) {
 	}
 	if !created {
 		if !s.isRunning(item.ID) {
-			item, created, err = s.store.retry(item.ID)
+			item, created, err = s.store.retry(item.ID, value)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/prototype/local-factory/server.go
+++ b/prototype/local-factory/server.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"html/template"
 	"log"
 	"mime"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -37,12 +39,20 @@ func newServer(cfg loadedConfig, github githubClient, writes bool, logger *log.L
 	if err != nil {
 		return nil, err
 	}
+	authToken, err := newAuthorityToken()
+	if err != nil {
+		return nil, err
+	}
 	state := newStore(cfg.Config.StateDirectory)
-	runner := &agentRunner{config: cfg, store: state, github: github, githubWrites: writes, executable: executable}
+	runner := &agentRunner{config: cfg, store: state, github: github, githubWrites: writes, executable: executable, authToken: authToken}
 	return &server{config: cfg, store: state, github: github, runner: runner, log: logger, running: make(map[string]struct{})}, nil
 }
 
 func (s *server) serve(ctx context.Context) error {
+	if err := s.store.activate(s.runner.authToken); err != nil {
+		return fmt.Errorf("activate local runtime authority: %w", err)
+	}
+	defer s.store.deactivate(s.runner.authToken)
 	if err := s.recoverInterrupted(); err != nil {
 		return err
 	}
@@ -52,11 +62,19 @@ func (s *server) serve(ctx context.Context) error {
 	mux.HandleFunc("GET /", s.handleHome)
 	mux.HandleFunc("GET /api/work", s.handleList)
 	mux.HandleFunc("POST /api/run", s.handleRun)
+	mux.HandleFunc("POST /api/internal", s.handleInternal)
 	mux.HandleFunc("POST /webhooks/github", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "GitHub webhooks are not enabled in this local spike; use the poller", http.StatusNotImplemented)
 	})
 
-	httpServer := &http.Server{Addr: s.config.Config.Server.Listen, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	httpServer := &http.Server{
+		Addr:              s.config.Config.Server.Listen,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		BaseContext: func(net.Listener) context.Context {
+			return serverContext
+		},
+	}
 	var loops sync.WaitGroup
 	loops.Add(2)
 	go func() {
@@ -93,6 +111,58 @@ func (s *server) serve(ctx context.Context) error {
 	return err
 }
 
+func (s *server) handleInternal(w http.ResponseWriter, request *http.Request) {
+	expected := "Bearer " + s.runner.authToken
+	provided := request.Header.Get("Authorization")
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+		http.Error(w, "unauthorized internal command", http.StatusUnauthorized)
+		return
+	}
+	mediaType, _, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	request.Body = http.MaxBytesReader(w, request.Body, 16<<10)
+	var input struct {
+		WorkID string   `json:"work_id"`
+		Action string   `json:"action"`
+		Args   []string `json:"args"`
+	}
+	if err := json.NewDecoder(request.Body).Decode(&input); err != nil || input.WorkID == "" {
+		http.Error(w, "invalid internal command", http.StatusBadRequest)
+		return
+	}
+	var output []byte
+	switch input.Action {
+	case "delegate":
+		if len(input.Args) != 1 {
+			http.Error(w, "delegate requires a role", http.StatusBadRequest)
+			return
+		}
+		output, err = s.runner.delegate(request.Context(), input.WorkID, input.Args[0])
+	case "publish-plan":
+		err = s.runner.publishPlan(request.Context(), input.WorkID)
+	case "finish":
+		err = s.runner.finish(request.Context(), input.WorkID)
+	case "block":
+		if len(input.Args) == 0 {
+			http.Error(w, "block requires a reason", http.StatusBadRequest)
+			return
+		}
+		err = s.runner.block(request.Context(), input.WorkID, strings.Join(input.Args, " "))
+	default:
+		http.Error(w, "unknown internal action", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusConflict)
+		return
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = w.Write(output)
+}
+
 func (s *server) recoverInterrupted() error {
 	items, err := s.store.list()
 	if err != nil {
@@ -117,7 +187,11 @@ func (s *server) recoverInterrupted() error {
 }
 
 func (s *server) poll(ctx context.Context) {
-	duration, _ := time.ParseDuration(s.config.Config.Server.PollEvery)
+	duration, err := time.ParseDuration(s.config.Config.Server.PollEvery)
+	if err != nil || duration <= 0 {
+		s.log.Printf("poll: invalid interval %q", s.config.Config.Server.PollEvery)
+		return
+	}
 	ticker := time.NewTicker(duration)
 	defer ticker.Stop()
 	s.pollOnce(ctx)
@@ -133,7 +207,9 @@ func (s *server) poll(ctx context.Context) {
 
 func (s *server) pollOnce(ctx context.Context) {
 	for _, repository := range s.config.Config.Repositories {
-		issues, err := s.github.LabeledIssues(ctx, repository.GitHub, s.config.Config.Server.TriggerLabel)
+		pollContext, cancel := context.WithTimeout(ctx, time.Minute)
+		issues, err := s.github.LabeledIssues(pollContext, repository.GitHub, s.config.Config.Server.TriggerLabel)
+		cancel()
 		if err != nil {
 			s.log.Printf("poll %s: %v", repository.GitHub, err)
 			continue

--- a/prototype/local-factory/state.go
+++ b/prototype/local-factory/state.go
@@ -67,7 +67,7 @@ func (s *store) activate(token string) error {
 		_ = file.Close()
 		return err
 	}
-	if err := file.Truncate(0); err == nil {
+	if err = file.Truncate(0); err == nil {
 		_, err = file.WriteAt(append(body, '\n'), 0)
 	}
 	if err != nil {

--- a/prototype/local-factory/state.go
+++ b/prototype/local-factory/state.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -10,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -18,7 +21,83 @@ type store struct {
 	mu   sync.Mutex
 }
 
+type runtimeAuthority struct {
+	Token string `json:"token"`
+	PID   int    `json:"pid"`
+}
+
 func newStore(root string) *store { return &store{root: root} }
+
+func newAuthorityToken() (string, error) {
+	value := make([]byte, 32)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("generate runtime authority: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(value), nil
+}
+
+func (s *store) activate(token string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(s.root, 0o755); err != nil {
+		return err
+	}
+	body, err := json.Marshal(runtimeAuthority{Token: token, PID: os.Getpid()})
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	path := filepath.Join(s.root, "authority.json")
+	for range 2 {
+		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			if _, writeErr := file.Write(body); writeErr != nil {
+				_ = file.Close()
+				_ = os.Remove(path)
+				return writeErr
+			}
+			if closeErr := file.Close(); closeErr != nil {
+				_ = os.Remove(path)
+				return closeErr
+			}
+			return nil
+		}
+		if !errors.Is(err, os.ErrExist) {
+			return err
+		}
+		existingBody, readErr := os.ReadFile(path)
+		var existing runtimeAuthority
+		if readErr == nil && json.Unmarshal(existingBody, &existing) == nil && processAlive(existing.PID) {
+			return fmt.Errorf("factory web is already running with PID %d", existing.PID)
+		}
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return removeErr
+		}
+	}
+	return errors.New("could not claim local runtime authority")
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func (s *store) deactivate(token string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	path := filepath.Join(s.root, "authority.json")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var authority runtimeAuthority
+	if json.Unmarshal(body, &authority) == nil && subtle.ConstantTimeCompare([]byte(token), []byte(authority.Token)) == 1 {
+		_ = os.Remove(path)
+	}
+}
 
 func (s *store) create(value issue) (work, bool, error) {
 	s.mu.Lock()
@@ -186,13 +265,13 @@ func atomicWrite(path string, body []byte, mode os.FileMode) error {
 		return err
 	}
 	temporaryPath := temporary.Name()
-	defer os.Remove(temporaryPath)
+	defer func() { _ = os.Remove(temporaryPath) }()
 	if _, err := temporary.Write(body); err != nil {
-		temporary.Close()
+		_ = temporary.Close()
 		return err
 	}
 	if err := temporary.Chmod(mode); err != nil {
-		temporary.Close()
+		_ = temporary.Close()
 		return err
 	}
 	if err := temporary.Close(); err != nil {

--- a/prototype/local-factory/state.go
+++ b/prototype/local-factory/state.go
@@ -145,7 +145,11 @@ func (s *store) retry(id string, refreshedIssue issue) (work, bool, error) {
 	item.ActiveRole = ""
 	item.Failure = ""
 	item.VerifyRuns = 0
+	item.Branch = ""
+	item.Workspace = ""
+	item.HeadSHA = ""
 	item.VerifiedSHA = ""
+	item.PRURL = ""
 	item.StartedAt = time.Time{}
 	item.CompletedAt = time.Time{}
 	item.UpdatedAt = now

--- a/prototype/local-factory/state.go
+++ b/prototype/local-factory/state.go
@@ -17,13 +17,14 @@ import (
 )
 
 type store struct {
-	root string
-	mu   sync.Mutex
+	root           string
+	mu             sync.Mutex
+	authorityFile  *os.File
+	authorityToken string
 }
 
 type runtimeAuthority struct {
-	Token string `json:"token"`
-	PID   int    `json:"pid"`
+	PID int `json:"pid"`
 }
 
 func newStore(root string) *store { return &store{root: root} }
@@ -39,64 +40,56 @@ func newAuthorityToken() (string, error) {
 func (s *store) activate(token string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if token == "" {
+		return errors.New("runtime authority token is required")
+	}
+	if s.authorityFile != nil {
+		return errors.New("this store already holds runtime authority")
+	}
 	if err := os.MkdirAll(s.root, 0o755); err != nil {
 		return err
 	}
-	body, err := json.Marshal(runtimeAuthority{Token: token, PID: os.Getpid()})
+	path := filepath.Join(s.root, "authority.lock")
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return err
 	}
-	body = append(body, '\n')
-	path := filepath.Join(s.root, "authority.json")
-	for range 2 {
-		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-		if err == nil {
-			if _, writeErr := file.Write(body); writeErr != nil {
-				_ = file.Close()
-				_ = os.Remove(path)
-				return writeErr
-			}
-			if closeErr := file.Close(); closeErr != nil {
-				_ = os.Remove(path)
-				return closeErr
-			}
-			return nil
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return errors.New("factory web is already running")
 		}
-		if !errors.Is(err, os.ErrExist) {
-			return err
-		}
-		existingBody, readErr := os.ReadFile(path)
-		var existing runtimeAuthority
-		if readErr == nil && json.Unmarshal(existingBody, &existing) == nil && processAlive(existing.PID) {
-			return fmt.Errorf("factory web is already running with PID %d", existing.PID)
-		}
-		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
-			return removeErr
-		}
+		return fmt.Errorf("lock runtime authority: %w", err)
 	}
-	return errors.New("could not claim local runtime authority")
-}
-
-func processAlive(pid int) bool {
-	if pid <= 0 {
-		return false
+	body, err := json.Marshal(runtimeAuthority{PID: os.Getpid()})
+	if err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		return err
 	}
-	err := syscall.Kill(pid, 0)
-	return err == nil || errors.Is(err, syscall.EPERM)
+	if err := file.Truncate(0); err == nil {
+		_, err = file.WriteAt(append(body, '\n'), 0)
+	}
+	if err != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+		return fmt.Errorf("write runtime authority: %w", err)
+	}
+	s.authorityFile = file
+	s.authorityToken = token
+	return nil
 }
 
 func (s *store) deactivate(token string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	path := filepath.Join(s.root, "authority.json")
-	body, err := os.ReadFile(path)
-	if err != nil {
+	if s.authorityFile == nil || subtle.ConstantTimeCompare([]byte(token), []byte(s.authorityToken)) != 1 {
 		return
 	}
-	var authority runtimeAuthority
-	if json.Unmarshal(body, &authority) == nil && subtle.ConstantTimeCompare([]byte(token), []byte(authority.Token)) == 1 {
-		_ = os.Remove(path)
-	}
+	_ = syscall.Flock(int(s.authorityFile.Fd()), syscall.LOCK_UN)
+	_ = s.authorityFile.Close()
+	s.authorityFile = nil
+	s.authorityToken = ""
 }
 
 func (s *store) create(value issue) (work, bool, error) {
@@ -139,6 +132,9 @@ func (s *store) retry(id string, refreshedIssue issue) (work, bool, error) {
 	if item.State != stateFailed && item.State != stateBlocked {
 		return item, false, nil
 	}
+	if err := s.archiveAttemptArtifactsUnlocked(id, item.Attempt); err != nil {
+		return work{}, false, fmt.Errorf("archive attempt artifacts: %w", err)
+	}
 	if err := atomicWrite(filepath.Join(s.workDir(id), "issue.md"), []byte(renderIssue(refreshedIssue)), 0o644); err != nil {
 		return work{}, false, fmt.Errorf("refresh issue snapshot: %w", err)
 	}
@@ -158,6 +154,31 @@ func (s *store) retry(id string, refreshedIssue issue) (work, bool, error) {
 		return work{}, false, err
 	}
 	return item, true, nil
+}
+
+func (s *store) archiveAttemptArtifactsUnlocked(id string, attempt int) error {
+	archiveDirectory := filepath.Join(s.workDir(id), "attempts", fmt.Sprintf("attempt-%d", attempt))
+	for _, name := range []string{"issue.md", "plan.md", "build.md", "review.md", "foreman.md"} {
+		source := filepath.Join(s.workDir(id), name)
+		if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(archiveDirectory, 0o755); err != nil {
+			return err
+		}
+		destination := filepath.Join(archiveDirectory, name)
+		if _, err := os.Stat(destination); err == nil {
+			continue
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if err := os.Rename(source, destination); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *store) get(id string) (work, error) {

--- a/prototype/local-factory/state.go
+++ b/prototype/local-factory/state.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+type store struct {
+	root string
+	mu   sync.Mutex
+}
+
+func newStore(root string) *store { return &store{root: root} }
+
+func (s *store) create(value issue) (work, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := workID(value.Repository, value.Number)
+	if existing, err := s.readUnlocked(id); err == nil {
+		return existing, false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return work{}, false, err
+	}
+	now := time.Now().UTC()
+	item := work{
+		ID:        id,
+		Issue:     value,
+		State:     stateQueued,
+		Attempt:   1,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Events:    []event{{At: now, Message: "work admitted"}},
+	}
+	if err := s.writeUnlocked(item); err != nil {
+		return work{}, false, err
+	}
+	if err := os.WriteFile(filepath.Join(s.workDir(id), "issue.md"), []byte(renderIssue(value)), 0o644); err != nil {
+		return work{}, false, fmt.Errorf("write issue snapshot: %w", err)
+	}
+	return item, true, nil
+}
+
+func (s *store) retry(id string) (work, bool, error) {
+	item, err := s.get(id)
+	if err != nil {
+		return work{}, false, err
+	}
+	if item.State != stateFailed && item.State != stateBlocked {
+		return item, false, nil
+	}
+	item, err = s.update(id, func(current *work) error {
+		now := time.Now().UTC()
+		current.State = stateQueued
+		current.Attempt++
+		current.ActiveRole = ""
+		current.Failure = ""
+		current.VerifyRuns = 0
+		current.VerifiedSHA = ""
+		current.StartedAt = time.Time{}
+		current.CompletedAt = time.Time{}
+		current.Events = append(current.Events, event{At: now, Message: fmt.Sprintf("attempt %d queued explicitly", current.Attempt)})
+		return nil
+	})
+	return item, true, err
+}
+
+func (s *store) get(id string) (work, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.readUnlocked(id)
+}
+
+func (s *store) update(id string, fn func(*work) error) (work, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	item, err := s.readUnlocked(id)
+	if err != nil {
+		return work{}, err
+	}
+	if err := fn(&item); err != nil {
+		return work{}, err
+	}
+	item.UpdatedAt = time.Now().UTC()
+	if err := s.writeUnlocked(item); err != nil {
+		return work{}, err
+	}
+	return item, nil
+}
+
+func (s *store) event(id, message string) (work, error) {
+	return s.update(id, func(item *work) error {
+		item.Events = append(item.Events, event{At: time.Now().UTC(), Message: message})
+		return nil
+	})
+}
+
+func (s *store) list() ([]work, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entries, err := os.ReadDir(filepath.Join(s.root, "work"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	items := make([]work, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		item, err := s.readUnlocked(entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].CreatedAt.After(items[j].CreatedAt) })
+	return items, nil
+}
+
+func (s *store) artifact(id, name string, body []byte) error {
+	if !validArtifact(name) {
+		return errors.New("invalid artifact name")
+	}
+	if err := os.MkdirAll(s.workDir(id), 0o755); err != nil {
+		return err
+	}
+	return atomicWrite(filepath.Join(s.workDir(id), name), body, 0o644)
+}
+
+func (s *store) readArtifact(id, name string) ([]byte, error) {
+	if !validArtifact(name) {
+		return nil, errors.New("invalid artifact name")
+	}
+	return os.ReadFile(filepath.Join(s.workDir(id), name))
+}
+
+func (s *store) workDir(id string) string { return filepath.Join(s.root, "work", id) }
+
+func (s *store) readUnlocked(id string) (work, error) {
+	body, err := os.ReadFile(filepath.Join(s.workDir(id), "work.json"))
+	if err != nil {
+		return work{}, err
+	}
+	var item work
+	if err := json.Unmarshal(body, &item); err != nil {
+		return work{}, fmt.Errorf("decode work %q: %w", id, err)
+	}
+	return item, nil
+}
+
+func (s *store) writeUnlocked(item work) error {
+	directory := s.workDir(item.ID)
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return err
+	}
+	body, err := json.MarshalIndent(item, "", "  ")
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	return atomicWrite(filepath.Join(directory, "work.json"), body, 0o644)
+}
+
+func atomicWrite(path string, body []byte, mode os.FileMode) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if _, err := temporary.Write(body); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Chmod(mode); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, path)
+}
+
+func workID(repository string, number int) string {
+	return strings.NewReplacer("/", "--", ".", "-").Replace(strings.ToLower(repository)) + fmt.Sprintf("--%d", number)
+}
+
+func validArtifact(name string) bool {
+	switch name {
+	case "issue.md", "plan.md", "build.md", "review.md", "foreman.md":
+		return true
+	default:
+		return false
+	}
+}
+
+func renderIssue(value issue) string {
+	return fmt.Sprintf("# %s\n\nRepository: %s\nIssue: #%d\nURL: %s\n\n%s\n", value.Title, value.Repository, value.Number, value.URL, value.Body)
+}

--- a/prototype/local-factory/state.go
+++ b/prototype/local-factory/state.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -48,28 +49,36 @@ func (s *store) create(value issue) (work, bool, error) {
 	return item, true, nil
 }
 
-func (s *store) retry(id string) (work, bool, error) {
-	item, err := s.get(id)
+func (s *store) retry(id string, refreshedIssue issue) (work, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	item, err := s.readUnlocked(id)
 	if err != nil {
 		return work{}, false, err
 	}
 	if item.State != stateFailed && item.State != stateBlocked {
 		return item, false, nil
 	}
-	item, err = s.update(id, func(current *work) error {
-		now := time.Now().UTC()
-		current.State = stateQueued
-		current.Attempt++
-		current.ActiveRole = ""
-		current.Failure = ""
-		current.VerifyRuns = 0
-		current.VerifiedSHA = ""
-		current.StartedAt = time.Time{}
-		current.CompletedAt = time.Time{}
-		current.Events = append(current.Events, event{At: now, Message: fmt.Sprintf("attempt %d queued explicitly", current.Attempt)})
-		return nil
-	})
-	return item, true, err
+	if err := atomicWrite(filepath.Join(s.workDir(id), "issue.md"), []byte(renderIssue(refreshedIssue)), 0o644); err != nil {
+		return work{}, false, fmt.Errorf("refresh issue snapshot: %w", err)
+	}
+	now := time.Now().UTC()
+	item.State = stateQueued
+	item.Issue = refreshedIssue
+	item.Attempt++
+	item.ActiveRole = ""
+	item.Failure = ""
+	item.VerifyRuns = 0
+	item.VerifiedSHA = ""
+	item.StartedAt = time.Time{}
+	item.CompletedAt = time.Time{}
+	item.UpdatedAt = now
+	item.Events = append(item.Events, event{At: now, Message: fmt.Sprintf("attempt %d queued explicitly", item.Attempt)})
+	if err := s.writeUnlocked(item); err != nil {
+		return work{}, false, err
+	}
+	return item, true, nil
 }
 
 func (s *store) get(id string) (work, error) {
@@ -193,7 +202,8 @@ func atomicWrite(path string, body []byte, mode os.FileMode) error {
 }
 
 func workID(repository string, number int) string {
-	return strings.NewReplacer("/", "--", ".", "-").Replace(strings.ToLower(repository)) + fmt.Sprintf("--%d", number)
+	encodedRepository := base64.RawURLEncoding.EncodeToString([]byte(strings.ToLower(repository)))
+	return encodedRepository + fmt.Sprintf("--%d", number)
 }
 
 func validArtifact(name string) bool {

--- a/prototype/local-factory/templates.go
+++ b/prototype/local-factory/templates.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const defaultForemanPrompt = `You are the Foreman for one software ticket. You own the result, not a fixed stage graph.
+
+Work hands-off. Never ask the user a question. If the ticket lacks information that cannot be recovered safely from the repository, block it with a precise reason.
+
+Use only the Factory commands supplied in the assignment. Run the planner first, then publish its plan. If planning reports a real blocker, block. Otherwise run the builder and verifier. Read every natural-language report. When verification finds a material problem, send that report back through another builder run, then verify again. Stop after the configured limit rather than looping forever.
+
+Call finish only after a verifier has inspected the exact committed revision and reports that the acceptance criteria and relevant checks pass. Do not write code, inspect the repository directly, or invent a child result yourself.`
+
+const defaultPlannerPrompt = `You are the planning agent for one GitHub ticket.
+
+Inspect the ticket and repository. Do not edit files and do not ask questions. Decide whether the work is safe and specific enough for a coding agent.
+
+Return concise Markdown with:
+
+1. Outcome: READY or BLOCKED, with the reason.
+2. Restated problem and observable acceptance criteria.
+3. Relevant code and constraints found in the repository.
+4. A short implementation plan.
+5. Checks that will prove the change.
+
+Block only for missing product decisions, unavailable dependencies, conflicting requirements, or work that cannot be bounded safely. Do not block because implementation is difficult.`
+
+const defaultBuilderPrompt = `You are the builder for one planned ticket. Work only in the supplied checkout.
+
+Read the ticket, current plan, repository instructions, and latest verification report if present. Implement the complete change. Fix causes, not symptoms. Run focused checks while working. Do not open a pull request, push, commit, change the plan, or ask questions.
+
+Return concise Markdown describing what changed, files touched, checks run with outcomes, and any remaining concern. If you cannot complete the work, explain the exact blocker and leave the checkout in the safest useful state.`
+
+const defaultVerifierPrompt = `You are the verifier for one ticket. You are running in a fresh detached checkout of the exact candidate revision.
+
+Independently inspect the ticket, plan, diff, repository rules, and implementation. Run the focused tests plus any cheap relevant lint or build checks. Do not trust the builder's report. Do not edit product files and do not ask questions.
+
+Return concise Markdown beginning with either "Verdict: PASS" or "Verdict: REVISE". For REVISE, list only concrete, reproducible problems with file locations and the evidence needed to fix them. For PASS, state which acceptance criteria and checks you verified. Natural Markdown is the handoff; no JSON or schema is required.`
+
+func initialise(directory, repository, repositoryPath, requestedBaseRef string) error {
+	abs, err := filepath.Abs(directory)
+	if err != nil {
+		return err
+	}
+	if !validRepositoryName(repository) {
+		return fmt.Errorf("--repo must use owner/repository format")
+	}
+	if repositoryPath == "" {
+		return fmt.Errorf("--repo-path is required")
+	}
+	repositoryPath, err = filepath.Abs(repositoryPath)
+	if err != nil {
+		return err
+	}
+	baseRef := requestedBaseRef
+	if baseRef == "" {
+		baseRef, err = detectBaseRef(repositoryPath, repository)
+		if err != nil {
+			return err
+		}
+	}
+	if entries, readErr := os.ReadDir(abs); readErr == nil && len(entries) != 0 {
+		return fmt.Errorf("directory %q is not empty", abs)
+	} else if readErr != nil && !os.IsNotExist(readErr) {
+		return readErr
+	}
+	if err := os.MkdirAll(filepath.Join(abs, "agents"), 0o755); err != nil {
+		return err
+	}
+	configBody := fmt.Sprintf(`version = 1
+state_directory = ".state"
+max_revisions = 2
+
+[server]
+listen = "127.0.0.1:7338"
+poll_every = "60s"
+trigger_label = "factory"
+max_concurrent = 1
+
+[[repositories]]
+github = %s
+path = %s
+base_ref = %s
+
+[roles]
+foreman = "foreman"
+plan = "planner"
+build = "builder"
+verify = "verifier"
+
+[agents.foreman]
+runtime = "claude"
+prompt = "agents/foreman.md"
+
+[agents.planner]
+runtime = "codex"
+prompt = "agents/planner.md"
+
+[agents.builder]
+runtime = "codex"
+prompt = "agents/builder.md"
+
+[agents.verifier]
+runtime = "codex"
+prompt = "agents/verifier.md"
+`, strconv.Quote(repository), strconv.Quote(repositoryPath), strconv.Quote(baseRef))
+	files := map[string]string{
+		"factory.toml":       configBody,
+		".gitignore":         ".state/\n",
+		"agents/foreman.md":  defaultForemanPrompt + "\n",
+		"agents/planner.md":  defaultPlannerPrompt + "\n",
+		"agents/builder.md":  defaultBuilderPrompt + "\n",
+		"agents/verifier.md": defaultVerifierPrompt + "\n",
+	}
+	for name, body := range files {
+		if err := atomicWrite(filepath.Join(abs, name), []byte(body), 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func detectBaseRef(repositoryPath, repository string) (string, error) {
+	body, err := commandOutput(context.Background(), repositoryPath, nil, "git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	if err == nil {
+		if value := strings.TrimSpace(string(body)); value != "" {
+			return value, nil
+		}
+	}
+	body, err = commandOutput(context.Background(), repositoryPath, nil, "gh", "repo", "view", repository, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name")
+	if err == nil {
+		if value := strings.TrimSpace(string(body)); value != "" {
+			return "origin/" + value, nil
+		}
+	}
+	return "", errors.New("cannot determine the repository default branch; pass --base-ref explicitly")
+}

--- a/prototype/local-factory/templates.go
+++ b/prototype/local-factory/templates.go
@@ -99,18 +99,22 @@ verify = "verifier"
 [agents.foreman]
 runtime = "claude"
 prompt = "agents/foreman.md"
+timeout = "2h"
 
 [agents.planner]
 runtime = "codex"
 prompt = "agents/planner.md"
+timeout = "30m"
 
 [agents.builder]
 runtime = "codex"
 prompt = "agents/builder.md"
+timeout = "45m"
 
 [agents.verifier]
 runtime = "codex"
 prompt = "agents/verifier.md"
+timeout = "45m"
 `, strconv.Quote(repository), strconv.Quote(repositoryPath), strconv.Quote(baseRef))
 	files := map[string]string{
 		"factory.toml":       configBody,

--- a/prototype/local-factory/templates.go
+++ b/prototype/local-factory/templates.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const defaultForemanPrompt = `You are the Foreman for one software ticket. You own the result, not a fixed stage graph.
@@ -128,13 +129,17 @@ prompt = "agents/verifier.md"
 }
 
 func detectBaseRef(repositoryPath, repository string) (string, error) {
-	body, err := commandOutput(context.Background(), repositoryPath, nil, "git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	body, err := commandOutput(ctx, repositoryPath, nil, "git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	cancel()
 	if err == nil {
 		if value := strings.TrimSpace(string(body)); value != "" {
 			return value, nil
 		}
 	}
-	body, err = commandOutput(context.Background(), repositoryPath, nil, "gh", "repo", "view", repository, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name")
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	body, err = commandOutput(ctx, repositoryPath, nil, "gh", "repo", "view", repository, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name")
+	cancel()
 	if err == nil {
 		if value := strings.TrimSpace(string(body)); value != "" {
 			return "origin/" + value, nil


### PR DESCRIPTION
## Summary

- add a standalone local Factory prototype under `prototype/local-factory`
- make `factory web` the always-on control plane for polling, scheduling, durable state, embedded workers, and the monitoring UI
- let one Foreman session own a configurable planner, builder, verifier revision loop using natural Markdown handoffs
- keep GitHub writes opt-in and document the trusted-local security boundary

## Product flow

```text
factory init -> edit factory.toml and agents/*.md -> factory web
                                                        |
GitHub label poller or factory run ISSUE ---------------+
                                                        |
                  Foreman -> plan -> build -> verify -> ready/block
                                      ^          |
                                      +-- revise-+
```

## Proof

- `go test ./...`
- `go test -count=1 -race ./prototype/local-factory`
- `go vet ./prototype/local-factory`
- `gofmt -d prototype/local-factory/*.go`
- `git diff --check`
- real dry run against issue #327 reached `ready` at exact verified SHA `17a942a`; no issue update, remote branch, or PR was created
- desktop and mobile browser checks showed the live issue, state, attempt, SHA lifecycle events, no overflow, and no console errors
- independent implementation review: Approve, no actionable findings

## Deliberate boundaries

- polling works now; signed webhook ingestion is reserved but not implemented
- configured agents are trusted local processes, not a credential or OS sandbox
- public-repository label-actor authorization, cloud workers, CI continuation, and restartable model sessions are deferred
- GitHub write mode was not exercised against the real repository


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a local factory for submitting, tracking, retrying, and executing repository work.
  - Added command-line setup, status, retry, and worker operations.
  - Added a local dashboard with persistent state, scheduling, polling, and concurrency controls.
  - Added configurable planner, builder, verifier, and foreman workflows.
  - Added GitHub issue integration, issue comments, and draft pull request creation.
  - Added isolated workspaces, verification safeguards, recovery, and retry handling.
  - Added configuration validation and safe repository and branch checks.

- **Documentation**
  - Added setup, configuration, workflow, safety, and verification guidance.

- **Tests**
  - Expanded validation, security, cleanup, recovery, and workflow coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->