### PR TITLE
refactor!: remove Shepherd schedules in favor of triggers

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -52,7 +52,7 @@ default branch is unchanged.
 
 The repository must start without the auto-merge label. Repeat its name with
 `--confirm-disposable` to acknowledge that the run creates and merges disposable pull
-requests. Use a Machinist definition without a configured Shepherd schedule so the
+requests. Use a Machinist definition without a Shepherd trigger so the
 disposable direct smoke cannot overlap production scheduled work. Set a token for a
 second GitHub account that can create pull requests in the scratch repository. The eval
 uses that account for candidates so Shepherd's authenticated account provides an

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,8 +6,8 @@ The files at this level are the small default installed by `machinist init`:
 - `worker.toml` shows local Codex and Claude Code executors.
 - `prompts/` contains the editable default prompts.
 
-`config.toml` includes a commented Shepherd schedule. Enable it only after its repository
-name exists in `worker.toml`. Shepherd ensures the repository defines the
+`config.toml` includes a commented cron trigger that schedules Shepherd. Enable it only
+after its repository name exists in `worker.toml`. Shepherd ensures the repository defines the
 `machinist:auto-merge` label, but it never applies the label to a pull request. Unlabelled
 pull requests remain read-only to Shepherd.
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -19,8 +19,13 @@ executor = "codex"
 prompt_file = "prompts/shepherd.md"
 timeout = "120m"
 
-# Opt in one configured repository by adding a schedule like this:
-# [shepherd.my-project]
+# Schedule Shepherd for one configured repository with a trigger like this:
+# [github.repositories]
+# my-project = "owner/my-project"
+#
+# [triggers.cron.shepherd-my-project]
+# schedule = "*/30 * * * *"
+# timezone = "UTC"
 # repository = "my-project"
-# every = "30m"
-# max_actions = 3
+# command = "shepherd"
+# prompt = "Run the Shepherd queue for my-project with max_actions=3. Perform at most 3 mutating actions in this run."

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -287,23 +287,7 @@ func runSelection(ctx context.Context, options *commandOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := validateDirectCommand(definitionPath, command); err != nil {
-		return err
-	}
 	return runConfiguredCommand(ctx, options, worker, command)
-}
-
-func validateDirectCommand(definitionPath string, command config.ResolvedCommand) error {
-	if command.Name == "shepherd" {
-		schedules, err := config.LoadShepherdSchedules(definitionPath)
-		if err != nil {
-			return err
-		}
-		if len(schedules) > 0 {
-			return errors.New("scheduled Shepherd cannot run directly; submit managed work so the control plane can enforce per-repository overlap protection")
-		}
-	}
-	return nil
 }
 
 func runConfiguredCommand(ctx context.Context, options *commandOptions, worker config.Worker, configured config.ResolvedCommand) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -349,39 +349,8 @@ func TestRunExecutesOneAgent(t *testing.T) {
 	}
 }
 
