### PR TITLE
fix(triggers): compare GitHub event IDs numerically

### DIFF
--- a/internal/controlplane/github_cli.go
+++ b/internal/controlplane/github_cli.go
@@ -568,12 +568,36 @@ func parseLatestGitHubLabelEvent(output []byte, requestedLabel string) (*GitHubL
 				actor = strings.TrimSpace(event.Actor.Login)
 			}
 			candidate := &GitHubLabelEvent{ID: id, Actor: actor, CreatedAt: createdAt, OccurrenceKey: "github.com:" + id}
-			if latest == nil || candidate.CreatedAt.After(latest.CreatedAt) || (candidate.CreatedAt.Equal(latest.CreatedAt) && candidate.ID > latest.ID) {
+			if latest == nil || candidate.CreatedAt.After(latest.CreatedAt) || (candidate.CreatedAt.Equal(latest.CreatedAt) && compareGitHubEventIDs(candidate.ID, latest.ID) > 0) {
 				latest = candidate
 			}
 		}
 	}
 	return latest, nil
+}
+
+func compareGitHubEventIDs(left, right string) int {
+	if isCanonicalDecimal(left) && isCanonicalDecimal(right) {
+		if len(left) < len(right) {
+			return -1
+		}
+		if len(left) > len(right) {
+			return 1
+		}
+	}
+	return strings.Compare(left, right)
+}
+
+func isCanonicalDecimal(value string) bool {
+	if value == "" || (len(value) > 1 && value[0] == '0') {
+		return false
+	}
+	for i := range value {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func parseGitHubEventID(raw json.RawMessage) (string, error) {

--- a/internal/controlplane/github_cli_test.go
+++ b/internal/controlplane/github_cli_test.go
@@ -150,6 +150,53 @@ func TestGitHubCLIIssueDetailsMatchesRequestedLabelCaseInsensitively(t *testing.
 	}
 }
 
+func TestParseLatestGitHubLabelEventOrdersTiedDecimalIDsNumerically(t *testing.T) {
+	output := []byte(`[[
+  {"id":9,"event":"labeled","created_at":"2026-01-02T00:00:00Z","actor":{"login":"older"},"label":{"name":"machinist:requested"}},
+  {"id":10,"event":"labeled","created_at":"2026-01-02T00:00:00Z","actor":{"login":"newer"},"label":{"name":"machinist:requested"}}
+]]`)
+
+	event, err := parseLatestGitHubLabelEvent(output, "machinist:requested")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event == nil || event.ID != "10" || event.Actor != "newer" || event.OccurrenceKey != "github.com:10" {
+		t.Fatalf("latest event = %#v, want ID 10 from newer actor", event)
+	}
+}
+
+func TestParseLatestGitHubLabelEventOrdersLargeTiedDecimalIDsLosslessly(t *testing.T) {
+	output := []byte(`[[
+  {"id":9999999999999999999,"event":"labeled","created_at":"2026-01-02T00:00:00Z","actor":{"login":"older"},"label":{"name":"machinist:requested"}},
+  {"id":10000000000000000000,"event":"labeled","created_at":"2026-01-02T00:00:00Z","actor":{"login":"newer"},"label":{"name":"machinist:requested"}}
+]]`)
+
+	event, err := parseLatestGitHubLabelEvent(output, "machinist:requested")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event == nil || event.ID != "10000000000000000000" || event.Actor != "newer" || event.OccurrenceKey != "github.com:10000000000000000000" {
+		t.Fatalf("latest event = %#v, want lossless newer large ID", event)
+	}
+}
+
+func TestGitHubEventIDValidationAndNonDecimalOrderingRemainUnchanged(t *testing.T) {
+	for _, raw := range []string{"null", `""`, "-1", "1.5", "18446744073709551616"} {
+		if _, err := parseGitHubEventID([]byte(raw)); err == nil {
+			t.Errorf("parseGitHubEventID(%s) accepted invalid numeric ID", raw)
+		}
+	}
+
+	for _, raw := range []string{`"event-9"`, `"event-10"`} {
+		if _, err := parseGitHubEventID([]byte(raw)); err != nil {
+			t.Errorf("parseGitHubEventID(%s) rejected string ID: %v", raw, err)
+		}
+	}
+	if compareGitHubEventIDs("event-9", "event-10") <= 0 {
+		t.Fatal("non-decimal IDs no longer use lexical ordering")
+	}
+}
+
 func TestGitHubCLIIssueDetailsIdentifiesPullRequestAndMissingEvent(t *testing.T) {
 	cli, _ := newScriptedGitHubCLI(
 		scriptedGitHubResult{stdout: `{"number":7,"html_url":"https://github.com/o/r/pull/7","state":"closed","created_at":"2026-01-01T00:00:00Z","pull_request":{"url":"x"},"labels":[]}`},


### PR DESCRIPTION
## Summary
- compare tied canonical decimal GitHub timeline event IDs by numeric magnitude
- preserve IDs as strings so large values remain lossless
- keep existing validation and non-decimal string ordering behavior

## Verification
- `go test ./internal/controlplane -run 'Test(ParseLatestGitHubLabelEventOrders|GitHubEventIDValidation)' -count=1`\n- `go test ./internal/controlplane -count=1`\n- `go test ./... -count=1`\n- `git diff --check`\n\nFixes #442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ordering of GitHub label events with numeric IDs, including very large IDs.
  * Preserved expected lexical ordering for non-numeric event IDs.
  * Improved validation and handling of invalid event IDs.

* **Tests**
  * Added coverage for numeric, large, invalid, and non-decimal event ID scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->