### PR TITLE
docs(examples): add Python pull request feedback loop workflow

### DIFF
--- a/examples/pr_feedback_loop_test.go
+++ b/examples/pr_feedback_loop_test.go
@@ -1,0 +1,111 @@
+package examples
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPRFeedbackLoopAddressesOneRoundThenStopsOnApproval runs the Python example
+// against a local bare remote, a fake gh that reports one review thread and then an
+// approval, and a fake agent that commits a file each time it is asked.
+func TestPRFeedbackLoopAddressesOneRoundThenStopsOnApproval(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 is not installed")
+	}
+	directory := t.TempDir()
+	remote := filepath.Join(directory, "remote.git")
+	repository := filepath.Join(directory, "repository")
+	bin := filepath.Join(directory, "bin")
+	state := filepath.Join(directory, "gh-calls")
+	for _, args := range [][]string{
+		{"init", "--quiet", "--bare", "--initial-branch=main", remote},
+		{"init", "--quiet", "--initial-branch=main", repository},
+		{"-C", repository, "config", "user.email", "test@example.com"},
+		{"-C", repository, "config", "user.name", "Test"},
+		{"-C", repository, "commit", "--quiet", "--allow-empty", "-m", "initial"},
+		{"-C", repository, "remote", "add", "origin", remote},
+		{"-C", repository, "push", "--quiet", "-u", "origin", "main"},
+	} {
+		if output, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, output)
+		}
+	}
+	if err := os.Mkdir(bin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// The fake gh answers by subcommand. GraphQL answers change with each call so the
+	// first round carries a fresh review thread and the second an approval.
+	gh := `#!/bin/sh
+case "$1 $2" in
+"repo view") printf '{"nameWithOwner":"owner/repo","defaultBranchRef":{"name":"main"}}\n' ;;
+"api user") printf '{"login":"bot"}\n' ;;
+"pr create") printf 'https://github.com/owner/repo/pull/7\n' ;;
+"pr checks") printf '[{"name":"tests","bucket":"pass","link":""}]\n' ;;
+"api graphql")
+  count=0; [ ! -f "$GH_STATE" ] || count=$(cat "$GH_STATE"); count=$((count + 1)); printf '%s' "$count" > "$GH_STATE"
+  if [ "$count" -eq 1 ]; then
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false,"isOutdated":false,"path":"main.go","line":3,"comments":{"nodes":[{"author":{"login":"reviewer"},"body":"Handle the empty case","createdAt":"2999-01-01T00:00:00Z","url":"https://github.com/owner/repo/pull/7#r1"}]}}]},"reviews":{"nodes":[]}}}}}'
+  else
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]},"reviews":{"nodes":[{"author":{"login":"reviewer"},"state":"APPROVED","submittedAt":"2999-01-01T00:00:00Z"}]}}}}}'
+  fi ;;
+*) printf 'unexpected gh %s\n' "$*" >&2; exit 9 ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte(gh), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	agent := `#!/bin/sh
+prompt=$(cat)
+printf '%s\n' "$prompt" >> "$AGENT_LOG"
+printf 'change\n' >> main.go
+git add main.go && git commit --quiet -m "agent change"
+`
+	agentPath := filepath.Join(bin, "agent")
+	if err := os.WriteFile(agentPath, []byte(agent), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	script, err := filepath.Abs(filepath.Join("workflows", "pr-feedback-loop", "pr_feedback_loop.py"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	agentLog := filepath.Join(directory, "agent.log")
+	command := exec.Command(python, script)
+	command.Dir = repository
+	command.Stdin = bytes.NewBufferString("Add a --json flag")
+	command.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"GH_STATE="+state,
+		"AGENT_LOG="+agentLog,
+		"MACHINIST_AGENT_COMMAND="+agentPath,
+		"MACHINIST_BASE_BRANCH=main",
+		"MACHINIST_MAX_ROUNDS=2",
+		"MACHINIST_FEEDBACK_WAIT=0",
+		"MACHINIST_POLL_INTERVAL=0",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("feedback loop: %v: %s", err, output)
+	}
+	text := string(output)
+	for _, want := range []string{"opened https://github.com/owner/repo/pull/7", "address feedback: round 1/2", "approved with green checks"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+	prompts, err := os.ReadFile(agentLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(prompts), "Add a --json flag") != 2 || !strings.Contains(string(prompts), "Handle the empty case") {
+		t.Fatalf("agent prompts = %s", prompts)
+	}
+	pushed, err := exec.Command("git", "-C", remote, "log", "--oneline", "--all").Output()
+	if err != nil || strings.Count(string(pushed), "agent change") != 2 {
+		t.Fatalf("remote log = %s, %v", pushed, err)
+	}
+}

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -4,7 +4,8 @@ These examples keep orchestration in repository-owned scripts. Configure each sc
 approved executor in `worker.toml`, then select its command with `--command`.
 
 - `multi-review` runs two agent CLIs in order with `set -e` behavior.
-- `review-loop` implements a bounded implement, wait, and repair loop.
+- `review-loop` implements a bounded implement, wait, and repair loop in shell.
+- `pr-feedback-loop` opens a pull request and answers its reviewers in bounded rounds, in Python.
 
 Stages are visible only through logs. Timeout or cancellation kills the script process tree.
 A new run starts from the beginning unless the script implements its own checkpointing.

--- a/examples/workflows/pr-feedback-loop/README.md
+++ b/examples/workflows/pr-feedback-loop/README.md
@@ -1,0 +1,51 @@
+# Pull request feedback loop
+
+One script takes a task from implementation to a pull request that has answered its
+reviewers. The script owns git and GitHub. The agent owns the code.
+
+1. Create a branch and ask the agent to implement the task, have a fresh subagent review
+   the diff, run the tests, and commit.
+2. Push and open the pull request with `gh pr create --fill`.
+3. Wait for feedback. Feedback is anything newer than the last push: an unresolved review
+   thread with a new comment, a review that requests changes, or a failing check on the
+   current head.
+4. Hand the feedback to the agent, which fixes it, replies in each thread, and commits.
+5. Push and go back to step 3, at most `MACHINIST_MAX_ROUNDS` times.
+
+The loop ends with exit 0 when the pull request is approved with green checks, or when no
+new feedback arrives within `MACHINIST_FEEDBACK_WAIT` seconds, or when the agent decides
+nothing needs to change. It ends with exit 1 when feedback is still open after the last
+round. The last push is the only cursor, so the script keeps no state on disk and a rerun
+starts from a fresh branch.
+
+## Set up
+
+Copy `pr_feedback_loop.py` into the repository Machinist will run, for example as
+`scripts/pr_feedback_loop.py`, and add the executor to `worker.toml`:
+
+```toml
+[executors.pr-feedback-loop-script]
+command = ["python3", "./scripts/pr_feedback_loop.py"]
+```
+
+You need Python 3.10 or newer, and authenticated `git`, `gh`, and `codex` commands. Set
+`MACHINIST_AGENT_COMMAND` to use a different agent, for example
+`claude -p --output-format stream-json --verbose`.
+
+## Run it
+
+```sh
+machinist run \
+  --machinist-config=/path/to/machinist/examples/workflows/pr-feedback-loop/config.toml \
+  --command=pr-feedback-loop \
+  --repo=/path/to/repo \
+  --prompt="Add a --json flag to the status command"
+```
+
+Or queue it through the control plane with `machinist submit`, or select it from a trigger.
+
+## Limits
+
+Machinist sees only the script's output and exit code. A timeout or cancellation kills the
+script and the agent underneath it. The script never resolves review threads and never
+merges; those stay with people.

--- a/examples/workflows/pr-feedback-loop/config.toml
+++ b/examples/workflows/pr-feedback-loop/config.toml
@@ -1,0 +1,3 @@
+[commands.pr-feedback-loop]
+executor = "pr-feedback-loop-script"
+timeout = "4h"

--- a/examples/workflows/pr-feedback-loop/pr_feedback_loop.py
+++ b/examples/workflows/pr-feedback-loop/pr_feedback_loop.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Implement a task, open a pull request, then address review feedback in bounded rounds.
+
+Machinist writes the task on standard input. The script owns git and GitHub
+mechanics; the coding agent owns the code. Each round it waits for feedback on
+the pull request, hands that feedback to the agent, and pushes the result.
+
+Feedback is anything newer than the last push: unresolved review threads with a
+new comment, reviews that request changes, or failing checks on the current head.
+That makes the last push the only cursor, so the script keeps no state on disk.
+
+Environment:
+  MACHINIST_AGENT_COMMAND   agent command that reads the prompt on stdin
+                            (default: "codex exec --json -")
+  MACHINIST_MAX_ROUNDS      feedback rounds before giving up (default: 3)
+  MACHINIST_FEEDBACK_WAIT   seconds to wait for feedback per round (default: 1800)
+  MACHINIST_POLL_INTERVAL   seconds between GitHub polls (default: 60)
+  MACHINIST_BASE_BRANCH     pull request base (default: repository default branch)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+AGENT_COMMAND = shlex.split(os.environ.get("MACHINIST_AGENT_COMMAND", "codex exec --json -"))
+MAX_ROUNDS = int(os.environ.get("MACHINIST_MAX_ROUNDS", "3"))
+FEEDBACK_WAIT = int(os.environ.get("MACHINIST_FEEDBACK_WAIT", "1800"))
+POLL_INTERVAL = int(os.environ.get("MACHINIST_POLL_INTERVAL", "60"))
+
+IMPLEMENT_PROMPT = """You are working in a Git repository on branch {branch}.
+
+Task:
+{task}
+
+Do this in order:
+1. Implement the task. Keep the change focused.
+2. Ask a fresh subagent to review the diff against the task for correctness,
+   missing tests, and anything a careful reviewer would flag. Fix what it finds.
+3. Run the repository's tests and linters. Fix failures.
+4. Commit with a clear message. Do not push and do not open a pull request.
+
+If the task cannot be completed, explain why and exit non-zero.
+"""
+
+FEEDBACK_PROMPT = """You are working in a Git repository on branch {branch}, which has an open
+pull request: {url}
+
+Original task:
+{task}
+
+Reviewers left feedback since your last push. Address every item below.
+For each review thread, reply in the thread with what you changed, or explain
+why no change is needed. Use `gh api` for replies; do not resolve threads.
+
+{feedback}
+
+Then run the tests, commit, and stop. Do not push.
+"""
+
+
+@dataclass
+class Feedback:
+    threads: list[dict] = field(default_factory=list)
+    changes_requested: list[str] = field(default_factory=list)
+    failing_checks: list[dict] = field(default_factory=list)
+    approved: bool = False
+    checks_pending: bool = False
+
+    def actionable(self) -> bool:
+        return bool(self.threads or self.changes_requested or self.failing_checks)
+
+
+def log(message: str) -> None:
+    print(f"pr-feedback-loop: {message}", flush=True)
+
+
+def run(args: list[str], stdin: str | None = None, check: bool = True) -> str:
+    result = subprocess.run(args, input=stdin, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"{' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def gh_json(args: list[str]) -> dict | list:
+    return json.loads(run(["gh", *args]))
+
+
+def agent(prompt: str) -> None:
+    # The agent's own output streams straight to Machinist's event log.
+    completed = subprocess.run(AGENT_COMMAND, input=prompt, text=True)
+    if completed.returncode != 0:
+        raise RuntimeError(f"agent exited with status {completed.returncode}")
+
+
+def slugify(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug[:40] or "task"
+
+
+def parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def repository() -> str:
+    return gh_json(["repo", "view", "--json", "nameWithOwner"])["nameWithOwner"]
+
+
+def base_branch() -> str:
+    return os.environ.get("MACHINIST_BASE_BRANCH") or gh_json(
+        ["repo", "view", "--json", "defaultBranchRef"]
+    )["defaultBranchRef"]["name"]
+
+
+def current_login() -> str:
+    return gh_json(["api", "user"])["login"]
+
+
+def create_branch(task: str) -> str:
+    branch = f"machinist/{slugify(task)}-{int(time.time())}"
+    run(["git", "checkout", "-q", "-b", branch])
+    return branch
+
+
+def head_sha() -> str:
+    return run(["git", "rev-parse", "HEAD"]).strip()
+
+
+def push(branch: str) -> datetime:
+    run(["git", "push", "-q", "-u", "origin", branch])
+    return datetime.now(timezone.utc)
+
+
+def open_pull_request(branch: str, base: str) -> str:
+    output = run(["gh", "pr", "create", "--fill", "--base", base, "--head", branch])
+    url = output.strip().splitlines()[-1]
+    if not url.startswith("https://"):
+        raise RuntimeError(f"could not find pull request URL in: {output}")
+    return url
+
+
+def has_new_commits(base: str) -> bool:
+    return run(["git", "rev-list", "--count", f"origin/{base}..HEAD"]).strip() != "0"
+
+
+def collect_feedback(repo: str, number: int, since: datetime, me: str) -> Feedback:
+    owner, name = repo.split("/")
+    query = """
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(last: 100) {
+            nodes {
+              isResolved isOutdated path line
+              comments(first: 50) { nodes { author { login } body createdAt url } }
+            }
+          }
+          reviews(last: 50) { nodes { author { login } state submittedAt } }
+        }
+      }
+    }
+    """
+    data = gh_json([
+        "api", "graphql", "-f", f"query={query}",
+        "-F", f"owner={owner}", "-F", f"name={name}", "-F", f"number={number}",
+    ])
+    pull = data["data"]["repository"]["pullRequest"]
+    feedback = Feedback()
+
+    for thread in pull["reviewThreads"]["nodes"]:
+        if thread["isResolved"]:
+            continue
+        comments = [
+            c for c in thread["comments"]["nodes"]
+            if c["author"]["login"] != me and parse_time(c["createdAt"]) > since
+        ]
+        if comments:
+            feedback.threads.append({"path": thread["path"], "line": thread["line"], "comments": comments})
+
+    latest: dict[str, dict] = {}
+    for review in pull["reviews"]["nodes"]:
+        login = review["author"]["login"]
+        if login == me or review["state"] not in ("APPROVED", "CHANGES_REQUESTED"):
+            continue
+        if login not in latest or review["submittedAt"] > latest[login]["submittedAt"]:
+            latest[login] = review
+    for login, review in latest.items():
+        if review["state"] == "CHANGES_REQUESTED" and parse_time(review["submittedAt"]) > since:
+            feedback.changes_requested.append(login)
+    feedback.approved = any(r["state"] == "APPROVED" for r in latest.values()) and not any(
+        r["state"] == "CHANGES_REQUESTED" for r in latest.values()
+    )
+
+    for check in gh_json(["pr", "checks", str(number), "--json", "name,bucket,link"]):
+        if check["bucket"] == "fail":
+            feedback.failing_checks.append(check)
+        elif check["bucket"] == "pending":
+            feedback.checks_pending = True
+    return feedback
+
+
+def wait_for_feedback(repo: str, number: int, since: datetime, me: str) -> Feedback:
+    deadline = time.monotonic() + FEEDBACK_WAIT
+    while True:
+        feedback = collect_feedback(repo, number, since, me)
+        if feedback.actionable():
+            return feedback
+        if feedback.approved and not feedback.checks_pending:
+            return feedback
+        if time.monotonic() >= deadline:
+            return feedback
+        time.sleep(POLL_INTERVAL)
+
+
+def describe(feedback: Feedback) -> str:
+    lines: list[str] = []
+    for check in feedback.failing_checks:
+        lines.append(f"- Failing check: {check['name']} ({check['link']})")
+    for login in feedback.changes_requested:
+        lines.append(f"- {login} requested changes")
+    for thread in feedback.threads:
+        location = f"{thread['path']}:{thread['line']}" if thread["line"] else thread["path"]
+        lines.append(f"- Review thread at {location} ({thread['comments'][0]['url']})")
+        for comment in thread["comments"]:
+            body = comment["body"].strip().replace("\n", "\n    ")
+            lines.append(f"  {comment['author']['login']} wrote:\n    {body}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    task = sys.stdin.read().strip()
+    if not task:
+        log("task is required on standard input")
+        return 2
+
+    repo = repository()
+    base = base_branch()
+    me = current_login()
+    run(["git", "fetch", "-q", "origin", base])
+    branch = create_branch(task)
+
+    log(f"implement on {branch}")
+    agent(IMPLEMENT_PROMPT.format(branch=branch, task=task))
+    if not has_new_commits(base):
+        log("agent produced no commits")
+        return 1
+    since = push(branch)
+    url = open_pull_request(branch, base)
+    number = int(url.rstrip("/").rsplit("/", 1)[-1])
+    log(f"opened {url}")
+
+    for round_number in range(1, MAX_ROUNDS + 1):
+        log(f"wait for feedback: round {round_number}/{MAX_ROUNDS}")
+        feedback = wait_for_feedback(repo, number, since, me)
+        if not feedback.actionable():
+            if feedback.approved:
+                log("pull request approved with green checks")
+            else:
+                log("no new feedback; leaving the pull request for people")
+            return 0
+        log(f"address feedback: round {round_number}/{MAX_ROUNDS}")
+        agent(FEEDBACK_PROMPT.format(branch=branch, url=url, task=task, feedback=describe(feedback)))
+        if head_sha() == run(["git", "rev-parse", f"origin/{branch}"]).strip():
+            log("agent made no changes; leaving the pull request for people")
+            return 0
+        since = push(branch)
+
+    log(f"feedback still open after {MAX_ROUNDS} rounds")
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except RuntimeError as error:
+        log(str(error))
+        sys.exit(1)


### PR DESCRIPTION
Adds `examples/workflows/pr-feedback-loop`, a Python script workflow for review:

1. Create a branch and ask the agent to implement the task, review its own diff with a fresh subagent, run tests, and commit.
2. Push and open the pull request with `gh pr create --fill`.
3. Wait for feedback: unresolved review threads with a comment newer than the last push, reviews requesting changes since the last push, or failing checks on the current head.
4. Hand the feedback to the agent, which fixes it, replies in each thread, and commits.
5. Push and repeat, at most `MACHINIST_MAX_ROUNDS` times.

The last push is the only cursor, so there is no state file. The script never resolves threads or merges. Exit 0 on approval with green checks, on no new feedback within the wait, or when the agent changes nothing. Exit 1 when feedback is still open after the last round.

Stdlib only, Python 3.10+. Agent command is configurable through `MACHINIST_AGENT_COMMAND`. Covered by an end-to-end Go test using a local bare remote, a fake `gh`, and a fake agent.

https://claude.ai/code/session_01YSTU7k537QJE2EE3aTc3L9