### PR TITLE
feat(deploy): add complete remote VM setup

### DIFF
--- a/deploy/systemd/machinist-control-plane.service
+++ b/deploy/systemd/machinist-control-plane.service
@@ -5,10 +5,10 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=root
-Group=root
-Environment=HOME=/root
-WorkingDirectory=/root
+User=machinist
+Group=machinist
+Environment=HOME=/home/machinist
+WorkingDirectory=/home/machinist
 ExecStart=/usr/local/bin/machinist start
 Restart=on-failure
 RestartSec=5s

--- a/deploy/systemd/machinist-control-plane.service
+++ b/deploy/systemd/machinist-control-plane.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Machinist control plane
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+Environment=HOME=/root
+WorkingDirectory=/root
+ExecStart=/usr/local/bin/machinist start
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/machinist-worker.service
+++ b/deploy/systemd/machinist-worker.service
@@ -8,10 +8,10 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
-User=root
-Group=root
-Environment=HOME=/root
-WorkingDirectory=/root
+User=machinist
+Group=machinist
+Environment=HOME=/home/machinist
+WorkingDirectory=/home/machinist
 ExecStart=/usr/local/bin/machinist worker start
 Restart=always
 RestartSec=5s

--- a/deploy/systemd/machinist-worker.service
+++ b/deploy/systemd/machinist-worker.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Machinist managed worker
+After=network-online.target machinist-control-plane.service
+Wants=network-online.target
+Requires=machinist-control-plane.service
+
+[Service]
+Type=simple
+User=root
+Group=root
+Environment=HOME=/root
+WorkingDirectory=/root
+ExecStart=/usr/local/bin/machinist worker start
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/machinist-worker.service
+++ b/deploy/systemd/machinist-worker.service
@@ -3,6 +3,8 @@ Description=Machinist managed worker
 After=network-online.target machinist-control-plane.service
 Wants=network-online.target
 Requires=machinist-control-plane.service
+StartLimitIntervalSec=60s
+StartLimitBurst=5
 
 [Service]
 Type=simple

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@
 - [Managed triggers](managed-triggers.md): start jobs from GitHub labels,
   intervals, and cron schedules
 - [Development](development.md): build, test, and navigate the repository
+- [Remote VM setup](vm-deployment.md): install Machinist and its coding agents,
+  configure GitHub SSH and CLI authentication, and connect securely
 - [Migration guide](migration-from-factory.md): clean installation, renamed
   interfaces, and rollback
 - [Architecture](../ARCHITECTURE.md): source of truth, dependency direction,

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -46,11 +46,12 @@ curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/scripts/s
 
 The script installs Git, GitHub CLI, Codex, Claude Code, and the latest stable
 Machinist release. It initializes `~/.machinist` without overwriting existing
-configuration, then installs and enables systemd services for the control plane
-and worker. It starts the control plane immediately and starts the worker when a
-repository is already configured. Re-running the bootstrap updates the installed
-files and restarts the applicable services. Review remote scripts before
-executing them when the repository or network is outside your trust boundary.
+configuration, then installs systemd services for the control plane and worker.
+It enables and starts the control plane immediately. It enables the worker only
+when a repository is already configured. Re-running the bootstrap updates the
+installed files and restarts the applicable services. Review remote scripts
+before executing them when the repository or network is outside your trust
+boundary.
 
 Verify the tools:
 
@@ -194,7 +195,7 @@ brackets.
 Start the enabled worker now that it has a repository:
 
 ```sh
-systemctl start machinist-worker.service
+systemctl enable --now machinist-worker.service
 ```
 
 ## 8. Run Machinist as a service
@@ -206,10 +207,10 @@ systemctl status machinist-control-plane.service
 systemctl status machinist-worker.service
 ```
 
-The control plane starts during bootstrap. The worker is enabled for future
-boots, but a fresh bootstrap leaves it stopped until you register a repository
-and start it in the previous step. The control plane remains bound to
-`127.0.0.1:7331`, and the worker connects to it locally.
+The control plane starts during bootstrap. A fresh bootstrap leaves the worker
+disabled until you register a repository and enable it in the previous step.
+The control plane remains bound to `127.0.0.1:7331`, and the worker connects to
+it locally.
 
 Follow their logs:
 

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -70,13 +70,18 @@ The v0.2.0 bootstrap deliberately stops if it detects services or configuration
 from the earlier root-based setup. It does not copy root-owned agent credentials
 into the unprivileged account.
 
-Back up the old configuration and remove the old units before bootstrapping:
+Move the old configuration and units into a recoverable backup before
+bootstrapping:
 
 ```sh
 systemctl disable --now machinist-worker.service machinist-control-plane.service
-mv /root/.machinist /root/.machinist.v0.1-backup
-rm -f /etc/systemd/system/machinist-worker.service \
-  /etc/systemd/system/machinist-control-plane.service
+mkdir -p /root/machinist-v0.1-backup
+mv /root/.machinist /root/machinist-v0.1-backup/config
+for unit in machinist-worker.service machinist-control-plane.service; do
+  if [ -f "/etc/systemd/system/$unit" ]; then
+    mv "/etc/systemd/system/$unit" /root/machinist-v0.1-backup/
+  fi
+done
 systemctl daemon-reload
 ```
 
@@ -84,6 +89,11 @@ Then run the pinned bootstrap command above. Recreate the configuration under
 `/home/machinist/.machinist`, reauthenticate GitHub, Codex, and Claude as the
 `machinist` user, and clone repositories under `/home/machinist`. Keep the
 backup until the new worker passes the smoke test.
+
+To roll back before then, stop the new services, move the saved configuration
+back to `/root/.machinist`, restore both saved unit files under
+`/etc/systemd/system`, run `systemctl daemon-reload`, and enable and start the
+old services again.
 
 Verify the tools:
 
@@ -254,7 +264,8 @@ journalctl -u machinist-control-plane.service -f
 journalctl -u machinist-worker.service -f
 ```
 
