### PR TITLE
docs: improve README diagram readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ flowchart TB
         REPAIR[Bounded repair] --> REVIEW
         REVIEW[Independent agent review] -->|approved| CHECKS[Pull request<br/>CI and automated review]
         CHECKS -->|green| HUMAN([Human review<br/>You decide whether to merge])
-        HUMAN ~~~ CONTROL_SPACE(( ))
         REVIEW -.->|findings| REPAIR
         CHECKS -.->|failure or finding| REPAIR
     end
 
     BUILD_PHASE -->|ready for review| VERIFY_PHASE
+    VERIFY_PHASE ~~~ CONTROL_SPACE(( ))
 
     classDef input fill:#f2a23a,stroke:#b95b16,color:#211408,stroke-width:2px
     classDef station fill:#f4efe6,stroke:#b95b16,color:#211408,stroke-width:1.5px
@@ -69,7 +69,7 @@ flowchart TB
     class CONTROL_SPACE spacer
     style BUILD_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
     style VERIFY_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
-    linkStyle 0,1,2,3,4,6,7,8 stroke:#b95b16,stroke-width:2px
+    linkStyle 0,1,2,3,4,5,6,7 stroke:#b95b16,stroke-width:2px
 ```
 
 The loop is deliberately bounded. If the work cannot be made safe after the

--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ flowchart TB
 
     subgraph VERIFY_PHASE[2 · Verify and hand off]
         direction LR
+        REPAIR[Bounded repair] --> REVIEW
         REVIEW[Independent agent review] -->|approved| CHECKS[Pull request<br/>CI and automated review]
         CHECKS -->|green| HUMAN([Human review<br/>You decide whether to merge])
         HUMAN ~~~ CONTROL_SPACE(( ))
-        REVIEW -.->|findings: bounded repair| REVIEW
-        CHECKS -.->|failure or finding: bounded repair| REVIEW
+        REVIEW -.->|findings| REPAIR
+        CHECKS -.->|failure or finding| REPAIR
     end
 
     BUILD_PHASE -->|ready for review| VERIFY_PHASE
@@ -59,14 +60,16 @@ flowchart TB
     classDef input fill:#f2a23a,stroke:#b95b16,color:#211408,stroke-width:2px
     classDef station fill:#f4efe6,stroke:#b95b16,color:#211408,stroke-width:1.5px
     classDef decision fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:2px
+    classDef repair fill:#fed7aa,stroke:#b95b16,color:#211408,stroke-width:1.5px
     classDef spacer fill:transparent,stroke:transparent,color:transparent
     class ISSUE input
     class PLAN,BUILD,REVIEW,CHECKS station
     class HUMAN decision
+    class REPAIR repair
     class CONTROL_SPACE spacer
     style BUILD_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
     style VERIFY_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
-    linkStyle 0,1,2,3,5,6,7 stroke:#b95b16,stroke-width:2px
+    linkStyle 0,1,2,3,4,6,7,8 stroke:#b95b16,stroke-width:2px
 ```
 
 The loop is deliberately bounded. If the work cannot be made safe after the
@@ -92,8 +95,9 @@ prove.
 ## Inside the factory
 
 Machinist separates portable workflow intent from machine-local authority. The
-control plane can queue work and track it, but only a worker can resolve an
-executor command, repository path, process environment, and credentials.
+control plane can queue and track work, but it does not execute it. In direct
+mode the CLI process resolves the executor command, repository path, process
+environment, and credentials; in managed mode the worker does.
 
 ```mermaid
 flowchart TB

--- a/README.md
+++ b/README.md
@@ -49,9 +49,8 @@ flowchart TB
         direction LR
         REVIEW[Independent agent review] -->|approved| CHECKS[Pull request<br/>CI and automated review]
         CHECKS -->|green| HUMAN([Human review<br/>You decide whether to merge])
-        REVIEW -->|findings| REPAIR[Bounded repair]
-        CHECKS -->|failure or finding| REPAIR
-        REPAIR --> REVIEW
+        REVIEW -.->|findings: bounded repair| REVIEW
+        CHECKS -.->|failure or finding: bounded repair| REVIEW
     end
 
     BUILD_PHASE -->|ready for review| VERIFY_PHASE
@@ -59,11 +58,9 @@ flowchart TB
     classDef input fill:#f2a23a,stroke:#b95b16,color:#211408,stroke-width:2px
     classDef station fill:#f4efe6,stroke:#b95b16,color:#211408,stroke-width:1.5px
     classDef decision fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:2px
-    classDef repair fill:#fed7aa,stroke:#b95b16,color:#211408,stroke-width:1.5px
     class ISSUE input
     class PLAN,BUILD,REVIEW,CHECKS station
     class HUMAN decision
-    class REPAIR repair
     style BUILD_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
     style VERIFY_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
     linkStyle default stroke:#b95b16,stroke-width:2px

--- a/README.md
+++ b/README.md
@@ -38,21 +38,34 @@ CI form a supervised production line. The shipped foreman never merges the
 result.
 
 ```mermaid
