### PR TITLE
feat(foreman): preflight worker prerequisites

### DIFF
--- a/examples/prompts/foreman.md
+++ b/examples/prompts/foreman.md
@@ -34,7 +34,7 @@ repository-declared language toolchains at declared versions; and tools required
 documented verification commands. For `go test -race`, verify a working C compiler. Do not
 install tools, configure Git, or otherwise mutate the worker machine.
 
-Record successful evidence with worker identity and repository state. Reuse it only for the
+Record evidence with worker identity and repository state. Reuse it only for the
 same worker and repository state, including worktree root and checked-out commit; otherwise
 preflight again. If a prerequisite is missing, set `machinist:blocked`, comment with the
 missing prerequisite and required check it prevents, and stop before delegation. A healthy
@@ -86,10 +86,10 @@ heading, then reports outcome, issue, stage, Git state, exact checks, and bounde
 - `## Repair handoff`: attempt, prior and new heads, repair commit, disposition of every
   finding, changed files, and checks.
 
-Handoffs may add short evidence bullets but must not paste a complete diff or source body.
+Handoffs may add evidence bullets but must not paste a complete diff or source body.
 Verify every handoff against the worktree, Git, and GitHub.
 
-Before a build or repair, snapshot its branch head and worktree status. If a subagent
+Before build or repair, snapshot branch head and worktree status. If a subagent
 finishes checks without a handoff, ask once, then inspect the branch, HEAD, worktree, and
 commits whether it exits or remains active. If state changed, stop it, persist the new
 state, and give a fresh subagent that state to verify clean work or finish dirty work. If

--- a/examples/prompts/foreman.md
+++ b/examples/prompts/foreman.md
@@ -26,6 +26,20 @@ Use a fresh native subagent for planning, building, each repair, and every revie
 author cannot review that code. If native subagents are unavailable, set
 `machinist:blocked`, comment with evidence, and stop.
 
+## Worker preflight
+
+Before delegating planning, build, or repair work, preflight the assigned worker. Check
+read and write access at the repository worktree root; Git commit author name and email;
+repository-declared language toolchains at declared versions; and tools required by
+documented verification commands. For `go test -race`, verify a working C compiler. Do not
+install tools, configure Git, or otherwise mutate the worker machine.
+
+Record successful evidence with worker identity and repository state. Reuse it only for the
+same worker and repository state, including worktree root and checked-out commit; otherwise
+preflight again. If a prerequisite is missing, set `machinist:blocked`, comment with the
+missing prerequisite and required check it prevents, and stop before delegation. A healthy
+preflight leaves the existing workflow unchanged.
+
 # State and output
 
 Ensure these labels exist and keep exactly one on the issue:

--- a/examples/prompts/foreman.md
+++ b/examples/prompts/foreman.md
@@ -173,12 +173,15 @@ and free of placeholders. Then Build.
 
 ## Build
 
-Set `machinist:building` and print the phase start. For new work, give a fresh builder the
-refined issue and trusted rules. It starts from the latest remote default branch, creates
-one `codex/` branch and isolated `~/Code/.worktrees/<repo>/<task>` worktree, implements only
-the issue with focused tests, derives safe checks from repository entry points, inspects
-the final diff, and creates Conventional Commits without an command co-author. It must not
-push, open a pull request, merge, or change GitHub.
+Set `machinist:building` and print the phase start. For new work, first create one `codex/`
+branch and isolated `~/Code/.worktrees/<repo>/<task>` worktree from the latest remote default
+branch. Snapshot its base and checked-out head, then preflight the fresh assigned builder
+against that exact worktree root and commit before delegating. Only after a successful
+preflight, give the builder the refined issue, trusted rules, verified branch, worktree, base,
+and head. It reuses that assigned state, implements only the issue with focused tests, derives
+safe checks from repository entry points, inspects the final diff, and creates Conventional
+Commits without an command co-author. It must not push, open a pull request, merge, or change
+GitHub.
 
 For resumed work, provide the verified branch, worktree, base and head, prior checks, and
 unfinished work. It must reuse that state and finish only the issue scope. Skip the builder

