### PR TITLE
fix(worker): avoid splitting multi-byte runes in bounded text truncation

### DIFF
--- a/internal/worker/supervisor.go
+++ b/internal/worker/supervisor.go
@@ -1035,14 +1035,10 @@ func readBoundedText(path string, limit int) (string, bool, error) {
 }
 
 func boundedText(value string, limit int) string {
-	if len(value) <= limit {
-		return value
+	if len(value) > limit {
+		value = value[:limit]
 	}
-	value = value[:limit]
-	for !utf8.ValidString(value) {
-		value = value[:len(value)-1]
-	}
-	return value
+	return strings.ToValidUTF8(value, "")
 }
 
 func startSupervisor(commandLine []string, init supervisorInit, errorOutput io.Writer) (*supervisorProcess, error) {

--- a/internal/worker/supervisor_test.go
+++ b/internal/worker/supervisor_test.go
@@ -209,6 +209,8 @@ func TestBoundedText(t *testing.T) {
 		{name: "splits multi byte rune", value: "héllo", limit: 2, want: "h"},
 		{name: "keeps whole multi byte rune", value: "héllo", limit: 3, want: "hé"},
 		{name: "splits four byte rune", value: "😀", limit: 3, want: ""},
+		{name: "removes partial trailing rune at limit", value: "aa\xf0", limit: 3, want: "aa"},
+		{name: "removes partial leading rune at limit", value: "\x9f\x98\x80bb", limit: 5, want: "bb"},
 	}
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -265,18 +267,14 @@ func TestReadBoundedText(t *testing.T) {
 		}
 	})
 
-	t.Run("truncation splits a multi byte rune", func(t *testing.T) {
-		// readBoundedText cuts the body to the limit before calling boundedText,
-		// which only trims when the value is longer than the limit, so the tail
-		// rune can be split. Tracked in #322; recorded here as current behaviour
-		// so a fix has to update this expectation deliberately.
+	t.Run("truncation drops a partial multi byte rune", func(t *testing.T) {
 		path := filepath.Join(directory, "utf8")
 		writeTestFile(t, path, "aa\U0001F600bb")
 		text, truncated, err := readBoundedText(path, 3)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if text != "aa\xf0" || !truncated {
+		if text != "aa" || !truncated {
 			t.Fatalf("readBoundedText = %q, %v", text, truncated)
 		}
 	})
@@ -321,6 +319,14 @@ func TestTailBuffer(t *testing.T) {
 	}
 	if got := buffer.String(); got != "efghijkl" {
 		t.Fatalf("tail buffer = %q, want %q", got, "efghijkl")
+	}
+
+	unicodeBuffer := &tailBuffer{limit: 5}
+	if _, err := unicodeBuffer.Write([]byte("aa\U0001F600bb")); err != nil {
+		t.Fatal(err)
+	}
+	if got := unicodeBuffer.String(); got != "bb" {
+		t.Fatalf("unicode tail buffer = %q, want %q", got, "bb")
 	}
 }
 


### PR DESCRIPTION
## Summary

Ensure byte-bounded worker text always remains valid UTF-8.

`readBoundedText` and `tailBuffer` can truncate data in the middle of a multi-byte rune before passing it to `boundedText`. When the truncated value was already at the byte limit, the previous implementation could return it unchanged with an invalid UTF-8 fragment.

The updated implementation applies the byte limit and removes invalid UTF-8 fragments before returning the text.

## Regression coverage

- partial trailing rune produced by `readBoundedText`
- partial leading rune retained by `tailBuffer`
- invalid UTF-8 fragments already at the configured limit

## Verification

- `go test -timeout 5m ./...` in Linux with Go 1.25.13
- `go vet ./internal/worker`
- focused `TestBoundedText`, `TestReadBoundedText`, and `TestTailBuffer` regression tests

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text and file output truncation to preserve valid UTF-8.
  * Prevented incomplete characters from appearing when content is shortened.
  * Applied the same protection to trailing buffered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->