-flowchart LR
-    ISSUE([GitHub issue]) --> PLAN[Plan and clarify]
-    PLAN --> BUILD[Build in an<br/>isolated worktree]
-    BUILD --> REVIEW[Independent<br/>agent review]
-    REVIEW -->|approved| CHECKS[Pull request<br/>CI and automated review]
-    CHECKS -->|green| HUMAN([Human review<br/>You decide whether to merge])
-    REVIEW -->|findings: repair| BUILD
-    CHECKS -->|failure or finding: repair| BUILD
+flowchart TB
+    subgraph BUILD_PHASE[1 · Build]
+        direction LR
+        ISSUE([GitHub issue]) --> PLAN[Plan and clarify]
+        PLAN --> BUILD[Build in an isolated worktree]
+    end
+
+    subgraph VERIFY_PHASE[2 · Verify and hand off]
+        direction LR
+        REVIEW[Independent agent review] -->|approved| CHECKS[Pull request<br/>CI and automated review]
+        CHECKS -->|green| HUMAN([Human review<br/>You decide whether to merge])
+        REVIEW -->|findings| REPAIR[Bounded repair]
+        CHECKS -->|failure or finding| REPAIR
+        REPAIR --> REVIEW
+    end
+
+    BUILD_PHASE -->|ready for review| VERIFY_PHASE
 
     classDef input fill:#f2a23a,stroke:#b95b16,color:#211408,stroke-width:2px
     classDef station fill:#f4efe6,stroke:#b95b16,color:#211408,stroke-width:1.5px
     classDef decision fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:2px
+    classDef repair fill:#fed7aa,stroke:#b95b16,color:#211408,stroke-width:1.5px
     class ISSUE input
     class PLAN,BUILD,REVIEW,CHECKS station
     class HUMAN decision
+    class REPAIR repair
+    style BUILD_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
+    style VERIFY_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
     linkStyle default stroke:#b95b16,stroke-width:2px
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,8 @@ flowchart TB
     subgraph VERIFY_PHASE[2 · Verify and hand off]
         direction LR
         REVIEW[Independent agent review] -->|approved| CHECKS[Pull request<br/>CI and automated review]
-        subgraph HANDOFF[ ]
-            direction TB
-            HUMAN([Human review<br/>You decide whether to merge])
-            HUMAN ~~~ CONTROL_SPACE[ ]
-        end
-        CHECKS -->|green| HUMAN
+        CHECKS -->|green| HUMAN([Human review<br/>You decide whether to merge])
+        HUMAN ~~~ CONTROL_SPACE(( ))
         REVIEW -.->|findings: bounded repair| REVIEW
         CHECKS -.->|failure or finding: bounded repair| REVIEW
     end
@@ -70,8 +66,7 @@ flowchart TB
     class CONTROL_SPACE spacer
     style BUILD_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
     style VERIFY_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
-    style HANDOFF fill:transparent,stroke:transparent
-    linkStyle default stroke:#b95b16,stroke-width:2px
+    linkStyle 0,1,2,3,5,6,7 stroke:#b95b16,stroke-width:2px
 ```
 
 The loop is deliberately bounded. If the work cannot be made safe after the

--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ flowchart TB
     subgraph VERIFY_PHASE[2 · Verify and hand off]
         direction LR
         REVIEW[Independent agent review] -->|approved| CHECKS[Pull request<br/>CI and automated review]
-        CHECKS -->|green| HUMAN([Human review<br/>You decide whether to merge])
+        subgraph HANDOFF[ ]
+            direction TB
+            HUMAN([Human review<br/>You decide whether to merge])
+            HUMAN ~~~ CONTROL_SPACE[ ]
+        end
+        CHECKS -->|green| HUMAN
         REVIEW -.->|findings: bounded repair| REVIEW
         CHECKS -.->|failure or finding: bounded repair| REVIEW
     end
@@ -58,11 +63,14 @@ flowchart TB
     classDef input fill:#f2a23a,stroke:#b95b16,color:#211408,stroke-width:2px
     classDef station fill:#f4efe6,stroke:#b95b16,color:#211408,stroke-width:1.5px
     classDef decision fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:2px
+    classDef spacer fill:transparent,stroke:transparent,color:transparent
     class ISSUE input
     class PLAN,BUILD,REVIEW,CHECKS station
     class HUMAN decision
+    class CONTROL_SPACE spacer
     style BUILD_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
     style VERIFY_PHASE fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
+    style HANDOFF fill:transparent,stroke:transparent
     linkStyle default stroke:#b95b16,stroke-width:2px
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,22 @@ CI form a supervised production line. The shipped foreman never merges the
 result.
 
 ```mermaid