-func TestRunRejectsScheduleOnlyShepherd(t *testing.T) {
+func TestRunExecutesShepherdCommandDirectly(t *testing.T) {
 	workerConfig := writeCLIConfig(t, "success")
-	for _, selection := range [][]string{{"--command=shepherd"}} {
-		var stdout bytes.Buffer
-		var stderr bytes.Buffer
-		args := append([]string{"run"}, selection...)
-		args = append(args,
-			"--prompt=clear the queue",
-			"--repo="+newCLIRepository(t),
-			"--config="+workerConfig,
-		)
-		exitCode := Execute(t.Context(), args, strings.NewReader(""), &stdout, &stderr, "test")
-		if exitCode != 2 || !strings.Contains(stderr.String(), "scheduled Shepherd cannot run directly") {
-			t.Fatalf("selection = %v, exit code = %d, stdout = %q, stderr = %q", selection, exitCode, stdout.String(), stderr.String())
-		}
-		if stdout.Len() != 0 {
-			t.Fatalf("selection = %v executed before rejection: %q", selection, stdout.String())
-		}
-	}
-}
-
-func TestRunAllowsDisposableShepherdWithoutSchedule(t *testing.T) {
-	workerConfig := writeCLIConfig(t, "success")
-	definitionPath := filepath.Join(filepath.Dir(workerConfig), "config.toml")
-	body, err := os.ReadFile(definitionPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body = bytes.ReplaceAll(body, []byte("\n[shepherd.test]\nrepository = \"test\"\nevery = \"15m\"\nmax_actions = 1\n"), nil)
-	if err := os.WriteFile(definitionPath, body, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	exitCode := Execute(t.Context(), []string{
@@ -852,11 +821,7 @@ func writeCLIConfig(t *testing.T, mode string) string {
 		"[commands.shepherd]\n" +
 		"executor = \"default\"\n" +
 		"prompt_file = \"shepherd.md\"\n" +
-		"timeout = \"5s\"\n\n" +
-		"[shepherd.test]\n" +
-		"repository = \"test\"\n" +
-		"every = \"15m\"\n" +
-		"max_actions = 1\n"
+		"timeout = \"5s\"\n"
 	if err := os.WriteFile(definition, []byte(definitionBody), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,11 +68,10 @@ type Server struct {
 }
 
 type Config struct {
-	Server   Server                      `toml:"server"`
-	Commands map[string]Command          `toml:"commands"`
-	Shepherd map[string]ShepherdSchedule `toml:"shepherd"`
-	GitHub   GitHub                      `toml:"github"`
-	Triggers TriggerDefinitions          `toml:"triggers"`
+	Server   Server             `toml:"server"`
+	Commands map[string]Command `toml:"commands"`
+	GitHub   GitHub             `toml:"github"`
+	Triggers TriggerDefinitions `toml:"triggers"`
 	path     string
 }
 
@@ -135,21 +134,6 @@ type Command struct {
 	Executor   string `toml:"executor"`
 	PromptFile string `toml:"prompt_file"`
 	Timeout    string `toml:"timeout"`
-}
-
-type ShepherdSchedule struct {
-	Repository string `toml:"repository"`
-	Every      string `toml:"every"`
-	MaxActions int    `toml:"max_actions"`
-}
-
-type ResolvedShepherdSchedule struct {
-	Name       string
-	Repository string
-	Every      time.Duration
-	MaxActions int
-	Prompt     string
-	Command    ResolvedCommand
 }
 
 type ResolvedCommand struct {
@@ -231,6 +215,9 @@ func loadConfigFile(path string) (Config, error) {
 	}
 	if _, ok := raw["pipelines"]; ok {
 		return Config{}, fmt.Errorf("parse Machinist config %q: pipelines were removed; replace each pipeline with a repository-owned orchestration script configured under [commands]", absPath)
+	}
+	if _, ok := raw["shepherd"]; ok {
+		return Config{}, fmt.Errorf("parse Machinist config %q: shepherd schedules were removed; schedule the shepherd command with a [triggers.cron.NAME] or [triggers.interval.NAME] trigger", absPath)
 	}
 	if _, ok := raw["agents"]; ok {
 		return Config{}, fmt.Errorf("parse Machinist config %q: agents were renamed to commands; move [agents.NAME] definitions to [commands.NAME] and use --command", absPath)
@@ -366,61 +353,6 @@ func (c Config) ResolveCommand(name string) (ResolvedCommand, error) {
 }
 
 func LoadDefinitions(path string) (Config, error) { return loadConfigFile(path) }
-
-func LoadShepherdSchedules(path string) ([]ResolvedShepherdSchedule, error) {
-	definition, err := loadConfigFile(path)
-	if err != nil {
-		return nil, err
-	}
-	if len(definition.Shepherd) == 0 {
-		return nil, nil
-	}
-	command, ok := definition.Commands["shepherd"]
-	if !ok {
-		return nil, errors.New("shepherd schedules require a commands.shepherd definition")
-	}
-	resolvedCommand, err := resolveCommand(definition.path, "shepherd", command)
-	if err != nil {
-		return nil, err
-	}
-	seenRepositories := make(map[string]string)
-	result := make([]ResolvedShepherdSchedule, 0, len(definition.Shepherd))
-	for _, name := range sortedMapKeys(definition.Shepherd) {
-		schedule := definition.Shepherd[name]
-		repository := strings.TrimSpace(schedule.Repository)
-		if strings.TrimSpace(name) == "" || repository == "" {
-			return nil, errors.New("shepherd schedule names and repositories must be non-empty")
-		}
-		if previous, exists := seenRepositories[repository]; exists {
-			return nil, fmt.Errorf("shepherd schedules %q and %q target the same repository %q", previous, name, repository)
-		}
-		seenRepositories[repository] = name
-		every, err := time.ParseDuration(schedule.Every)
-		if err != nil {
-			return nil, fmt.Errorf("shepherd schedule %q every: %w", name, err)
-		}
-		if every < time.Minute {
-			return nil, fmt.Errorf("shepherd schedule %q every must be at least 1m", name)
-		}
-		if schedule.MaxActions <= 0 {
-			return nil, fmt.Errorf("shepherd schedule %q max_actions must be positive", name)
-		}
-		prompt := fmt.Sprintf("Run the scheduled Shepherd queue for repository %q with max_actions=%d. Perform at most %d mutating actions in this run.", repository, schedule.MaxActions, schedule.MaxActions)
-		rendered, err := RenderPrompt(resolvedCommand, prompt)
-		if err != nil {
-			return nil, fmt.Errorf("render shepherd schedule %q: %w", name, err)
-		}
-		result = append(result, ResolvedShepherdSchedule{
-			Name:       name,
-			Repository: repository,
-			Every:      every,
-			MaxActions: schedule.MaxActions,
-			Prompt:     prompt,
-			Command:    rendered,
-		})
-	}
-	return result, nil
-}
 
 func resolveCommand(definitionPath, name string, command Command) (ResolvedCommand, error) {
 	if strings.TrimSpace(command.Executor) == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -203,72 +203,6 @@ func TestLoadConfigValidatesOptionalConcurrentJobLimit(t *testing.T) {
 	}
 }
 
-func TestLoadShepherdSchedulesResolvesAgentAndLimits(t *testing.T) {
-	directory := t.TempDir()
-	writeTestFile(t, filepath.Join(directory, "shepherd.md"), "Policy:\n{{machinist.prompt}}\n")
-	path := filepath.Join(directory, "config.toml")
-	writeTestFile(t, path, `[commands.shepherd]
-executor = "test"
-prompt_file = "shepherd.md"
-timeout = "2h"
-
-[shepherd.api]
-repository = "api"
-every = "15m"
-max_actions = 4
-`)
-
-	schedules, err := LoadShepherdSchedules(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(schedules) != 1 {
-		t.Fatalf("schedules = %#v", schedules)
-	}
-	schedule := schedules[0]
-	if schedule.Name != "api" || schedule.Repository != "api" || schedule.Every != 15*time.Minute || schedule.MaxActions != 4 {
-		t.Fatalf("schedule = %#v", schedule)
-	}
-	if schedule.Command.Name != "shepherd" || schedule.Command.Timeout != 2*time.Hour || !strings.Contains(schedule.Command.Prompt, "max_actions=4") || !strings.Contains(schedule.Command.Prompt, "at most 4 mutating actions") {
-		t.Fatalf("scheduled agent = %#v", schedule.Command)
-	}
-}
-
-func TestLoadShepherdSchedulesRejectsUnsafeConfiguration(t *testing.T) {
-	for name, test := range map[string]struct {
-		body string
-		want string
-	}{
-		"missing agent": {
-			body: "[shepherd.api]\nrepository=\"api\"\nevery=\"15m\"\nmax_actions=1\n",
-			want: "commands.shepherd",
-		},
-		"short interval": {
-			body: "[commands.shepherd]\nexecutor=\"test\"\nprompt_file=\"shepherd.md\"\n[shepherd.api]\nrepository=\"api\"\nevery=\"30s\"\nmax_actions=1\n",
-			want: "at least 1m",
-		},
-		"zero actions": {
-			body: "[commands.shepherd]\nexecutor=\"test\"\nprompt_file=\"shepherd.md\"\n[shepherd.api]\nrepository=\"api\"\nevery=\"15m\"\nmax_actions=0\n",
-			want: "must be positive",
-		},
-		"duplicate repository": {
-			body: "[commands.shepherd]\nexecutor=\"test\"\nprompt_file=\"shepherd.md\"\n[shepherd.first]\nrepository=\"api\"\nevery=\"15m\"\nmax_actions=1\n[shepherd.second]\nrepository=\"api\"\nevery=\"30m\"\nmax_actions=2\n",
-			want: "same repository",
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			directory := t.TempDir()
-			writeTestFile(t, filepath.Join(directory, "shepherd.md"), "{{machinist.prompt}}\n")
-			path := filepath.Join(directory, "config.toml")
-			writeTestFile(t, path, test.body)
-			_, err := LoadShepherdSchedules(path)
-			if err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("error = %v, want %q", err, test.want)
-			}
-		})
-	}
-}
-
 func TestLoadCommandResolvesPromptAndHashesDefinition(t *testing.T) {
 	directory := t.TempDir()
 	writeTestFile(t, filepath.Join(directory, "plan.md"), "Inspect the repository for {{machinist.prompt}}.\n")
@@ -725,5 +659,16 @@ func writeTestFile(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestLoadConfigRejectsRemovedShepherdSchedules(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "config.toml")
+	writeTestFile(t, filepath.Join(directory, "shepherd.md"), "{{machinist.prompt}}\n")
+	writeTestFile(t, path, "[commands.shepherd]\nexecutor=\"test\"\nprompt_file=\"shepherd.md\"\n[shepherd.api]\nrepository=\"api\"\nevery=\"15m\"\nmax_actions=1\n")
+	_, err := LoadDefinitions(path)
+	if err == nil || !strings.Contains(err.Error(), "shepherd schedules were removed") {
+		t.Fatalf("error = %v, want removed shepherd schedule guidance", err)
 	}
 }

--- a/internal/config/triggers.go
+++ b/internal/config/triggers.go
@@ -294,9 +294,6 @@ func (c Config) resolveTriggerSelection(identity string, selection TriggerSelect
 	if err != nil {
 		return "", ResolvedCommand{}, fmt.Errorf("trigger %q: %w", identity, err)
 	}
-	if resolved.Name == "shepherd" {
-		return "", ResolvedCommand{}, fmt.Errorf("trigger %q cannot select Shepherd", identity)
-	}
 	if prompt != "" {
 		resolved, err = RenderPrompt(resolved, prompt)
 		if err != nil {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -37,7 +37,6 @@ var webAssets embed.FS
 type Server struct {
 	store             *Store
 	definitionPath    string
-	schedules         []config.ResolvedShepherdSchedule
 	triggers          []config.ResolvedTrigger
 	github            githubTriggerClient
 	schedulerEvery    time.Duration
@@ -89,10 +88,6 @@ func NewServer(store *Store, definitionPath, workerToken string, maxConcurrentJo
 	if err != nil {
 		return nil, err
 	}
-	schedules, err := config.LoadShepherdSchedules(definitionPath)
-	if err != nil {
-		return nil, err
-	}
 	managedTriggers, err := config.LoadTriggers(definitionPath)
 	if err != nil {
 		return nil, err
@@ -109,7 +104,7 @@ func NewServer(store *Store, definitionPath, workerToken string, maxConcurrentJo
 		return nil, fmt.Errorf("restore managed triggers: %w", err)
 	}
 	server := &Server{
-		store: store, definitionPath: definitionPath, schedules: schedules, triggers: managedTriggers,
+		store: store, definitionPath: definitionPath, triggers: managedTriggers,
 		github: NewGitHubCLI("gh", 30*time.Second), now: time.Now,
 		schedulerEvery: 30 * time.Second, shutdownTimeout: 5 * time.Second,
 		schedulerError:    func(err error) { log.Printf("scheduler: %v", err) },
@@ -211,9 +206,6 @@ func (s *Server) runScheduler(ctx context.Context) error {
 			}
 		}()
 	}
-	if len(s.schedules) > 0 {
-		loop(false, s.enqueueScheduledRuns)
-	}
 	for _, trigger := range s.triggers {
 		loop(false, func(ctx context.Context) error {
 			if err := s.processManagedTrigger(ctx, trigger); err != nil {
@@ -244,16 +236,6 @@ func (s *Server) maintainState(ctx context.Context) error {
 	_, reclaimErr := s.store.ReclaimExpiredLeases(ctx)
 	_, pruneErr := s.store.PruneSupersededWorkers(ctx, s.store.now().UTC().Add(-workerAvailabilityWindow))
 	return errors.Join(reclaimErr, pruneErr)
-}
-
-func (s *Server) enqueueScheduledRuns(ctx context.Context) error {
-	var failures []error
-	for _, schedule := range s.schedules {
-		if _, _, err := s.store.CreateScheduledJob(ctx, schedule); err != nil {
-			failures = append(failures, fmt.Errorf("queue shepherd schedule %q: %w", schedule.Name, err))
-		}
-	}
-	return errors.Join(failures...)
 }
 
 func (s *Server) reportSchedulerError(err error) {

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -394,48 +394,6 @@ func TestServerServeDoesNotReportListeningWhenAddressIsInUse(t *testing.T) {
 	}
 }
 
-func TestServerDoesNotAdmitShepherdScheduleWhenBindFails(t *testing.T) {
-	directory := t.TempDir()
-	if err := os.WriteFile(filepath.Join(directory, "shepherd.md"), []byte("Queue policy:\n{{machinist.prompt}}\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	definitionPath := filepath.Join(directory, "config.toml")
-	definition := `[commands.shepherd]
-executor = "test"
-prompt_file = "shepherd.md"
-timeout = "1m"
-
-[shepherd.machinist]
-repository = "machinist"
-every = "10m"
-max_actions = 2
-`
-	if err := os.WriteFile(definitionPath, []byte(definition), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	store := openTestStore(t, filepath.Join(directory, "machinist.db"))
-	server, err := NewServer(store, definitionPath, "secret", 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	occupied, err := new(net.ListenConfig).Listen(t.Context(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer occupied.Close()
-
-	if err := server.Serve(t.Context(), occupied.Addr().String(), nil); err == nil {
-		t.Fatal("Serve succeeded on an occupied address")
-	}
-	snapshot, err := store.Snapshot(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(snapshot.Jobs) != 0 {
-		t.Fatalf("failed server start admitted scheduled jobs: %#v", snapshot.Jobs)
-	}
-}
-
 func TestServerExposesReadOnlyDefinitions(t *testing.T) {
 	_, webServer := newTestHTTPServer(t)
 	defer webServer.Close()
@@ -719,49 +677,6 @@ func TestCompletionEndpointClassifiesClientAndPersistenceErrors(t *testing.T) {
 	}
 }
 
-func TestServerEnqueuesConfiguredShepherdSchedule(t *testing.T) {
-	directory := t.TempDir()
-	promptPath := filepath.Join(directory, "shepherd.md")
-	if err := os.WriteFile(promptPath, []byte("Queue policy:\n{{machinist.prompt}}\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	definitionPath := filepath.Join(directory, "config.toml")
-	definition := `[commands.shepherd]
-executor = "test"
-prompt_file = "shepherd.md"
-timeout = "1m"
-
-[shepherd.machinist]
-repository = "machinist"
-every = "10m"
-max_actions = 2
-`
-	if err := os.WriteFile(definitionPath, []byte(definition), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	store := openTestStore(t, filepath.Join(directory, "machinist.db"))
-	server, err := NewServer(store, definitionPath, "secret", 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := server.enqueueScheduledRuns(t.Context()); err != nil {
-		t.Fatal(err)
-	}
-	if err := server.enqueueScheduledRuns(t.Context()); err != nil {
-		t.Fatal(err)
-	}
-	snapshot, err := store.Snapshot(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(snapshot.Jobs) != 1 || snapshot.Jobs[0].ScheduleName != "machinist" || snapshot.Jobs[0].Prompt == "" {
-		t.Fatalf("scheduled jobs = %#v", snapshot.Jobs)
-	}
-	if len(snapshot.Jobs[0].Runs) != 1 || !strings.Contains(snapshot.Jobs[0].Runs[0].Command, "shepherd") {
-		t.Fatalf("scheduled runs = %#v", snapshot.Jobs[0].Runs)
-	}
-}
-
 func TestServerCancellationAlwaysStopsHTTPServer(t *testing.T) {
 	for range 32 {
 		directory := t.TempDir()
@@ -854,94 +769,6 @@ func TestServerForcesCloseWhenGracefulShutdownTimesOut(t *testing.T) {
 	case <-requestDone:
 	case <-time.After(time.Second):
 		t.Fatal("stalled request did not finish after forced close")
-	}
-}
-
-func TestScheduledAdmissionFailureDoesNotStopServer(t *testing.T) {
-	directory := t.TempDir()
-	promptPath := filepath.Join(directory, "shepherd.md")
-	if err := os.WriteFile(promptPath, []byte("Queue policy:\n{{machinist.prompt}}\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	definitionPath := filepath.Join(directory, "config.toml")
-	definition := `[commands.shepherd]
-executor = "test"
-prompt_file = "shepherd.md"
-timeout = "1m"
-
-[shepherd.machinist]
-repository = "machinist"
-every = "10m"
-max_actions = 2
-
-[shepherd.other]
-repository = "other"
-every = "10m"
-max_actions = 2
-`
-	if err := os.WriteFile(definitionPath, []byte(definition), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	store := openTestStore(t, filepath.Join(directory, "machinist.db"))
-	server, err := NewServer(store, definitionPath, "secret", 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	server.schedulerEvery = time.Millisecond
-	schedulerErrors := make(chan error, 16)
-	server.schedulerError = func(err error) {
-		select {
-		case schedulerErrors <- err:
-		default:
-		}
-	}
-	probe, err := new(net.ListenConfig).Listen(t.Context(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	address := probe.Addr().String()
-	if err := probe.Close(); err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithCancel(t.Context())
-	serveDone := make(chan error, 1)
-	go func() { serveDone <- server.Serve(ctx, address, nil) }()
-	waitForServer(t, address)
-	if err := store.Close(); err != nil {
-		t.Fatal(err)
-	}
-	deadline := time.After(time.Second)
-
-waitForSchedulerFailure:
-	for {
-		select {
-		case err := <-schedulerErrors:
-			if strings.Contains(err.Error(), "queue shepherd schedule") {
-				break waitForSchedulerFailure
-			}
-		case <-deadline:
-			t.Fatal("scheduler admission failure was not reported")
-		}
-	}
-	allFailures := server.enqueueScheduledRuns(t.Context())
-	if allFailures == nil || !strings.Contains(allFailures.Error(), `schedule "machinist"`) || !strings.Contains(allFailures.Error(), `schedule "other"`) {
-		t.Fatalf("scheduler did not continue after the first admission failure: %v", allFailures)
-	}
-	dialCtx, cancelDial := context.WithTimeout(t.Context(), 100*time.Millisecond)
-	connection, err := new(net.Dialer).DialContext(dialCtx, "tcp", address)
-	cancelDial()
-	if err != nil {
-		t.Fatalf("HTTP server stopped after scheduled admission failure: %v", err)
-	}
-	connection.Close()
-	cancel()
-	select {
-	case err := <-serveDone:
-		if err != nil {
-			t.Fatalf("Serve returned %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Serve did not return after cancellation")
 	}
 }
 

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -46,7 +46,6 @@ type Job struct {
 	Repository       string    `json:"repository"`
 	GitHubIssueTitle string    `json:"github_issue_title,omitempty"`
 	Command          string    `json:"command"`
-	ScheduleName     string    `json:"schedule_name,omitempty"`
 	TriggerID        string    `json:"trigger_id,omitempty"`
 	OccurrenceKey    string    `json:"occurrence_key,omitempty"`
 	TriggerSubject   string    `json:"trigger_subject,omitempty"`
@@ -173,7 +172,7 @@ func OpenStore(path string) (*Store, error) {
 func (s *Store) Close() error { return s.db.Close() }
 
 func (s *Store) initialize(ctx context.Context) error {
-	const schemaVersion = 1
+	const schemaVersion = 2
 	var version int
 	if err := s.db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&version); err != nil {
 		return fmt.Errorf("read database schema version: %w", err)
@@ -181,7 +180,7 @@ func (s *Store) initialize(ctx context.Context) error {
 	if version > schemaVersion {
 		return fmt.Errorf("database schema version %d is newer than supported version %d", version, schemaVersion)
 	}
-	if version < schemaVersion {
+	if version < 1 {
 		if _, err := s.db.ExecContext(ctx, `PRAGMA foreign_keys=OFF;
 DROP TABLE IF EXISTS github_trigger_requests; DROP TABLE IF EXISTS trigger_state; DROP TABLE IF EXISTS schedule_state;
 DROP TABLE IF EXISTS known_repositories; DROP TABLE IF EXISTS worker_repositories; DROP TABLE IF EXISTS workers;
@@ -189,11 +188,18 @@ DROP TABLE IF EXISTS runs; DROP TABLE IF EXISTS jobs; PRAGMA foreign_keys=ON;`);
 			return fmt.Errorf("replace legacy database schema: %w", err)
 		}
 	}
+	if version == 1 {
+		// Version 2 removed Shepherd schedules. Jobs keep their rows; only the
+		// schedule bookkeeping goes away.
+		if _, err := s.db.ExecContext(ctx, `DROP INDEX IF EXISTS jobs_active_shepherd_repository; DROP TABLE IF EXISTS schedule_state;
+ALTER TABLE jobs DROP COLUMN has_shepherd; ALTER TABLE jobs DROP COLUMN schedule_name;`); err != nil {
+			return fmt.Errorf("upgrade database schema to version 2: %w", err)
+		}
+	}
 	const schema = `
 PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;
 CREATE TABLE IF NOT EXISTS jobs (
  id TEXT PRIMARY KEY, prompt TEXT NOT NULL, repository TEXT NOT NULL, command TEXT NOT NULL,
- schedule_name TEXT NOT NULL DEFAULT '', has_shepherd INTEGER NOT NULL DEFAULT 0,
  trigger_identity TEXT NOT NULL DEFAULT '', trigger_config_signature TEXT NOT NULL DEFAULT '',
  trigger_generation_id TEXT NOT NULL DEFAULT '', occurrence_key TEXT NOT NULL DEFAULT '',
  trigger_subject TEXT NOT NULL DEFAULT '', github_issue_title TEXT NOT NULL DEFAULT '',
@@ -208,15 +214,13 @@ CREATE INDEX IF NOT EXISTS runs_dispatch ON runs(state, job_id);
 CREATE TABLE IF NOT EXISTS workers (instance_id TEXT PRIMARY KEY, name TEXT NOT NULL, last_seen_at TEXT NOT NULL);
 CREATE TABLE IF NOT EXISTS worker_repositories (worker_instance TEXT NOT NULL REFERENCES workers(instance_id) ON DELETE CASCADE, repository TEXT NOT NULL, PRIMARY KEY(worker_instance,repository));
 CREATE TABLE IF NOT EXISTS known_repositories (repository TEXT PRIMARY KEY);
-CREATE TABLE IF NOT EXISTS schedule_state (name TEXT PRIMARY KEY,next_run_at TEXT NOT NULL,repository TEXT NOT NULL DEFAULT '',every_ms INTEGER NOT NULL DEFAULT 0,execution_signature TEXT NOT NULL DEFAULT '');
 CREATE TABLE IF NOT EXISTS trigger_state (identity TEXT PRIMARY KEY,family TEXT NOT NULL,config_signature TEXT NOT NULL,generation_id TEXT NOT NULL,next_due_at TEXT,pending_occurrence_at TEXT,last_attempt_at TEXT,last_success_at TEXT,last_job_state TEXT NOT NULL DEFAULT '',last_job_error TEXT NOT NULL DEFAULT '',health TEXT NOT NULL DEFAULT 'healthy',latest_error TEXT NOT NULL DEFAULT '',candidate_count INTEGER NOT NULL DEFAULT 0,admission_count INTEGER NOT NULL DEFAULT 0,coalesced_count INTEGER NOT NULL DEFAULT 0,updated_at TEXT NOT NULL);
 CREATE TABLE IF NOT EXISTS github_trigger_requests (trigger_identity TEXT NOT NULL,occurrence_key TEXT NOT NULL,config_generation TEXT NOT NULL,repository TEXT NOT NULL,issue_number INTEGER NOT NULL,subject TEXT NOT NULL,actor TEXT NOT NULL,request_label TEXT NOT NULL,requested_at TEXT NOT NULL,state TEXT NOT NULL CHECK(state IN ('pending','admitted','rejected')),job_id TEXT,needs_reconciliation INTEGER NOT NULL DEFAULT 1,updated_at TEXT NOT NULL,PRIMARY KEY(trigger_identity,occurrence_key));
-CREATE UNIQUE INDEX IF NOT EXISTS jobs_active_shepherd_repository ON jobs(repository) WHERE has_shepherd=1 AND state IN ('queued','running');
 CREATE UNIQUE INDEX IF NOT EXISTS jobs_trigger_occurrence ON jobs(trigger_identity,occurrence_key) WHERE trigger_identity<>'' AND occurrence_key<>'';
 CREATE UNIQUE INDEX IF NOT EXISTS jobs_active_fixed_trigger ON jobs(trigger_identity) WHERE fixed_trigger=1 AND state IN ('queued','running');
 CREATE UNIQUE INDEX IF NOT EXISTS jobs_active_trigger_subject ON jobs(trigger_subject) WHERE trigger_subject<>'' AND state IN ('queued','running');
 CREATE INDEX IF NOT EXISTS github_trigger_requests_reconciliation ON github_trigger_requests(trigger_identity,needs_reconciliation,requested_at);
-PRAGMA user_version=1;`
+PRAGMA user_version=2;`
 	if _, err := s.db.ExecContext(ctx, schema); err != nil {
 		return fmt.Errorf("initialize database: %w", err)
 	}
@@ -237,7 +241,7 @@ func (s *Store) CreateJob(ctx context.Context, prompt, repository, name string, 
 		return "", err
 	}
 	defer tx.Rollback()
-	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id,prompt,repository,command,has_shepherd,state,created_at,updated_at) VALUES(?,?,?,?,?,'queued',?,?)`, jobID, prompt, repository, name, command.Name == "shepherd", now, now); err != nil {
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id,prompt,repository,command,state,created_at,updated_at) VALUES(?,?,?,?,'queued',?,?)`, jobID, prompt, repository, name, now, now); err != nil {
 		return "", fmt.Errorf("insert job: %w", err)
 	}
 	runID, err := randomID("run", 12)
@@ -437,7 +441,7 @@ WHERE github_trigger_requests.state='pending'`, admission.Identity, admission.Oc
 		return "", false, err
 	}
 	now := s.now().UTC().Format(time.RFC3339Nano)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id,prompt,repository,command,has_shepherd,trigger_identity,trigger_config_signature,trigger_generation_id,occurrence_key,trigger_subject,github_issue_title,fixed_trigger,state,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,'queued',?,?)`, jobID, admission.Prompt, admission.Repository, admission.SelectionName, admission.Command.Name == "shepherd", admission.Identity, admission.ConfigSignature, admission.ConfigGeneration, admission.OccurrenceKey, admission.Subject, admission.GitHubIssueTitle, fixed, now, now); err != nil {
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id,prompt,repository,command,trigger_identity,trigger_config_signature,trigger_generation_id,occurrence_key,trigger_subject,github_issue_title,fixed_trigger,state,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,'queued',?,?)`, jobID, admission.Prompt, admission.Repository, admission.SelectionName, admission.Identity, admission.ConfigSignature, admission.ConfigGeneration, admission.OccurrenceKey, admission.Subject, admission.GitHubIssueTitle, fixed, now, now); err != nil {
 		return "", false, fmt.Errorf("insert triggered job: %w", err)
 	}
 	if admission.Family == "github" {
@@ -651,81 +655,6 @@ func (s *Store) AddTriggerCoalesced(ctx context.Context, identity, configGenerat
 		return fmt.Errorf("%w: %s", ErrTriggerStale, identity)
 	}
 	return nil
-}
-
-// CreateScheduledJob queues one due Shepherd run. It persists the next due time and uses
-// a partial unique index so separate server processes and manual submissions cannot
-// overlap Shepherd runs for a repository.
-func (s *Store) CreateScheduledJob(ctx context.Context, schedule config.ResolvedShepherdSchedule) (string, bool, error) {
-	nowTime := s.now().UTC()
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return "", false, err
-	}
-	defer tx.Rollback()
-	signature, err := shepherdScheduleSignature(schedule)
-	if err != nil {
-		return "", false, err
-	}
-	var nextRun, repository, executionSignature string
-	var everyMillis int64
-	err = tx.QueryRowContext(ctx, `SELECT next_run_at,repository,every_ms,execution_signature FROM schedule_state WHERE name=?`, schedule.Name).Scan(&nextRun, &repository, &everyMillis, &executionSignature)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "", false, fmt.Errorf("read shepherd schedule %q: %w", schedule.Name, err)
-	}
-	if err == nil {
-		next, parseErr := time.Parse(time.RFC3339Nano, nextRun)
-		if parseErr != nil {
-			return "", false, fmt.Errorf("parse shepherd schedule %q next run: %w", schedule.Name, parseErr)
-		}
-		unchanged := repository == schedule.Repository && everyMillis == schedule.Every.Milliseconds() && executionSignature == signature
-		if unchanged && next.After(nowTime) {
-			return "", false, tx.Commit()
-		}
-	}
-	jobID, err := randomID("job", 12)
-	if err != nil {
-		return "", false, err
-	}
-	runID, err := randomID("run", 12)
-	if err != nil {
-		return "", false, err
-	}
-	now := nowTime.Format(time.RFC3339Nano)
-	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO jobs(id,prompt,repository,command,schedule_name,has_shepherd,state,created_at,updated_at) VALUES(?,?,?,'shepherd',?,1,'queued',?,?)`, jobID, schedule.Prompt, schedule.Repository, schedule.Name, now, now)
-	if err != nil {
-		return "", false, fmt.Errorf("insert scheduled job: %w", err)
-	}
-	changed, err := result.RowsAffected()
-	if err != nil {
-		return "", false, err
-	}
-	if changed == 0 {
-		return "", false, tx.Commit()
-	}
-	command := schedule.Command
-	if _, err := tx.ExecContext(ctx, `INSERT INTO runs(id,job_id,command,command_hash,executor,model,repository,rendered_prompt,timeout_ms,state) VALUES(?,?,?,?,?,?,?,?,?,?)`, runID, jobID, command.Name, command.Hash, command.Executor, command.Model, schedule.Repository, command.Prompt, command.Timeout.Milliseconds(), "queued"); err != nil {
-		return "", false, fmt.Errorf("insert scheduled run: %w", err)
-	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO schedule_state(name,next_run_at,repository,every_ms,execution_signature) VALUES(?,?,?,?,?) ON CONFLICT(name) DO UPDATE SET next_run_at=excluded.next_run_at,repository=excluded.repository,every_ms=excluded.every_ms,execution_signature=excluded.execution_signature`, schedule.Name, nowTime.Add(schedule.Every).Format(time.RFC3339Nano), schedule.Repository, schedule.Every.Milliseconds(), signature); err != nil {
-		return "", false, fmt.Errorf("advance shepherd schedule %q: %w", schedule.Name, err)
-	}
-	if err := tx.Commit(); err != nil {
-		return "", false, err
-	}
-	return jobID, true, nil
-}
-
-func shepherdScheduleSignature(schedule config.ResolvedShepherdSchedule) (string, error) {
-	body, err := json.Marshal(struct {
-		MaxActions int                    `json:"max_actions"`
-		Prompt     string                 `json:"prompt"`
-		Command    config.ResolvedCommand `json:"command"`
-	}{schedule.MaxActions, schedule.Prompt, schedule.Command})
-	if err != nil {
-		return "", fmt.Errorf("encode shepherd schedule %q execution settings: %w", schedule.Name, err)
-	}
-	return string(body), nil
 }
 
 func (s *Store) Poll(ctx context.Context, request protocol.PollRequest) (*protocol.RunSpec, error) {
@@ -1077,7 +1006,7 @@ func (s *Store) RunOutput(ctx context.Context, runID string) (RunOutput, error) 
 }
 
 func (s *Store) listJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT j.id,j.prompt,j.repository,j.github_issue_title,j.command,j.schedule_name,j.trigger_identity,j.occurrence_key,j.trigger_subject,j.state,j.created_at,j.updated_at,
+	rows, err := s.db.QueryContext(ctx, `SELECT j.id,j.prompt,j.repository,j.github_issue_title,j.command,j.trigger_identity,j.occurrence_key,j.trigger_subject,j.state,j.created_at,j.updated_at,
 COALESCE(r.id,''),COALESCE(r.command,''),COALESCE(r.executor,''),COALESCE(r.model,''),COALESCE(r.state,''),COALESCE(NULLIF(r.worker_name,''),w.name,''),r.exit_code,COALESCE(r.error,''),COALESCE(r.started_at,''),COALESCE(r.completed_at,''),r.duration_millis,r.token_usage
 FROM jobs j LEFT JOIN runs r ON r.job_id=j.id LEFT JOIN workers w ON w.instance_id=r.worker_instance ORDER BY j.created_at DESC`)
 	if err != nil {
@@ -1089,7 +1018,7 @@ FROM jobs j LEFT JOIN runs r ON r.job_id=j.id LEFT JOIN workers w ON w.instance_
 		job := Job{Runs: []Run{}}
 		var run Run
 		var created, updated, started, completed string
-		if err := rows.Scan(&job.ID, &job.Prompt, &job.Repository, &job.GitHubIssueTitle, &job.Command, &job.ScheduleName, &job.TriggerID, &job.OccurrenceKey, &job.TriggerSubject, &job.State, &created, &updated,
+		if err := rows.Scan(&job.ID, &job.Prompt, &job.Repository, &job.GitHubIssueTitle, &job.Command, &job.TriggerID, &job.OccurrenceKey, &job.TriggerSubject, &job.State, &created, &updated,
 			&run.ID, &run.Command, &run.Executor, &run.Model, &run.State, &run.WorkerName, &run.ExitCode, &run.Error, &started, &completed, &run.DurationMillis, &run.TokenUsage); err != nil {
 			return nil, err
 		}

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -189,10 +189,7 @@ DROP TABLE IF EXISTS runs; DROP TABLE IF EXISTS jobs; PRAGMA foreign_keys=ON;`);
 		}
 	}
 	if version == 1 {
-		// Version 2 removed Shepherd schedules. Jobs keep their rows; only the
-		// schedule bookkeeping goes away.
-		if _, err := s.db.ExecContext(ctx, `DROP INDEX IF EXISTS jobs_active_shepherd_repository; DROP TABLE IF EXISTS schedule_state;
-ALTER TABLE jobs DROP COLUMN has_shepherd; ALTER TABLE jobs DROP COLUMN schedule_name;`); err != nil {
+		if err := s.upgradeToVersionTwo(ctx); err != nil {
 			return fmt.Errorf("upgrade database schema to version 2: %w", err)
 		}
 	}
@@ -225,6 +222,36 @@ PRAGMA user_version=2;`
 		return fmt.Errorf("initialize database: %w", err)
 	}
 	return nil
+}
+
+// upgradeToVersionTwo removes the Shepherd schedule bookkeeping. Jobs keep their
+// rows. The steps run in one transaction and skip columns that are already gone,
+// so an interrupted upgrade completes on the next start.
+func (s *Store) upgradeToVersionTwo(ctx context.Context) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `DROP INDEX IF EXISTS jobs_active_shepherd_repository; DROP TABLE IF EXISTS schedule_state;`); err != nil {
+		return err
+	}
+	for _, column := range []string{"has_shepherd", "schedule_name"} {
+		var present int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('jobs') WHERE name=?`, column).Scan(&present); err != nil {
+			return err
+		}
+		if present == 0 {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `ALTER TABLE jobs DROP COLUMN `+column); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `PRAGMA user_version=2`); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 func (s *Store) CreateJob(ctx context.Context, prompt, repository, name string, command config.ResolvedCommand) (string, error) {

--- a/internal/controlplane/store.go
+++ b/internal/controlplane/store.go
@@ -224,9 +224,11 @@ PRAGMA user_version=2;`
 	return nil
 }
 
-// upgradeToVersionTwo removes the Shepherd schedule bookkeeping. Jobs keep their
-// rows. The steps run in one transaction and skip columns that are already gone,
-// so an interrupted upgrade completes on the next start.
+// upgradeToVersionTwo removes the Shepherd schedule bookkeeping. Finished jobs
+// keep their rows. Queued schedule jobs are failed so they cannot overlap a
+// replacement trigger, and a running one blocks the upgrade until it finishes.
+// The steps run in one transaction and skip columns that are already gone, so
+// an interrupted upgrade completes on the next start.
 func (s *Store) upgradeToVersionTwo(ctx context.Context) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -236,13 +238,18 @@ func (s *Store) upgradeToVersionTwo(ctx context.Context) error {
 	if _, err := tx.ExecContext(ctx, `DROP INDEX IF EXISTS jobs_active_shepherd_repository; DROP TABLE IF EXISTS schedule_state;`); err != nil {
 		return err
 	}
-	for _, column := range []string{"has_shepherd", "schedule_name"} {
+	for _, column := range []string{"schedule_name", "has_shepherd"} {
 		var present int
 		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('jobs') WHERE name=?`, column).Scan(&present); err != nil {
 			return err
 		}
 		if present == 0 {
 			continue
+		}
+		if column == "schedule_name" {
+			if err := s.drainScheduledJobs(ctx, tx); err != nil {
+				return err
+			}
 		}
 		if _, err := tx.ExecContext(ctx, `ALTER TABLE jobs DROP COLUMN `+column); err != nil {
 			return err
@@ -252,6 +259,23 @@ func (s *Store) upgradeToVersionTwo(ctx context.Context) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+func (s *Store) drainScheduledJobs(ctx context.Context, tx *sql.Tx) error {
+	var running int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs WHERE schedule_name<>'' AND state='running'`).Scan(&running); err != nil {
+		return err
+	}
+	if running > 0 {
+		return fmt.Errorf("%d scheduled Shepherd jobs are still running; let them finish and start again", running)
+	}
+	now := s.now().UTC().Format(time.RFC3339Nano)
+	const reason = "cancelled by schema upgrade: shepherd schedules were removed"
+	if _, err := tx.ExecContext(ctx, `UPDATE runs SET state='failed',exit_code=1,error=?,completed_at=? WHERE state='queued' AND job_id IN (SELECT id FROM jobs WHERE schedule_name<>'' AND state='queued')`, reason, now); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `UPDATE jobs SET state='failed',updated_at=? WHERE schedule_name<>'' AND state='queued'`, now)
+	return err
 }
 
 func (s *Store) CreateJob(ctx context.Context, prompt, repository, name string, command config.ResolvedCommand) (string, error) {

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -1084,6 +1084,15 @@ func assertReclaimedRun(t *testing.T, store *Store, runID, jobID string) {
 }
 
 func TestOpenStoreUpgradesVersionOneSchema(t *testing.T) {
+	for name, partial := range map[string]string{
+		"complete version one": "",
+		"interrupted upgrade":  "DROP INDEX jobs_active_shepherd_repository; ALTER TABLE jobs DROP COLUMN has_shepherd;",
+	} {
+		t.Run(name, func(t *testing.T) { testVersionOneUpgrade(t, partial) })
+	}
+}
+
+func testVersionOneUpgrade(t *testing.T, partial string) {
 	path := filepath.Join(t.TempDir(), "machinist.db")
 	legacy, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -1098,7 +1107,7 @@ func TestOpenStoreUpgradesVersionOneSchema(t *testing.T) {
 CREATE UNIQUE INDEX jobs_active_shepherd_repository ON jobs(repository) WHERE has_shepherd=1 AND state IN ('queued','running');
 CREATE TABLE schedule_state (name TEXT PRIMARY KEY, next_run_at TEXT NOT NULL);
 INSERT INTO jobs(id,prompt,repository,command,schedule_name,has_shepherd,state,created_at,updated_at) VALUES('job_1','p','api','shepherd','api',1,'succeeded','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z');
-PRAGMA user_version=1;`); err != nil {
+PRAGMA user_version=1;` + partial); err != nil {
 		t.Fatal(err)
 	}
 	if err := legacy.Close(); err != nil {

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -1092,27 +1092,48 @@ func TestOpenStoreUpgradesVersionOneSchema(t *testing.T) {
 	}
 }
 
-func testVersionOneUpgrade(t *testing.T, partial string) {
-	path := filepath.Join(t.TempDir(), "machinist.db")
+func TestOpenStoreUpgradeDrainsScheduledShepherdJobs(t *testing.T) {
+	path := openVersionOneDatabase(t, `INSERT INTO jobs(id,prompt,repository,command,schedule_name,has_shepherd,state,created_at,updated_at) VALUES('job_queued','p','api','shepherd','api',1,'queued','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z');
+INSERT INTO runs(id,job_id,command,command_hash,executor,repository,rendered_prompt,timeout_ms,state) VALUES('run_queued','job_queued','shepherd','h','codex','api','p',1000,'queued');`)
+	store, err := OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	snapshot, err := store.Snapshot(t.Context())
+	if err != nil || len(snapshot.Jobs) != 1 || snapshot.Jobs[0].State != "failed" || len(snapshot.Jobs[0].Runs) != 1 || snapshot.Jobs[0].Runs[0].State != "failed" {
+		t.Fatalf("snapshot = %#v, %v", snapshot, err)
+	}
+	if !strings.Contains(snapshot.Jobs[0].Runs[0].Error, "shepherd schedules were removed") {
+		t.Fatalf("run error = %q", snapshot.Jobs[0].Runs[0].Error)
+	}
+}
+
+func TestOpenStoreUpgradeWaitsForRunningScheduledShepherdJob(t *testing.T) {
+	path := openVersionOneDatabase(t, `INSERT INTO jobs(id,prompt,repository,command,schedule_name,has_shepherd,state,created_at,updated_at) VALUES('job_running','p','api','shepherd','api',1,'running','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z');`)
+	store, err := OpenStore(path)
+	if store != nil {
+		store.Close()
+	}
+	if err == nil || !strings.Contains(err.Error(), "still running") {
+		t.Fatalf("open error = %v, want running job refusal", err)
+	}
 	legacy, err := sql.Open("sqlite", path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := legacy.Exec(`CREATE TABLE jobs (id TEXT PRIMARY KEY, prompt TEXT NOT NULL, repository TEXT NOT NULL, command TEXT NOT NULL,
- schedule_name TEXT NOT NULL DEFAULT '', has_shepherd INTEGER NOT NULL DEFAULT 0,
- trigger_identity TEXT NOT NULL DEFAULT '', trigger_config_signature TEXT NOT NULL DEFAULT '',
- trigger_generation_id TEXT NOT NULL DEFAULT '', occurrence_key TEXT NOT NULL DEFAULT '',
- trigger_subject TEXT NOT NULL DEFAULT '', github_issue_title TEXT NOT NULL DEFAULT '',
- fixed_trigger INTEGER NOT NULL DEFAULT 0, state TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
-CREATE UNIQUE INDEX jobs_active_shepherd_repository ON jobs(repository) WHERE has_shepherd=1 AND state IN ('queued','running');
-CREATE TABLE schedule_state (name TEXT PRIMARY KEY, next_run_at TEXT NOT NULL);
-INSERT INTO jobs(id,prompt,repository,command,schedule_name,has_shepherd,state,created_at,updated_at) VALUES('job_1','p','api','shepherd','api',1,'succeeded','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z');
-PRAGMA user_version=1;` + partial); err != nil {
-		t.Fatal(err)
+	defer legacy.Close()
+	var version, columns int
+	if err := legacy.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil || version != 1 {
+		t.Fatalf("schema version = %d, %v, want untouched version 1", version, err)
 	}
-	if err := legacy.Close(); err != nil {
-		t.Fatal(err)
+	if err := legacy.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('jobs') WHERE name IN ('has_shepherd','schedule_name')`).Scan(&columns); err != nil || columns != 2 {
+		t.Fatalf("legacy columns = %d, %v, want both retained", columns, err)
 	}
+}
+
+func testVersionOneUpgrade(t *testing.T, partial string) {
+	path := openVersionOneDatabase(t, `INSERT INTO jobs(id,prompt,repository,command,schedule_name,has_shepherd,state,created_at,updated_at) VALUES('job_1','p','api','shepherd','api',1,'succeeded','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z');`+partial)
 	store, err := OpenStore(path)
 	if err != nil {
 		t.Fatal(err)
@@ -1130,4 +1151,36 @@ PRAGMA user_version=1;` + partial); err != nil {
 	if err != nil || len(snapshot.Jobs) != 1 || snapshot.Jobs[0].ID != "job_1" {
 		t.Fatalf("snapshot = %#v, %v", snapshot, err)
 	}
+}
+
+// openVersionOneDatabase creates a schema version 1 database and runs extra
+// statements against it before returning its path.
+func openVersionOneDatabase(t *testing.T, extra string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "machinist.db")
+	legacy, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.Exec(`CREATE TABLE jobs (id TEXT PRIMARY KEY, prompt TEXT NOT NULL, repository TEXT NOT NULL, command TEXT NOT NULL,
+ schedule_name TEXT NOT NULL DEFAULT '', has_shepherd INTEGER NOT NULL DEFAULT 0,
+ trigger_identity TEXT NOT NULL DEFAULT '', trigger_config_signature TEXT NOT NULL DEFAULT '',
+ trigger_generation_id TEXT NOT NULL DEFAULT '', occurrence_key TEXT NOT NULL DEFAULT '',
+ trigger_subject TEXT NOT NULL DEFAULT '', github_issue_title TEXT NOT NULL DEFAULT '',
+ fixed_trigger INTEGER NOT NULL DEFAULT 0, state TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+CREATE TABLE runs (
+ id TEXT PRIMARY KEY, job_id TEXT NOT NULL UNIQUE REFERENCES jobs(id), command TEXT NOT NULL, command_hash TEXT NOT NULL,
+ executor TEXT NOT NULL, model TEXT NOT NULL DEFAULT '', repository TEXT NOT NULL, rendered_prompt TEXT NOT NULL,
+ timeout_ms INTEGER NOT NULL, state TEXT NOT NULL, worker_instance TEXT, worker_name TEXT NOT NULL DEFAULT '',
+ lease_token TEXT, lease_expires_at INTEGER, exit_code INTEGER, error TEXT, result TEXT, events TEXT,
+ started_at TEXT, completed_at TEXT, duration_millis INTEGER, token_usage INTEGER);
+CREATE UNIQUE INDEX jobs_active_shepherd_repository ON jobs(repository) WHERE has_shepherd=1 AND state IN ('queued','running');
+CREATE TABLE schedule_state (name TEXT PRIMARY KEY, next_run_at TEXT NOT NULL);
+PRAGMA user_version=1;` + extra); err != nil {
+		t.Fatal(err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/internal/controlplane/store_test.go
+++ b/internal/controlplane/store_test.go
@@ -72,7 +72,7 @@ func TestOpenStoreReplacesLegacySchema(t *testing.T) {
 	if err := store.db.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
 		t.Fatal(err)
 	}
-	if count != 0 || version != 1 {
+	if count != 0 || version != 2 {
 		t.Fatalf("migrated database count=%d version=%d", count, version)
 	}
 }
@@ -83,7 +83,7 @@ func TestOpenStoreRejectsNewerSchemaWithoutDeletingIt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`CREATE TABLE future_data(value TEXT); INSERT INTO future_data VALUES('preserved'); PRAGMA user_version=2;`); err != nil {
+	if _, err := db.Exec(`CREATE TABLE future_data(value TEXT); INSERT INTO future_data VALUES('preserved'); PRAGMA user_version=3;`); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Close(); err != nil {
@@ -591,203 +591,6 @@ func TestAvailableRepositoriesIncludesWorkerWithRunningExecution(t *testing.T) {
 	}
 }
 
-func TestStoreSchedulesOneNonOverlappingShepherdRunPerRepository(t *testing.T) {
-	store := openTestStore(t, filepath.Join(t.TempDir(), "machinist.db"))
-	clock := newTestClock(time.Date(2026, 8, 27, 8, 0, 0, 0, time.UTC))
-	store.now = clock.Now
-	schedule := config.ResolvedShepherdSchedule{
-		Name: "api", Repository: "api", Every: 15 * time.Minute, MaxActions: 3,
-		Command: testAgent("shepherd", "Inspect every pull request; at most 3 actions."),
-	}
-
-	jobID, created, err := store.CreateScheduledJob(t.Context(), schedule)
-	if err != nil || !created || jobID == "" {
-		t.Fatalf("first schedule = %q, %t, %v", jobID, created, err)
-	}
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedule); err != nil || created {
-		t.Fatalf("duplicate schedule created = %t, %v", created, err)
-	}
-	if _, err := store.CreateJob(t.Context(), "manual", "api", "shepherd", schedule.Command); err == nil {
-		t.Fatal("manual Shepherd overlapped the scheduled run")
-	}
-	other := schedule
-	other.Name = "api-second"
-	if _, created, err := store.CreateScheduledJob(t.Context(), other); err != nil || created {
-		t.Fatalf("overlapping repository schedule created = %t, %v", created, err)
-	}
-
-	run, err := store.Poll(t.Context(), pollRequest("worker-a", []string{"codex"}, []string{"api"}))
-	if err != nil || run == nil || run.Command != "shepherd" || run.RenderedPrompt != schedule.Command.Prompt {
-		t.Fatalf("scheduled lease = %#v, %v", run, err)
-	}
-	if err := store.Complete(t.Context(), run.ID, protocol.Completion{InstanceID: "worker-a", LeaseToken: run.LeaseToken, State: "succeeded", ExitCode: 0}); err != nil {
-		t.Fatal(err)
-	}
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedule); err != nil || created {
-		t.Fatalf("schedule repeated before due = %t, %v", created, err)
-	}
-
-	clock.Advance(15 * time.Minute)
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedule); err != nil || !created {
-		t.Fatalf("due schedule created = %t, %v", created, err)
-	}
-	snapshot, err := store.Snapshot(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(snapshot.Jobs) != 2 || snapshot.Jobs[0].ScheduleName != "api" || snapshot.Jobs[1].ScheduleName != "api" {
-		t.Fatalf("scheduled jobs = %#v", snapshot.Jobs)
-	}
-}
-
-func TestStoreReschedulesWhenScheduleConfigurationChanges(t *testing.T) {
-	database := filepath.Join(t.TempDir(), "machinist.db")
-	store, err := OpenStore(database)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = store.Close() })
-	clock := newTestClock(time.Date(2026, 8, 27, 8, 0, 0, 0, time.UTC))
-	store.now = clock.Now
-	schedule := config.ResolvedShepherdSchedule{
-		Name: "queue", Repository: "api", Every: time.Hour, MaxActions: 1,
-		Command: testAgent("shepherd", "Inspect every pull request"),
-	}
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedule); err != nil || !created {
-		t.Fatalf("initial schedule created = %t, %v", created, err)
-	}
-	run, err := store.Poll(t.Context(), pollRequest("worker-a", []string{"codex"}, []string{"api"}))
-	if err != nil || run == nil {
-		t.Fatalf("lease initial schedule = %#v, %v", run, err)
-	}
-	if err := store.Complete(t.Context(), run.ID, protocol.Completion{InstanceID: "worker-a", LeaseToken: run.LeaseToken, State: "succeeded"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := store.Close(); err != nil {
-		t.Fatal(err)
-	}
-	store, err = OpenStore(database)
-	if err != nil {
-		t.Fatal(err)
-	}
-	store.now = clock.Now
-
-	schedule.Repository = "web"
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedule); err != nil || !created {
-		t.Fatalf("repository change rescheduled = %t, %v", created, err)
-	}
-	run, err = store.Poll(t.Context(), pollRequest("worker-b", []string{"codex"}, []string{"web"}))
-	if err != nil || run == nil {
-		t.Fatalf("lease changed repository schedule = %#v, %v", run, err)
-	}
-	if err := store.Complete(t.Context(), run.ID, protocol.Completion{InstanceID: "worker-b", LeaseToken: run.LeaseToken, State: "succeeded"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := store.Close(); err != nil {
-		t.Fatal(err)
-	}
-	store, err = OpenStore(database)
-	if err != nil {
-		t.Fatal(err)
-	}
-	store.now = clock.Now
-
-	schedule.Every = 10 * time.Minute
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedule); err != nil || !created {
-		t.Fatalf("interval change rescheduled = %t, %v", created, err)
-	}
-	run, err = store.Poll(t.Context(), pollRequest("worker-c", []string{"codex"}, []string{"web"}))
-	if err != nil || run == nil {
-		t.Fatalf("lease interval-changed schedule = %#v, %v", run, err)
-	}
-	if err := store.Complete(t.Context(), run.ID, protocol.Completion{InstanceID: "worker-c", LeaseToken: run.LeaseToken, State: "succeeded"}); err != nil {
-		t.Fatal(err)
-	}
-	if err := store.Close(); err != nil {
-		t.Fatal(err)
-	}
-	store, err = OpenStore(database)
-	if err != nil {
-		t.Fatal(err)
-	}
-	store.now = clock.Now
-
-	schedule.MaxActions = 4
-	schedule.Prompt = "Run Shepherd with max_actions=4"
-	schedule.Command = testAgent("shepherd", "Updated policy; at most 4 actions")
-	schedule.Command.Timeout = 2 * time.Minute
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedule); err != nil || !created {
-		t.Fatalf("execution settings change rescheduled = %t, %v", created, err)
-	}
-	run, err = store.Poll(t.Context(), pollRequest("worker-d", []string{"codex"}, []string{"web"}))
-	if err != nil || run == nil || run.RenderedPrompt != schedule.Command.Prompt || run.TimeoutMillis != schedule.Command.Timeout.Milliseconds() {
-		t.Fatalf("lease execution-settings schedule = %#v, %v", run, err)
-	}
-}
-
-func TestStorePersistsShepherdScheduleAcrossRestart(t *testing.T) {
-	database := filepath.Join(t.TempDir(), "machinist.db")
-	clock := newTestClock(time.Date(2026, 8, 27, 8, 0, 0, 0, time.UTC))
-	schedule := config.ResolvedShepherdSchedule{
-		Name: "api", Repository: "api", Every: time.Hour, MaxActions: 1,
-		Command: testAgent("shepherd", "Inspect every pull request; at most 1 action."),
-	}
-	store, err := OpenStore(database)
-	if err != nil {
-		t.Fatal(err)
-	}
-	store.now = clock.Now
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedule); err != nil || !created {
-		t.Fatalf("initial schedule created = %t, %v", created, err)
-	}
-	if err := store.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	reopened, err := OpenStore(database)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = reopened.Close() })
-	reopened.now = clock.Now
-	if _, created, err := reopened.CreateScheduledJob(t.Context(), schedule); err != nil || created {
-		t.Fatalf("restart repeated schedule = %t, %v", created, err)
-	}
-}
-
-func TestShepherdScheduleSignatureCoversExecutionSettings(t *testing.T) {
-	base := config.ResolvedShepherdSchedule{
-		Name: "api", Repository: "api", Every: time.Hour, MaxActions: 1,
-		Prompt:  "Run with max_actions=1",
-		Command: testAgent("shepherd", "Inspect every pull request; at most 1 action."),
-	}
-	want, err := shepherdScheduleSignature(base)
-	if err != nil {
-		t.Fatal(err)
-	}
-	variants := map[string]func(*config.ResolvedShepherdSchedule){
-		"max actions":     func(schedule *config.ResolvedShepherdSchedule) { schedule.MaxActions = 2 },
-		"schedule prompt": func(schedule *config.ResolvedShepherdSchedule) { schedule.Prompt = "Run with max_actions=2" },
-		"agent prompt":    func(schedule *config.ResolvedShepherdSchedule) { schedule.Command.Prompt = "Updated queue policy" },
-		"executor":        func(schedule *config.ResolvedShepherdSchedule) { schedule.Command.Executor = "claude" },
-		"model":           func(schedule *config.ResolvedShepherdSchedule) { schedule.Command.Model = "sol" },
-		"timeout":         func(schedule *config.ResolvedShepherdSchedule) { schedule.Command.Timeout = 2 * time.Hour },
-	}
-	for name, change := range variants {
-		t.Run(name, func(t *testing.T) {
-			changed := base
-			change(&changed)
-			got, err := shepherdScheduleSignature(changed)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got == want {
-				t.Fatal("execution setting did not change schedule signature")
-			}
-		})
-	}
-}
-
 func TestStoreSyncsDurableTriggerStateAcrossRestartAndConfigurationChanges(t *testing.T) {
 	database := filepath.Join(t.TempDir(), "machinist.db")
 	clock := newTestClock(time.Date(2026, time.August, 27, 9, 0, 0, 0, time.UTC))
@@ -1277,5 +1080,45 @@ func assertReclaimedRun(t *testing.T, store *Store, runID, jobID string) {
 	}
 	if jobState != "running" {
 		t.Fatalf("job state = %q, want running", jobState)
+	}
+}
+
+func TestOpenStoreUpgradesVersionOneSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "machinist.db")
+	legacy, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.Exec(`CREATE TABLE jobs (id TEXT PRIMARY KEY, prompt TEXT NOT NULL, repository TEXT NOT NULL, command TEXT NOT NULL,
+ schedule_name TEXT NOT NULL DEFAULT '', has_shepherd INTEGER NOT NULL DEFAULT 0,
+ trigger_identity TEXT NOT NULL DEFAULT '', trigger_config_signature TEXT NOT NULL DEFAULT '',
+ trigger_generation_id TEXT NOT NULL DEFAULT '', occurrence_key TEXT NOT NULL DEFAULT '',
+ trigger_subject TEXT NOT NULL DEFAULT '', github_issue_title TEXT NOT NULL DEFAULT '',
+ fixed_trigger INTEGER NOT NULL DEFAULT 0, state TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+CREATE UNIQUE INDEX jobs_active_shepherd_repository ON jobs(repository) WHERE has_shepherd=1 AND state IN ('queued','running');
+CREATE TABLE schedule_state (name TEXT PRIMARY KEY, next_run_at TEXT NOT NULL);
+INSERT INTO jobs(id,prompt,repository,command,schedule_name,has_shepherd,state,created_at,updated_at) VALUES('job_1','p','api','shepherd','api',1,'succeeded','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z');
+PRAGMA user_version=1;`); err != nil {
+		t.Fatal(err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	var version int
+	if err := store.db.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil || version != 2 {
+		t.Fatalf("schema version = %d, %v, want 2", version, err)
+	}
+	var columns int
+	if err := store.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('jobs') WHERE name IN ('has_shepherd','schedule_name')`).Scan(&columns); err != nil || columns != 0 {
+		t.Fatalf("legacy columns = %d, %v, want 0", columns, err)
+	}
+	snapshot, err := store.Snapshot(t.Context())
+	if err != nil || len(snapshot.Jobs) != 1 || snapshot.Jobs[0].ID != "job_1" {
+		t.Fatalf("snapshot = %#v, %v", snapshot, err)
 	}
 }

--- a/internal/managedworker/worker_test.go
+++ b/internal/managedworker/worker_test.go
@@ -107,7 +107,7 @@ func TestManagedWorkerExecutesControlPlaneRun(t *testing.T) {
 	}
 }
 
-func TestScheduledShepherdExecutesInDisposableRepository(t *testing.T) {
+func TestManagedWorkerExecutesQueuedShepherdCommand(t *testing.T) {
 	directory := t.TempDir()
 	repository := filepath.Join(directory, "repository")
 	if output, err := exec.Command("git", "init", "--quiet", repository).CombinedOutput(); err != nil {
@@ -121,26 +121,25 @@ func TestScheduledShepherdExecutesInDisposableRepository(t *testing.T) {
 executor = "test"
 prompt_file = "shepherd.md"
 timeout = "5s"
-
-[shepherd.disposable]
-repository = "disposable"
-every = "1m"
-max_actions = 2
 `
 	if err := os.WriteFile(definitionPath, []byte(definition), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	schedules, err := config.LoadShepherdSchedules(definitionPath)
-	if err != nil || len(schedules) != 1 {
-		t.Fatalf("schedules = %#v, %v", schedules, err)
+	command, err := config.LoadCommand(definitionPath, "shepherd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	command, err = config.RenderPrompt(command, "Perform at most 2 mutating actions in this run.")
+	if err != nil {
+		t.Fatal(err)
 	}
 	store, err := controlplane.OpenStore(filepath.Join(directory, "machinist.db"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer store.Close()
-	if _, created, err := store.CreateScheduledJob(t.Context(), schedules[0]); err != nil || !created {
-		t.Fatalf("scheduled job created = %t, %v", created, err)
+	if _, err := store.CreateJob(t.Context(), "queued shepherd", "disposable", "shepherd", command); err != nil {
+		t.Fatal(err)
 	}
 	server, err := controlplane.NewServer(store, definitionPath, "secret", 0)
 	if err != nil {
@@ -173,13 +172,13 @@ max_actions = 2
 			t.Fatal(err)
 		}
 		if len(snapshot.Jobs) == 1 && snapshot.Jobs[0].State == "succeeded" {
-			if snapshot.Jobs[0].ScheduleName != "disposable" || snapshot.Jobs[0].Runs[0].Command != "shepherd" {
-				t.Fatalf("scheduled job = %#v", snapshot.Jobs[0])
+			if snapshot.Jobs[0].Runs[0].Command != "shepherd" {
+				t.Fatalf("queued job = %#v", snapshot.Jobs[0])
 			}
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("scheduled job did not complete: %#v", snapshot.Jobs)
+			t.Fatalf("queued job did not complete: %#v", snapshot.Jobs)
 		}
 		time.Sleep(25 * time.Millisecond)
 	}


### PR DESCRIPTION
Shepherd schedules (`[shepherd.NAME]`) were a second scheduling system next to triggers. A `[triggers.cron.NAME]` or `[triggers.interval.NAME]` trigger that selects the `shepherd` command covers the same use, so this removes the schedule path end to end.

**Removed**
- `[shepherd.*]` config section, `LoadShepherdSchedules`, and the resolved schedule types
- The CLI guard that refused to run a scheduled Shepherd directly
- The server's schedule enqueue loop and `Store.CreateScheduledJob`
- The `schedule_state` table, `jobs_active_shepherd_repository` index, and the `has_shepherd` and `schedule_name` columns
- The rule that triggers cannot select the shepherd command

**Migration**
- Database schema version bumps 1 → 2. Version 1 databases upgrade in place: the index and table are dropped and the two columns removed; job rows are kept. Covered by `TestOpenStoreUpgradesVersionOneSchema`.
- A config that still defines `[shepherd.*]` fails to load with a message pointing at triggers.
- `examples/config.toml` shows a commented cron trigger instead of the old schedule.

13 files, +103 / -695. `go vet` and `go test ./...` pass.

https://claude.ai/code/session_01YSTU7k537QJE2EE3aTc3L9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shepherd commands can now run directly and through configured cron or interval triggers.
  * Added support for repository-mapped Shepherd cron trigger configuration.

* **Breaking Changes**
  * Legacy Shepherd schedule sections are no longer supported; use cron or interval triggers instead.
  * Existing Shepherd scheduling state is migrated and removed from local databases.

* **Documentation**
  * Updated configuration and smoke-test guidance for the new trigger behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->