-After changing `~/.machinist/config.toml` or `worker.toml`, restart both:
+After changing `/home/machinist/.machinist/config.toml` or
+`/home/machinist/.machinist/worker.toml`, restart both:
 
 ```sh
 su - machinist

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -28,7 +28,7 @@ On your computer, add this entry to `~/.ssh/config`:
 
 ```sshconfig
 Host machinist
-  HostName 89.167.49.125
+  HostName <VM_IP_OR_HOSTNAME>
   User root
   IdentityFile ~/.ssh/id_ed25519
   IdentitiesOnly yes

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -195,6 +195,7 @@ brackets.
 Enable and start the worker now that it has a repository:
 
 ```sh
+machinist worker validate
 systemctl enable --now machinist-worker.service
 ```
 
@@ -249,6 +250,7 @@ Verify the configuration and credentials before assigning a real issue:
 ```sh
 machinist version
 machinist update
+machinist worker validate
 systemctl is-active machinist-control-plane.service machinist-worker.service
 gh auth status
 ssh -T git@github.com

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -1,114 +1,352 @@
-# Deploy Machinist on a VM
+# Set up Machinist on a remote VM
 
-The supported VM layout runs a published Machinist binary and keeps source
-checkouts only for repositories that coding agents work on. The VM does not need
-Go, Node.js, or a clone of the Machinist repository at runtime.
+This guide sets up a dedicated Ubuntu or Debian VM that runs Machinist with
+Codex and Claude Code. Machinist runs from a published binary. Git checkouts are
+needed only for repositories that coding agents may inspect or change.
 
-## Bootstrap Ubuntu or Debian
+The examples use a local SSH alias named `machinist` and configure root as the
+runtime account. Treat this as a dedicated, privileged coding worker.
 
-Connect to the VM and run the bootstrap script:
+## Understand the four logins
+
+The VM needs separate credentials for separate jobs:
+
+| Credential | Used for |
+| --- | --- |
+| Your local SSH key for the VM | `ssh machinist` from your computer |
+| A new GitHub SSH key created on the VM | Git clone, fetch, and push from the VM |
+| GitHub CLI authentication on the VM | Issues, pull requests, comments, checks, and releases |
+| Codex and Claude authentication on the VM | Running the coding-agent executors |
+
+Do not copy private keys or Codex, Claude, or GitHub credential files from your
+computer. Create and authenticate each VM credential on the VM itself.
+
+## 1. Add the local SSH alias
+
+On your computer, add this entry to `~/.ssh/config`:
+
+```sshconfig
+Host machinist
+  HostName 89.167.49.125
+  User root
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+```
+
+Test it with `ssh machinist`. Use the actual host name, user, and local identity
+file on another VM.
+
+## 2. Bootstrap the VM
+
+While connected to the VM, run:
 
 ```sh
-ssh machinist
 curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/scripts/setup-vm.sh | bash
 ```
 
-The script installs Git, GitHub CLI, Codex, Claude Code, and the latest published
-Machinist release. It then creates the default configuration under
-`~/.machinist`. Codex and Claude Code remain installed under `~/.local/bin`; the
-root bootstrap links their launchers into `/usr/local/bin` so non-interactive
-workers and services can find them. Review remote scripts before piping them
-into a shell when the repository or network is outside your trust boundary.
+The script installs Git, GitHub CLI, Codex, Claude Code, and the latest stable
+Machinist release. It initializes `~/.machinist` without overwriting existing
+configuration, then installs and starts systemd services for the control plane
+and worker. Review remote scripts before executing them when the repository or
+network is outside your trust boundary.
 
-Authenticate each tool interactively on the VM:
+Verify the tools:
 
 ```sh
-gh auth login
+git --version
+gh --version
+codex --version
+claude --version
+machinist version
+```
+
+## 3. Create a dedicated GitHub SSH key on the VM
+
+Create a key used only by this worker:
+
+```sh
+ssh-keygen -t ed25519 \
+  -C "machinist@$(hostname)" \
+  -f ~/.ssh/id_ed25519_machinist
+```
+
+An autonomous worker cannot unlock an interactive passphrase after a restart.
+For a dedicated worker, leave the passphrase empty and protect the key through
+host access, file permissions, and limited GitHub permissions. Use a passphrase
+and persistent SSH agent only when you have designed that operational flow.
+
+Protect the private key and print only the public key:
+
+```sh
+chmod 700 ~/.ssh
+chmod 600 ~/.ssh/id_ed25519_machinist
+chmod 644 ~/.ssh/id_ed25519_machinist.pub
+cat ~/.ssh/id_ed25519_machinist.pub
+```
+
+Never print, copy, or upload `~/.ssh/id_ed25519_machinist` without the `.pub`
+suffix. That file is the private key.
+
+## 4. Add the public key to GitHub
+
+In GitHub, open **Settings → SSH and GPG keys → New SSH key**.
+
+1. Use a descriptive title such as `machinist-vm`.
+2. Select **Authentication Key**.
+3. Paste the complete `.pub` line printed by the previous command.
+4. Save the key.
+
+An account SSH key can access every repository the GitHub account permits. For
+tighter isolation, use a dedicated GitHub machine account or repository deploy
+keys. A deploy key is repository-specific and needs write access when the agent
+must push branches.
+
+Add this to `~/.ssh/config` on the VM:
+
+```sshconfig
+Host github.com
+  HostName github.com
+  User git
+  IdentityFile ~/.ssh/id_ed25519_machinist
+  IdentitiesOnly yes
+```
+
+Protect and test the configuration:
+
+```sh
+chmod 600 ~/.ssh/config
+ssh -T git@github.com
+```
+
+On the first connection, compare the displayed host fingerprint with GitHub's
+published SSH fingerprints before accepting it. A successful test says GitHub
+authenticated the account and notes that shell access is unavailable.
+
+## 5. Log in to GitHub CLI
+
+SSH authentication and GitHub CLI authentication are separate. The shipped
+agents use both Git and `gh`, so complete both:
+
+```sh
+gh auth login --hostname github.com --git-protocol ssh --web
+```
+
+Follow the device or browser instructions. Then verify:
+
+```sh
+gh auth status
+gh api user --jq .login
+```
+
+Use a GitHub identity with only the repository access the worker needs.
+
+## 6. Log in to Codex and Claude Code
+
+Run each CLI interactively on the VM and follow its sign-in flow:
+
+```sh
 codex
 claude
 ```
 
-Do not copy local Codex, Claude, or GitHub credential files to the VM.
+The official OpenAI documentation says the first `codex` run offers the
+available sign-in methods. Do not copy a local credential store to the VM.
 
-## Install or update Machinist
-
-Install the latest stable release without the full VM bootstrap:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-Install a specific release:
+Verify the executors are visible to non-interactive processes:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh |
-  MACHINIST_VERSION=v0.2.0 sh
+command -v codex
+command -v claude
 ```
 