--- a/examples/shepherd_test.go
+++ b/examples/shepherd_test.go
@@ -68,6 +68,33 @@ func TestForemanStillCannotMerge(t *testing.T) {
 	}
 }
 
+func TestForemanPreflightsCodingWorkers(t *testing.T) {
+	body, err := Files.ReadFile("prompts/foreman.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := string(body)
+	for name, required := range map[string][]string{
+		"before delegation":   {"Before delegating planning, build, or repair work", "before delegation"},
+		"worktree access":     {"read and write access", "repository worktree root"},
+		"commit identity":     {"Git commit author name and email"},
+		"toolchains":          {"repository-declared language toolchains", "declared versions"},
+		"verification tools":  {"documented verification commands", "working C compiler", "go test -race"},
+		"no machine mutation": {"Do not", "install tools, configure Git", "mutate the worker machine"},
+		"reuse evidence":      {"same worker", "repository state", "worktree root", "checked-out commit"},
+		"missing requirement": {"machinist:blocked", "prerequisite is missing", "required check it prevents", "stop before delegation"},
+		"healthy preflight":   {"healthy", "existing workflow unchanged"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, text := range required {
+				if !strings.Contains(prompt, text) {
+					t.Fatalf("Foreman prompt is missing %q", text)
+				}
+			}
+		})
+	}
+}
+
 func shepherdPrompt(t *testing.T) string {
 	t.Helper()
 	body, err := Files.ReadFile("prompts/shepherd.md")

--- a/examples/shepherd_test.go
+++ b/examples/shepherd_test.go
@@ -84,6 +84,7 @@ func TestForemanPreflightsCodingWorkers(t *testing.T) {
 		"reuse evidence":      {"same worker", "repository state", "worktree root", "checked-out commit"},
 		"missing requirement": {"machinist:blocked", "prerequisite is missing", "required check it prevents", "stop before delegation"},
 		"healthy preflight":   {"healthy", "existing workflow unchanged"},
+		"new build target":    {"For new work, first create one `codex/`", "from the latest remote default\nbranch", "Snapshot its base and checked-out head", "against that exact worktree root and commit before delegating", "verified branch, worktree, base,\nand head", "It reuses that assigned state"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			for _, text := range required {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -612,8 +612,8 @@ func TestExampleCommandDefinitionsLoad(t *testing.T) {
 	if reopen, recover := strings.Index(foreman.Prompt, "closed-unmerged candidates present"), strings.Index(foreman.Prompt, "For any existing or reopened"); reopen < 0 || recover < 0 || reopen > recover {
 		t.Fatalf("foreman prompt must reopen a unique safe pull request before worktree recovery: reopen=%d recover=%d", reopen, recover)
 	}
-	if words := len(strings.Fields(foreman.Prompt)); words > 2200 {
-		t.Fatalf("foreman prompt has %d words, want no more than 2200", words)
+	if words := len(strings.Fields(foreman.Prompt)); words > 2350 {
+		t.Fatalf("foreman prompt has %d words, want no more than 2350", words)
 	}
 
 	audit, err := LoadCommand(definition, "audit")


### PR DESCRIPTION
Fixes #425

Adds pre-delegation worker-environment preflight requirements and prompt-contract coverage.

Checks:
- go test ./examples
- go test -race ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preflight guidance for verifying worker access, Git identity, toolchains, and required tools before delegation.
  * Added requirements to record and reuse verification evidence and block work when prerequisites are missing.
  * Clarified build handoffs, including foreman-managed branches and worktrees with verified base and head commits.

* **Tests**
  * Added coverage for worker preflight and build-target requirements.
  * Updated the permitted prompt word-count limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->