### PR TITLE
fix(protocol): default legacy task pipeline snapshots

### DIFF
--- a/internal/controlplane/resume_test.go
+++ b/internal/controlplane/resume_test.go
@@ -968,6 +968,59 @@ func TestExactReplacementCopiesFrozenExecutionAndReplayWinsBeforeEligibility(t *
 	}
 }
 
+func TestLegacyReplacementPreservesResolvedPromptLiterally(t *testing.T) {
+	store := newTestStore(t)
+	worker := registerTestWorker(t, store, workerA, 1, protocol.RepositoryRegistration{
+		Key: "factory", RemoteIdentity: "github.com/owainlewis/factory",
+	})
+	task, err := store.CreateTask(context.Background(), protocol.SaveTaskRequest{
+		Name: "Legacy replacement", Prompt: "Keep {{ repository }} literal.", Runtime: protocol.RuntimeCodex,
+		RepositoryIDs: []string{worker.Repositories[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := store.RunTask(context.Background(), task.ID, protocol.RunTaskRequest{
+		RequestKey: "legacy-replacement-first",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessor := first.Sessions[0]
+	if _, err := store.db.Exec(`
+		UPDATE runs SET task_snapshot = json_remove(task_snapshot, '$.pipeline') WHERE id = ?
+	`, first.Run.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.db.Exec(`
+		UPDATE sessions
+		SET state = 'failed', terminal_at = admitted_at, terminal_message = 'failed'
+		WHERE id = ?
+	`, predecessor.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	replacement, err := store.ReplaceWork(context.Background(), protocol.ReplaceWorkRequest{
+		RequestKey: "legacy-replacement", WorkID: predecessor.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacementSession := replacement.Run.Sessions[0]
+	var got string
+	if err := store.db.QueryRow(`
+		SELECT prompt
+		FROM session_stages
+		WHERE session_id = ? AND position = 0
+	`, replacementSession.ID).Scan(&got); err != nil {
+		t.Fatalf("load replacement stage prompt: %v", err)
+	}
+	if got != predecessor.ResolvedPrompt {
+		t.Fatalf("legacy replacement stage prompt = %q, want frozen resolved prompt %q",
+			got, predecessor.ResolvedPrompt)
+	}
+}
+
 func needsInputWork(t *testing.T) (*Store, protocol.Worker, protocol.RunDetail, protocol.Work) {
 	t.Helper()
 	store := newTestStore(t)

--- a/internal/protocol/tasks.go
+++ b/internal/protocol/tasks.go
@@ -317,7 +317,7 @@ func (snapshot *TaskSnapshot) UnmarshalJSON(data []byte) error {
 			Stages: []PipelineStage{{
 				Position: 0,
 				Name:     "Do the task",
-				Prompt:   decoded.Prompt,
+				Prompt:   "{{ task.prompt }}",
 			}},
 		}
 	}

--- a/internal/protocol/tasks.go
+++ b/internal/protocol/tasks.go
@@ -303,6 +303,28 @@ type TaskSnapshot struct {
 	ScheduleTimezone   string           `json:"timezone,omitempty"`
 }
 
+func (snapshot *TaskSnapshot) UnmarshalJSON(data []byte) error {
+	type taskSnapshot TaskSnapshot
+	var decoded taskSnapshot
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	if decoded.Pipeline.ID == "" {
+		decoded.Pipeline = PipelineSnapshot{
+			ID:         DefaultPipelineID,
+			Name:       "Single agent",
+			Generation: 1,
+			Stages: []PipelineStage{{
+				Position: 0,
+				Name:     "Do the task",
+				Prompt:   decoded.Prompt,
+			}},
+		}
+	}
+	*snapshot = TaskSnapshot(decoded)
+	return nil
+}
+
 // ProcedureSnapshot is the product name for the immutable Task snapshot.
 // The alias keeps existing Task and scheduled Run clients source compatible.
 type ProcedureSnapshot = TaskSnapshot

--- a/internal/protocol/tasks_test.go
+++ b/internal/protocol/tasks_test.go
@@ -1,0 +1,52 @@
+package protocol
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTaskSnapshotUnmarshalDefaultsLegacyPipeline(t *testing.T) {
+	var snapshot TaskSnapshot
+	if err := json.Unmarshal([]byte(`{
+		"id":"task-1",
+		"name":"Legacy task",
+		"prompt":"Review the repository.",
+		"runtime":"codex",
+		"generation":1
+	}`), &snapshot); err != nil {
+		t.Fatal(err)
+	}
+
+	if snapshot.Pipeline.ID != DefaultPipelineID || snapshot.Pipeline.Name != "Single agent" ||
+		snapshot.Pipeline.Generation != 1 || len(snapshot.Pipeline.Stages) != 1 {
+		t.Fatalf("legacy Pipeline snapshot = %#v, want the single-agent default", snapshot.Pipeline)
+	}
+	stage := snapshot.Pipeline.Stages[0]
+	if stage.Position != 0 || stage.Name != "Do the task" || stage.Prompt != snapshot.Prompt {
+		t.Fatalf("legacy Pipeline stage = %#v, want the frozen task prompt", stage)
+	}
+}
+
+func TestTaskSnapshotUnmarshalPreservesPipeline(t *testing.T) {
+	var snapshot TaskSnapshot
+	if err := json.Unmarshal([]byte(`{
+		"id":"task-1",
+		"name":"Current task",
+		"runtime":"codex",
+		"generation":1,
+		"pipeline":{
+			"id":"pipeline-1",
+			"name":"Review",
+			"generation":2,
+			"stages":[{"position":0,"name":"Inspect","prompt":"Check the diff."}]
+		}
+	}`), &snapshot); err != nil {
+		t.Fatal(err)
+	}
+
+	if snapshot.Pipeline.ID != "pipeline-1" || snapshot.Pipeline.Name != "Review" ||
+		snapshot.Pipeline.Generation != 2 || len(snapshot.Pipeline.Stages) != 1 ||
+		snapshot.Pipeline.Stages[0].Name != "Inspect" {
+		t.Fatalf("current Pipeline snapshot changed during unmarshal: %#v", snapshot.Pipeline)
+	}
+}

--- a/internal/protocol/tasks_test.go
+++ b/internal/protocol/tasks_test.go
@@ -22,8 +22,8 @@ func TestTaskSnapshotUnmarshalDefaultsLegacyPipeline(t *testing.T) {
 		t.Fatalf("legacy Pipeline snapshot = %#v, want the single-agent default", snapshot.Pipeline)
 	}
 	stage := snapshot.Pipeline.Stages[0]
-	if stage.Position != 0 || stage.Name != "Do the task" || stage.Prompt != snapshot.Prompt {
-		t.Fatalf("legacy Pipeline stage = %#v, want the frozen task prompt", stage)
+	if stage.Position != 0 || stage.Name != "Do the task" || stage.Prompt != "{{ task.prompt }}" {
+		t.Fatalf("legacy Pipeline stage = %#v, want the default task prompt template", stage)
 	}
 }
 


### PR DESCRIPTION
## Problem

Runs admitted before Pipeline snapshots were introduced decode with a zero-value `PipelineSnapshot`. Re-encoding those Runs exposes `pipeline.stages` as `null`, so the Work board and Run detail can crash when they read `.length`.

## Reproduction

A regression test unmarshals the pre-Pipeline frozen Task snapshot shape. Before this change it produced:

```text
PipelineSnapshot{ID:"", Name:"", Generation:0, Stages:nil}
```

A control-plane regression test also replaces a legacy Run whose frozen resolved prompt contains `{{ repository }}`. With the raw task prompt stored as the synthesized stage template, replacement rendered that token again and changed the prompt.

## Fix

Default only snapshots with no Pipeline ID to the frozen single-agent Pipeline. Its synthesized stage uses the built-in `{{ task.prompt }}` template so replacement resolves the predecessor's already-frozen prompt exactly once. Snapshots that already contain a Pipeline are preserved unchanged.

## Tests

- `go test ./internal/protocol -run TestTaskSnapshotUnmarshalDefaultsLegacyPipeline -count=1 -v`
- `go test ./internal/controlplane -run TestLegacyReplacementPreservesResolvedPromptLiterally -count=1 -v`
- `go test ./internal/controlplane -run TestPipelineMigrationBackfillsQueuedSessionForStageProtocol -count=1 -v`
- `go test -timeout 5m ./...`
- `go vet ./...`
- `staticcheck -checks 'SA*,U1000' ./...`
- Worker dependency-boundary check

Closes #364