-An installed binary can update itself. The update is checksum-verified and the
-current executable is replaced only after the new archive passes validation:
+The root bootstrap exposes both launchers through `/usr/local/bin` for workers
+and services.
 
-```sh
-machinist update
-machinist update --version v0.2.0
-```
+## 7. Clone and register repositories
 
-When Machinist is installed in a root-owned directory, run the update with the
-matching account or reinstall into a user-writable directory:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh |
-  MACHINIST_INSTALL_DIR="$HOME/.local/bin" sh
-```
-
-## Clone agent repositories
-
-Clone every repository the worker may change. A clone is required for agent
-work, but Machinist itself still runs from the release binary:
+Clone each repository the worker may use:
 
 ```sh
 mkdir -p ~/Code/github/owainlewis
-gh repo clone owainlewis/machinist ~/Code/github/owainlewis/machinist
+git clone git@github.com:owainlewis/machinist.git \
+  ~/Code/github/owainlewis/machinist
 ```
 
-Register each checkout in `~/.machinist/worker.toml`:
+Confirm Git can access the repository:
+
+```sh
+git -C ~/Code/github/owainlewis/machinist remote -v
+git -C ~/Code/github/owainlewis/machinist fetch --dry-run
+```
+
+Register the checkout in `~/.machinist/worker.toml`:
 
 ```toml
 [repositories.machinist]
 path = "~/Code/github/owainlewis/machinist"
 ```
 
-## Run and connect
+Add one entry for every repository and use a distinct logical name inside the
+brackets.
 
-Start the control plane and worker in separate terminals:
+## 8. Run Machinist as a service
+
+The bootstrap installs and enables these services:
 
 ```sh
-machinist start
+systemctl status machinist-control-plane.service
+systemctl status machinist-worker.service
 ```
+
+They start automatically after a reboot. The control plane remains bound to
+`127.0.0.1:7331`, and the worker connects to it locally.
+
+Follow their logs:
 
 ```sh
