### PR TITLE
fix(deploy): expose agent CLIs to services

### DIFF
--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -15,8 +15,10 @@ curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/scripts/s
 
 The script installs Git, GitHub CLI, Codex, Claude Code, and the latest published
 Machinist release. It then creates the default configuration under
-`~/.machinist`. Review remote scripts before piping them into a shell when the
-repository or network is outside your trust boundary.
+`~/.machinist`. Codex and Claude Code remain installed under `~/.local/bin`; the
+root bootstrap links their launchers into `/usr/local/bin` so non-interactive
+workers and services can find them. Review remote scripts before piping them
+into a shell when the repository or network is outside your trust boundary.
 
 Authenticate each tool interactively on the VM:
 

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -27,6 +27,17 @@ curl -fsSL https://chatgpt.com/codex/install.sh | sh
 curl -fsSL https://claude.ai/install.sh | bash
 curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
 
+# Standalone agent installers use ~/.local/bin. Login shells commonly add that
+# directory to PATH, but services and other non-interactive processes do not.
+for agent_command in codex claude; do
+  agent_path="$HOME/.local/bin/$agent_command"
+  if [[ ! -x "$agent_path" ]]; then
+    echo "$agent_command installer did not create $agent_path" >&2
+    exit 1
+  fi
+  ln -sfn "$agent_path" "/usr/local/bin/$agent_command"
+done
+
 machinist init
 
 cat <<'EOF'


### PR DESCRIPTION
## Summary

- link standalone Codex and Claude Code launchers into /usr/local/bin during root VM bootstrap
- fail bootstrap when an expected agent launcher is missing
- document why service-visible links are required

## Reproduction

After the v0.1.0 bootstrap, a non-interactive login shell could not find either codex or claude.

## Verification

- just check
- bash -n scripts/setup-vm.sh
- git diff --check