### PR TITLE
feat(cli): validate complete local configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,13 @@ path = "/absolute/path/to/my-project"
 Managed triggers select one command with `command = "audit"`. Model selection remains
 available when the executor command includes `{{machinist.model}}`.
 
+Validate a control-plane configuration together with its sibling `worker.toml` using
+`machinist validate`. When the files live in different directories, supply both paths:
+
+```sh
+machinist validate --config=/path/to/config.toml --worker-config=/path/to/worker.toml
+```
+
 ## Migration
 
 The `agents` table was renamed to `commands`. Move `[agents.NAME]` to `[commands.NAME]`

--- a/docs/vm-deployment.md
+++ b/docs/vm-deployment.md
@@ -237,7 +237,7 @@ brackets.
 Enable and start the worker now that it has a repository:
 
 ```sh
-machinist worker validate
+machinist validate
 exit
 systemctl enable --now machinist-worker.service
 ```
@@ -269,7 +269,7 @@ After changing `/home/machinist/.machinist/config.toml` or
 
 ```sh
 su - machinist
-machinist worker validate
+machinist validate
 exit
 systemctl restart machinist-control-plane.service machinist-worker.service
 ```
@@ -298,7 +298,7 @@ Verify the configuration and credentials before assigning a real issue:
 systemctl is-active machinist-control-plane.service machinist-worker.service
 su - machinist
 machinist version
-machinist worker validate
+machinist validate
 gh auth status
 ssh -T git@github.com
 command -v codex

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -73,6 +73,7 @@ func newRootCommand(options *commandOptions) *cobra.Command {
 	root.AddCommand(newSubmitCommand(options))
 	root.AddCommand(newStartCommand(options))
 	root.AddCommand(newUpdateCommand(options))
+	root.AddCommand(newValidateCommand(options))
 
 	worker := &cobra.Command{Use: "worker", Short: "Run or connect a Machinist Worker"}
 	worker.AddCommand(newRunCommand(options))
@@ -89,6 +90,38 @@ func newRootCommand(options *commandOptions) *cobra.Command {
 		},
 	})
 	return root