-machinist worker start
+journalctl -u machinist-control-plane.service -f
+journalctl -u machinist-worker.service -f
 ```
 
-The current control plane intentionally listens only on loopback. From your
-computer, create an SSH tunnel:
+After changing `~/.machinist/config.toml` or `worker.toml`, restart both:
+
+```sh
+systemctl restart machinist-control-plane.service machinist-worker.service
+```
+
+Stop or start the complete deployment:
+
+```sh
+systemctl stop machinist-worker.service machinist-control-plane.service
+systemctl start machinist-control-plane.service machinist-worker.service
+```
+
+From your computer, open an SSH tunnel:
 
 ```sh
 ssh -N -L 7331:127.0.0.1:7331 machinist
 ```
 
-Then open <http://127.0.0.1:7331>. Do not expose port 7331 directly or place the
+Open <http://127.0.0.1:7331>. Do not expose port 7331 directly or place the
 current unauthenticated UI behind a public reverse proxy.
 
-The bootstrap command above runs as root and configures root as the Machinist
-runtime account. Treat that VM as a dedicated, privileged coding worker. For a
-long-running deployment, run both processes under a service manager as the same
-account that owns the agent credentials, Machinist configuration, and repository
-checkouts.
+## 9. Run a smoke test
 
-To use a non-root runtime account instead, create that account first, run the
-Codex, Claude Code, and Machinist installers plus `machinist init` while logged in
-as that account, and keep its repositories and credentials under its home
-directory. Do not mix configuration or credentials between root and a service
-account.
+Verify the configuration and credentials before assigning a real issue:
+
+```sh
+machinist version
+machinist update
+systemctl is-active machinist-control-plane.service machinist-worker.service
+gh auth status
+ssh -T git@github.com
+command -v codex
+command -v claude
+```
+
+Then run the shipped read-only audit agent against a narrow area:
+
+```sh
+machinist run \
+  --agent=audit \
+  --repo=~/Code/github/owainlewis/machinist \
+  --prompt="Inspect one narrow package and report only proven bugs"
+```
+
+The audit agent is read-only by instruction, but the coding CLI still has the
+operating-system and network permissions of the VM account.
+
+## 10. Update Machinist
+
+Install the latest stable release:
+
+```sh
+machinist update
+```
+
+Install a specific release for rollback or reproducibility:
+
+```sh
+machinist update --version v0.1.1
+```
+
+Machinist replaces the executable only after the matching release archive
+passes SHA-256 verification.
+
+Restart the services so they run the updated binary:
+
+```sh
+systemctl restart machinist-control-plane.service machinist-worker.service
+```
+
+## Optional agent prompt
+
+Give this prompt to an agent that already has SSH access to the VM. It performs
+non-interactive setup and stops for steps that require you:
+
+```text
+Set up Machinist on the remote Ubuntu or Debian VM available through
+`ssh machinist`.
+
+Follow docs/vm-deployment.md from the Machinist repository. You may install
+system packages, run the official bootstrap, create a dedicated GitHub SSH key,
+configure SSH, clone repositories after authentication, edit worker.toml, and
+run verification commands.
+
+Safety requirements:
+- Never print, copy, or transmit a private SSH key.
+- Never copy Codex, Claude, or GitHub credential files from another machine.
+- Keep the Machinist control plane bound to 127.0.0.1.
+- Do not expose port 7331 publicly.
+- Do not weaken SSH host-key verification.
+- Do not start real agent work or modify a GitHub repository.
+
+Stop when SSH-key registration, a browser or device code, Codex login, or Claude
+login requires me. Tell me exactly what I need to do, then wait. After I confirm
+completion, resume the guide, verify every credential without revealing it, and
+report any remaining manual steps.
+```
+
+## Troubleshooting
+
+### `Permission denied (publickey)` from GitHub
+
+Check that the public key is registered, the private key has mode `0600`, and
+SSH selects it:
+
+```sh
+ssh -vT git@github.com
+```
+
+### `gh auth status` reports no account
+
+Run `gh auth login --hostname github.com --git-protocol ssh --web` again. GitHub
+SSH access does not automatically authenticate GitHub CLI.
+
+### Machinist cannot find `codex` or `claude`
+
+```sh
+ls -l /usr/local/bin/codex /usr/local/bin/claude
+command -v codex claude
+```
+
+Re-run the bootstrap if either launcher is missing.
+
+### The browser cannot reach Machinist
+
+Check the service and keep the SSH tunnel running on your computer:
+
+```sh
+systemctl status machinist-control-plane.service
+ss -ltnp | grep 7331
+```
+
+The listener should be `127.0.0.1:7331`, not `0.0.0.0:7331`.
+
+## Non-root alternative
+
+Create the runtime account first. Run the Codex, Claude Code, and Machinist
+installers, SSH-key setup, GitHub CLI authentication, and `machinist init` while
+logged in as that account. Keep its repositories and credentials under its home
+directory. Run the control plane and worker as that same account. Do not mix
+configuration or credentials between accounts.

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -47,8 +47,9 @@ curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/scripts/s
 The script installs Git, GitHub CLI, Codex, Claude Code, and the latest stable
 Machinist release. It initializes `~/.machinist` without overwriting existing
 configuration, then installs and starts systemd services for the control plane
-and worker. Review remote scripts before executing them when the repository or
-network is outside your trust boundary.
+and worker. Re-running the bootstrap updates the installed files and restarts
+both services. Review remote scripts before executing them when the repository
+or network is outside your trust boundary.
 
 Verify the tools:
 

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -192,7 +192,7 @@ path = "~/Code/github/owainlewis/machinist"
 Add one entry for every repository and use a distinct logical name inside the
 brackets.
 
-Start the enabled worker now that it has a repository:
+Enable and start the worker now that it has a repository:
 
 ```sh
 systemctl enable --now machinist-worker.service
@@ -200,7 +200,8 @@ systemctl enable --now machinist-worker.service
 
 ## 8. Run Machinist as a service
 
-The bootstrap installs and enables these services:
+The bootstrap installs both services and enables the control plane. It enables
+the worker after a repository is configured:
 
 ```sh
 systemctl status machinist-control-plane.service

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -64,6 +64,27 @@ key, cloning repositories, or editing Machinist configuration:
 su - machinist
 ```
 
+### Migrating a root-based v0.1.x installation
+
+The v0.2.0 bootstrap deliberately stops if it detects services or configuration
+from the earlier root-based setup. It does not copy root-owned agent credentials
+into the unprivileged account.
+
+Back up the old configuration and remove the old units before bootstrapping:
+
+```sh
+systemctl disable --now machinist-worker.service machinist-control-plane.service
+mv /root/.machinist /root/.machinist.v0.1-backup
+rm -f /etc/systemd/system/machinist-worker.service \
+  /etc/systemd/system/machinist-control-plane.service
+systemctl daemon-reload
+```
+
+Then run the pinned bootstrap command above. Recreate the configuration under
+`/home/machinist/.machinist`, reauthenticate GitHub, Codex, and Claude as the
+`machinist` user, and clone repositories under `/home/machinist`. Keep the
+backup until the new worker passes the smoke test.
+
 Verify the tools:
 
 ```sh
@@ -236,7 +257,9 @@ journalctl -u machinist-worker.service -f
 After changing `~/.machinist/config.toml` or `worker.toml`, restart both:
 
 ```sh
+su - machinist
 machinist worker validate
+exit
 systemctl restart machinist-control-plane.service machinist-worker.service
 ```
 
@@ -278,6 +301,7 @@ machinist run \
   --agent=audit \
   --repo=~/Code/github/owainlewis/machinist \
   --prompt="Inspect one narrow package and report only proven bugs"
+exit
 ```
 
 The audit agent is read-only by instruction, but the coding CLI still has the

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -4,8 +4,9 @@ This guide sets up a dedicated Ubuntu or Debian VM that runs Machinist with
 Codex and Claude Code. Machinist runs from a published binary. Git checkouts are
 needed only for repositories that coding agents may inspect or change.
 
