### PR TITLE
fix: reject invalid Worker server ports

### DIFF
--- a/internal/worker/config.go
+++ b/internal/worker/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -216,8 +217,13 @@ func validateServerURL(value string) error {
 		return errors.New("server URL must not contain a path")
 	}
 	host := parsed.Hostname()
-	if host == "" || parsed.Port() == "" {
+	port := parsed.Port()
+	if host == "" || port == "" {
 		return errors.New("server URL must include a host and port")
+	}
+	portNumber, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || portNumber == 0 || strconv.FormatUint(portNumber, 10) != port {
+		return errors.New("server URL port must be a canonical integer between 1 and 65535")
 	}
 	if parsed.Scheme == "https" {
 		return nil

--- a/internal/worker/config_test.go
+++ b/internal/worker/config_test.go
@@ -110,6 +110,46 @@ func TestLoadConfigAcceptsRemoteWorkerSettings(t *testing.T) {
 	}
 }
 
+func TestLoadConfigRejectsInvalidServerPorts(t *testing.T) {
+	for _, server := range []string{
+		"http://127.0.0.1:0",
+		"http://127.0.0.1:00",
+		"http://127.0.0.1:01",
+		"https://factory.example.com:65536",
+	} {
+		t.Run(server, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "worker.toml")
+			body := "server = \"" + server + "\"\nname = \"pool\"\n"
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadConfig(path); err == nil ||
+				!strings.Contains(err.Error(), "port must be a canonical integer between 1 and 65535") {
+				t.Fatalf("LoadConfig server %q error = %v", server, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfigAcceptsValidServerPorts(t *testing.T) {
+	for _, server := range []string{
+		"http://127.0.0.1:1",
+		"http://[::1]:65535",
+		"https://factory.example.com:7443",
+	} {
+		t.Run(server, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "worker.toml")
+			body := "server = \"" + server + "\"\nname = \"pool\"\n"
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadConfig(path); err != nil {
+				t.Fatalf("LoadConfig server %q: %v", server, err)
+			}
+		})
+	}
+}
+
 func TestWorkerCapacityUsesSharedRange(t *testing.T) {
 	for _, capacity := range []int{protocol.MinWorkerCapacity, protocol.MaxWorkerCapacity} {
 		config := Config{


### PR DESCRIPTION
## Summary

- validate Worker server ports as canonical integers from 1 through 65535
- reject zero, leading-zero, and out-of-range ports during config loading
- cover invalid and valid loopback HTTP and remote HTTPS configurations

## Verification

- `go test -timeout 2m -count=1 ./internal/worker -run '^(TestLoadConfig.*|TestWorkerCapacityUsesSharedRange)$'`
- `go vet ./...`
- `go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 -checks 'SA*,U1000' ./...`
- Worker dependency-boundary check
- independent review: Approve, no findings

The broader `go test ./...` run passed all non-worker packages, but existing Worker supervisor tests require `ps`, which this managed sandbox prohibits, so those process tests timed out locally. GitHub CI provides the unrestricted full-suite result.

Closes #362