### PR TITLE
fix(worker): retry completion persistence failures

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -477,7 +477,8 @@ func (s *Server) complete(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 	if err != nil {
-		writeError(response, http.StatusInternalServerError, err)
+		log.Printf("complete run %q: %v", request.PathValue("id"), err)
+		writeError(response, http.StatusInternalServerError, errors.New("complete run"))
 		return
 	}
 	response.WriteHeader(http.StatusNoContent)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -472,8 +472,12 @@ func (s *Server) complete(response http.ResponseWriter, request *http.Request) {
 		writeError(response, http.StatusNotFound, errors.New("run not found"))
 		return
 	}
-	if err != nil {
+	if errors.Is(err, ErrInvalidCompletion) {
 		writeError(response, http.StatusBadRequest, err)
+		return
+	}
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, err)
 		return
 	}
 	response.WriteHeader(http.StatusNoContent)

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -710,6 +710,13 @@ func TestCompletionEndpointClassifiesClientAndPersistenceErrors(t *testing.T) {
 	if persistenceFailure.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("persistence failure status = %d, want %d", persistenceFailure.StatusCode, http.StatusInternalServerError)
 	}
+	persistenceBody, err := io.ReadAll(persistenceFailure.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(persistenceBody, []byte("temporary completion write failure")) {
+		t.Fatalf("persistence response exposes storage error: %s", persistenceBody)
+	}
 }
 
 func TestServerEnqueuesConfiguredShepherdSchedule(t *testing.T) {

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -645,6 +645,73 @@ func TestHeartbeatEndpointAuthenticatesAndRejectsInvalidLeases(t *testing.T) {
 	nonRunning.Body.Close()
 }
 
+func TestCompletionEndpointClassifiesClientAndPersistenceErrors(t *testing.T) {
+	server, webServer := newTestHTTPServer(t)
+	defer webServer.Close()
+	auth := map[string]string{"Authorization": "Bearer secret"}
+
+	missing := postJSON(t, webServer.URL+"/api/v1/runs/missing/complete", protocol.Completion{
+		InstanceID: "worker-a", LeaseToken: "lease", State: "succeeded", ExitCode: 0,
+	}, auth)
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing run status = %d", missing.StatusCode)
+	}
+	missing.Body.Close()
+
+	if _, err := server.store.CreateJob(t.Context(), "request", "machinist", "plan", testAgent("plan", "Plan request")); err != nil {
+		t.Fatal(err)
+	}
+	run, err := server.store.Poll(t.Context(), pollRequest("worker-a", []string{"codex"}, []string{"machinist"}))
+	if err != nil || run == nil {
+		t.Fatalf("poll = %#v, %v", run, err)
+	}
+	endpoint := webServer.URL + "/api/v1/runs/" + run.ID + "/complete"
+
+	for name, test := range map[string]struct {
+		completion protocol.Completion
+		want       int
+	}{
+		"invalid lease": {
+			completion: protocol.Completion{InstanceID: "worker-a", LeaseToken: "stale", State: "succeeded", ExitCode: 0},
+			want:       http.StatusConflict,
+		},
+		"invalid terminal state": {
+			completion: protocol.Completion{InstanceID: "worker-a", LeaseToken: run.LeaseToken, State: "running", ExitCode: 0},
+			want:       http.StatusBadRequest,
+		},
+		"invalid outcome": {
+			completion: protocol.Completion{InstanceID: "worker-a", LeaseToken: run.LeaseToken, State: "succeeded", ExitCode: 1},
+			want:       http.StatusBadRequest,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			response := postJSON(t, endpoint, test.completion, auth)
+			defer response.Body.Close()
+			if response.StatusCode != test.want {
+				t.Fatalf("status = %d, want %d", response.StatusCode, test.want)
+			}
+		})
+	}
+
+	if _, err := server.store.db.ExecContext(t.Context(), `
+		CREATE TRIGGER fail_completion
+		BEFORE UPDATE OF state ON runs
+		WHEN NEW.state = 'succeeded'
+		BEGIN
+			SELECT RAISE(FAIL, 'temporary completion write failure');
+		END
+	`); err != nil {
+		t.Fatal(err)
+	}
+	persistenceFailure := postJSON(t, endpoint, protocol.Completion{
+		InstanceID: "worker-a", LeaseToken: run.LeaseToken, State: "succeeded", ExitCode: 0,
+	}, auth)
+	defer persistenceFailure.Body.Close()
+	if persistenceFailure.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("persistence failure status = %d, want %d", persistenceFailure.StatusCode, http.StatusInternalServerError)
+	}
+}
+
 func TestServerEnqueuesConfiguredShepherdSchedule(t *testing.T) {
 	directory := t.TempDir()
 	promptPath := filepath.Join(directory, "shepherd.md")

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -21,6 +21,7 @@ import (
 var (
 	ErrLeaseConflict                   = errors.New("run lease does not match")
 	ErrRunState                        = errors.New("run is not active")
+	ErrInvalidCompletion               = errors.New("invalid run completion")
 	ErrJobActive                       = errors.New("active job cannot be deleted")
 	ErrTriggerMissing                  = errors.New("trigger state does not exist")
 	ErrTriggerStale                    = errors.New("trigger state configuration changed")
@@ -876,10 +877,10 @@ func (s *Store) Complete(ctx context.Context, runID string, completion protocol.
 		return ErrLeaseConflict
 	}
 	if !terminalRunState(completion.State) {
-		return fmt.Errorf("invalid terminal run state %q", completion.State)
+		return fmt.Errorf("%w: invalid terminal run state %q", ErrInvalidCompletion, completion.State)
 	}
 	if err := validateOutcome(completion.State, completion.ExitCode); err != nil {
-		return err
+		return fmt.Errorf("%w: %v", ErrInvalidCompletion, err)
 	}
 	durationMillis, tokenUsage := resultMetrics(completion.Result)
 	completedAt := s.now().UTC()


### PR DESCRIPTION
## Summary

- classify invalid completion payloads explicitly as client errors
- return unexpected completion persistence failures as sanitized HTTP 500 responses so managed workers retry without receiving storage details
- retain detailed persistence diagnostics in control-plane logs
- cover client, lease, missing-run, SQLite persistence, and response-sanitization behavior at the HTTP boundary

## Verification

- `go test ./internal/controlplane ./internal/managedworker`
- `go test -race ./...`
- `git diff --check`

Fixes #437