-The examples use a local SSH alias named `machinist` and configure root as the
-runtime account. Treat this as a dedicated, privileged coding worker.
+The examples use a local SSH alias named `machinist`. Root performs bootstrap
+and service administration, while coding agents run as a dedicated unprivileged
+`machinist` account.
 
 ## Understand the four logins
 
@@ -41,17 +42,27 @@ file on another VM.
 While connected to the VM, run:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/scripts/setup-vm.sh | bash
+curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/v0.2.0/scripts/setup-vm.sh | \
+  MACHINIST_VERSION=v0.2.0 bash
 ```
 
-The script installs Git, GitHub CLI, Codex, Claude Code, and the latest stable
+The script installs Git, GitHub CLI, Codex, Claude Code, and the pinned
 Machinist release. It initializes `~/.machinist` without overwriting existing
 configuration, then installs systemd services for the control plane and worker.
 It enables and starts the control plane immediately. It enables the worker only
-when a repository is already configured. Re-running the bootstrap updates the
-installed files and restarts the applicable services. Review remote scripts
-before executing them when the repository or network is outside your trust
-boundary.
+when a repository is already configured. Re-running the bootstrap reinstalls
+that pinned release and restarts the applicable services. Change both version
+values together when installing another release. Machinist's installer verifies
+the release archive against its published SHA-256 checksum. Review remote
+scripts before executing them when the repository or network is outside your
+trust boundary.
+
+Switch to the runtime account before authenticating tools, creating its GitHub
+key, cloning repositories, or editing Machinist configuration:
+
+```sh
+su - machinist
+```
 
 Verify the tools:
 
@@ -196,6 +207,7 @@ Enable and start the worker now that it has a repository:
 
 ```sh
 machinist worker validate
+exit
 systemctl enable --now machinist-worker.service
 ```
 
@@ -224,6 +236,7 @@ journalctl -u machinist-worker.service -f
 After changing `~/.machinist/config.toml` or `worker.toml`, restart both:
 
 ```sh
+machinist worker validate
 systemctl restart machinist-control-plane.service machinist-worker.service
 ```
 
@@ -248,10 +261,10 @@ current unauthenticated UI behind a public reverse proxy.
 Verify the configuration and credentials before assigning a real issue:
 
 ```sh
-machinist version
-machinist update
-machinist worker validate
 systemctl is-active machinist-control-plane.service machinist-worker.service
+su - machinist
+machinist version
+machinist worker validate
 gh auth status
 ssh -T git@github.com
 command -v codex
@@ -357,10 +370,9 @@ ss -ltnp | grep 7331
 
 The listener should be `127.0.0.1:7331`, not `0.0.0.0:7331`.
 
-## Non-root alternative
+## Runtime security boundary
 
-Create the runtime account first. Run the Codex, Claude Code, and Machinist
-installers, SSH-key setup, GitHub CLI authentication, and `machinist init` while
-logged in as that account. Keep its repositories and credentials under its home
-directory. Run the control plane and worker as that same account. Do not mix
-configuration or credentials between accounts.
+The bootstrap creates the unprivileged `machinist` account and the supplied
+services run as that account. Its repositories, configuration, SSH keys, and
+Codex, Claude, and GitHub credentials must remain under `/home/machinist`.
+Do not give this account passwordless sudo or access to unrelated host data.

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -46,10 +46,11 @@ curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/scripts/s
 
 The script installs Git, GitHub CLI, Codex, Claude Code, and the latest stable
 Machinist release. It initializes `~/.machinist` without overwriting existing
-configuration, then installs and starts systemd services for the control plane
-and worker. Re-running the bootstrap updates the installed files and restarts
-both services. Review remote scripts before executing them when the repository
-or network is outside your trust boundary.
+configuration, then installs and enables systemd services for the control plane
+and worker. It starts the control plane immediately and starts the worker when a
+repository is already configured. Re-running the bootstrap updates the installed
+files and restarts the applicable services. Review remote scripts before
+executing them when the repository or network is outside your trust boundary.
 
 Verify the tools:
 
@@ -190,6 +191,12 @@ path = "~/Code/github/owainlewis/machinist"
 Add one entry for every repository and use a distinct logical name inside the
 brackets.
 
+Start the enabled worker now that it has a repository:
+
+```sh
+systemctl start machinist-worker.service
+```
+
 ## 8. Run Machinist as a service
 
 The bootstrap installs and enables these services:
@@ -199,7 +206,9 @@ systemctl status machinist-control-plane.service
 systemctl status machinist-worker.service
 ```
 
-They start automatically after a reboot. The control plane remains bound to
+The control plane starts during bootstrap. The worker is enabled for future
+boots, but a fresh bootstrap leaves it stopped until you register a repository
+and start it in the previous step. The control plane remains bound to
 `127.0.0.1:7331`, and the worker connects to it locally.
 
 Follow their logs:

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -78,6 +78,7 @@ func newRootCommand(options *commandOptions) *cobra.Command {
 	worker := &cobra.Command{Use: "worker", Short: "Run or connect a Machinist Worker"}
 	worker.AddCommand(newRunCommand(options, false))
 	worker.AddCommand(newWorkerStartCommand(options))
+	worker.AddCommand(newWorkerValidateCommand(options))
 	root.AddCommand(worker)
 
 	root.AddCommand(&cobra.Command{
@@ -89,6 +90,25 @@ func newRootCommand(options *commandOptions) *cobra.Command {
 		},
 	})
 	return root
+}
+
+func newWorkerValidateCommand(options *commandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate",
+		Short: "Validate the managed worker configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			workerConfig, err := config.LoadWorker(options.configPath)
+			if err != nil {
+				return err
+			}
+			if _, err := managedworker.New(workerConfig, io.Discard, io.Discard); err != nil {
+				return err
+			}
+			fmt.Fprintln(options.stdout, "worker configuration is valid")
+			return nil
+		},
+	}
 }
 
 func newUpdateCommand(options *commandOptions) *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -105,8 +105,8 @@ func newWorkerValidateCommand(options *commandOptions) *cobra.Command {
 			if _, err := managedworker.New(workerConfig, io.Discard, io.Discard); err != nil {
 				return err
 			}
-			fmt.Fprintln(options.stdout, "worker configuration is valid")
-			return nil
+			_, err = fmt.Fprintln(options.stdout, "worker configuration is valid")
+			return err
 		},
 	}
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -794,6 +794,47 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestWorkerValidateRequiresRepository(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"worker", "validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+	if exitCode != 2 || !strings.Contains(stderr.String(), "requires at least one executor and repository") {
+		t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+	}
+}
+
+func TestWorkerValidateAcceptsCompleteConfiguration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	workerPath := filepath.Join(home, ".machinist", "worker.toml")
+	file, err := os.OpenFile(workerPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("\n[repositories.example]\npath = \"" + filepath.ToSlash(t.TempDir()) + "\"\n"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"worker", "validate"}, strings.NewReader(""), &stdout, &stderr, "test")
+	if exitCode != 0 || strings.TrimSpace(stdout.String()) != "worker configuration is valid" {
+		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", exitCode, stdout.String(), stderr.String())
+	}
+}
+
 func TestStartReportsListeningAfterBindAndStopsOnCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	stderr := &cancelWriter{cancel: cancel}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -820,7 +820,9 @@ func TestWorkerValidateAcceptsCompleteConfiguration(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := file.WriteString("\n[repositories.example]\npath = \"" + filepath.ToSlash(t.TempDir()) + "\"\n"); err != nil {
-		file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			t.Errorf("close worker configuration after write failure: %v", closeErr)
+		}
 		t.Fatal(err)
 	}
 	if err := file.Close(); err != nil {

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -72,7 +72,11 @@ if machinist worker validate --help >/dev/null 2>&1; then
   fi
 else
   if [[ $worker_was_active == true ]]; then
-    systemctl enable machinist-worker.service
+    if [[ $worker_was_enabled == true ]]; then
+      systemctl enable machinist-worker.service
+    else
+      systemctl disable machinist-worker.service
+    fi
     systemctl restart machinist-worker.service
     echo "installed Machinist release does not support worker validation; restored the previously active worker" >&2
   else

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -40,6 +40,17 @@ done
 
 machinist init
 
+service_base_url=https://raw.githubusercontent.com/owainlewis/machinist/main/deploy/systemd
+curl -fsSL "$service_base_url/machinist-control-plane.service" \
+  -o /etc/systemd/system/machinist-control-plane.service
+curl -fsSL "$service_base_url/machinist-worker.service" \
+  -o /etc/systemd/system/machinist-worker.service
+chmod 0644 \
+  /etc/systemd/system/machinist-control-plane.service \
+  /etc/systemd/system/machinist-worker.service
+systemctl daemon-reload
+systemctl enable --now machinist-control-plane.service machinist-worker.service
+
 cat <<'EOF'
 
 VM bootstrap complete.
@@ -50,7 +61,7 @@ Next steps:
   3. Run `claude` once and sign in.
   4. Clone each repository agents may use and register its absolute path in
      ~/.machinist/worker.toml.
-  5. Start `machinist start` and `machinist worker start`.
+  5. Check `systemctl status machinist-control-plane machinist-worker`.
 
 Keep the control plane on 127.0.0.1. Reach it from your computer with:
   ssh -N -L 7331:127.0.0.1:7331 machinist

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -40,6 +40,15 @@ done
 
 machinist init
 
+worker_was_enabled=false
+worker_was_active=false
+if systemctl is-enabled --quiet machinist-worker.service 2>/dev/null; then
+  worker_was_enabled=true
+fi
+if systemctl is-active --quiet machinist-worker.service 2>/dev/null; then
+  worker_was_active=true
+fi
+
 service_base_url=https://raw.githubusercontent.com/owainlewis/machinist/main/deploy/systemd
 service_tmp_dir=$(mktemp -d)
 trap 'rm -rf "$service_tmp_dir"' EXIT
@@ -62,7 +71,16 @@ if machinist worker validate --help >/dev/null 2>&1; then
     systemctl disable --now machinist-worker.service
   fi
 else
-  echo "installed Machinist release does not support worker validation; leaving the worker service unchanged" >&2
+  if [[ $worker_was_active == true ]]; then
+    systemctl enable machinist-worker.service
+    systemctl restart machinist-worker.service
+    echo "installed Machinist release does not support worker validation; restored the previously active worker" >&2
+  else
+    systemctl disable --now machinist-worker.service
+    if [[ $worker_was_enabled == true ]]; then
+      echo "installed Machinist release does not support worker validation; disabled the previously inactive worker" >&2
+    fi
+  fi
 fi
 
 cat <<'EOF'

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -41,15 +41,20 @@ done
 machinist init
 
 service_base_url=https://raw.githubusercontent.com/owainlewis/machinist/main/deploy/systemd
+service_tmp_dir=$(mktemp -d)
+trap 'rm -rf "$service_tmp_dir"' EXIT
 curl -fsSL "$service_base_url/machinist-control-plane.service" \
-  -o /etc/systemd/system/machinist-control-plane.service
+  -o "$service_tmp_dir/machinist-control-plane.service"
 curl -fsSL "$service_base_url/machinist-worker.service" \
-  -o /etc/systemd/system/machinist-worker.service
-chmod 0644 \
-  /etc/systemd/system/machinist-control-plane.service \
+  -o "$service_tmp_dir/machinist-worker.service"
+install -m 0644 "$service_tmp_dir/machinist-control-plane.service" \
+  /etc/systemd/system/machinist-control-plane.service
+install -m 0644 "$service_tmp_dir/machinist-worker.service" \
   /etc/systemd/system/machinist-worker.service
 systemctl daemon-reload
-systemctl enable --now machinist-control-plane.service machinist-worker.service
+systemctl enable machinist-control-plane.service machinist-worker.service
+systemctl restart machinist-control-plane.service
+systemctl restart machinist-worker.service
 
 cat <<'EOF'
 

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -54,7 +54,11 @@ install -m 0644 "$service_tmp_dir/machinist-worker.service" \
 systemctl daemon-reload
 systemctl enable machinist-control-plane.service machinist-worker.service
 systemctl restart machinist-control-plane.service
-systemctl restart machinist-worker.service
+if grep -Eq '^[[:space:]]*\[repositories\.[^]]+\]' /root/.machinist/worker.toml; then
+  systemctl restart machinist-worker.service
+else
+  systemctl stop machinist-worker.service
+fi
 
 cat <<'EOF'
 
@@ -66,7 +70,8 @@ Next steps:
   3. Run `claude` once and sign in.
   4. Clone each repository agents may use and register its absolute path in
      ~/.machinist/worker.toml.
-  5. Check `systemctl status machinist-control-plane machinist-worker`.
+  5. Run `systemctl start machinist-worker` after registering a repository.
+  6. Check `systemctl status machinist-control-plane machinist-worker`.
 
 Keep the control plane on 127.0.0.1. Reach it from your computer with:
   ssh -N -L 7331:127.0.0.1:7331 machinist

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -52,12 +52,13 @@ install -m 0644 "$service_tmp_dir/machinist-control-plane.service" \
 install -m 0644 "$service_tmp_dir/machinist-worker.service" \
   /etc/systemd/system/machinist-worker.service
 systemctl daemon-reload
-systemctl enable machinist-control-plane.service machinist-worker.service
+systemctl enable machinist-control-plane.service
 systemctl restart machinist-control-plane.service
 if grep -Eq '^[[:space:]]*\[repositories\.[^]]+\]' /root/.machinist/worker.toml; then
+  systemctl enable machinist-worker.service
   systemctl restart machinist-worker.service
 else
-  systemctl stop machinist-worker.service
+  systemctl disable --now machinist-worker.service
 fi
 
 cat <<'EOF'
@@ -70,7 +71,7 @@ Next steps:
   3. Run `claude` once and sign in.
   4. Clone each repository agents may use and register its absolute path in
      ~/.machinist/worker.toml.
-  5. Run `systemctl start machinist-worker` after registering a repository.
+  5. Run `systemctl enable --now machinist-worker` after registering a repository.
   6. Check `systemctl status machinist-control-plane machinist-worker`.
 
 Keep the control plane on 127.0.0.1. Reach it from your computer with:

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -7,6 +7,12 @@ if [[ $(id -u) -ne 0 ]]; then
   exit 1
 fi
 
+machinist_version=${MACHINIST_VERSION:-}
+if [[ ! $machinist_version =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+  echo "set MACHINIST_VERSION to the release being installed, such as v0.2.0" >&2
+  exit 2
+fi
+
 if [[ ! -r /etc/os-release ]]; then
   echo "unsupported Linux distribution: /etc/os-release is missing" >&2
   exit 1
@@ -21,16 +27,29 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y ca-certificates curl git gh jq openssh-client tar
 
+runtime_user=machinist
+if ! id "$runtime_user" >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash "$runtime_user"
+fi
+runtime_home=$(getent passwd "$runtime_user" | cut -d: -f6)
+if [[ -z $runtime_home || ! -d $runtime_home ]]; then
+  echo "could not determine home directory for $runtime_user" >&2
+  exit 1
+fi
+
 # Codex and Claude Code use per-user credentials, so install their standalone
 # distributions as the account that will run Machinist.
-curl -fsSL https://chatgpt.com/codex/install.sh | sh
-curl -fsSL https://claude.ai/install.sh | bash
-curl -fsSL https://raw.githubusercontent.com/owainlewis/machinist/main/install.sh | sh
+runuser -u "$runtime_user" -- env HOME="$runtime_home" \
+  bash -c 'curl -fsSL https://chatgpt.com/codex/install.sh | sh'
+runuser -u "$runtime_user" -- env HOME="$runtime_home" \
+  bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
+curl -fsSL "https://raw.githubusercontent.com/owainlewis/machinist/$machinist_version/install.sh" | \
+  env MACHINIST_VERSION="$machinist_version" sh
 
 # Standalone agent installers use ~/.local/bin. Login shells commonly add that
 # directory to PATH, but services and other non-interactive processes do not.
 for agent_command in codex claude; do
-  agent_path="$HOME/.local/bin/$agent_command"
+  agent_path="$runtime_home/.local/bin/$agent_command"
   if [[ ! -x "$agent_path" ]]; then
     echo "$agent_command installer did not create $agent_path" >&2
     exit 1
@@ -38,7 +57,7 @@ for agent_command in codex claude; do
   ln -sfn "$agent_path" "/usr/local/bin/$agent_command"
 done
 
-machinist init
+runuser -u "$runtime_user" -- env HOME="$runtime_home" machinist init
 
 worker_was_enabled=false
 worker_was_active=false
@@ -49,7 +68,7 @@ if systemctl is-active --quiet machinist-worker.service 2>/dev/null; then
   worker_was_active=true
 fi
 
-service_base_url=https://raw.githubusercontent.com/owainlewis/machinist/main/deploy/systemd
+service_base_url="https://raw.githubusercontent.com/owainlewis/machinist/$machinist_version/deploy/systemd"
 service_tmp_dir=$(mktemp -d)
 trap 'rm -rf "$service_tmp_dir"' EXIT
 curl -fsSL "$service_base_url/machinist-control-plane.service" \
@@ -63,8 +82,8 @@ install -m 0644 "$service_tmp_dir/machinist-worker.service" \
 systemctl daemon-reload
 systemctl enable machinist-control-plane.service
 systemctl restart machinist-control-plane.service
-if machinist worker validate --help >/dev/null 2>&1; then
-  if machinist worker validate >/dev/null 2>&1; then
+if runuser -u "$runtime_user" -- env HOME="$runtime_home" machinist worker validate --help >/dev/null 2>&1; then
+  if runuser -u "$runtime_user" -- env HOME="$runtime_home" machinist worker validate >/dev/null 2>&1; then
     systemctl enable machinist-worker.service
     systemctl restart machinist-worker.service
   else
@@ -80,9 +99,12 @@ else
     systemctl restart machinist-worker.service
     echo "installed Machinist release does not support worker validation; restored the previously active worker" >&2
   else
-    systemctl disable --now machinist-worker.service
     if [[ $worker_was_enabled == true ]]; then
-      echo "installed Machinist release does not support worker validation; disabled the previously inactive worker" >&2
+      systemctl enable machinist-worker.service
+      systemctl stop machinist-worker.service
+      echo "installed Machinist release does not support worker validation; preserved the enabled but inactive worker" >&2
+    else
+      systemctl disable --now machinist-worker.service
     fi
   fi
 fi
@@ -92,13 +114,14 @@ cat <<'EOF'
 VM bootstrap complete.
 
 Next steps:
-  1. Run `gh auth login`.
-  2. Run `codex` once and sign in.
-  3. Run `claude` once and sign in.
-  4. Clone each repository agents may use and register its absolute path in
+  1. Run `su - machinist`, then complete the remaining login and repository steps as that user.
+  2. Run `gh auth login`.
+  3. Run `codex` once and sign in.
+  4. Run `claude` once and sign in.
+  5. Clone each repository agents may use and register its absolute path in
      ~/.machinist/worker.toml.
-  5. Run `systemctl enable --now machinist-worker` after registering a repository.
-  6. Check `systemctl status machinist-control-plane machinist-worker`.
+  6. Exit back to root and run `systemctl enable --now machinist-worker` after registering a repository.
+  7. Check `systemctl status machinist-control-plane machinist-worker`.
 
 Keep the control plane on 127.0.0.1. Reach it from your computer with:
   ssh -N -L 7331:127.0.0.1:7331 machinist

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -54,7 +54,7 @@ install -m 0644 "$service_tmp_dir/machinist-worker.service" \
 systemctl daemon-reload
 systemctl enable machinist-control-plane.service
 systemctl restart machinist-control-plane.service
-if grep -Eq '^[[:space:]]*\[repositories\.[^]]+\]' /root/.machinist/worker.toml; then
+if machinist worker validate >/dev/null 2>&1; then
   systemctl enable machinist-worker.service
   systemctl restart machinist-worker.service
 else

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -54,11 +54,15 @@ install -m 0644 "$service_tmp_dir/machinist-worker.service" \
 systemctl daemon-reload
 systemctl enable machinist-control-plane.service
 systemctl restart machinist-control-plane.service
-if machinist worker validate >/dev/null 2>&1; then
-  systemctl enable machinist-worker.service
-  systemctl restart machinist-worker.service
+if machinist worker validate --help >/dev/null 2>&1; then
+  if machinist worker validate >/dev/null 2>&1; then
+    systemctl enable machinist-worker.service
+    systemctl restart machinist-worker.service
+  else
+    systemctl disable --now machinist-worker.service
+  fi
 else
-  systemctl disable --now machinist-worker.service
+  echo "installed Machinist release does not support worker validation; leaving the worker service unchanged" >&2
 fi
 
 cat <<'EOF'

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -13,6 +13,21 @@ if [[ ! $machinist_version =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]];
   exit 2
 fi
 
+legacy_root_install=false
+if [[ -d /root/.machinist ]]; then
+  legacy_root_install=true
+fi
+for legacy_unit in machinist-control-plane.service machinist-worker.service; do
+  if [[ -f /etc/systemd/system/$legacy_unit ]] && grep -q '^User=root$' "/etc/systemd/system/$legacy_unit"; then
+    legacy_root_install=true
+  fi
+done
+if [[ $legacy_root_install == true ]]; then
+  echo "legacy root-based Machinist installation detected" >&2
+  echo "follow the v0.1.x migration steps in docs/vm-deployment.md before running this bootstrap" >&2
+  exit 3
+fi
+
 if [[ ! -r /etc/os-release ]]; then
   echo "unsupported Linux distribution: /etc/os-release is missing" >&2
   exit 1


### PR DESCRIPTION
## Summary

- expand the remote VM guide with GitHub SSH, GitHub CLI, Codex, and Claude authentication
- add a safe agent-assisted setup prompt and troubleshooting steps
- install the control plane and worker as enabled systemd services during bootstrap
- add the VM guide to the documentation index

## Verification

- just check
- bash -n scripts/setup-vm.sh
- git diff --check
- systemd-analyze verify on the Ubuntu 26.04 deployment VM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system services for automatically running the Machinist control plane and worker.
  * Added `worker validate` to check worker configuration before startup.
  * VM setup now installs, configures, and manages both services automatically.

* **Documentation**
  * Added a VM deployment guide covering authentication, service management, smoke testing, and troubleshooting.
  * Updated the documentation index with the new deployment guide.

* **Bug Fixes**
  * Improved setup behavior by enabling the worker only when its configuration is valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->