### PR TITLE
refactor: remove duplicated helpers and N+1 queries

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,17 +1,13 @@
 package cli
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
-	"net/http"
-	"net/url"
+	"slices"
 	"strings"
-	"time"
 
 	"github.com/owainlewis/machinist/internal/config"
 	"github.com/owainlewis/machinist/internal/controlplane"
@@ -152,18 +148,6 @@ type submitJobResponse struct {
 	ID string `json:"id"`
 }
 
-type submitHTTPError struct {
-	status int
-	body   string
-}
-
-func (err *submitHTTPError) Error() string {
-	if err.body == "" {
-		return fmt.Sprintf("control plane returned %s", http.StatusText(err.status))
-	}
-	return fmt.Sprintf("control plane returned %s: %s", http.StatusText(err.status), err.body)
-}
-
 func newSubmitCommand(options *commandOptions) *cobra.Command {
 	var commandName, prompt, model, repository string
 	submit := &cobra.Command{
@@ -189,108 +173,30 @@ func submitSelection(ctx context.Context, options *commandOptions, commandName, 
 	if err != nil {
 		return err
 	}
-	token, err := worker.WorkerToken()
+	client, err := managedworker.NewClient(worker)
 	if err != nil {
 		return err
 	}
-	endpoint, err := controlPlaneEndpoint(worker.ControlPlane.URL)
-	if err != nil {
-		return err
+	var catalog submitCatalog
+	if err := client.Get(ctx, "/api/v1/catalog", &catalog); err != nil {
+		return fmt.Errorf("read control plane catalog: %w", err)
 	}
-	client := &http.Client{Timeout: 15 * time.Second}
-	catalog, err := getSubmitCatalog(ctx, client, endpoint, token)
-	if err != nil {
-		return err
-	}
-	if !contains(catalog.Repositories, repository) {
+	if !slices.Contains(catalog.Repositories, repository) {
 		return fmt.Errorf("repository %q is not defined in the control plane; check the configured repository name and worker registration", repository)
 	}
-	if !contains(catalog.Commands, commandName) {
+	if !slices.Contains(catalog.Commands, commandName) {
 		return fmt.Errorf("command %q is not defined in the control plane", commandName)
 	}
-
-	body, err := json.Marshal(submitJobRequest{
-		Prompt:     prompt,
-		Repository: repository,
-		Command:    commandName,
-		Model:      model,
-	})
-	if err != nil {
-		return fmt.Errorf("encode submission: %w", err)
-	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/api/v1/jobs", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("create submission request: %w", err)
-	}
-	request.Header.Set("Authorization", "Bearer "+token)
-	request.Header.Set("Content-Type", "application/json")
-	response, err := client.Do(request)
-	if err != nil {
-		return fmt.Errorf("submit job: %w", err)
-	}
-	defer response.Body.Close()
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		message, _ := io.ReadAll(io.LimitReader(response.Body, 8<<10))
-		return &submitHTTPError{status: response.StatusCode, body: strings.TrimSpace(string(message))}
-	}
 	var result submitJobResponse
-	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&result); err != nil {
-		return fmt.Errorf("decode submission response: %w", err)
+	request := submitJobRequest{Prompt: prompt, Repository: repository, Command: commandName, Model: model}
+	if err := client.Post(ctx, "/api/v1/jobs", request, &result); err != nil {
+		return fmt.Errorf("submit job: %w", err)
 	}
 	if strings.TrimSpace(result.ID) == "" {
 		return errors.New("control plane submission response did not include a job ID")
 	}
 	fmt.Fprintln(options.stdout, result.ID)
 	return nil
-}
-
-func getSubmitCatalog(ctx context.Context, client *http.Client, endpoint, token string) (submitCatalog, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/api/v1/catalog", nil)
-	if err != nil {
-		return submitCatalog{}, fmt.Errorf("create control plane catalog request: %w", err)
-	}
-	request.Header.Set("Authorization", "Bearer "+token)
-	response, err := client.Do(request)
-	if err != nil {
-		return submitCatalog{}, fmt.Errorf("read control plane catalog: %w", err)
-	}
-	defer response.Body.Close()
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		message, _ := io.ReadAll(io.LimitReader(response.Body, 8<<10))
-		return submitCatalog{}, &submitHTTPError{status: response.StatusCode, body: strings.TrimSpace(string(message))}
-	}
-	var catalog submitCatalog
-	if err := json.NewDecoder(response.Body).Decode(&catalog); err != nil {
-		return submitCatalog{}, fmt.Errorf("decode control plane catalog: %w", err)
-	}
-	return catalog, nil
-}
-
-func controlPlaneEndpoint(raw string) (string, error) {
-	endpoint, err := url.Parse(raw)
-	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
-		return "", fmt.Errorf("invalid control_plane.url %q", raw)
-	}
-	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
-		return "", errors.New("control_plane.url must use http or https")
-	}
-	if endpoint.Scheme == "http" && !loopbackHost(endpoint.Hostname()) {
-		return "", errors.New("control_plane.url must use https for a non-loopback host")
-	}
-	return strings.TrimRight(raw, "/"), nil
-}
-
-func loopbackHost(host string) bool {
-	return strings.EqualFold(host, "localhost") || net.ParseIP(host) != nil && net.ParseIP(host).IsLoopback()
-}
-
-func contains(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
 }
 
 func newStartCommand(options *commandOptions) *cobra.Command {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -49,6 +49,10 @@ type ControlPlane struct {
 type Executor struct {
 	Command []string          `toml:"command"`
 	Models  map[string]string `toml:"models"`
+}
+
+func (e Executor) supportsModel() bool {
+	return slices.ContainsFunc(e.Command, func(argument string) bool { return strings.Contains(argument, modelParameter) })
 }
 
 type Repository struct {
@@ -162,7 +166,7 @@ type ResolvedCommand struct {
 func LoadWorker(path string) (Worker, error) {
 	worker := Worker{}
 	if path == "" {
-		defaultPath, err := defaultWorkerConfigPath()
+		defaultPath, err := defaultConfigPath("worker.toml")
 		if err != nil {
 			return Worker{}, err
 		}
@@ -194,7 +198,7 @@ func LoadWorker(path string) (Worker, error) {
 
 func LoadConfig(path string) (Config, error) {
 	if path == "" {
-		defaultPath, err := defaultMachinistConfigPath()
+		defaultPath, err := defaultConfigPath("config.toml")
 		if err != nil {
 			return Config{}, err
 		}
@@ -245,29 +249,14 @@ func loadConfigFile(path string) (Config, error) {
 
 func (c Config) Path() string { return c.path }
 
-func (w Worker) ResolveMachinistConfig(override string) (string, error) {
-	path := override
-	base := ""
-	if path == "" {
-		path = "config.toml"
-		base = w.configDir
-	}
-	path, err := expandHome(path)
-	if err != nil {
-		return "", err
-	}
-	if !filepath.IsAbs(path) && base != "" {
-		path = filepath.Join(base, path)
-	}
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return "", fmt.Errorf("resolve Machinist config: %w", err)
-	}
-	return filepath.Clean(absPath), nil
-}
+// CommandNames lists the defined command names in sorted order.
+func (c Config) CommandNames() []string { return sortedMapKeys(c.Commands) }
 
-func (w Worker) ResolveCommand(command ResolvedCommand) (ResolvedCommand, error) {
-	return w.ResolveCommandModel(command, "")
+func (w Worker) ResolveMachinistConfig(override string) (string, error) {
+	if override != "" {
+		return resolveConfigPath(override, "")
+	}
+	return resolveConfigPath("config.toml", w.configDir)
 }
 
 func (w Worker) ResolveCommandModel(command ResolvedCommand, requestedModel string) (ResolvedCommand, error) {
@@ -295,14 +284,10 @@ func (w Worker) ResolveCommandModel(command ResolvedCommand, requestedModel stri
 
 func resolveModel(name string, executor Executor, requested string) (string, error) {
 	model := strings.TrimSpace(requested)
-	hasParameter := false
-	for _, argument := range executor.Command {
-		hasParameter = hasParameter || strings.Contains(argument, modelParameter)
-	}
 	if model == "" {
 		return "", nil
 	}
-	if !hasParameter {
+	if !executor.supportsModel() {
 		return "", fmt.Errorf("executor %q does not support model selection; add %s to its command", name, modelParameter)
 	}
 	if resolved, ok := executor.Models[model]; ok {
@@ -340,11 +325,8 @@ func (w Worker) ExecutorNames() []string { return sortedMapKeys(w.Executors) }
 func (w Worker) ModelCapabilities() map[string][]string {
 	capabilities := make(map[string][]string)
 	for name, executor := range w.Executors {
-		for _, argument := range executor.Command {
-			if strings.Contains(argument, modelParameter) {
-				capabilities[name] = sortedMapKeys(executor.Models)
-				break
-			}
+		if executor.supportsModel() {
+			capabilities[name] = sortedMapKeys(executor.Models)
 		}
 	}
 	return capabilities
@@ -371,11 +353,16 @@ func LoadCommand(definitionPath, name string) (ResolvedCommand, error) {
 	if err != nil {
 		return ResolvedCommand{}, err
 	}
-	command, ok := definition.Commands[name]
+	return definition.ResolveCommand(name)
+}
+
+// ResolveCommand resolves one named command from an already loaded definition.
+func (c Config) ResolveCommand(name string) (ResolvedCommand, error) {
+	command, ok := c.Commands[name]
 	if !ok {
-		return ResolvedCommand{}, fmt.Errorf("command %q is not defined in %s", name, definitionPath)
+		return ResolvedCommand{}, fmt.Errorf("command %q is not defined in %s", name, c.path)
 	}
-	return resolveCommand(definitionPath, name, command)
+	return resolveCommand(c.path, name, command)
 }
 
 func LoadDefinitions(path string) (Config, error) { return loadConfigFile(path) }
@@ -590,14 +577,8 @@ func applyWorkerDefaultsWithHostname(worker Worker, getHostname func() (string, 
 				return Worker{}, fmt.Errorf("executor %q model aliases and values must be non-empty", name)
 			}
 		}
-		if len(executor.Models) > 0 {
-			hasParameter := false
-			for _, argument := range executor.Command {
-				hasParameter = hasParameter || strings.Contains(argument, modelParameter)
-			}
-			if !hasParameter {
-				return Worker{}, fmt.Errorf("executor %q defines models but its command does not contain %s", name, modelParameter)
-			}
+		if len(executor.Models) > 0 && !executor.supportsModel() {
+			return Worker{}, fmt.Errorf("executor %q defines models but its command does not contain %s", name, modelParameter)
 		}
 	}
 	return worker, nil
@@ -687,24 +668,16 @@ func sortedMapKeys[T any](values map[string]T) []string {
 	for key := range values {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return keys
 }
 
-func defaultWorkerConfigPath() (string, error) {
+func defaultConfigPath(name string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("find user home directory: %w", err)
 	}
-	return filepath.Join(home, ".machinist", "worker.toml"), nil
-}
-
-func defaultMachinistConfigPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("find user home directory: %w", err)
-	}
-	return filepath.Join(home, ".machinist", "config.toml"), nil
+	return filepath.Join(home, ".machinist", name), nil
 }
 
 func expandHome(path string) (string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -107,7 +107,7 @@ path = "repository"
 	if token, err := worker.WorkerToken(); err != nil || token != "secret" {
 		t.Fatalf("token = %q, %v", token, err)
 	}
-	resolved, err := worker.ResolveCommand(ResolvedCommand{Executor: "test"})
+	resolved, err := worker.ResolveCommandModel(ResolvedCommand{Executor: "test"}, "")
 	if err != nil || len(resolved.Command) != 2 || resolved.Command[1] != "run" {
 		t.Fatalf("agent = %#v, %v", resolved, err)
 	}
@@ -289,7 +289,7 @@ timeout = "45s"
 	if agent.Timeout != 45*time.Second {
 		t.Fatalf("timeout = %s", agent.Timeout)
 	}
-	resolved, err := (Worker{Executors: map[string]Executor{"test": {Command: []string{"agent", "run"}}}}).ResolveCommand(agent)
+	resolved, err := (Worker{Executors: map[string]Executor{"test": {Command: []string{"agent", "run"}}}}).ResolveCommandModel(agent, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestResolveCommandModelUsesAliasAndLeavesDefaultOptional(t *testing.T) {
 	if resolved.Model != "gpt-5.6-luna" || strings.Join(resolved.Command, " ") != "codex exec --model=gpt-5.6-luna -" {
 		t.Fatalf("resolved = %#v", resolved)
 	}
-	defaulted, err := worker.ResolveCommand(agent)
+	defaulted, err := worker.ResolveCommandModel(agent, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/triggers.go
+++ b/internal/config/triggers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"regexp"
 	"strings"
 	"time"
@@ -121,14 +122,12 @@ func (c Config) ResolveTriggers() ([]ResolvedTrigger, error) {
 		}
 		resolved := ResolvedTrigger{
 			Identity: identity, Family: "github", Name: name,
-			GitHubRepositories: cloneStrings(repositories), Every: every, Label: label,
+			GitHubRepositories: maps.Clone(repositories), Every: every, Label: label,
 			SelectionName: selection, Model: strings.TrimSpace(definition.Model), Command: command,
 		}
-		resolved.Signature, err = triggerSignature(resolved)
-		if err != nil {
-			return nil, fmt.Errorf("trigger %q signature: %w", identity, err)
+		if result, err = appendTrigger(result, resolved); err != nil {
+			return nil, err
 		}
-		result = append(result, resolved)
 	}
 
 	for _, name := range sortedMapKeys(c.Triggers.Interval) {
@@ -157,11 +156,9 @@ func (c Config) ResolveTriggers() ([]ResolvedTrigger, error) {
 			Identity: identity, Family: "interval", Name: name, Repository: repository, GitHubRepository: slug,
 			Every: every, SelectionName: selection, Model: strings.TrimSpace(definition.Model), Prompt: prompt, Command: command,
 		}
-		resolved.Signature, err = triggerSignature(resolved)
-		if err != nil {
-			return nil, fmt.Errorf("trigger %q signature: %w", identity, err)
+		if result, err = appendTrigger(result, resolved); err != nil {
+			return nil, err
 		}
-		result = append(result, resolved)
 	}
 
 	for _, name := range sortedMapKeys(c.Triggers.Cron) {
@@ -191,11 +188,9 @@ func (c Config) ResolveTriggers() ([]ResolvedTrigger, error) {
 			Schedule: parsed.Expression(), Timezone: parsed.Timezone(), SelectionName: selection,
 			Model: strings.TrimSpace(definition.Model), Prompt: prompt, Command: command, cron: parsed,
 		}
-		resolved.Signature, err = triggerSignature(resolved)
-		if err != nil {
-			return nil, fmt.Errorf("trigger %q signature: %w", identity, err)
+		if result, err = appendTrigger(result, resolved); err != nil {
+			return nil, err
 		}
-		result = append(result, resolved)
 	}
 	return result, nil
 }
@@ -334,6 +329,15 @@ func (t ResolvedTrigger) NextDue(after time.Time) time.Time {
 	return time.Time{}
 }
 
+func appendTrigger(result []ResolvedTrigger, trigger ResolvedTrigger) ([]ResolvedTrigger, error) {
+	signature, err := triggerSignature(trigger)
+	if err != nil {
+		return nil, fmt.Errorf("trigger %q signature: %w", trigger.Identity, err)
+	}
+	trigger.Signature = signature
+	return append(result, trigger), nil
+}
+
 func triggerSignature(trigger ResolvedTrigger) (string, error) {
 	type repositoryPair struct{ Name, Slug string }
 	repositories := make([]repositoryPair, 0, len(trigger.GitHubRepositories))
@@ -358,12 +362,4 @@ func triggerSignature(trigger ResolvedTrigger) (string, error) {
 	}
 	sum := sha256.Sum256(body)
 	return hex.EncodeToString(sum[:]), nil
-}
-
-func cloneStrings(input map[string]string) map[string]string {
-	result := make(map[string]string, len(input))
-	for key, value := range input {
-		result[key] = value
-	}
-	return result
 }

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -14,7 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -196,61 +196,48 @@ func (s *Server) Serve(ctx context.Context, listen string, onListening func(net.
 
 func (s *Server) runScheduler(ctx context.Context) error {
 	var schedulers sync.WaitGroup
-	start := func(work func(context.Context) error) {
+	loop := func(delayFirst bool, work func(context.Context) error) {
 		schedulers.Add(1)
 		go func() {
 			defer schedulers.Done()
+			if delayFirst && !sleep(ctx, s.schedulerEvery) {
+				return
+			}
 			for {
 				s.reportSchedulerError(work(ctx))
-				timer := time.NewTimer(s.schedulerEvery)
-				select {
-				case <-ctx.Done():
-					if !timer.Stop() {
-						select {
-						case <-timer.C:
-						default:
-						}
-					}
+				if !sleep(ctx, s.schedulerEvery) {
 					return
-				case <-timer.C:
 				}
 			}
 		}()
 	}
 	if len(s.schedules) > 0 {
-		start(s.enqueueScheduledRuns)
+		loop(false, s.enqueueScheduledRuns)
 	}
 	for _, trigger := range s.triggers {
-		trigger := trigger
-		start(func(ctx context.Context) error {
+		loop(false, func(ctx context.Context) error {
 			if err := s.processManagedTrigger(ctx, trigger); err != nil {
 				return fmt.Errorf("trigger %q: %w", trigger.Identity, err)
 			}
 			return nil
 		})
 	}
-	schedulers.Add(1)
-	go func() {
-		defer schedulers.Done()
-		for {
-			timer := time.NewTimer(s.schedulerEvery)
-			select {
-			case <-ctx.Done():
-				if !timer.Stop() {
-					select {
-					case <-timer.C:
-					default:
-					}
-				}
-				return
-			case <-timer.C:
-				s.reportSchedulerError(s.maintainState(ctx))
-			}
-		}
-	}()
+	loop(true, s.maintainState)
 	<-ctx.Done()
 	schedulers.Wait()
 	return nil
+}
+
+// sleep waits for the duration and reports false when ctx ends first.
+func sleep(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func (s *Server) maintainState(ctx context.Context) error {
@@ -301,8 +288,8 @@ func (s *Server) definitions(response http.ResponseWriter, request *http.Request
 		return
 	}
 	commands := make([]commandDefinitionResponse, 0, len(definition.Commands))
-	for _, name := range mapKeys(definition.Commands) {
-		command, err := config.LoadCommand(s.definitionPath, name)
+	for _, name := range definition.CommandNames() {
+		command, err := definition.ResolveCommand(name)
 		if err != nil {
 			writeError(response, http.StatusInternalServerError, err)
 			return
@@ -338,7 +325,7 @@ func (s *Server) status(response http.ResponseWriter, request *http.Request) {
 	}
 	writeJSON(response, http.StatusOK, statusResponse{
 		Snapshot:     snapshot,
-		Commands:     mapKeys(definition.Commands),
+		Commands:     definition.CommandNames(),
 		Repositories: repositories,
 		CSRFToken:    s.csrfToken,
 	})
@@ -357,7 +344,7 @@ func (s *Server) catalog(response http.ResponseWriter, request *http.Request) {
 	}
 	response.Header().Set("Cache-Control", "no-store")
 	writeJSON(response, http.StatusOK, catalogResponse{
-		Commands:     mapKeys(definition.Commands),
+		Commands:     definition.CommandNames(),
 		Repositories: repositories,
 	})
 }
@@ -380,7 +367,7 @@ func (s *Server) submit(response http.ResponseWriter, request *http.Request) {
 		writeError(response, http.StatusInternalServerError, repositoryErr)
 		return
 	}
-	if !containsString(repositories, input.Repository) {
+	if !slices.Contains(repositories, input.Repository) {
 		writeError(response, http.StatusBadRequest, fmt.Errorf("repository %q is not defined in the control plane", input.Repository))
 		return
 	}
@@ -560,15 +547,6 @@ func (s *Server) validBrowserRequest(request *http.Request) bool {
 	return hostname == "localhost" || net.ParseIP(hostname) != nil && net.ParseIP(hostname).IsLoopback()
 }
 
-func containsString(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
-}
-
 func validateLoopbackListen(listen string) error {
 	host, _, err := net.SplitHostPort(listen)
 	if err != nil {
@@ -634,13 +612,4 @@ func securityHeaders(next http.Handler) http.Handler {
 		response.Header().Set("X-Content-Type-Options", "nosniff")
 		next.ServeHTTP(response, request)
 	})
-}
-
-func mapKeys[T any](values map[string]T) []string {
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/owainlewis/machinist/internal/config"
@@ -30,6 +31,9 @@ var (
 
 const leaseDuration = 30 * time.Second
 const maxTriggerErrorLength = 2000
+
+// reclaimExpiredLeasesSQL returns running runs whose lease lapsed to the queue.
+const reclaimExpiredLeasesSQL = `UPDATE runs SET state='queued',worker_instance=NULL,worker_name='',lease_token=NULL,lease_expires_at=NULL,started_at=NULL WHERE state='running' AND (lease_expires_at IS NULL OR lease_expires_at<=?)`
 
 type Store struct {
 	db  *sql.DB
@@ -269,58 +273,35 @@ func (s *Store) SyncTriggers(ctx context.Context, definitions []TriggerDefinitio
 	}
 	defer tx.Rollback()
 	now := s.now().UTC().Format(time.RFC3339Nano)
+	placeholders := make([]string, 0, len(definitions))
+	identities := make([]any, 0, len(definitions))
 	for _, definition := range definitions {
+		placeholders = append(placeholders, "?")
+		identities = append(identities, definition.Identity)
 		generationID, err := randomID("trigger", 12)
 		if err != nil {
 			return fmt.Errorf("generate trigger %q configuration generation: %w", definition.Identity, err)
 		}
-		nextDue := nullableTimeText(definition.NextDueAt)
+		// A changed family or signature discards every piece of durable state, so the
+		// row is recreated from scratch. An unchanged trigger keeps its schedule and
+		// generation, gaining a generation only if it never had one.
+		if _, err := tx.ExecContext(ctx, `DELETE FROM trigger_state WHERE identity=? AND (family<>? OR config_signature<>?)`, definition.Identity, definition.Family, definition.ConfigSignature); err != nil {
+			return fmt.Errorf("sync trigger %q: %w", definition.Identity, err)
+		}
 		if _, err := tx.ExecContext(ctx, `INSERT INTO trigger_state(identity,family,config_signature,generation_id,next_due_at,health,updated_at)
 VALUES(?,?,?,?,?,'healthy',?)
 ON CONFLICT(identity) DO UPDATE SET
-  family=excluded.family,
-  config_signature=excluded.config_signature,
-  generation_id=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature OR trigger_state.generation_id='' THEN excluded.generation_id ELSE trigger_state.generation_id END,
-  next_due_at=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN excluded.next_due_at ELSE trigger_state.next_due_at END,
-  pending_occurrence_at=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN NULL ELSE trigger_state.pending_occurrence_at END,
-  last_attempt_at=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN NULL ELSE trigger_state.last_attempt_at END,
-  last_success_at=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN NULL ELSE trigger_state.last_success_at END,
-  last_job_state=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN '' ELSE trigger_state.last_job_state END,
-  last_job_error=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN '' ELSE trigger_state.last_job_error END,
-  health=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN 'healthy' ELSE trigger_state.health END,
-  latest_error=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN '' ELSE trigger_state.latest_error END,
-  candidate_count=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN 0 ELSE trigger_state.candidate_count END,
-  admission_count=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN 0 ELSE trigger_state.admission_count END,
-  coalesced_count=CASE WHEN trigger_state.family<>excluded.family OR trigger_state.config_signature<>excluded.config_signature THEN 0 ELSE trigger_state.coalesced_count END,
-  updated_at=excluded.updated_at`, definition.Identity, definition.Family, definition.ConfigSignature, generationID, nextDue, now); err != nil {
+  generation_id=CASE WHEN trigger_state.generation_id='' THEN excluded.generation_id ELSE trigger_state.generation_id END,
+  updated_at=excluded.updated_at`, definition.Identity, definition.Family, definition.ConfigSignature, generationID, nullableTimeText(definition.NextDueAt), now); err != nil {
 			return fmt.Errorf("sync trigger %q: %w", definition.Identity, err)
 		}
 	}
-	rows, err := tx.QueryContext(ctx, `SELECT identity FROM trigger_state`)
-	if err != nil {
-		return fmt.Errorf("list durable triggers: %w", err)
+	removeStale := `DELETE FROM trigger_state`
+	if len(identities) > 0 {
+		removeStale += ` WHERE identity NOT IN (` + strings.Join(placeholders, ",") + `)`
 	}
-	var removed []string
-	for rows.Next() {
-		var identity string
-		if err := rows.Scan(&identity); err != nil {
-			rows.Close()
-			return fmt.Errorf("list durable triggers: %w", err)
-		}
-		if !seen[identity] {
-			removed = append(removed, identity)
-		}
-	}
-	if err := rows.Close(); err != nil {
-		return fmt.Errorf("list durable triggers: %w", err)
-	}
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("list durable triggers: %w", err)
-	}
-	for _, identity := range removed {
-		if _, err := tx.ExecContext(ctx, `DELETE FROM trigger_state WHERE identity=?`, identity); err != nil {
-			return fmt.Errorf("remove trigger %q: %w", identity, err)
-		}
+	if _, err := tx.ExecContext(ctx, removeStale, identities...); err != nil {
+		return fmt.Errorf("remove stale triggers: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit trigger sync: %w", err)
@@ -767,13 +748,14 @@ func (s *Store) poll(ctx context.Context, request protocol.PollRequest, maxConcu
 	if _, err := tx.ExecContext(ctx, `INSERT INTO workers(instance_id,name,last_seen_at) VALUES(?,?,?) ON CONFLICT(instance_id) DO UPDATE SET name=excluded.name,last_seen_at=excluded.last_seen_at`, request.InstanceID, request.Name, now); err != nil {
 		return nil, fmt.Errorf("update worker: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `UPDATE runs SET state='queued',worker_instance=NULL,worker_name='',lease_token=NULL,lease_expires_at=NULL,started_at=NULL WHERE state='running' AND (lease_expires_at IS NULL OR lease_expires_at<=?)`, nowTime.UnixNano()); err != nil {
+	if _, err := tx.ExecContext(ctx, reclaimExpiredLeasesSQL, nowTime.UnixNano()); err != nil {
 		return nil, fmt.Errorf("reclaim expired leases: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM worker_repositories WHERE worker_instance=?`, request.InstanceID); err != nil {
 		return nil, fmt.Errorf("clear worker repositories: %w", err)
 	}
-	for repository := range stringSet(request.Repositories) {
+	repositories := stringSet(request.Repositories)
+	for repository := range repositories {
 		if _, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO known_repositories(repository) VALUES(?)`, repository); err != nil {
 			return nil, fmt.Errorf("store known repository: %w", err)
 		}
@@ -801,7 +783,6 @@ func (s *Store) poll(ctx context.Context, request protocol.PollRequest, maxConcu
 	}
 
 	executors := stringSet(request.Executors)
-	repositories := stringSet(request.Repositories)
 	rows, err := tx.QueryContext(ctx, `SELECT r.id,r.job_id,r.command,r.command_hash,r.executor,r.model,r.repository,r.rendered_prompt,r.timeout_ms,j.state FROM runs r JOIN jobs j ON j.id=r.job_id WHERE r.state='queued' ORDER BY r.rowid`)
 	if err != nil {
 		return nil, err
@@ -983,7 +964,7 @@ func (s *Store) DeleteJob(ctx context.Context, jobID string) error {
 }
 
 func (s *Store) ReclaimExpiredLeases(ctx context.Context) (int64, error) {
-	result, err := s.db.ExecContext(ctx, `UPDATE runs SET state='queued',worker_instance=NULL,worker_name='',lease_token=NULL,lease_expires_at=NULL,started_at=NULL WHERE state='running' AND (lease_expires_at IS NULL OR lease_expires_at<=?)`, s.now().UTC().UnixNano())
+	result, err := s.db.ExecContext(ctx, reclaimExpiredLeasesSQL, s.now().UTC().UnixNano())
 	if err != nil {
 		return 0, fmt.Errorf("reclaim expired leases: %w", err)
 	}
@@ -1096,54 +1077,32 @@ func (s *Store) RunOutput(ctx context.Context, runID string) (RunOutput, error) 
 }
 
 func (s *Store) listJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id,prompt,repository,github_issue_title,command,schedule_name,trigger_identity,occurrence_key,trigger_subject,state,created_at,updated_at FROM jobs ORDER BY created_at DESC`)
-	if err != nil {
-		return nil, err
-	}
-	jobs := []Job{}
-	for rows.Next() {
-		var job Job
-		var created, updated string
-		if err := rows.Scan(&job.ID, &job.Prompt, &job.Repository, &job.GitHubIssueTitle, &job.Command, &job.ScheduleName, &job.TriggerID, &job.OccurrenceKey, &job.TriggerSubject, &job.State, &created, &updated); err != nil {
-			return nil, err
-		}
-		job.CreatedAt, _ = time.Parse(time.RFC3339Nano, created)
-		job.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updated)
-		jobs = append(jobs, job)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	for index := range jobs {
-		jobs[index].Runs, err = s.listRuns(ctx, jobs[index].ID)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return jobs, nil
-}
-
-func (s *Store) listRuns(ctx context.Context, jobID string) ([]Run, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT r.id,r.command,r.executor,r.model,r.state,COALESCE(NULLIF(r.worker_name,''),w.name,''),r.exit_code,COALESCE(r.error,''),COALESCE(r.started_at,''),COALESCE(r.completed_at,''),r.duration_millis,r.token_usage FROM runs r LEFT JOIN workers w ON w.instance_id=r.worker_instance WHERE r.job_id=?`, jobID)
+	rows, err := s.db.QueryContext(ctx, `SELECT j.id,j.prompt,j.repository,j.github_issue_title,j.command,j.schedule_name,j.trigger_identity,j.occurrence_key,j.trigger_subject,j.state,j.created_at,j.updated_at,
+COALESCE(r.id,''),COALESCE(r.command,''),COALESCE(r.executor,''),COALESCE(r.model,''),COALESCE(r.state,''),COALESCE(NULLIF(r.worker_name,''),w.name,''),r.exit_code,COALESCE(r.error,''),COALESCE(r.started_at,''),COALESCE(r.completed_at,''),r.duration_millis,r.token_usage
+FROM jobs j LEFT JOIN runs r ON r.job_id=j.id LEFT JOIN workers w ON w.instance_id=r.worker_instance ORDER BY j.created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	runs := []Run{}
+	jobs := []Job{}
 	for rows.Next() {
+		job := Job{Runs: []Run{}}
 		var run Run
-		var started, completed string
-		if err := rows.Scan(&run.ID, &run.Command, &run.Executor, &run.Model, &run.State, &run.WorkerName, &run.ExitCode, &run.Error, &started, &completed, &run.DurationMillis, &run.TokenUsage); err != nil {
+		var created, updated, started, completed string
+		if err := rows.Scan(&job.ID, &job.Prompt, &job.Repository, &job.GitHubIssueTitle, &job.Command, &job.ScheduleName, &job.TriggerID, &job.OccurrenceKey, &job.TriggerSubject, &job.State, &created, &updated,
+			&run.ID, &run.Command, &run.Executor, &run.Model, &run.State, &run.WorkerName, &run.ExitCode, &run.Error, &started, &completed, &run.DurationMillis, &run.TokenUsage); err != nil {
 			return nil, err
 		}
-		run.StartedAt, _ = time.Parse(time.RFC3339Nano, started)
-		run.CompletedAt, _ = time.Parse(time.RFC3339Nano, completed)
-		runs = append(runs, run)
+		job.CreatedAt, _ = time.Parse(time.RFC3339Nano, created)
+		job.UpdatedAt, _ = time.Parse(time.RFC3339Nano, updated)
+		if run.ID != "" {
+			run.StartedAt, _ = time.Parse(time.RFC3339Nano, started)
+			run.CompletedAt, _ = time.Parse(time.RFC3339Nano, completed)
+			job.Runs = append(job.Runs, run)
+		}
+		jobs = append(jobs, job)
 	}
-	return runs, rows.Err()
+	return jobs, rows.Err()
 }
 
 func resultMetrics(result []byte) (*int64, *int64) {
@@ -1182,44 +1141,37 @@ func (s *Store) listWorkers(ctx context.Context) ([]Worker, error) {
 	}
 	workers := []Worker{}
 	for rows.Next() {
-		var worker Worker
+		worker := Worker{Repositories: []string{}}
 		var lastSeen string
 		if err := rows.Scan(&worker.InstanceID, &worker.Name, &lastSeen); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		worker.LastSeenAt, _ = time.Parse(time.RFC3339Nano, lastSeen)
 		workers = append(workers, worker)
 	}
-	if err := rows.Close(); err != nil {
+	if err := errors.Join(rows.Err(), rows.Close()); err != nil {
 		return nil, err
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	for index := range workers {
-		workers[index].Repositories, err = s.listWorkerRepositories(ctx, workers[index].InstanceID)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return workers, nil
-}
-
-func (s *Store) listWorkerRepositories(ctx context.Context, instanceID string) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT repository FROM worker_repositories WHERE worker_instance=? ORDER BY repository`, instanceID)
+	repositories, err := s.db.QueryContext(ctx, `SELECT worker_instance,repository FROM worker_repositories ORDER BY worker_instance,repository`)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	repositories := []string{}
-	for rows.Next() {
-		var repository string
-		if err := rows.Scan(&repository); err != nil {
+	defer repositories.Close()
+	byInstance := make(map[string]int, len(workers))
+	for index, worker := range workers {
+		byInstance[worker.InstanceID] = index
+	}
+	for repositories.Next() {
+		var instanceID, repository string
+		if err := repositories.Scan(&instanceID, &repository); err != nil {
 			return nil, err
 		}
-		repositories = append(repositories, repository)
+		if index, ok := byInstance[instanceID]; ok {
+			workers[index].Repositories = append(workers[index].Repositories, repository)
+		}
 	}
-	return repositories, rows.Err()
+	return workers, repositories.Err()
 }
 
 func scanRunSpec(row *sql.Row) (protocol.RunSpec, error) {

--- a/internal/controlplane/trigger_scheduler.go
+++ b/internal/controlplane/trigger_scheduler.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -18,16 +19,6 @@ type githubTriggerClient interface {
 	IssueDetails(context.Context, string, int, string) (GitHubIssueDetails, error)
 	Permission(context.Context, string, string) (string, error)
 	AcknowledgeRequest(context.Context, string, int, string, string, bool) error
-}
-
-func (s *Server) processManagedTriggers(ctx context.Context) error {
-	var failures []error
-	for _, trigger := range s.triggers {
-		if err := s.processManagedTrigger(ctx, trigger); err != nil {
-			failures = append(failures, fmt.Errorf("trigger %q: %w", trigger.Identity, err))
-		}
-	}
-	return errors.Join(failures...)
 }
 
 func (s *Server) processManagedTrigger(ctx context.Context, trigger config.ResolvedTrigger) error {
@@ -135,11 +126,9 @@ func fixedOccurrenceWindow(trigger config.ResolvedTrigger, firstDue, now time.Ti
 }
 
 func (s *Server) processGitHubTrigger(ctx context.Context, trigger config.ResolvedTrigger, generation string) error {
-	repositories := make([]string, 0, len(trigger.GitHubRepositories))
-	for _, slug := range trigger.GitHubRepositories {
-		repositories = append(repositories, slug)
-	}
-	sort.Slice(repositories, func(i, j int) bool { return strings.ToLower(repositories[i]) < strings.ToLower(repositories[j]) })
+	repositories := slices.SortedFunc(maps.Values(trigger.GitHubRepositories), func(left, right string) int {
+		return strings.Compare(strings.ToLower(left), strings.ToLower(right))
+	})
 	var failures []error
 	reconciliations, err := s.store.GitHubTriggerReconciliations(ctx, trigger.Identity)
 	if err != nil {

--- a/internal/controlplane/trigger_scheduler_test.go
+++ b/internal/controlplane/trigger_scheduler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -137,7 +138,7 @@ func TestManagedGitHubTriggerCommitsBeforeLabelsAndRepairsWithoutDuplicate(t *te
 	}
 	server := &Server{store: store, triggers: []config.ResolvedTrigger{trigger}, github: client, now: func() time.Time { return clock }}
 
-	if err := server.processManagedTriggers(t.Context()); err == nil {
+	if err := processManagedTriggers(t.Context(), server); err == nil {
 		t.Fatal("expected label update failure")
 	}
 	snapshot, err := store.Snapshot(t.Context())
@@ -150,7 +151,7 @@ func TestManagedGitHubTriggerCommitsBeforeLabelsAndRepairsWithoutDuplicate(t *te
 
 	clock = clock.Add(trigger.Every)
 	client.replaceErr = nil
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err = store.Snapshot(t.Context())
@@ -178,7 +179,7 @@ func TestManagedGitHubTriggerFinishesAdmittedLabelRepairAfterRepositoryRemoval(t
 		permission: "write", replaceErr: errors.New("label update failed"),
 	}
 	server := &Server{store: store, triggers: []config.ResolvedTrigger{trigger}, github: client, now: func() time.Time { return clock }}
-	if err := server.processManagedTriggers(t.Context()); err == nil {
+	if err := processManagedTriggers(t.Context(), server); err == nil {
 		t.Fatal("expected initial label update failure")
 	}
 
@@ -191,7 +192,7 @@ func TestManagedGitHubTriggerFinishesAdmittedLabelRepairAfterRepositoryRemoval(t
 	}
 	server.triggers = []config.ResolvedTrigger{current}
 	client.replaceErr = nil
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	if client.replaceCalls != 2 || hasGitHubLabel(client.details.Labels, trigger.Label) || !hasGitHubLabel(client.details.Labels, queuedGitHubLabel) {
@@ -219,7 +220,7 @@ func TestManagedGitHubTriggerRejectsUnauthorizedActor(t *testing.T) {
 		permission: "read",
 	}
 	server := &Server{store: store, triggers: []config.ResolvedTrigger{trigger}, github: client, now: func() time.Time { return clock }}
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err := store.Snapshot(t.Context())
@@ -256,7 +257,7 @@ func TestManagedGitHubTriggerRecoversNewerRequestAfterPostRemovalReadFailure(t *
 	}
 	server := &Server{store: store, triggers: []config.ResolvedTrigger{trigger}, github: client, now: func() time.Time { return clock }}
 
-	if err := server.processManagedTriggers(t.Context()); err == nil {
+	if err := processManagedTriggers(t.Context(), server); err == nil {
 		t.Fatal("expected the post-removal read to fail")
 	}
 	if err := store.Close(); err != nil {
@@ -278,7 +279,7 @@ func TestManagedGitHubTriggerRecoversNewerRequestAfterPostRemovalReadFailure(t *
 	server.triggers = []config.ResolvedTrigger{currentTrigger}
 	delete(client.detailsErrors, 2)
 	clock = clock.Add(currentTrigger.Every)
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err := store.Snapshot(t.Context())
@@ -296,7 +297,7 @@ func TestManagedGitHubTriggerRecoversNewerRequestAfterPostRemovalReadFailure(t *
 		t.Fatal(err)
 	}
 	clock = clock.Add(currentTrigger.Every)
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err = store.Snapshot(t.Context())
@@ -310,7 +311,7 @@ func TestManagedGitHubTriggerRecoversNewerRequestAfterPostRemovalReadFailure(t *
 	if len(snapshot.Jobs) != 2 || !newerAdmitted {
 		t.Fatalf("newer durable request was not admitted: %#v", snapshot.Jobs)
 	}
-	if !containsString(client.permissionActors, "second-owner") || containsString(client.permissionActors, "machinist") {
+	if !slices.Contains(client.permissionActors, "second-owner") || slices.Contains(client.permissionActors, "machinist") {
 		t.Fatalf("permission actors = %v, want original newer actor", client.permissionActors)
 	}
 }
@@ -333,11 +334,11 @@ func TestManagedGitHubTriggerConsumesUnauthorizedCandidatesBeyondSearchWindow(t 
 		client.detailsByNumber[number] = GitHubIssueDetails{GitHubCandidate: candidate, Labels: []string{"machinist:requested"}, RequestedEvent: &GitHubLabelEvent{ID: fmt.Sprint(number), Actor: actor, CreatedAt: candidate.CreatedAt, OccurrenceKey: fmt.Sprintf("github.com:%d", number)}}
 	}
 	server := &Server{store: store, triggers: []config.ResolvedTrigger{trigger}, github: client, now: func() time.Time { return clock }}
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	clock = clock.Add(trigger.Every)
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err := store.Snapshot(t.Context())
@@ -381,7 +382,7 @@ func TestManagedGitHubTriggerAdmitsAuthorizedWorkflowTokenActor(t *testing.T) {
 	}
 	server := &Server{store: store, triggers: []config.ResolvedTrigger{trigger}, github: client, now: func() time.Time { return clock }}
 
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err := store.Snapshot(t.Context())
@@ -489,7 +490,7 @@ func TestManagedIntervalTriggerCoalescesBacklogAndActiveOccurrences(t *testing.T
 		t.Fatal(err)
 	}
 	server := &Server{store: store, triggers: []config.ResolvedTrigger{trigger}, now: func() time.Time { return clock }}
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err := store.Snapshot(t.Context())
@@ -502,7 +503,7 @@ func TestManagedIntervalTriggerCoalescesBacklogAndActiveOccurrences(t *testing.T
 	}
 
 	clock = startup.Add(4 * time.Hour)
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err = store.Snapshot(t.Context())
@@ -634,7 +635,7 @@ func assertFixedTriggerRetriesPendingOccurrence(t *testing.T, trigger config.Res
 	invalid := trigger
 	invalid.Command = config.ResolvedCommand{}
 	server := &Server{store: store, triggers: []config.ResolvedTrigger{invalid}, now: func() time.Time { return clock }}
-	if err := server.processManagedTriggers(t.Context()); err == nil {
+	if err := processManagedTriggers(t.Context(), server); err == nil {
 		t.Fatal("expected first admission to fail")
 	}
 	statuses, err := store.TriggerSnapshot(t.Context())
@@ -659,7 +660,7 @@ func assertFixedTriggerRetriesPendingOccurrence(t *testing.T, trigger config.Res
 		t.Fatal(err)
 	}
 	server = &Server{store: reopened, triggers: []config.ResolvedTrigger{trigger}, now: func() time.Time { return clock }}
-	if err := server.processManagedTriggers(t.Context()); err != nil {
+	if err := processManagedTriggers(t.Context(), server); err != nil {
 		t.Fatal(err)
 	}
 	snapshot, err := reopened.Snapshot(t.Context())
@@ -694,4 +695,14 @@ func openManagedTriggerTestStore(t *testing.T, clock *time.Time) *Store {
 	store.now = func() time.Time { return *clock }
 	t.Cleanup(func() { _ = store.Close() })
 	return store
+}
+
+func processManagedTriggers(ctx context.Context, server *Server) error {
+	var failures []error
+	for _, trigger := range server.triggers {
+		if err := server.processManagedTrigger(ctx, trigger); err != nil {
+			failures = append(failures, fmt.Errorf("trigger %q: %w", trigger.Identity, err))
+		}
+	}
+	return errors.Join(failures...)
 }

--- a/internal/managedworker/client.go
+++ b/internal/managedworker/client.go
@@ -31,10 +31,14 @@ type ResponseError struct {
 }
 
 func (err *ResponseError) Error() string {
-	if err.Body == "" {
-		return fmt.Sprintf("control plane returned %s", http.StatusText(err.Status))
+	message := fmt.Sprintf("control plane returned HTTP %d", err.Status)
+	if text := http.StatusText(err.Status); text != "" {
+		message += " " + text
 	}
-	return fmt.Sprintf("control plane returned %s: %s", http.StatusText(err.Status), err.Body)
+	if err.Body != "" {
+		message += ": " + err.Body
+	}
+	return message
 }
 
 // Retryable reports whether the request may succeed later. Client errors other

--- a/internal/managedworker/client.go
+++ b/internal/managedworker/client.go
@@ -1,0 +1,125 @@
+package managedworker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/owainlewis/machinist/internal/config"
+)
+
+// Client calls the control plane API with the shared worker token. Both the
+// managed worker and the submit command use it.
+type Client struct {
+	base  string
+	token string
+	http  *http.Client
+}
+
+// ResponseError reports a non-2xx control plane response.
+type ResponseError struct {
+	Status int
+	Body   string
+}
+
+func (err *ResponseError) Error() string {
+	if err.Body == "" {
+		return fmt.Sprintf("control plane returned %s", http.StatusText(err.Status))
+	}
+	return fmt.Sprintf("control plane returned %s: %s", http.StatusText(err.Status), err.Body)
+}
+
+// Retryable reports whether the request may succeed later. Client errors other
+// than timeouts and rate limits are permanent.
+func (err *ResponseError) Retryable() bool {
+	return err.Status < 400 || err.Status >= 500 || err.Status == http.StatusRequestTimeout || err.Status == http.StatusTooManyRequests
+}
+
+func NewClient(workerConfig config.Worker) (*Client, error) {
+	base, err := controlPlaneEndpoint(workerConfig.ControlPlane.URL)
+	if err != nil {
+		return nil, err
+	}
+	token, err := workerConfig.WorkerToken()
+	if err != nil {
+		return nil, err
+	}
+	return newClient(base, token, &http.Client{Timeout: 15 * time.Second}), nil
+}
+
+func newClient(base, token string, httpClient *http.Client) *Client {
+	return &Client{base: strings.TrimRight(base, "/"), token: token, http: httpClient}
+}
+
+func (c *Client) Get(ctx context.Context, path string, output any) error {
+	return c.do(ctx, http.MethodGet, path, nil, output)
+}
+
+func (c *Client) Post(ctx context.Context, path string, input, output any) error {
+	return c.do(ctx, http.MethodPost, path, input, output)
+}
+
+func (c *Client) do(ctx context.Context, method, path string, input, output any) error {
+	var body io.Reader
+	if input != nil {
+		encoded, err := json.Marshal(input)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, c.base+path, body)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Authorization", "Bearer "+c.token)
+	if input != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := c.http.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		message, _ := io.ReadAll(io.LimitReader(response.Body, 8<<10))
+		return &ResponseError{Status: response.StatusCode, Body: strings.TrimSpace(string(message))}
+	}
+	if output == nil || response.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(output); err != nil {
+		return fmt.Errorf("decode control plane response: %w", err)
+	}
+	return nil
+}
+
+func controlPlaneEndpoint(raw string) (string, error) {
+	endpoint, err := url.Parse(raw)
+	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
+		return "", fmt.Errorf("invalid control_plane.url %q", raw)
+	}
+	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
+		return "", errors.New("control_plane.url must use http or https")
+	}
+	if endpoint.Scheme == "http" && !loopbackHost(endpoint.Hostname()) {
+		return "", errors.New("control_plane.url must use https for a non-loopback host")
+	}
+	return strings.TrimRight(raw, "/"), nil
+}
+
+func loopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/internal/managedworker/worker.go
+++ b/internal/managedworker/worker.go
@@ -1,16 +1,12 @@
 package managedworker
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -24,9 +20,8 @@ import (
 
 type Worker struct {
 	config         config.Worker
-	token          string
 	instanceID     string
-	client         *http.Client
+	client         *Client
 	stdout         io.Writer
 	stderr         io.Writer
 	heartbeatTicks <-chan time.Time
@@ -35,15 +30,6 @@ type Worker struct {
 
 const heartbeatInterval = 10 * time.Second
 
-type responseError struct {
-	status int
-	body   string
-}
-
-func (err *responseError) Error() string {
-	return fmt.Sprintf("control plane returned %s: %s", http.StatusText(err.status), err.body)
-}
-
 func New(workerConfig config.Worker, stdout, stderr io.Writer) (*Worker, error) {
 	if strings.TrimSpace(workerConfig.Name) == "" {
 		return nil, errors.New("worker name is required")
@@ -51,17 +37,7 @@ func New(workerConfig config.Worker, stdout, stderr io.Writer) (*Worker, error) 
 	if len(workerConfig.Executors) == 0 || len(workerConfig.Repositories) == 0 {
 		return nil, errors.New("managed worker requires at least one executor and repository")
 	}
-	endpoint, err := url.Parse(workerConfig.ControlPlane.URL)
-	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" {
-		return nil, fmt.Errorf("invalid control_plane.url %q", workerConfig.ControlPlane.URL)
-	}
-	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
-		return nil, errors.New("control_plane.url must use http or https")
-	}
-	if endpoint.Scheme == "http" && !loopbackHost(endpoint.Hostname()) {
-		return nil, errors.New("control_plane.url must use https for a non-loopback host")
-	}
-	token, err := workerConfig.WorkerToken()
+	client, err := NewClient(workerConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -71,9 +47,8 @@ func New(workerConfig config.Worker, stdout, stderr io.Writer) (*Worker, error) 
 	}
 	return &Worker{
 		config:     workerConfig,
-		token:      token,
 		instanceID: instanceID,
-		client:     &http.Client{Timeout: 15 * time.Second},
+		client:     client,
 		stdout:     stdout,
 		stderr:     stderr,
 	}, nil
@@ -106,28 +81,39 @@ func (w *Worker) Run(ctx context.Context) error {
 }
 
 func (w *Worker) executeWithHeartbeats(ctx context.Context, spec protocol.RunSpec) protocol.Completion {
-	ticks := w.heartbeatTicks
-	var ticker *time.Ticker
-	if ticks == nil {
-		ticker = time.NewTicker(heartbeatInterval)
-		ticks = ticker.C
-		defer ticker.Stop()
-	}
 	execute := w.executeRun
 	if execute == nil {
 		execute = w.execute
 	}
-	done := make(chan protocol.Completion, 1)
-	go func() {
-		done <- execute(ctx, spec)
-	}()
+	return withHeartbeats(ctx, w, spec, "", func() protocol.Completion { return execute(ctx, spec) })
+}
+
+func (w *Worker) deliverWithHeartbeats(ctx context.Context, spec protocol.RunSpec, completion protocol.Completion) error {
+	if err := w.heartbeat(ctx, spec); err != nil {
+		fmt.Fprintf(w.stderr, "machinist: heartbeat run %s before completion: %v\n", spec.ID, err)
+	}
+	return withHeartbeats(ctx, w, spec, " during completion", func() error { return w.deliver(ctx, spec.ID, completion) })
+}
+
+// withHeartbeats runs work in the background and keeps the run lease alive
+// until it returns. Cancellation does not abandon the work; the work observes
+// ctx itself and its result is always returned.
+func withHeartbeats[T any](ctx context.Context, w *Worker, spec protocol.RunSpec, phase string, work func() T) T {
+	ticks := w.heartbeatTicks
+	if ticks == nil {
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+		ticks = ticker.C
+	}
+	done := make(chan T, 1)
+	go func() { done <- work() }()
 	for {
 		select {
-		case completion := <-done:
-			return completion
+		case result := <-done:
+			return result
 		case <-ticks:
 			if err := w.heartbeat(ctx, spec); err != nil {
-				fmt.Fprintf(w.stderr, "machinist: heartbeat run %s: %v\n", spec.ID, err)
+				fmt.Fprintf(w.stderr, "machinist: heartbeat run %s%s: %v\n", spec.ID, phase, err)
 			}
 		case <-ctx.Done():
 			return <-done
@@ -144,7 +130,7 @@ func (w *Worker) poll(ctx context.Context) (*protocol.RunSpec, error) {
 		Models:       w.config.ModelCapabilities(),
 	}
 	var response protocol.PollResponse
-	if err := w.post(ctx, "/api/v1/workers/poll", request, &response); err != nil {
+	if err := w.client.Post(ctx, "/api/v1/workers/poll", request, &response); err != nil {
 		return nil, err
 	}
 	return response.Run, nil
@@ -192,94 +178,30 @@ func (w *Worker) execute(ctx context.Context, spec protocol.RunSpec) protocol.Co
 	return completion
 }
 
-func (w *Worker) deliverWithHeartbeats(ctx context.Context, spec protocol.RunSpec, completion protocol.Completion) error {
-	if err := w.heartbeat(ctx, spec); err != nil {
-		fmt.Fprintf(w.stderr, "machinist: heartbeat run %s before completion: %v\n", spec.ID, err)
-	}
-	ticks := w.heartbeatTicks
-	var ticker *time.Ticker
-	if ticks == nil {
-		ticker = time.NewTicker(heartbeatInterval)
-		ticks = ticker.C
-		defer ticker.Stop()
-	}
-	done := make(chan error, 1)
-	go func() {
-		done <- w.deliver(ctx, spec.ID, completion)
-	}()
-	for {
-		select {
-		case err := <-done:
-			return err
-		case <-ticks:
-			if err := w.heartbeat(ctx, spec); err != nil {
-				fmt.Fprintf(w.stderr, "machinist: heartbeat run %s during completion: %v\n", spec.ID, err)
-			}
-		case <-ctx.Done():
-			return <-done
-		}
-	}
-}
-
 func (w *Worker) deliver(ctx context.Context, runID string, completion protocol.Completion) error {
 	backoff := 250 * time.Millisecond
 	for {
-		err := w.post(ctx, "/api/v1/runs/"+url.PathEscape(runID)+"/complete", completion, nil)
+		err := w.client.Post(ctx, "/api/v1/runs/"+url.PathEscape(runID)+"/complete", completion, nil)
 		if err == nil {
 			return nil
 		}
-		var responseErr *responseError
-		if errors.As(err, &responseErr) && responseErr.status >= 400 && responseErr.status < 500 && responseErr.status != http.StatusRequestTimeout && responseErr.status != http.StatusTooManyRequests {
+		var responseErr *ResponseError
+		if errors.As(err, &responseErr) && !responseErr.Retryable() {
 			return err
 		}
 		fmt.Fprintf(w.stderr, "machinist: report run %s: %v\n", runID, err)
 		if !wait(ctx, backoff) {
 			return ctx.Err()
 		}
-		if backoff < 5*time.Second {
-			backoff *= 2
-			if backoff > 5*time.Second {
-				backoff = 5 * time.Second
-			}
-		}
+		backoff = min(backoff*2, 5*time.Second)
 	}
 }
 
 func (w *Worker) heartbeat(ctx context.Context, spec protocol.RunSpec) error {
-	return w.post(ctx, "/api/v1/runs/"+url.PathEscape(spec.ID)+"/heartbeat", protocol.Heartbeat{
+	return w.client.Post(ctx, "/api/v1/runs/"+url.PathEscape(spec.ID)+"/heartbeat", protocol.Heartbeat{
 		InstanceID: w.instanceID,
 		LeaseToken: spec.LeaseToken,
 	}, nil)
-}
-
-func (w *Worker) post(ctx context.Context, path string, input, output any) error {
-	body, err := json.Marshal(input)
-	if err != nil {
-		return err
-	}
-	endpoint := strings.TrimRight(w.config.ControlPlane.URL, "/") + path
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	request.Header.Set("Authorization", "Bearer "+w.token)
-	request.Header.Set("Content-Type", "application/json")
-	response, err := w.client.Do(request)
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		message, _ := io.ReadAll(io.LimitReader(response.Body, 8<<10))
-		return &responseError{status: response.StatusCode, body: strings.TrimSpace(string(message))}
-	}
-	if output == nil || response.StatusCode == http.StatusNoContent {
-		return nil
-	}
-	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(output); err != nil {
-		return fmt.Errorf("decode control plane response: %w", err)
-	}
-	return nil
 }
 
 func wait(ctx context.Context, duration time.Duration) bool {
@@ -291,14 +213,6 @@ func wait(ctx context.Context, duration time.Duration) bool {
 	case <-timer.C:
 		return true
 	}
-}
-
-func loopbackHost(host string) bool {
-	if strings.EqualFold(host, "localhost") {
-		return true
-	}
-	ip := net.ParseIP(host)
-	return ip != nil && ip.IsLoopback()
 }
 
 func randomID(prefix string, byteCount int) (string, error) {

--- a/internal/managedworker/worker_test.go
+++ b/internal/managedworker/worker_test.go
@@ -229,9 +229,8 @@ func TestCompletionDoesNotRetryPermanentClientError(t *testing.T) {
 	defer server.Close()
 	worker := &Worker{
 		config:     config.Worker{ControlPlane: config.ControlPlane{URL: server.URL}},
-		token:      "secret",
 		instanceID: "worker-test",
-		client:     server.Client(),
+		client:     newClient(server.URL, "secret", server.Client()),
 		stderr:     io.Discard,
 	}
 	err := worker.deliver(t.Context(), "run_0123456789abcdef01234567", protocol.Completion{})
@@ -269,9 +268,8 @@ func TestManagedWorkerHeartbeatsDuringExecutionAndContinuesAfterFailure(t *testi
 	var stderr strings.Builder
 	worker := &Worker{
 		config:         config.Worker{ControlPlane: config.ControlPlane{URL: server.URL}},
-		token:          "secret",
 		instanceID:     "worker-test",
-		client:         server.Client(),
+		client:         newClient(server.URL, "secret", server.Client()),
 		stderr:         &stderr,
 		heartbeatTicks: ticks,
 		executeRun: func(context.Context, protocol.RunSpec) protocol.Completion {
@@ -341,9 +339,8 @@ func TestManagedWorkerHeartbeatsUntilCompletionIsAcknowledged(t *testing.T) {
 	ticks := make(chan time.Time, 1)
 	worker := &Worker{
 		config:         config.Worker{ControlPlane: config.ControlPlane{URL: server.URL}},
-		token:          "secret",
 		instanceID:     "worker-test",
-		client:         server.Client(),
+		client:         newClient(server.URL, "secret", server.Client()),
 		stderr:         io.Discard,
 		heartbeatTicks: ticks,
 	}

--- a/internal/runner/claude_usage_test.go
+++ b/internal/runner/claude_usage_test.go
@@ -60,7 +60,7 @@ func TestClaudeDebugFlagPreservesExplicitOutputFormat(t *testing.T) {
 	if got := structuredClaudeCommand("claude", command); !slices.Equal(got, command) {
 		t.Fatalf("command = %q, want unchanged", got)
 	}
-	if got := newClaudeUsageCollector("claude", command); got == nil {
+	if got := newUsageCollector("claude", command); got == nil {
 		t.Fatal("collector = nil, want enabled for explicit JSON output")
 	}
 }
@@ -70,7 +70,7 @@ func TestClaudeDebugFilterSeparateValueIsRejected(t *testing.T) {
 	if got := structuredClaudeCommand("claude", command); !slices.Equal(got, command) {
 		t.Fatalf("command = %q, want unchanged", got)
 	}
-	if got := newClaudeUsageCollector("claude", command); got != nil {
+	if got := newUsageCollector("claude", command); got != nil {
 		t.Fatalf("collector = %#v, want disabled", got)
 	}
 }
@@ -89,7 +89,7 @@ func TestClaudeUsageCollectorAcceptsCurrentPrintOptions(t *testing.T) {
 		{"claude", "--print", "--strict-mcp-config"},
 		{"claude", "--print", "--prompt-suggestions=false"},
 	} {
-		if got := newClaudeUsageCollector("claude", command); got == nil {
+		if got := newUsageCollector("claude", command); got == nil {
 			t.Fatalf("collector disabled for command %q", command)
 		}
 	}
@@ -105,7 +105,7 @@ func TestClaudeCommandRecognitionRejectsTrailingNiceWrappers(t *testing.T) {
 		if got := structuredClaudeCommand("claude", command); !slices.Equal(got, command) {
 			t.Fatalf("command = %q, want unchanged", got)
 		}
-		if got := newClaudeUsageCollector("claude", command); got != nil {
+		if got := newUsageCollector("claude", command); got != nil {
 			t.Fatalf("collector = %#v, want disabled", got)
 		}
 	}
@@ -133,7 +133,7 @@ func TestClaudeCommandRecognitionRejectsAmbiguousArguments(t *testing.T) {
 			if got := structuredClaudeCommand(test.executor, test.command); !slices.Equal(got, test.command) {
 				t.Fatalf("command = %q, want unchanged", got)
 			}
-			if got := newClaudeUsageCollector(test.executor, test.command); got != nil {
+			if got := newUsageCollector(test.executor, test.command); got != nil {
 				t.Fatalf("collector = %#v, want disabled", got)
 			}
 		})
@@ -141,7 +141,7 @@ func TestClaudeCommandRecognitionRejectsAmbiguousArguments(t *testing.T) {
 }
 
 func TestClaudeUsageCollectorReadsAllUsageFields(t *testing.T) {
-	collector := newClaudeUsageCollector("claude", []string{"claude", "--print"})
+	collector := newUsageCollector("claude", []string{"claude", "--print"})
 	output := `{"type":"system","subtype":"init"}` + "\n" +
 		`{"type":"result","usage":{"input_tokens":100,"cache_creation_input_tokens":20,"cache_read_input_tokens":30,"output_tokens":4}}`
 	if _, err := collector.Write([]byte(output)); err != nil {
@@ -165,7 +165,7 @@ func TestClaudeUsageCollectorRejectsInvalidFinalUsage(t *testing.T) {
 		{name: "malformed field before type", line: `{"usage":invalid,"type":"result"}`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			collector := newClaudeUsageCollector("claude", []string{"claude", "--print"})
+			collector := newUsageCollector("claude", []string{"claude", "--print"})
 			_, _ = collector.Write([]byte(`{"type":"result","usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":3,"output_tokens":4}}` + "\n" + test.line + "\n"))
 			if got := collector.tokenUsage(); got != nil {
 				t.Fatalf("token usage = %d, want unavailable", *got)

--- a/internal/runner/codex_usage.go
+++ b/internal/runner/codex_usage.go
@@ -10,7 +10,6 @@ import (
 )
 
 const maxStructuredEventBytes = 1 << 20
-const maxCodexEventBytes = maxStructuredEventBytes
 
 type structuredUsageCollector struct {
 	buffer     []byte
@@ -20,29 +19,17 @@ type structuredUsageCollector struct {
 	cache      bool
 }
 
-type codexUsageCollector = structuredUsageCollector
-
-func newCodexUsageCollector(executor string, command []string) *codexUsageCollector {
-	execIndex := codexExecIndex(executor, command)
-	if execIndex < 1 || !slices.Contains(command[execIndex+1:], "--json") {
-		return nil
+// newUsageCollector returns a collector for the executor's structured output,
+// or nil when the command does not emit a parseable usage event.
+func newUsageCollector(executor string, command []string) *structuredUsageCollector {
+	if execIndex := codexExecIndex(executor, command); execIndex >= 1 && slices.Contains(command[execIndex+1:], "--json") {
+		return &structuredUsageCollector{resultType: "turn.completed"}
 	}
-	return newStructuredUsageCollector("turn.completed", false)
-}
-
-func newClaudeUsageCollector(executor string, command []string) *structuredUsageCollector {
 	info, ok := claudeCommandInfo(executor, command)
-	if !ok {
+	if !ok || (info.hasOutputFormat && info.outputFormat != "json" && info.outputFormat != "stream-json") {
 		return nil
 	}
-	if info.hasOutputFormat && info.outputFormat != "json" && info.outputFormat != "stream-json" {
-		return nil
-	}
-	return newStructuredUsageCollector("result", true)
-}
-
-func newStructuredUsageCollector(resultType string, cache bool) *structuredUsageCollector {
-	return &structuredUsageCollector{resultType: resultType, cache: cache}
+	return &structuredUsageCollector{resultType: "result", cache: true}
 }
 
 func structuredCommand(executor string, command []string) []string {
@@ -75,7 +62,7 @@ type claudeCommand struct {
 
 func claudeCommandInfo(executor string, command []string) (claudeCommand, bool) {
 	programIndex := claudeProgramIndex(command)
-	if programIndex < 0 || (claudeExecutableName(command[programIndex]) != "claude" && !claudeExecutorName(executor)) {
+	if programIndex < 0 || (executableName(command[programIndex]) != "claude" && !executorNamed(executor, "claude")) {
 		return claudeCommand{}, false
 	}
 	return claudeCommandInfoAfter(command, programIndex)
@@ -83,7 +70,7 @@ func claudeCommandInfo(executor string, command []string) (claudeCommand, bool) 
 
 func claudeProgramIndex(command []string) int {
 	programIndex := wrappedProgramIndex(command)
-	if programIndex >= 0 && claudeExecutableName(command[programIndex]) == "nice" {
+	if programIndex >= 0 && executableName(command[programIndex]) == "nice" {
 		programIndex++
 		if programIndex >= len(command) {
 			return -1
@@ -206,17 +193,6 @@ func claudeVariadicOption(argument string) bool {
 	return slices.Contains(variadicOptions, argument)
 }
 
-func claudeExecutorName(executor string) bool {
-	parts := strings.FieldsFunc(strings.ToLower(executor), func(character rune) bool {
-		return character == '-' || character == '_' || character == '.'
-	})
-	return slices.Contains(parts, "claude")
-}
-
-func claudeExecutableName(command string) string {
-	return strings.TrimSuffix(strings.ToLower(filepath.Base(command)), ".exe")
-}
-
 func structuredCodexCommand(executor string, command []string) []string {
 	execIndex := codexExecIndex(executor, command)
 	if execIndex < 1 || slices.Contains(command[execIndex+1:], "--json") {
@@ -229,9 +205,9 @@ func structuredCodexCommand(executor string, command []string) []string {
 }
 
 func codexExecIndex(executor string, command []string) int {
-	if codexExecutorName(executor) {
+	if executorNamed(executor, "codex") {
 		for programIndex, argument := range command {
-			if codexExecutableName(argument) == "codex" {
+			if executableName(argument) == "codex" {
 				if execIndex := codexExecIndexAfter(command, programIndex); execIndex >= 0 {
 					return execIndex
 				}
@@ -239,7 +215,7 @@ func codexExecIndex(executor string, command []string) int {
 		}
 	}
 	programIndex := wrappedProgramIndex(command)
-	if programIndex < 0 || (codexExecutableName(command[programIndex]) != "codex" && !codexExecutorName(executor)) {
+	if programIndex < 0 || (executableName(command[programIndex]) != "codex" && !executorNamed(executor, "codex")) {
 		return -1
 	}
 	return codexExecIndexAfter(command, programIndex)
@@ -252,7 +228,7 @@ func wrappedProgramIndex(command []string) int {
 	programIndex := 0
 	for programIndex < len(command) {
 		var nestedProgramIndex int
-		switch codexExecutableName(command[programIndex]) {
+		switch executableName(command[programIndex]) {
 		case "env":
 			nestedProgramIndex = envProgramIndex(command[programIndex:])
 		case "mise":
@@ -440,14 +416,16 @@ func codexRootOption(argument string) (bool, bool) {
 	return false, false
 }
 
-func codexExecutorName(executor string) bool {
+// executorNamed reports whether a configured executor name contains the tool
+// name as one dash, underscore, or dot separated word, such as "claude-fast".
+func executorNamed(executor, tool string) bool {
 	parts := strings.FieldsFunc(strings.ToLower(executor), func(character rune) bool {
 		return character == '-' || character == '_' || character == '.'
 	})
-	return slices.Contains(parts, "codex")
+	return slices.Contains(parts, tool)
 }
 
-func codexExecutableName(command string) string {
+func executableName(command string) string {
 	return strings.TrimSuffix(strings.ToLower(filepath.Base(command)), ".exe")
 }
 

--- a/internal/runner/codex_usage_test.go
+++ b/internal/runner/codex_usage_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCodexUsageCollectorReadsFinalStructuredUsage(t *testing.T) {
-	collector := newCodexUsageCollector("codex", []string{"codex", "exec", "--json", "-"})
+	collector := newUsageCollector("codex", []string{"codex", "exec", "--json", "-"})
 	chunks := []string{
 		`{"type":"turn.completed","usage":{"input_tokens":10,"cached_input_tokens":8,"output_tokens":2}}` + "\n" + `{"type":"item.completed",`,
 		`"item":{"type":"agent_message","text":"done"}}` + "\n" + `{"type":"turn.completed","usage":{"input_tokens":40,`,
@@ -43,7 +43,7 @@ func TestCodexUsageCollectorLeavesInvalidUsageUnavailable(t *testing.T) {
 		{name: "overflow", line: `{"type":"turn.completed","usage":{"input_tokens":` + "9223372036854775807" + `,"output_tokens":1}}`},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			collector := newCodexUsageCollector("codex", []string{"codex", "exec", "--json"})
+			collector := newUsageCollector("codex", []string{"codex", "exec", "--json"})
 			_, _ = collector.Write([]byte(test.line + "\n"))
 			if got := collector.tokenUsage(); got != nil {
 				t.Fatalf("token usage = %d, want unavailable", *got)
@@ -53,7 +53,7 @@ func TestCodexUsageCollectorLeavesInvalidUsageUnavailable(t *testing.T) {
 }
 
 func TestCodexUsageCollectorUsesTheLastCompletedTurn(t *testing.T) {
-	collector := newCodexUsageCollector("codex", []string{"codex", "exec", "--json"})
+	collector := newUsageCollector("codex", []string{"codex", "exec", "--json"})
 	_, _ = collector.Write([]byte(`{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":5}}` + "\n"))
 	_, _ = collector.Write([]byte(`{"type":"turn.completed","usage":{"input_tokens":"invalid","output_tokens":5}}` + "\n"))
 	if got := collector.tokenUsage(); got != nil {
@@ -62,7 +62,7 @@ func TestCodexUsageCollectorUsesTheLastCompletedTurn(t *testing.T) {
 }
 
 func TestCodexUsageCollectorInvalidatesUsageForTruncatedFinalCompletedTurn(t *testing.T) {
-	collector := newCodexUsageCollector("codex", []string{"codex", "exec", "--json"})
+	collector := newUsageCollector("codex", []string{"codex", "exec", "--json"})
 	_, _ = collector.Write([]byte(`{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":5}}` + "\n"))
 	_, _ = collector.Write([]byte(`{"type":"turn.completed","usage":{"input_tokens":8`))
 	if got := collector.tokenUsage(); got != nil {
@@ -71,9 +71,9 @@ func TestCodexUsageCollectorInvalidatesUsageForTruncatedFinalCompletedTurn(t *te
 }
 
 func TestCodexUsageCollectorInvalidatesUsageForOversizedFinalCompletedTurn(t *testing.T) {
-	collector := newCodexUsageCollector("codex", []string{"codex", "exec", "--json"})
+	collector := newUsageCollector("codex", []string{"codex", "exec", "--json"})
 	_, _ = collector.Write([]byte(`{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":5}}` + "\n"))
-	oversized := `{"type":"turn.completed","usage":{"input_tokens":8,"output_tokens":` + strings.Repeat("1", maxCodexEventBytes) + `}}` + "\n"
+	oversized := `{"type":"turn.completed","usage":{"input_tokens":8,"output_tokens":` + strings.Repeat("1", maxStructuredEventBytes) + `}}` + "\n"
 	_, _ = collector.Write([]byte(oversized))
 	if got := collector.tokenUsage(); got != nil {
 		t.Fatalf("token usage = %d, want unavailable for oversized final event", *got)
@@ -81,7 +81,7 @@ func TestCodexUsageCollectorInvalidatesUsageForOversizedFinalCompletedTurn(t *te
 }
 
 func TestCodexUsageCollectorIgnoresUnrelatedMalformedOutput(t *testing.T) {
-	collector := newCodexUsageCollector("codex", []string{"codex", "exec", "--json"})
+	collector := newUsageCollector("codex", []string{"codex", "exec", "--json"})
 	_, _ = collector.Write([]byte(`{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":5}}` + "\n"))
 	_, _ = collector.Write([]byte(`{"type":"item.completed","item":`))
 	if got := collector.tokenUsage(); got == nil || *got != 9 {
@@ -92,7 +92,7 @@ func TestCodexUsageCollectorIgnoresUnrelatedMalformedOutput(t *testing.T) {
 func TestStructuredUsageCollectorIgnoresNestedMalformedTerminalEvents(t *testing.T) {
 	for _, resultType := range []string{"result", "turn.completed"} {
 		t.Run(resultType, func(t *testing.T) {
-			collector := newStructuredUsageCollector(resultType, resultType == "result")
+			collector := &structuredUsageCollector{resultType: resultType, cache: resultType == "result"}
 			valid := `{"type":"` + resultType + `","usage":{"input_tokens":4,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":5}}`
 			if resultType == "turn.completed" {
 				valid = `{"type":"turn.completed","usage":{"input_tokens":4,"output_tokens":5}}`
@@ -118,7 +118,7 @@ func TestCodexUsageCollectorIsEnabledOnlyForStructuredCodexOutput(t *testing.T) 
 		{name: "wrapped renamed executable", executor: "codex-local", command: []string{"/usr/bin/env", "agent", "exec", "--json"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if collector := newCodexUsageCollector(test.executor, test.command); collector == nil {
+			if collector := newUsageCollector(test.executor, test.command); collector == nil {
 				t.Fatalf("collector disabled for executor %q command %q", test.executor, test.command)
 			}
 		})
@@ -132,7 +132,7 @@ func TestCodexUsageCollectorIsEnabledOnlyForStructuredCodexOutput(t *testing.T) 
 		{executor: "codex", command: []string{"agent", "serve", "--json"}},
 		{executor: "custom", command: []string{"agent", "exec", "--json"}},
 	} {
-		if collector := newCodexUsageCollector(test.executor, test.command); collector != nil {
+		if collector := newUsageCollector(test.executor, test.command); collector != nil {
 			t.Fatalf("collector enabled for executor %q command %q", test.executor, test.command)
 		}
 	}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -192,10 +192,7 @@ func Execute(ctx context.Context, options Options) (result Result, returnErr err
 	streamErrors := make(chan error, 2)
 	var streams sync.WaitGroup
 	streams.Add(2)
-	usageCollector := newCodexUsageCollector(options.Command.Executor, executorCommand)
-	if usageCollector == nil {
-		usageCollector = newClaudeUsageCollector(options.Command.Executor, executorCommand)
-	}
+	usageCollector := newUsageCollector(options.Command.Executor, executorCommand)
 	stdoutDestination := options.Stdout
 	if usageCollector != nil {
 		stdoutDestination = io.MultiWriter(options.Stdout, usageCollector)
@@ -261,6 +258,15 @@ func supervise(ctx context.Context, process *os.Process, timeout time.Duration, 
 	setOutputDeadline(timeoutAt, outputWriters...)
 	inputDone := false
 	var inputErr error
+	// abort stops the process immediately, releases every pipe, and returns the
+	// process result so callers can decide how to report the failure.
+	abort := func() processWait {
+		setOutputDeadline(time.Now(), outputWriters...)
+		_ = terminateProcessTree(process)
+		closeInput()
+		closeStreams()
+		return <-processResult
+	}
 
 	for {
 		select {
@@ -288,38 +294,22 @@ func supervise(ctx context.Context, process *os.Process, timeout time.Duration, 
 			inputDone = true
 			inputErr = err
 			if err != nil {
-				setOutputDeadline(time.Now(), outputWriters...)
-				_ = terminateProcessTree(process)
-				closeInput()
-				closeStreams()
-				waited := <-processResult
+				waited := abort()
 				<-streamsDone
 				return operationFailure(waited, err)
 			}
 		case err := <-streamErrors:
-			setOutputDeadline(time.Now(), outputWriters...)
-			_ = terminateProcessTree(process)
-			closeInput()
-			closeStreams()
-			waited := <-processResult
+			waited := abort()
 			inputErr = awaitInput(inputResult, inputDone, inputErr)
 			<-streamsDone
 			return operationFailure(waited, errors.Join(err, inputErr))
 		case <-ctx.Done():
-			setOutputDeadline(time.Now(), outputWriters...)
-			_ = terminateProcessTree(process)
-			closeInput()
-			closeStreams()
-			<-processResult
+			abort()
 			_ = awaitInput(inputResult, inputDone, inputErr)
 			<-streamsDone
 			return StateCancelled, 130, errors.New("run cancelled")
 		case <-timer.C:
-			setOutputDeadline(time.Now(), outputWriters...)
-			_ = terminateProcessTree(process)
-			closeInput()
-			closeStreams()
-			<-processResult
+			abort()
 			_ = awaitInput(inputResult, inputDone, inputErr)
 			<-streamsDone
 			return StateTimedOut, 124, fmt.Errorf("command exceeded timeout %s", timeout)


### PR DESCRIPTION
Behavior-preserving simplification pass across the Go packages.

- Share one control plane `Client` between the managed worker and `machinist submit`
- Merge the worker's execute and deliver heartbeat loops into `withHeartbeats`
- Collapse the four identical abort branches in runner `supervise`
- Unify Claude and Codex usage collector constructors and name helpers
- Replace the 13-branch `CASE WHEN` trigger sync SQL with delete-if-changed then insert-or-keep
- List jobs and workers with one query each instead of N+1
- Share a `sleep` helper across scheduler loops; add `Config.ResolveCommand` and `CommandNames` so the definitions endpoint reads the config once

14 files, +259 / -584. `go vet` and `go test ./...` pass.

https://claude.ai/code/session_01YSTU7k537QJE2EE3aTc3L9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated communication for managed workers and job submission.
  * Improved command discovery, model selection, and resolved command names in listings.

* **Bug Fixes**
  * Improved retry handling for temporary worker communication failures.
  * Scheduled and managed-triggered tasks now begin promptly.
  * Improved trigger synchronization and cleanup of expired or outdated data.

* **Refactor**
  * Consolidated usage tracking and process cancellation handling for supported command-line tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->