+}
+
+func newValidateCommand(options *commandOptions) *cobra.Command {
+	return &cobra.Command{
+		Use:   "validate",
+		Short: "Validate the complete local Machinist configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			machinistConfig, err := config.LoadConfig(options.configPath)
+			if err != nil {
+				return err
+			}
+			if _, err := machinistConfig.Server.WorkerToken(); err != nil {
+				return err
+			}
+			if _, err := config.LoadShepherdSchedules(machinistConfig.Path()); err != nil {
+				return err
+			}
+			if _, err := config.LoadTriggers(machinistConfig.Path()); err != nil {
+				return err
+			}
+			workerConfig, err := config.LoadWorker(options.configPath)
+			if err != nil {
+				return err
+			}
+			if _, err := managedworker.New(workerConfig, io.Discard, io.Discard); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(options.stdout, "configuration is valid")
+			return err
+		},
+	}
 }
 
 func newWorkerValidateCommand(options *commandOptions) *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -221,6 +222,13 @@ func validateWorkerControlPlane(listen, rawURL string) error {
 	listenHost, listenPort, err := net.SplitHostPort(listen)
 	if err != nil {
 		return fmt.Errorf("invalid listen address %q: %w", listen, err)
+	}
+	listenPortNumber, err := strconv.Atoi(listenPort)
+	if err != nil {
+		return fmt.Errorf("invalid listen address %q: %w", listen, err)
+	}
+	if listenPortNumber == 0 {
+		return fmt.Errorf("managed worker control plane cannot use ephemeral listen port 0")
 	}
 	endpoint, err := url.Parse(rawURL)
 	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -106,6 +106,9 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if err := controlplane.ValidateStore(machinistConfig.Server.Database); err != nil {
+				return err
+			}
 			if err := controlplane.ValidateLoopbackListen(machinistConfig.Server.Listen); err != nil {
 				return err
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -113,10 +113,12 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if _, err := config.LoadShepherdSchedules(machinistConfig.Path()); err != nil {
+			schedules, err := config.LoadShepherdSchedules(machinistConfig.Path())
+			if err != nil {
 				return err
 			}
-			if _, err := config.LoadTriggers(machinistConfig.Path()); err != nil {
+			triggers, err := config.LoadTriggers(machinistConfig.Path())
+			if err != nil {
 				return err
 			}
 			if workerConfigPath == "" {
@@ -133,6 +135,9 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 				return err
 			}
 			if err := validateConfiguredCommands(machinistConfig.Path(), workerConfig); err != nil {
+				return err
+			}
+			if err := validateManagedWorkloads(schedules, triggers, workerConfig); err != nil {
 				return err
 			}
 			workerToken, err := workerConfig.WorkerToken()
@@ -170,6 +175,40 @@ func validateConfiguredCommands(definitionPath string, worker config.Worker) err
 		}
 	}
 	return nil
+}
+
+func validateManagedWorkloads(schedules []config.ResolvedShepherdSchedule, triggers []config.ResolvedTrigger, worker config.Worker) error {
+	for _, schedule := range schedules {
+		if _, ok := worker.Repositories[schedule.Repository]; !ok {
+			return fmt.Errorf("shepherd schedule %q repository %q is not configured on this worker", schedule.Name, schedule.Repository)
+		}
+	}
+	for _, trigger := range triggers {
+		if _, err := worker.ResolveCommandModel(trigger.Command, trigger.Model); err != nil {
+			return fmt.Errorf("trigger %q: %w", trigger.Identity, err)
+		}
+		if trigger.Family == "github" {
+			for _, repository := range sortedKeys(trigger.GitHubRepositories) {
+				if _, ok := worker.Repositories[repository]; !ok {
+					return fmt.Errorf("trigger %q repository %q is not configured on this worker", trigger.Identity, repository)
+				}
+			}
+			continue
+		}
+		if _, ok := worker.Repositories[trigger.Repository]; !ok {
+			return fmt.Errorf("trigger %q repository %q is not configured on this worker", trigger.Identity, trigger.Repository)
+		}
+	}
+	return nil
+}
+
+func sortedKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // validateWorkerControlPlane verifies that the managed worker can reach the

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -111,7 +112,7 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 			if _, err := config.LoadTriggers(machinistConfig.Path()); err != nil {
 				return err
 			}
-			workerConfig, err := config.LoadWorker(options.configPath)
+			workerConfig, err := config.LoadWorker(filepath.Join(filepath.Dir(machinistConfig.Path()), "worker.toml"))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -129,6 +129,9 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 			if _, err := managedworker.New(workerConfig, io.Discard, io.Discard); err != nil {
 				return err
 			}
+			if err := validateWorkerControlPlane(machinistConfig.Server.Listen, workerConfig.ControlPlane.URL); err != nil {
+				return err
+			}
 			if err := validateConfiguredCommands(machinistConfig.Path(), workerConfig); err != nil {
 				return err
 			}
@@ -167,6 +170,40 @@ func validateConfiguredCommands(definitionPath string, worker config.Worker) err
 		}
 	}
 	return nil
+}
+
+// validateWorkerControlPlane verifies that the managed worker can reach the
+// plain-HTTP loopback control plane configured alongside it. It performs no
+// network operations.
+func validateWorkerControlPlane(listen, rawURL string) error {
+	listenHost, listenPort, err := net.SplitHostPort(listen)
+	if err != nil {
+		return fmt.Errorf("invalid listen address %q: %w", listen, err)
+	}
+	endpoint, err := url.Parse(rawURL)
+	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
+		return fmt.Errorf("invalid control_plane.url %q", rawURL)
+	}
+	if endpoint.Scheme != "http" {
+		return fmt.Errorf("control_plane.url %q must use http for the configured local control plane", rawURL)
+	}
+	endpointPort := endpoint.Port()
+	if endpointPort == "" {
+		endpointPort = "80"
+	}
+	if endpointPort != listenPort || !sameLoopbackHost(listenHost, endpoint.Hostname()) {
+		return fmt.Errorf("control_plane.url %q must target the configured local control plane at %s", rawURL, net.JoinHostPort(listenHost, listenPort))
+	}
+	return nil
+}
+
+func sameLoopbackHost(listenHost, endpointHost string) bool {
+	if strings.EqualFold(listenHost, "localhost") || strings.EqualFold(endpointHost, "localhost") {
+		return strings.EqualFold(listenHost, endpointHost)
+	}
+	listenIP := net.ParseIP(listenHost)
+	endpointIP := net.ParseIP(endpointHost)
+	return listenIP != nil && endpointIP != nil && listenIP.Equal(endpointIP)
 }
 
 func newWorkerValidateCommand(options *commandOptions) *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -95,7 +96,8 @@ func newRootCommand(options *commandOptions) *cobra.Command {
 }
 
 func newValidateCommand(options *commandOptions) *cobra.Command {
-	return &cobra.Command{
+	var workerConfigPath string
+	validate := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate the complete local Machinist configuration",
 		Args:  cobra.NoArgs,
@@ -117,11 +119,17 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 			if _, err := config.LoadTriggers(machinistConfig.Path()); err != nil {
 				return err
 			}
-			workerConfig, err := config.LoadWorker(filepath.Join(filepath.Dir(machinistConfig.Path()), "worker.toml"))
+			if workerConfigPath == "" {
+				workerConfigPath = filepath.Join(filepath.Dir(machinistConfig.Path()), "worker.toml")
+			}
+			workerConfig, err := config.LoadWorker(workerConfigPath)
 			if err != nil {
 				return err
 			}
 			if _, err := managedworker.New(workerConfig, io.Discard, io.Discard); err != nil {
+				return err
+			}
+			if err := validateConfiguredCommands(machinistConfig.Path(), workerConfig); err != nil {
 				return err
 			}
 			workerToken, err := workerConfig.WorkerToken()
@@ -135,6 +143,30 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 			return err
 		},
 	}
