### PR TITLE
fix: remove Foreman repair-attempt cap

### DIFF
--- a/.github/site/index.html
+++ b/.github/site/index.html
@@ -147,7 +147,7 @@
         <div class="factory-values">
           <article><span>DEFINED</span><h3>Configuration in files</h3><p>Prompts, agents, models, and pipelines use TOML and Markdown that you can review and version.</p></article>
           <article><span>INDEPENDENT</span><h3>Separate builder and reviewer</h3><p>The agent that writes the code does not review it. A fresh agent reviews the exact commit before handoff.</p></article>
-          <article><span>BOUNDED</span><h3>Limited repair attempts</h3><p>Repair loops have a fixed limit. If the work still cannot pass, Machinist stops and reports why.</p></article>
+          <article><span>PERSISTENT</span><h3>Verified repair loop</h3><p>Valid code defects return to a fresh repair and review cycle. External blockers still stop safely with clear evidence.</p></article>
         </div>
       </section>
 
@@ -173,7 +173,7 @@
           <div class="eval-rows">
             <div><span><i class="pass"></i>Issue lifecycle</span><strong>PASS</strong><small>1.00</small></div>
             <div><span><i class="pass"></i>Independent review</span><strong>PASS</strong><small>1.00</small></div>
-            <div><span><i class="pass"></i>Bounded repair</span><strong>PASS</strong><small>0.96</small></div>
+            <div><span><i class="pass"></i>Verified repair</span><strong>PASS</strong><small>0.96</small></div>
             <div class="eval-warning"><span><i class="warn"></i>Time to handoff</span><strong>WATCH</strong><small>0.78</small></div>
           </div>
           <div class="compare-row"><span>CONFIG</span><strong>foreman-v12</strong><span>MODEL</span><strong>terra</strong></div>

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Machinist stops instead of carrying on with a broken result.
 
 The default `foreman` plans a GitHub issue, gives implementation and review to
 fresh agents, opens a pull request, and waits for repository CI. Review or CI