-flowchart TB
+flowchart LR
     ISSUE([GitHub issue]) --> PLAN[Plan and clarify]
-    PLAN --> BUILD[Build in an isolated worktree]
-    BUILD --> REVIEW[Independent agent review]
-    REVIEW -->|findings| REPAIR[Bounded repair]
-    REPAIR --> REVIEW
-    REVIEW -->|approved| PR[Open or update pull request]
-    PR --> CHECKS[Repository CI and automated review]
-    CHECKS -->|failure or finding| REPAIR
-    CHECKS -->|green| HANDOFF([Ready for human review])
-    HANDOFF --> DECIDE{You decide whether to merge}
+    PLAN --> BUILD[Build in an<br/>isolated worktree]
+    BUILD --> REVIEW[Independent<br/>agent review]
+    REVIEW -->|approved| CHECKS[Pull request<br/>CI and automated review]
+    CHECKS -->|green| HUMAN([Human review<br/>You decide whether to merge])
+    REVIEW -->|findings: repair| BUILD
+    CHECKS -->|failure or finding: repair| BUILD
+
+    classDef input fill:#f2a23a,stroke:#b95b16,color:#211408,stroke-width:2px
+    classDef station fill:#f4efe6,stroke:#b95b16,color:#211408,stroke-width:1.5px
+    classDef decision fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:2px
+    class ISSUE input
+    class PLAN,BUILD,REVIEW,CHECKS station
+    class HUMAN decision
+    linkStyle default stroke:#b95b16,stroke-width:2px
 ```
 
 The loop is deliberately bounded. If the work cannot be made safe after the
@@ -78,33 +83,24 @@ control plane can queue work and track it, but only a worker can resolve an
 executor command, repository path, process environment, and credentials.
 
 ```mermaid
-flowchart LR
-    OP([Operator or script]) --> CLI
-    OP --> UI
-
-    subgraph ENTRY[Entrypoints]
-        direction TB
-        CLI[Machinist CLI]
-        UI[Local browser UI]
-    end
-
-    subgraph CONTROL[Managed coordination]
-        direction TB
-        CP[Local control plane] <--> DB[(SQLite queue and history)]
-        CP <-->|leases and results| WORKER[Managed worker]
-    end
-
-    subgraph EXECUTION[Machine-local execution]
-        direction TB
-        RUNNER[Supervised runner] --> EXEC[Configured coding-agent executor]
-        RUNNER --> ART[(Local run artifacts)]
-    end
-
-    UI --> CP
-    CLI -->|managed| CP
+flowchart TB
+    UI[Local browser UI] --> CP
+    CLI[Machinist CLI] -->|managed| CP[Control plane<br/>SQLite queue and history]
+    CP <-->|leases and results| WORKER[Managed worker]
     CLI -->|direct| RUNNER
     WORKER --> RUNNER
-    EXEC --> REPO[(Existing Git worktree)]
+    RUNNER[Supervised runner<br/>Configured coding-agent executor] --> REPO[(Existing Git worktree)]
+    RUNNER --> ART[(Local run artifacts)]
+
+    classDef entry fill:#f4efe6,stroke:#b95b16,color:#211408,stroke-width:1.5px
+    classDef managed fill:#ffedd5,stroke:#b95b16,color:#211408,stroke-width:1.5px
+    classDef execution fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
+    classDef data fill:#fff7ed,stroke:#b95b16,color:#211408,stroke-width:1.5px
+    class CLI,UI entry
+    class CP,WORKER managed
+    class RUNNER execution
+    class ART,REPO data
+    linkStyle default stroke:#b95b16,stroke-width:2px
 ```
 
 The shared `config.toml` supplies portable agents, prompts, and pipelines to the


### PR DESCRIPTION
## Summary
- give both Mermaid diagrams explicit high-contrast Machinist colors
- replace the page-length development flow with a compact two-phase factory line
- keep repair, independent review, CI, and human merge authority explicit
- enlarge and simplify the component diagram for useful README-scale labels
- clarify direct CLI authority versus managed-worker authority
- reserve unobtrusive blank space for GitHub Mermaid controls

## Verification
- `just check`
- `git diff --check`
- GitHub Markdown API accepted both diagrams
- inspected both diagrams in the real GitHub dark UI at exact head `5c44e91f0b874afa3b5d547549d3c40e184e089c`
- fresh independent review: Approve at 1024px
- Linux, macOS, aggregate CI, Greptile, and CodeRabbit status checks are green
- automated review findings addressed in `038d54e` with replies on the original threads