### PR TITLE
feat(cli): add release installer and updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ Build Machinist and create the default config:
 ```sh
 mkdir -p ./bin
 go build -o ./bin/machinist ./cmd/machinist
-./bin/machinist init
+export PATH="$PWD/bin:$PATH"
+machinist init
 ```
 
 Or install the latest published binary:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
+machinist init
 ```
 
 `machinist init` writes editable agent and worker settings to `~/.machinist`.
@@ -98,7 +100,7 @@ It does not overwrite existing files.
 Run the foreman against a small, well-defined issue:
 
 ```sh
-./bin/machinist run \
+machinist run \
   --agent=foreman \
   --repo=/absolute/path/to/your-repository \
   --prompt="Complete https://github.com/your-org/your-repo/issues/123"
@@ -170,18 +172,18 @@ path = "/absolute/path/to/my-project"
 Start the server and worker in separate terminals:
 
 ```sh
-./bin/machinist start
+machinist start
 ```
 
 ```sh
-./bin/machinist worker start
+machinist worker start
 ```
 
 Open [http://127.0.0.1:7331](http://127.0.0.1:7331) to submit work, or use the
 CLI:
 
 ```sh
-./bin/machinist submit \
+machinist submit \
   --agent=foreman \
   --prompt="Complete https://github.com/your-org/your-repo/issues/123" \
   --repo=my-project
@@ -193,7 +195,7 @@ The read-only `audit` agent looks for bugs and opens an issue only when it can
 show evidence:
 
 ```sh
-./bin/machinist run \
+machinist run \
   --agent=audit \
   --repo=/absolute/path/to/your-repository \
   --prompt="Audit the request handling and persistence code"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Or install the latest published binary:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
 machinist init
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repositories, and order of work.
 [![MIT licensed](https://img.shields.io/badge/license-MIT-7c3aed)](LICENSE)
 
 [Getting started](docs/getting-started.md) · [How it works](docs/how-it-works.md) ·
-[Architecture](ARCHITECTURE.md)
+[Architecture](ARCHITECTURE.md) · [VM deployment](docs/vm-deployment.md)
 
 </div>
 
@@ -84,6 +84,12 @@ Build Machinist and create the default config:
 mkdir -p ./bin
 go build -o ./bin/machinist ./cmd/machinist
 ./bin/machinist init
+```
+
+Or install the latest published binary:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
 ```
 
 `machinist init` writes editable agent and worker settings to `~/.machinist`.
@@ -213,6 +219,7 @@ lifecycle labels, resume work, and hand a verified pull request to a person.
 - [Local control plane](docs/control-plane.md)
 - [Architecture](ARCHITECTURE.md)
 - [Development](docs/development.md)
+- [VM deployment](docs/vm-deployment.md)
 - [Migration from Factory](docs/migration-from-factory.md)
 
 ## Project status

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -34,6 +34,7 @@ Install the latest stable release without the full VM bootstrap:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 Install a specific release:

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -98,7 +98,14 @@ ssh -N -L 7331:127.0.0.1:7331 machinist
 Then open <http://127.0.0.1:7331>. Do not expose port 7331 directly or place the
 current unauthenticated UI behind a public reverse proxy.
 
-For a long-running deployment, run the control plane and worker under a service
-manager after authentication and repository configuration are complete. Both
-processes must run as the same non-root account that owns the agent credentials,
-Machinist configuration, and repository checkouts.
+The bootstrap command above runs as root and configures root as the Machinist
+runtime account. Treat that VM as a dedicated, privileged coding worker. For a
+long-running deployment, run both processes under a service manager as the same
+account that owns the agent credentials, Machinist configuration, and repository
+checkouts.
+
+To use a non-root runtime account instead, create that account first, run the
+Codex, Claude Code, and Machinist installers plus `machinist init` while logged in
+as that account, and keep its repositories and credentials under its home
+directory. Do not mix configuration or credentials between root and a service
+account.

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -73,7 +73,7 @@ Register each checkout in `~/.machinist/worker.toml`:
 
 ```toml
 [repositories.machinist]
-path = "/root/Code/github/owainlewis/machinist"
+path = "~/Code/github/owainlewis/machinist"
 ```
 
 ## Run and connect

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -1,0 +1,104 @@
+# Deploy Machinist on a VM
+
+The supported VM layout runs a published Machinist binary and keeps source
+checkouts only for repositories that coding agents work on. The VM does not need
+Go, Node.js, or a clone of the Machinist repository at runtime.
+
+## Bootstrap Ubuntu or Debian
+
+Connect to the VM and run the bootstrap script:
+
+```sh
+ssh machinist
+curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/scripts/setup-vm.sh | bash
+```
+
+The script installs Git, GitHub CLI, Codex, Claude Code, and the latest published
+Machinist release. It then creates the default configuration under
+`~/.machinist`. Review remote scripts before piping them into a shell when the
+repository or network is outside your trust boundary.
+
+Authenticate each tool interactively on the VM:
+
+```sh
+gh auth login
+codex
+claude
+```
+
+Do not copy local Codex, Claude, or GitHub credential files to the VM.
+
+## Install or update Machinist
+
+Install the latest stable release without the full VM bootstrap:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
+```
+
+Install a specific release:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh |
+  MACHINIST_VERSION=v0.2.0 sh
+```
+
+An installed binary can update itself. The update is checksum-verified and the
+current executable is replaced only after the new archive passes validation:
+
+```sh
+machinist update
+machinist update --version v0.2.0
+```
+
+When Machinist is installed in a root-owned directory, run the update with the
+matching account or reinstall into a user-writable directory:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh |
+  MACHINIST_INSTALL_DIR="$HOME/.local/bin" sh
+```
+
+## Clone agent repositories
+
+Clone every repository the worker may change. A clone is required for agent
+work, but Machinist itself still runs from the release binary:
+
+```sh
+mkdir -p ~/Code/github/owainlewis
+gh repo clone owainlewis/machinist ~/Code/github/owainlewis/machinist
+```
+
+Register each checkout in `~/.machinist/worker.toml`:
+
+```toml
+[repositories.machinist]
+path = "/root/Code/github/owainlewis/machinist"
+```
+
+## Run and connect
+
+Start the control plane and worker in separate terminals:
+
+```sh
+machinist start
+```
+
+```sh
+machinist worker start
+```
+
+The current control plane intentionally listens only on loopback. From your
+computer, create an SSH tunnel:
+
+```sh
+ssh -N -L 7331:127.0.0.1:7331 machinist
+```
+
+Then open <http://127.0.0.1:7331>. Do not expose port 7331 directly or place the
+current unauthenticated UI behind a public reverse proxy.
+
+For a long-running deployment, run the control plane and worker under a service
+manager after authentication and repository configuration are complete. Both
+processes must run as the same non-root account that owns the agent credentials,
+Machinist configuration, and repository checkouts.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+set -eu
+
+repository=${MACHINIST_REPOSITORY:-owainlewis/machinist}
+version=${MACHINIST_VERSION:-}
+install_dir=${MACHINIST_INSTALL_DIR:-}
+
+fail() {
+  printf 'machinist installer: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+command -v tar >/dev/null 2>&1 || fail "tar is required"
+
+case $(uname -s) in
+  Linux) os=linux ;;
+  Darwin) os=darwin ;;
+  *) fail "unsupported operating system: $(uname -s)" ;;
+esac
+
+case $(uname -m) in
+  x86_64|amd64) arch=amd64 ;;
+  arm64|aarch64) arch=arm64 ;;
+  *) fail "unsupported architecture: $(uname -m)" ;;
+esac
+
+if [ -z "$version" ]; then
+  metadata=$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+    -H 'User-Agent: machinist-installer' \
+    "https://api.github.com/repos/$repository/releases/latest") || \
+    fail "could not find a published release"
+  version=$(printf '%s\n' "$metadata" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+fi
+
+printf '%s\n' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$' ||
+  fail "invalid release version: $version"
+
+if [ -z "$install_dir" ]; then
+  if [ -w /usr/local/bin ]; then
+    install_dir=/usr/local/bin
+  else
+    install_dir=${HOME:?HOME is required}/.local/bin
+  fi
+fi
+
+release_name=${version#v}
+archive_name="machinist_${release_name}_${os}_${arch}.tar.gz"
+release_url="https://github.com/$repository/releases/download/$version"
+temporary_dir=$(mktemp -d)
+trap 'rm -rf "$temporary_dir"' EXIT HUP INT TERM
+
+curl -fsSL "$release_url/checksums.txt" -o "$temporary_dir/checksums.txt" || \
+  fail "could not download checksums for $version"
+curl -fsSL "$release_url/$archive_name" -o "$temporary_dir/$archive_name" || \
+  fail "could not download $archive_name"
+
+expected=$(awk -v name="$archive_name" '$2 == name || $2 == "*" name { print $1; exit }' "$temporary_dir/checksums.txt")
+[ -n "$expected" ] || fail "release checksums do not contain $archive_name"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum "$temporary_dir/$archive_name" | awk '{print $1}')
+elif command -v shasum >/dev/null 2>&1; then
+  actual=$(shasum -a 256 "$temporary_dir/$archive_name" | awk '{print $1}')
+else
+  fail "sha256sum or shasum is required"
+fi
+[ "$actual" = "$expected" ] || fail "checksum mismatch for $archive_name"
+
+tar -xzf "$temporary_dir/$archive_name" -C "$temporary_dir" machinist
+mkdir -p "$install_dir"
+install -m 0755 "$temporary_dir/machinist" "$install_dir/machinist"
+
+printf 'installed machinist %s to %s/machinist\n' "$version" "$install_dir"
+case ":$PATH:" in
+  *":$install_dir:"*) ;;
+  *) printf 'add %s to PATH before running machinist\n' "$install_dir" ;;
+esac

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/owainlewis/machinist/internal/controlplane"
 	"github.com/owainlewis/machinist/internal/managedworker"
 	"github.com/owainlewis/machinist/internal/runner"
+	"github.com/owainlewis/machinist/internal/updater"
 	"github.com/spf13/cobra"
 )
 
@@ -72,6 +73,7 @@ func newRootCommand(options *commandOptions) *cobra.Command {
 	root.AddCommand(newRunCommand(options, true))
 	root.AddCommand(newSubmitCommand(options))
 	root.AddCommand(newStartCommand(options))
+	root.AddCommand(newUpdateCommand(options))
 
 	worker := &cobra.Command{Use: "worker", Short: "Run or connect a Machinist Worker"}
 	worker.AddCommand(newRunCommand(options, false))
@@ -87,6 +89,32 @@ func newRootCommand(options *commandOptions) *cobra.Command {
 		},
 	})
 	return root
+}
+
+func newUpdateCommand(options *commandOptions) *cobra.Command {
+	var requestedVersion string
+	update := &cobra.Command{
+		Use:   "update",
+		Short: "Update Machinist to a released version",
+		Args:  cobra.NoArgs,
+		RunE: func(command *cobra.Command, _ []string) error {
+			result, err := updater.Update(command.Context(), updater.Options{
+				Version: requestedVersion,
+				Current: options.version,
+			})
+			if err != nil {
+				return err
+			}
+			if result.AlreadyCurrent {
+				fmt.Fprintf(options.stdout, "machinist %s is already installed\n", result.Version)
+				return nil
+			}
+			fmt.Fprintf(options.stdout, "updated machinist to %s\n", result.Version)
+			return nil
+		},
+	}
+	update.Flags().StringVar(&requestedVersion, "version", "", "release version to install, such as v0.2.0 (default latest)")
+	return update
 }
 
 type submitCatalog struct {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,254 @@
+package updater
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+const (
+	defaultAPIBase     = "https://api.github.com/repos/owainlewis/machinist"
+	defaultReleaseBase = "https://github.com/owainlewis/machinist/releases/download"
+	maxMetadataSize    = 1 << 20
+	maxChecksumsSize   = 1 << 20
+	maxArchiveSize     = 100 << 20
+	maxBinarySize      = 100 << 20
+)
+
+var releaseVersionPattern = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$`)
+
+type Options struct {
+	Version     string
+	Current     string
+	Executable  string
+	GOOS        string
+	GOARCH      string
+	Client      *http.Client
+	APIBase     string
+	ReleaseBase string
+}
+
+type Result struct {
+	Version        string
+	AlreadyCurrent bool
+}
+
+type release struct {
+	TagName string `json:"tag_name"`
+}
+
+func Update(ctx context.Context, options Options) (Result, error) {
+	if options.Client == nil {
+		options.Client = http.DefaultClient
+	}
+	if options.APIBase == "" {
+		options.APIBase = defaultAPIBase
+	}
+	if options.ReleaseBase == "" {
+		options.ReleaseBase = defaultReleaseBase
+	}
+	if options.GOOS == "" {
+		options.GOOS = runtime.GOOS
+	}
+	if options.GOARCH == "" {
+		options.GOARCH = runtime.GOARCH
+	}
+	if options.Executable == "" {
+		path, err := os.Executable()
+		if err != nil {
+			return Result{}, fmt.Errorf("find current executable: %w", err)
+		}
+		options.Executable = path
+	}
+
+	version := options.Version
+	if version == "" {
+		var err error
+		version, err = latestVersion(ctx, options.Client, options.APIBase)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	if err := validateVersion(version); err != nil {
+		return Result{}, err
+	}
+	if version == options.Current {
+		return Result{Version: version, AlreadyCurrent: true}, nil
+	}
+	if options.GOOS != "linux" && options.GOOS != "darwin" {
+		return Result{}, fmt.Errorf("unsupported operating system %q", options.GOOS)
+	}
+	if options.GOARCH != "amd64" && options.GOARCH != "arm64" {
+		return Result{}, fmt.Errorf("unsupported architecture %q", options.GOARCH)
+	}
+
+	releaseName := strings.TrimPrefix(version, "v")
+	archiveName := fmt.Sprintf("machinist_%s_%s_%s.tar.gz", releaseName, options.GOOS, options.GOARCH)
+	baseURL := strings.TrimRight(options.ReleaseBase, "/") + "/" + version
+	checksums, err := download(ctx, options.Client, baseURL+"/checksums.txt", maxChecksumsSize)
+	if err != nil {
+		return Result{}, fmt.Errorf("download checksums: %w", err)
+	}
+	want, err := checksumFor(checksums, archiveName)
+	if err != nil {
+		return Result{}, err
+	}
+	archive, err := download(ctx, options.Client, baseURL+"/"+archiveName, maxArchiveSize)
+	if err != nil {
+		return Result{}, fmt.Errorf("download release archive: %w", err)
+	}
+	got := sha256.Sum256(archive)
+	if !strings.EqualFold(hex.EncodeToString(got[:]), want) {
+		return Result{}, fmt.Errorf("checksum mismatch for %s", archiveName)
+	}
+	binary, err := extractBinary(archive)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := replaceExecutable(options.Executable, binary); err != nil {
+		return Result{}, err
+	}
+	return Result{Version: version}, nil
+}
+
+func latestVersion(ctx context.Context, client *http.Client, apiBase string) (string, error) {
+	body, err := download(ctx, client, strings.TrimRight(apiBase, "/")+"/releases/latest", maxMetadataSize)
+	if err != nil {
+		return "", fmt.Errorf("find latest release: %w", err)
+	}
+	var metadata release
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return "", fmt.Errorf("decode latest release: %w", err)
+	}
+	if err := validateVersion(metadata.TagName); err != nil {
+		return "", fmt.Errorf("latest release: %w", err)
+	}
+	return metadata.TagName, nil
+}
+
+func validateVersion(version string) error {
+	if !releaseVersionPattern.MatchString(version) {
+		return fmt.Errorf("invalid release version %q; expected vMAJOR.MINOR.PATCH", version)
+	}
+	return nil
+}
+
+func download(ctx context.Context, client *http.Client, endpoint string, limit int64) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("User-Agent", "machinist-updater")
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		message, _ := io.ReadAll(io.LimitReader(response.Body, 8<<10))
+		return nil, fmt.Errorf("%s returned %s: %s", endpoint, response.Status, strings.TrimSpace(string(message)))
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("response from %s exceeds %d bytes", endpoint, limit)
+	}
+	return body, nil
+}
+
+func checksumFor(checksums []byte, archiveName string) (string, error) {
+	for _, line := range strings.Split(string(checksums), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && strings.TrimPrefix(fields[1], "*") == archiveName {
+			decoded, err := hex.DecodeString(fields[0])
+			if err != nil || len(decoded) != sha256.Size {
+				return "", fmt.Errorf("invalid checksum for %s", archiveName)
+			}
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("checksums.txt does not contain %s", archiveName)
+}
+
+func extractBinary(archive []byte) ([]byte, error) {
+	gzipReader, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, fmt.Errorf("open release archive: %w", err)
+	}
+	defer gzipReader.Close()
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read release archive: %w", err)
+		}
+		if header.Name != "machinist" || !header.FileInfo().Mode().IsRegular() {
+			continue
+		}
+		if header.Size < 1 || header.Size > maxBinarySize {
+			return nil, errors.New("release archive contains an invalid machinist binary size")
+		}
+		binary, err := io.ReadAll(io.LimitReader(tarReader, maxBinarySize+1))
+		if err != nil {
+			return nil, fmt.Errorf("read machinist binary: %w", err)
+		}
+		return binary, nil
+	}
+	return nil, errors.New("release archive does not contain machinist")
+}
+
+func replaceExecutable(path string, binary []byte) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("inspect current executable: %w", err)
+	}
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, ".machinist-update-*")
+	if err != nil {
+		return fmt.Errorf("create update beside %s: %w", path, err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	mode := info.Mode().Perm()
+	if mode&0o111 == 0 {
+		mode = 0o755
+	}
+	if err := temporary.Chmod(mode); err != nil {
+		temporary.Close()
+		return fmt.Errorf("set update permissions: %w", err)
+	}
+	if _, err := temporary.Write(binary); err != nil {
+		temporary.Close()
+		return fmt.Errorf("write update: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		temporary.Close()
+		return fmt.Errorf("sync update: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close update: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,149 @@
+package updater
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpdateInstallsLatestVerifiedRelease(t *testing.T) {
+	binary := []byte("new machinist")
+	archive := testArchive(t, binary)
+	digest := sha256.Sum256(archive)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/releases/latest":
+			fmt.Fprint(response, `{"tag_name":"v1.2.3"}`)
+		case "/downloads/v1.2.3/checksums.txt":
+			fmt.Fprintf(response, "%x  machinist_1.2.3_linux_amd64.tar.gz\n", digest)
+		case "/downloads/v1.2.3/machinist_1.2.3_linux_amd64.tar.gz":
+			response.Write(archive)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	executable := filepath.Join(t.TempDir(), "machinist")
+	if err := os.WriteFile(executable, []byte("old machinist"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	result, err := Update(t.Context(), Options{
+		Current:     "v1.0.0",
+		Executable:  executable,
+		GOOS:        "linux",
+		GOARCH:      "amd64",
+		Client:      server.Client(),
+		APIBase:     server.URL + "/api",
+		ReleaseBase: server.URL + "/downloads",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Version != "v1.2.3" || result.AlreadyCurrent {
+		t.Fatalf("result = %#v", result)
+	}
+	got, err := os.ReadFile(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, binary) {
+		t.Fatalf("installed binary = %q", got)
+	}
+}
+
+func TestUpdateChecksumFailureLeavesExecutableUntouched(t *testing.T) {
+	archive := testArchive(t, []byte("new machinist"))
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch {
+		case strings.HasSuffix(request.URL.Path, "/checksums.txt"):
+			fmt.Fprintln(response, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  machinist_1.2.3_linux_amd64.tar.gz")
+		case strings.HasSuffix(request.URL.Path, ".tar.gz"):
+			response.Write(archive)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	executable := filepath.Join(t.TempDir(), "machinist")
+	original := []byte("old machinist")
+	if err := os.WriteFile(executable, original, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Update(t.Context(), Options{
+		Version:     "v1.2.3",
+		Current:     "v1.0.0",
+		Executable:  executable,
+		GOOS:        "linux",
+		GOARCH:      "amd64",
+		Client:      server.Client(),
+		ReleaseBase: server.URL,
+	})
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %v", err)
+	}
+	got, readErr := os.ReadFile(executable)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("executable changed to %q", got)
+	}
+}
+
+func TestUpdateRejectsInvalidVersionBeforeNetworkAccess(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "machinist")
+	if err := os.WriteFile(executable, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Update(t.Context(), Options{Version: "latest", Executable: executable})
+	if err == nil || !strings.Contains(err.Error(), "expected vMAJOR.MINOR.PATCH") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestUpdateReportsCurrentVersionWithoutDownloadingAssets(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/releases/latest" {
+			t.Fatalf("unexpected request: %s", request.URL.Path)
+		}
+		fmt.Fprint(response, `{"tag_name":"v1.2.3"}`)
+	}))
+	defer server.Close()
+	result, err := Update(t.Context(), Options{Current: "v1.2.3", Client: server.Client(), APIBase: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.AlreadyCurrent || result.Version != "v1.2.3" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func testArchive(t *testing.T, binary []byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	if err := tarWriter.WriteHeader(&tar.Header{Name: "machinist", Mode: 0o755, Size: int64(len(binary))}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tarWriter.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $(id -u) -ne 0 ]]; then
+  echo "run this script as root" >&2
+  exit 1
+fi
+
+if [[ ! -r /etc/os-release ]]; then
+  echo "unsupported Linux distribution: /etc/os-release is missing" >&2
+  exit 1
+fi
+. /etc/os-release
+if [[ ${ID:-} != ubuntu && ${ID:-} != debian ]]; then
+  echo "unsupported Linux distribution: ${ID:-unknown}" >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y ca-certificates curl git gh jq openssh-client tar
+
+# Codex and Claude Code use per-user credentials, so install their standalone
+# distributions as the account that will run Machinist.
+curl -fsSL https://chatgpt.com/codex/install.sh | sh
+curl -fsSL https://claude.ai/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
+
+machinist init
+
+cat <<'EOF'
+
+VM bootstrap complete.
+
+Next steps:
+  1. Run `gh auth login`.
+  2. Run `codex` once and sign in.
+  3. Run `claude` once and sign in.
+  4. Clone each repository agents may use and register its absolute path in
+     ~/.machinist/worker.toml.
+  5. Start `machinist start` and `machinist worker start`.
+
+Keep the control plane on 127.0.0.1. Reach it from your computer with:
+  ssh -N -L 7331:127.0.0.1:7331 machinist
+EOF


### PR DESCRIPTION
## Summary

- add a checksum-verified one-line installer for published Machinist binaries
- add `machinist update` with latest and pinned-version support
- document and automate Ubuntu/Debian VM bootstrap with Codex and Claude Code

## Verification

- `just check`
- `bash scripts/release.sh v0.1.0 <temp>/dist`
- `bash scripts/verify-release.sh <temp>/dist v0.1.0`
- `sh -n install.sh`
- `bash -n scripts/setup-vm.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a portable installer for Linux and macOS with platform detection and checksum verification.
  - Added a CLI update command supporting latest or version-pinned releases.
  - Added VM bootstrap tooling for Ubuntu and Debian deployments.

- **Documentation**
  - Added comprehensive VM deployment guidance, including installation, authentication, configuration, and SSH access.
  - Updated the README with deployment documentation and binary installation instructions.

- **Bug Fixes**
  - Updates now validate releases and preserve the existing installation if verification fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->