-failures go back for repair. The foreman allows up to three repair attempts and
-does not merge the pull request.
+failures go back for repair until review and automation pass. Repair attempts are
+numbered and preserved across resumed work. The foreman does not merge the pull
+request.
 
 ```mermaid
 flowchart LR

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ The default foreman:
 1. turns the issue into a small specification;
 2. gives implementation to a fresh coding agent;
 3. gives the finished change to a different review agent;
-4. sends valid findings through at most three repair attempts;
+4. sends valid findings through numbered repair attempts until verification passes;
 5. opens a non-draft pull request and waits for available checks; and
 6. hands the verified pull request back without merging it.
 

--- a/examples/agents/foreman.md
+++ b/examples/agents/foreman.md
@@ -52,8 +52,8 @@ At each phase boundary print only:
 
 `FOREMAN phase=<planning|building|reviewing|repairing|ci> attempt=<number> outcome=<started|passed|failed|needs-human>`
 
-Attempt `0` covers the initial path. Attempts `1`, `2`, and `3` are the allowed repairs,
-shared across local review, CI, and pull request feedback. Finish with the issue and
+Attempt `0` is initial. Positive numbers are repairs and increase without a cap
+across local review, CI, pull request feedback, and resumes. Finish with the issue and
 pull request URLs, final label, checks, review verdict, and repair count. Do not print a
 complete diff, issue body, review, bot comment, or generated asset. Use summaries,
 paths, URLs, and SHAs.
@@ -108,9 +108,9 @@ worktree existed or was recovered, fast-forward a clean local head that is an an
 the remote pull request head to that exact remote SHA. Preserve dirty, ahead, or unpublished
 state; send divergent history to `machinist:needs-human`.
 
-Reconstruct used repair attempts from the state comment, repair commits, and issue or pull
-request history. Use the greatest proved count. A resumed run still has at most three total
-repair attempts.
+Reconstruct the repair count from the state comment, commits, and issue or pull request
+history. Use the greatest proved count. Reserve the next number for each code repair. Never
+reset, reuse, or cap it on resume.
 
 If `machinist:ready-for-review` or a verified ready/completed state exists, first require a
 clean worktree and equality between the local branch head, remote pull request head, and
@@ -224,7 +224,7 @@ including feedback found on a resumed run:
 1. Recheck findings against the current head and keep only valid unresolved code defects.
    If none remain, return to the originating stage without consuming an attempt. The
    Automation gate handles terminal non-code failures.
-2. Reserve the next repair count and block if it would exceed three.
+2. Reserve the next positive repair count without a maximum.
 3. Set `machinist:building` and prompt a fresh repair subagent with only the refined task,
    verified branch and worktree, current head, exact failing evidence, and valid findings.
    It fixes only those findings, runs affected checks, inspects its diff, commits without an

--- a/examples/workflows/issue-to-pr/agents/issue-to-pr.md
+++ b/examples/workflows/issue-to-pr/agents/issue-to-pr.md
@@ -58,9 +58,9 @@ Finish with one line:
    evidence. It must inspect every changed line and verify the criteria. It must not edit,
    commit, push, or change GitHub state.
 6. If review finds a valid defect, give its exact finding to a repair subagent in the same
-   worktree, require a focused commit and affected checks, then use a new reviewer. Allow
-   at most three repair rounds. Repair subagents must not push. If defects remain, set the
-   state to `machinist:blocked`, comment with the evidence, and stop.
+   worktree, require a focused commit and affected checks, then use a new reviewer. Number
+   repair rounds monotonically and continue without a fixed cap until review passes. Repair
+   subagents must not push.
 7. Only the foreman may push. Before every push, verify that
    `refs/heads/<branch>` equals the exact SHA approved by the latest local reviewer. If it
    differs, do not push; obtain a fresh local review of the new HEAD first. Push the
@@ -74,12 +74,10 @@ Finish with one line:
    treat an empty set as stable while expected automation is missing. Then wait until
    every discovered check and reviewer for the current head is terminal. Poll no more
    often than every 30 seconds and wait at most 20 minutes for registration and completion
-   together. Repair confirmed code defects within the same three-round limit and run a
+   together. Repair confirmed code defects with the next repair number and run a
    fresh local review before each push, then repeat registration and completion checks for
-   the new head. Do not spend a repair round on unavailable infrastructure. If a confirmed
-   code defect remains after all three repair rounds, set the state to `machinist:blocked`,
-   comment with the unresolved evidence, and stop. If expected automation is missing or
-   any discovered check or reviewer is still pending at the deadline, set the state to
+   the new head. Do not spend a repair round on unavailable infrastructure. If expected
+   automation is missing or any discovered check or reviewer is still pending at the deadline, set the state to
    `machinist:blocked`, comment with the missing or pending names and elapsed time, and stop.
    After all automation is terminal, if an unsuccessful result is not a confirmed code
    defect that can enter the repair loop, set the state to `machinist:blocked`, comment with

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -704,6 +704,18 @@ func TestWorkflowExampleDefinitionsLoad(t *testing.T) {
 	}
 }
 
+func TestMachinistSkillDoesNotDescribeARepairCap(t *testing.T) {
+	body, err := os.ReadFile(filepath.Join("..", "..", "skills", "machinist", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, obsolete := range []string{"repair limit", "at most two repair", "at most three repair"} {
+		if strings.Contains(string(body), obsolete) {
+			t.Fatalf("machinist skill still contains %q", obsolete)
+		}
+	}
+}
+
 func writeTestFile(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -517,9 +517,9 @@ func TestExampleAgentDefinitionsLoad(t *testing.T) {
 		"**New issue:**",
 		"a verified branch without an open pull request",
 		"any dirty or incomplete work",
-		"Attempts `1`, `2`, and `3` are the allowed repairs",
-		"at most three total",
-		"block if it would exceed three",
+		"Positive numbers are repairs",
+		"reset, reuse, or cap it on resume",
+		"repair count without a maximum",
 		"Existing work must reuse its branch, worktree, and pull request",
 		"create a second pull request for the issue",
 		"`machinist:ready-for-review` or a verified ready/completed state",
@@ -592,6 +592,9 @@ func TestExampleAgentDefinitionsLoad(t *testing.T) {
 		"Attempts `1` and `2` are the two allowed repairs",
 		"at most two total",
 		"block if it would exceed two",
+		"Attempts `1`, `2`, and `3` are the allowed repairs",
+		"at most three total",
+		"block if it would exceed three",
 	} {
 		if strings.Contains(foreman.Prompt, forbidden) {
 			t.Fatalf("foreman prompt still contains %q", forbidden)
@@ -665,12 +668,12 @@ func TestWorkflowExampleDefinitionsLoad(t *testing.T) {
 					t.Fatalf("agent %q prompt does not contain %s", name, promptParameter)
 				}
 				if test.name == "issue-to-pr" {
-					for _, rule := range []string{"at most three repair rounds", "after all three repair rounds"} {
+					for _, rule := range []string{"continue without a fixed cap", "Repair confirmed code defects with the next repair number"} {
 						if !strings.Contains(agent.Prompt, rule) {
 							t.Fatalf("agent %q prompt does not contain %q", name, rule)
 						}
 					}
-					for _, obsolete := range []string{"at most two repair rounds", "same two-round limit", "after both repair rounds"} {
+					for _, obsolete := range []string{"at most two repair rounds", "same two-round limit", "after both repair rounds", "at most three repair rounds", "same three-round limit", "after all three repair rounds"} {
 						if strings.Contains(agent.Prompt, obsolete) {
 							t.Fatalf("agent %q prompt still contains %q", name, obsolete)
 						}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -704,14 +704,20 @@ func TestWorkflowExampleDefinitionsLoad(t *testing.T) {
 	}
 }
 
-func TestMachinistSkillDoesNotDescribeARepairCap(t *testing.T) {
-	body, err := os.ReadFile(filepath.Join("..", "..", "skills", "machinist", "SKILL.md"))
-	if err != nil {
-		t.Fatal(err)
+func TestShippedGuidanceDoesNotDescribeARepairCap(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "..", "skills", "machinist", "SKILL.md"),
+		filepath.Join("..", "..", ".github", "site", "index.html"),
 	}
-	for _, obsolete := range []string{"repair limit", "at most two repair", "at most three repair"} {
-		if strings.Contains(string(body), obsolete) {
-			t.Fatalf("machinist skill still contains %q", obsolete)
+	for _, path := range paths {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, obsolete := range []string{"repair limit", "Limited repair attempts", "Repair loops have a fixed limit", "Bounded repair"} {
+			if strings.Contains(string(body), obsolete) {
+				t.Fatalf("%s still contains %q", path, obsolete)
+			}
 		}
 	}
 }

--- a/skills/machinist/SKILL.md
+++ b/skills/machinist/SKILL.md
@@ -66,7 +66,7 @@ Keep exactly one lifecycle or exception label on the issue:
 | `machinist:verifying` | Independent review, CI, or automated review is running. | Wait for the current head to finish verification. |
 | `machinist:ready-for-review` | The pull request is verified and ready for a person. | Hand the pull request to a person. Do not merge it. |
 | `machinist:needs-human` | A product or technical decision is missing. | Answer the precise issue question, then assign the same issue again. |
-| `machinist:blocked` | Tooling, credentials, infrastructure, or the repair limit stopped work. | Read the evidence, remove the external blocker, then assign the same issue again. |
+| `machinist:blocked` | Tooling, credentials, or infrastructure stopped work. | Read the evidence, remove the external blocker, then assign the same issue again. |
 
 The foreman creates and transitions these labels. If a label is missing during manual
 recovery, create it with GitHub CLI, then add it to the issue:


### PR DESCRIPTION
Follow-up to #397 and #398.

The earlier PR increased the cap from two to three. This follow-up removes the numeric cap entirely.

Summary:
- keep attempt 0 for the initial path
- number code repairs monotonically without a maximum across local review, CI, pull-request feedback, and resumed work
- preserve non-code stopping conditions for product decisions, tooling, credentials, infrastructure, and invalid handoffs
- align the companion workflow, installed skill, documentation, and public site
- add regression coverage for obsolete capped-repair guidance

Verification:
- `just check` passed at `c2701ae`
- independent local review approved with no findings