### PR TITLE
feat: add local startup recipes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,47 @@ build: frontend
     mkdir -p bin
     go build -o bin/machinist ./cmd/machinist
 
+# Start the local control plane.
+control-plane: build
+    ./bin/machinist start
+
+# Start the local managed worker.
+worker: build
+    ./bin/machinist worker start
+
+# Start the local control plane and managed worker together.
+local: build
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    cleanup() {
+        trap - EXIT INT TERM
+        while IFS= read -r child_pid; do
+            kill "$child_pid" 2>/dev/null || true
+        done < <(jobs -pr)
+        wait 2>/dev/null || true
+    }
+    trap cleanup EXIT
+    trap 'exit 130' INT TERM
+
+    ./bin/machinist start &
+    control_plane_pid=$!
+    ./bin/machinist worker start &
+    worker_pid=$!
+
+    while kill -0 "$control_plane_pid" 2>/dev/null && kill -0 "$worker_pid" 2>/dev/null; do
+        sleep 1
+    done
+
+    status=0
+    if ! kill -0 "$control_plane_pid" 2>/dev/null; then
+        wait "$control_plane_pid" || status=$?
+    fi
+    if ! kill -0 "$worker_pid" 2>/dev/null; then
+        wait "$worker_pid" || status=$?
+    fi
+    exit "$status"
+
 test:
     go test -race ./...
 

--- a/Justfile
+++ b/Justfile
@@ -35,17 +35,18 @@ local: build
     ./bin/machinist worker start &
     worker_pid=$!
 
-    while kill -0 "$control_plane_pid" 2>/dev/null && kill -0 "$worker_pid" 2>/dev/null; do
+    status=0
+    while true; do
+        if ! kill -0 "$control_plane_pid" 2>/dev/null; then
+            wait "$control_plane_pid" || status=$?
+            break
+        fi
+        if ! kill -0 "$worker_pid" 2>/dev/null; then
+            wait "$worker_pid" || status=$?
+            break
+        fi
         sleep 1
     done
-
-    status=0
-    if ! kill -0 "$control_plane_pid" 2>/dev/null; then
-        wait "$control_plane_pid" || status=$?
-    fi
-    if ! kill -0 "$worker_pid" 2>/dev/null; then
-        wait "$worker_pid" || status=$?
-    fi
     exit "$status"
 
 test:


### PR DESCRIPTION
## Summary

- add `just control-plane` for the local server
- add `just worker` for the managed worker
- add `just local` to run both with coordinated cleanup and failure propagation

## Verification

- `just check`
- `just --list`
- `just --dry-run control-plane`
- `just --dry-run worker`
- `just --dry-run local`
- `git diff --check`
- focused lifecycle checks for child failure and startup interruption cleanup
- independent review: Approve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to start the control plane locally.
  * Added commands to start a managed worker locally.
  * Added a combined command to run and monitor both processes together.
  * Improved local process cleanup when stopping or interrupting the combined command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->