+	validate.Flags().StringVar(&workerConfigPath, "worker-config", "", "managed worker configuration file")
+	return validate
+}
+
+func validateConfiguredCommands(definitionPath string, worker config.Worker) error {
+	definitions, err := config.LoadDefinitions(definitionPath)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(definitions.Commands))
+	for name := range definitions.Commands {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		command, err := config.LoadCommand(definitionPath, name)
+		if err != nil {
+			return err
+		}
+		if _, err := worker.ResolveCommand(command); err != nil {
+			return fmt.Errorf("validate command %q: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func newWorkerValidateCommand(options *commandOptions) *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -248,12 +248,15 @@ func validateWorkerControlPlane(listen, rawURL string) error {
 }
 
 func sameLoopbackHost(listenHost, endpointHost string) bool {
-	if strings.EqualFold(listenHost, "localhost") || strings.EqualFold(endpointHost, "localhost") {
-		return strings.EqualFold(listenHost, endpointHost)
-	}
 	listenIP := net.ParseIP(listenHost)
 	endpointIP := net.ParseIP(endpointHost)
-	return listenIP != nil && endpointIP != nil && listenIP.Equal(endpointIP)
+	if strings.EqualFold(listenHost, "localhost") {
+		return strings.EqualFold(endpointHost, "localhost") || endpointIP != nil && endpointIP.IsLoopback()
+	}
+	if strings.EqualFold(endpointHost, "localhost") {
+		return listenIP != nil && listenIP.IsLoopback()
+	}
+	return listenIP != nil && listenIP.IsLoopback() && endpointIP != nil && endpointIP.IsLoopback() && listenIP.Equal(endpointIP)
 }
 
 func newWorkerValidateCommand(options *commandOptions) *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -103,7 +104,11 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if _, err := machinistConfig.Server.WorkerToken(); err != nil {
+			if err := controlplane.ValidateLoopbackListen(machinistConfig.Server.Listen); err != nil {
+				return err
+			}
+			serverToken, err := machinistConfig.Server.WorkerToken()
+			if err != nil {
 				return err
 			}
 			if _, err := config.LoadShepherdSchedules(machinistConfig.Path()); err != nil {
@@ -118,6 +123,13 @@ func newValidateCommand(options *commandOptions) *cobra.Command {
 			}
 			if _, err := managedworker.New(workerConfig, io.Discard, io.Discard); err != nil {
 				return err
+			}
+			workerToken, err := workerConfig.WorkerToken()
+			if err != nil {
+				return err
+			}
+			if subtle.ConstantTimeCompare([]byte(serverToken), []byte(workerToken)) != 1 {
+				return errors.New("server and worker authentication tokens do not match")
 			}
 			_, err = fmt.Fprintln(options.stdout, "configuration is valid")
 			return err

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -703,6 +703,23 @@ func TestValidateAcceptsCompleteConfiguration(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsExplicitControlPlaneConfiguration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	addCLIWorkerRepository(t, home)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	configPath := filepath.Join(home, ".machinist", "config.toml")
+	exitCode := Execute(t.Context(), []string{"validate", "--config=" + configPath}, strings.NewReader(""), &stdout, &stderr, "test")
+	if exitCode != 0 || strings.TrimSpace(stdout.String()) != "configuration is valid" {
+		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", exitCode, stdout.String(), stderr.String())
+	}
+}
+
 func TestValidateRejectsInvalidControlPlaneConfiguration(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -687,6 +687,54 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsCompleteConfiguration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	addCLIWorkerRepository(t, home)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &stdout, &stderr, "test")
+	if exitCode != 0 || strings.TrimSpace(stdout.String()) != "configuration is valid" {
+		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", exitCode, stdout.String(), stderr.String())
+	}
+}
+
+func TestValidateRejectsInvalidControlPlaneConfiguration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	configPath := filepath.Join(home, ".machinist", "config.toml")
+	if err := os.WriteFile(configPath, []byte("[server]\nworker_token_file = \"server/worker.token\"\nmax_concurrent_jobs = 0\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+	if exitCode != 2 || !strings.Contains(stderr.String(), "max_concurrent_jobs must be positive") {
+		t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+	}
+}
+
+func TestValidateRejectsInvalidWorkerConfiguration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+	if exitCode != 2 || !strings.Contains(stderr.String(), "requires at least one executor and repository") {
+		t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+	}
+}
+
 func TestWorkerValidateRequiresRepository(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -707,6 +755,18 @@ func TestWorkerValidateAcceptsCompleteConfiguration(t *testing.T) {
 	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
 		t.Fatalf("init exit code = %d", exitCode)
 	}
+	addCLIWorkerRepository(t, home)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"worker", "validate"}, strings.NewReader(""), &stdout, &stderr, "test")
+	if exitCode != 0 || strings.TrimSpace(stdout.String()) != "worker configuration is valid" {
+		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", exitCode, stdout.String(), stderr.String())
+	}
+}
+
+func addCLIWorkerRepository(t *testing.T, home string) {
+	t.Helper()
 	workerPath := filepath.Join(home, ".machinist", "worker.toml")
 	file, err := os.OpenFile(workerPath, os.O_APPEND|os.O_WRONLY, 0)
 	if err != nil {
@@ -720,13 +780,6 @@ func TestWorkerValidateAcceptsCompleteConfiguration(t *testing.T) {
 	}
 	if err := file.Close(); err != nil {
 		t.Fatal(err)
-	}
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	exitCode := Execute(t.Context(), []string{"worker", "validate"}, strings.NewReader(""), &stdout, &stderr, "test")
-	if exitCode != 0 || strings.TrimSpace(stdout.String()) != "worker configuration is valid" {
-		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", exitCode, stdout.String(), stderr.String())
 	}
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1031,6 +1031,24 @@ func TestValidateWorkerControlPlaneAcceptsEquivalentIPv6LoopbackSpelling(t *test
 	}
 }
 
+func TestValidateWorkerControlPlaneAcceptsEquivalentLocalEndpointSpellings(t *testing.T) {
+	for _, test := range []struct {
+		listen string
+		url    string
+	}{
+		{listen: "localhost:7331", url: "http://127.0.0.1:7331"},
+		{listen: "127.0.0.1:7331", url: "http://localhost:7331"},
+		{listen: "localhost:7331", url: "http://[::1]:7331"},
+		{listen: "[::1]:7331", url: "http://localhost:7331"},
+	} {
+		t.Run(test.listen+"/"+test.url, func(t *testing.T) {
+			if err := validateWorkerControlPlane(test.listen, test.url); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestValidateRejectsMismatchedServerAndWorkerTokens(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -701,6 +701,31 @@ func TestValidateAcceptsCompleteConfiguration(t *testing.T) {
 	if exitCode != 0 || strings.TrimSpace(stdout.String()) != "configuration is valid" {
 		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", exitCode, stdout.String(), stderr.String())
 	}
+	if _, err := os.Stat(filepath.Join(home, ".machinist", "server", "machinist.db")); !os.IsNotExist(err) {
+		t.Fatalf("validate created database: %v", err)
+	}
+}
+
+func TestValidateRejectsUnreadableControlPlaneDatabase(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	addCLIWorkerRepository(t, home)
+	database := filepath.Join(home, ".machinist", "server", "machinist.db")
+	if err := os.MkdirAll(filepath.Dir(database), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(database, []byte("not a sqlite database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+	if exitCode != 2 || !strings.Contains(stderr.String(), "read database schema version") {
+		t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+	}
 }
 
 func TestValidateAcceptsExplicitControlPlaneConfiguration(t *testing.T) {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -991,6 +991,40 @@ func TestValidateRejectsWorkerEndpointThatCannotReachLocalControlPlane(t *testin
 	}
 }
 
+func TestValidateRejectsEphemeralControlPlanePortForManagedWorker(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	addCLIWorkerRepository(t, home)
+
+	configPath := filepath.Join(home, ".machinist", "config.toml")
+	configBody, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configBody = bytes.Replace(configBody, []byte(`listen = "127.0.0.1:7331"`), []byte(`listen = "127.0.0.1:0"`), 1)
+	if err := os.WriteFile(configPath, configBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	workerPath := filepath.Join(home, ".machinist", "worker.toml")
+	workerBody, err := os.ReadFile(workerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerBody = bytes.Replace(workerBody, []byte(`url = "http://127.0.0.1:7331"`), []byte(`url = "http://127.0.0.1:0"`), 1)
+	if err := os.WriteFile(workerPath, workerBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+	if exitCode != 2 || !strings.Contains(stderr.String(), "cannot use ephemeral listen port 0") {
+		t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+	}
+}
+
 func TestValidateWorkerControlPlaneAcceptsEquivalentIPv6LoopbackSpelling(t *testing.T) {
 	if err := validateWorkerControlPlane("[::1]:7331", "http://[0:0:0:0:0:0:0:1]:7331"); err != nil {
 		t.Fatal(err)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -738,6 +738,61 @@ func TestValidateRejectsInvalidControlPlaneConfiguration(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsInvalidControlPlaneListenAddress(t *testing.T) {
+	for _, listen := range []string{"not an address", "0.0.0.0:7331"} {
+		t.Run(listen, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+				t.Fatalf("init exit code = %d", exitCode)
+			}
+			addCLIWorkerRepository(t, home)
+			configPath := filepath.Join(home, ".machinist", "config.toml")
+			body, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body = bytes.Replace(body, []byte(`listen = "127.0.0.1:7331"`), []byte("listen = "+strconv.Quote(listen)), 1)
+			if err := os.WriteFile(configPath, body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			var stderr bytes.Buffer
+			exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+			if exitCode != 2 || !strings.Contains(stderr.String(), "listen address") {
+				t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+			}
+		})
+	}
+}
+
+func TestValidateRejectsMismatchedServerAndWorkerTokens(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	addCLIWorkerRepository(t, home)
+	workerPath := filepath.Join(home, ".machinist", "worker.toml")
+	workerBody, err := os.ReadFile(workerPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workerBody = bytes.Replace(workerBody, []byte(`token_file = "~/.machinist/server/worker.token"`), []byte(`token_file = "worker.token"`), 1)
+	if err := os.WriteFile(workerPath, workerBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".machinist", "worker.token"), []byte("different-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+	if exitCode != 2 || !strings.Contains(stderr.String(), "authentication tokens do not match") {
+		t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+	}
+}
+
 func TestValidateRejectsInvalidWorkerConfiguration(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -829,6 +829,44 @@ func TestValidateRejectsInvalidControlPlaneListenAddress(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsWorkerEndpointThatCannotReachLocalControlPlane(t *testing.T) {
+	for name, endpoint := range map[string]string{
+		"different port": "http://127.0.0.1:7332",
+		"different host": "http://127.0.0.2:7331",
+		"HTTPS endpoint": "https://127.0.0.1:7331",
+	} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+				t.Fatalf("init exit code = %d", exitCode)
+			}
+			addCLIWorkerRepository(t, home)
+			workerPath := filepath.Join(home, ".machinist", "worker.toml")
+			body, err := os.ReadFile(workerPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body = bytes.Replace(body, []byte(`url = "http://127.0.0.1:7331"`), []byte("url = "+strconv.Quote(endpoint)), 1)
+			if err := os.WriteFile(workerPath, body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			var stderr bytes.Buffer
+			exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+			if exitCode != 2 || !strings.Contains(stderr.String(), "configured local control plane") {
+				t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+			}
+		})
+	}
+}
+
+func TestValidateWorkerControlPlaneAcceptsEquivalentIPv6LoopbackSpelling(t *testing.T) {
+	if err := validateWorkerControlPlane("[::1]:7331", "http://[0:0:0:0:0:0:0:1]:7331"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestValidateRejectsMismatchedServerAndWorkerTokens(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -783,6 +783,111 @@ func TestValidateRejectsInvalidUnusedCommand(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsTriggerModelUnsupportedByWorkerExecutor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	addCLIWorkerRepository(t, home)
+	configPath := filepath.Join(home, ".machinist", "config.toml")
+	file, err := os.OpenFile(configPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(`
+[github.repositories]
+example = "owner/example"
+
+[triggers.interval.unsupported-model]
+every = "1h"
+repository = "example"
+command = "audit"
+model = "missing"
+prompt = "Audit the repository."
+`); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+	if exitCode != 2 || !strings.Contains(stderr.String(), `trigger "interval/unsupported-model"`) || !strings.Contains(stderr.String(), `model "missing" is not configured for executor "codex"`) {
+		t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+	}
+}
+
+func TestValidateRejectsManagedWorkloadRepositoryMissingFromWorker(t *testing.T) {
+	for name, definition := range map[string]string{
+		"shepherd schedule": `
+[shepherd.unconfigured]
+repository = "unconfigured"
+every = "1h"
+max_actions = 1
+`,
+		"interval trigger": `
+[github.repositories]
+unconfigured = "owner/repository"
+
+[triggers.interval.unconfigured]
+every = "1h"
+repository = "unconfigured"
+command = "audit"
+prompt = "Audit the repository."
+`,
+		"cron trigger": `
+[github.repositories]
+unconfigured = "owner/repository"
+
+[triggers.cron.unconfigured]
+schedule = "0 * * * *"
+timezone = "UTC"
+repository = "unconfigured"
+command = "audit"
+prompt = "Audit the repository."
+`,
+		"github trigger": `
+[github.repositories]
+unconfigured = "owner/repository"
+
+[triggers.github.unconfigured]
+every = "1h"
+label = "machinist:requested"
+command = "audit"
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+				t.Fatalf("init exit code = %d", exitCode)
+			}
+			addCLIWorkerRepository(t, home)
+			configPath := filepath.Join(home, ".machinist", "config.toml")
+			file, err := os.OpenFile(configPath, os.O_APPEND|os.O_WRONLY, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := file.WriteString(definition); err != nil {
+				_ = file.Close()
+				t.Fatal(err)
+			}
+			if err := file.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			var stderr bytes.Buffer
+			exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+			if exitCode != 2 || !strings.Contains(stderr.String(), `repository "unconfigured" is not configured on this worker`) {
+				t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+			}
+		})
+	}
+}
+
 func TestValidateRejectsInvalidControlPlaneConfiguration(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -720,6 +720,69 @@ func TestValidateAcceptsExplicitControlPlaneConfiguration(t *testing.T) {
 	}
 }
 
+func TestValidateAcceptsSeparateWorkerConfiguration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+		t.Fatalf("init exit code = %d", exitCode)
+	}
+	addCLIWorkerRepository(t, home)
+	configPath := filepath.Join(home, ".machinist", "config.toml")
+	workerPath := filepath.Join(t.TempDir(), "custom-worker.toml")
+	workerBody, err := os.ReadFile(filepath.Join(home, ".machinist", "worker.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workerPath, workerBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(home, ".machinist", "worker.toml")); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := Execute(t.Context(), []string{"validate", "--config=" + configPath, "--worker-config=" + workerPath}, strings.NewReader(""), &stdout, &stderr, "test")
+	if exitCode != 0 || strings.TrimSpace(stdout.String()) != "configuration is valid" {
+		t.Fatalf("exit code = %d, stdout = %q, stderr = %q", exitCode, stdout.String(), stderr.String())
+	}
+}
+
+func TestValidateRejectsInvalidUnusedCommand(t *testing.T) {
+	for name, command := range map[string]string{
+		"prompt":   "[commands.unused]\nexecutor = \"codex\"\nprompt_file = \"prompts/missing.md\"\n",
+		"timeout":  "[commands.unused]\nexecutor = \"codex\"\ntimeout = \"never\"\n",
+		"executor": "[commands.unused]\nexecutor = \"missing\"\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if exitCode := Execute(t.Context(), []string{"init"}, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}, "test"); exitCode != 0 {
+				t.Fatalf("init exit code = %d", exitCode)
+			}
+			addCLIWorkerRepository(t, home)
+			configPath := filepath.Join(home, ".machinist", "config.toml")
+			file, err := os.OpenFile(configPath, os.O_APPEND|os.O_WRONLY, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := file.WriteString("\n" + command); err != nil {
+				_ = file.Close()
+				t.Fatal(err)
+			}
+			if err := file.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			var stderr bytes.Buffer
+			exitCode := Execute(t.Context(), []string{"validate"}, strings.NewReader(""), &bytes.Buffer{}, &stderr, "test")
+			if exitCode != 2 || !strings.Contains(stderr.String(), "command \"unused\"") {
+				t.Fatalf("exit code = %d, stderr = %q", exitCode, stderr.String())
+			}
+		})
+	}
+}
+
 func TestValidateRejectsInvalidControlPlaneConfiguration(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -679,7 +679,19 @@ func readToken(path string) (string, error) {
 	if token == "" {
 		return "", fmt.Errorf("token file %q is empty", path)
 	}
+	if !validHTTPHeaderValue(token) {
+		return "", fmt.Errorf("token file %q contains an invalid HTTP header value", path)
+	}
 	return token, nil
+}
+
+func validHTTPHeaderValue(value string) bool {
+	for _, character := range value {
+		if character != '\t' && (character < ' ' || character == 0x7f) {
+			return false
+		}
+	}
+	return true
 }
 
 func sortedMapKeys[T any](values map[string]T) []string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -113,6 +113,23 @@ path = "repository"
 	}
 }
 
+func TestReadTokenRejectsInvalidHTTPHeaderValues(t *testing.T) {
+	for name, token := range map[string]string{
+		"null":    "secret\x00value",
+		"newline": "secret\nvalue",
+		"control": "secret\x01value",
+		"delete":  "secret\x7fvalue",
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "token")
+			writeTestFile(t, path, token)
+			if _, err := readToken(path); err == nil || !strings.Contains(err.Error(), "invalid HTTP header value") {
+				t.Fatalf("readToken() error = %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadConfigCombinesServerAndCommands(t *testing.T) {
 	directory := t.TempDir()
 	writeTestFile(t, filepath.Join(directory, "token"), "secret")

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -125,7 +125,7 @@ func NewServer(store *Store, definitionPath, workerToken string, maxConcurrentJo
 func (s *Server) Handler() http.Handler { return s.handler }
 
 func (s *Server) Serve(ctx context.Context, listen string, onListening func(net.Addr)) error {
-	if err := validateLoopbackListen(listen); err != nil {
+	if err := ValidateLoopbackListen(listen); err != nil {
 		return err
 	}
 	listener, err := net.Listen("tcp", listen)
@@ -564,7 +564,9 @@ func containsString(values []string, want string) bool {
 	return false
 }
 
-func validateLoopbackListen(listen string) error {
+// ValidateLoopbackListen verifies that a control-plane listen address has a
+// loopback host. It performs no network operations.
+func ValidateLoopbackListen(listen string) error {
 	host, _, err := net.SplitHostPort(listen)
 	if err != nil {
 		return fmt.Errorf("invalid listen address %q: %w", listen, err)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -567,9 +568,13 @@ func containsString(values []string, want string) bool {
 // ValidateLoopbackListen verifies that a control-plane listen address has a
 // loopback host. It performs no network operations.
 func ValidateLoopbackListen(listen string) error {
-	host, _, err := net.SplitHostPort(listen)
+	host, port, err := net.SplitHostPort(listen)
 	if err != nil {
 		return fmt.Errorf("invalid listen address %q: %w", listen, err)
+	}
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 0 || portNumber > 65535 {
+		return fmt.Errorf("invalid listen address %q: port must be between 0 and 65535", listen)
 	}
 	if host == "localhost" {
 		return nil

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -338,10 +338,10 @@ func TestServerServesEmbeddedReactAppAndRejectsRemoteListen(t *testing.T) {
 	if response.StatusCode != http.StatusOK || !strings.Contains(body.String(), `<div id="root"></div>`) {
 		t.Fatalf("status = %d body = %q", response.StatusCode, body.String())
 	}
-	if err := validateLoopbackListen("0.0.0.0:7331"); err == nil {
+	if err := ValidateLoopbackListen("0.0.0.0:7331"); err == nil {
 		t.Fatal("expected non-loopback listen rejection")
 	}
-	if err := validateLoopbackListen("127.0.0.1:7331"); err != nil {
+	if err := ValidateLoopbackListen("127.0.0.1:7331"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -338,10 +338,12 @@ func TestServerServesEmbeddedReactAppAndRejectsRemoteListen(t *testing.T) {
 	if response.StatusCode != http.StatusOK || !strings.Contains(body.String(), `<div id="root"></div>`) {
 		t.Fatalf("status = %d body = %q", response.StatusCode, body.String())
 	}
-	if err := ValidateLoopbackListen("0.0.0.0:7331"); err == nil {
-		t.Fatal("expected non-loopback listen rejection")
+	for _, listen := range []string{"0.0.0.0:7331", "127.0.0.1:not-a-port", "127.0.0.1:65536", "127.0.0.1:-1"} {
+		if err := ValidateLoopbackListen(listen); err == nil {
+			t.Errorf("ValidateLoopbackListen(%q) succeeded", listen)
+		}
 	}
-	if err := ValidateLoopbackListen("127.0.0.1:7331"); err != nil {
+	if err := ValidateLoopbackListen("127.0.0.1:0"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -163,6 +164,40 @@ func OpenStore(path string) (*Store, error) {
 		return nil, err
 	}
 	return store, nil
+}
+
+// ValidateStore verifies that an existing database can be read by this version
+// of Machinist without changing it. A missing database is valid because startup
+// creates and initializes it.
+func ValidateStore(path string) error {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect database: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("database %q is not a regular file", path)
+	}
+
+	databaseURL := (&url.URL{Scheme: "file", Path: filepath.ToSlash(path), RawQuery: "mode=ro"}).String()
+	db, err := sql.Open("sqlite", databaseURL)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	const schemaVersion = 1
+	var version int
+	if err := db.QueryRowContext(context.Background(), `PRAGMA user_version`).Scan(&version); err != nil {
+		return fmt.Errorf("read database schema version: %w", err)
+	}
+	if version > schemaVersion {
+		return fmt.Errorf("database schema version %d is newer than supported version %d", version, schemaVersion)
+	}
+	return nil
 }
 
 func (s *Store) Close() error { return s.db.Close() }

--- a/internal/managedworker/worker.go
+++ b/internal/managedworker/worker.go
@@ -58,6 +58,9 @@ func New(workerConfig config.Worker, stdout, stderr io.Writer) (*Worker, error) 
 	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
 		return nil, errors.New("control_plane.url must use http or https")
 	}
+	if (endpoint.Path != "" && endpoint.Path != "/") || endpoint.RawQuery != "" || endpoint.ForceQuery || endpoint.User != nil || endpoint.Fragment != "" || strings.Contains(workerConfig.ControlPlane.URL, "#") {
+		return nil, errors.New("control_plane.url must not include a path, query, fragment, or userinfo")
+	}
 	if endpoint.Scheme == "http" && !loopbackHost(endpoint.Hostname()) {
 		return nil, errors.New("control_plane.url must use https for a non-loopback host")
 	}

--- a/internal/managedworker/worker_test.go
+++ b/internal/managedworker/worker_test.go
@@ -220,6 +220,54 @@ func TestManagedWorkerRequiresHTTPSForRemoteControlPlane(t *testing.T) {
 	}
 }
 
+func TestManagedWorkerRejectsControlPlaneURLComponents(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, endpoint := range map[string]string{
+		"path":     "http://127.0.0.1:7331/control-plane",
+		"query":    "http://127.0.0.1:7331?debug=true",
+		"fragment": "http://127.0.0.1:7331#fragment",
+		"userinfo": "http://user@127.0.0.1:7331",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := New(config.Worker{
+				Name:         "worker",
+				ControlPlane: config.ControlPlane{URL: endpoint, TokenFile: tokenPath},
+				Executors:    map[string]config.Executor{"test": {Command: []string{"agent"}}},
+				Repositories: map[string]config.Repository{"machinist": {Path: "."}},
+			}, io.Discard, io.Discard)
+			if err == nil || !strings.Contains(err.Error(), "must not include a path, query, fragment, or userinfo") {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
+func TestManagedWorkerAcceptsRootControlPlaneURL(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for name, endpoint := range map[string]string{
+		"without slash": "http://127.0.0.1:7331",
+		"with slash":    "http://127.0.0.1:7331/",
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := New(config.Worker{
+				Name:         "worker",
+				ControlPlane: config.ControlPlane{URL: endpoint, TokenFile: tokenPath},
+				Executors:    map[string]config.Executor{"test": {Command: []string{"agent"}}},
+				Repositories: map[string]config.Repository{"machinist": {Path: "."}},
+			}, io.Discard, io.Discard)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestCompletionDoesNotRetryPermanentClientError(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

- add read-only root configuration preflight for control plane and managed worker
- cover valid and invalid configuration cases
- update VM deployment validation instructions

## Verification

- `go test -count=1 ./internal/cli`
- `go vet ./...`
- `go test -count=1 ./...`
- `go build ./...`

Closes #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation for control-plane and worker configurations, including database compatibility, loopback connectivity, commands, repositories, schedules, triggers, and authentication tokens.
  * Added `--worker-config` to validate configurations stored in separate locations.
  * Added clear success and actionable error messages.
* **Bug Fixes**
  * Improved validation for listen addresses, control-plane URLs, and authentication tokens.
* **Documentation**
  * Updated deployment and configuration guidance for `machinist validate`.
* **Tests**
  * Expanded coverage for valid and invalid configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->