### PR TITLE
test(runner): stabilize Claude timeout fallback

### DIFF
--- a/internal/runner/claude_usage_test.go
+++ b/internal/runner/claude_usage_test.go
@@ -209,7 +209,7 @@ func TestExecuteUsesClaudeFileFallbackForExplicitText(t *testing.T) {
 }
 
 func TestExecuteUsesClaudeFileFallbackForExplicitTextAfterTimeout(t *testing.T) {
-	claude := claudeAgentWithCommand(t, []string{"--print", "--output-format", "text"}, `cat >/dev/null; printf 2468 > "$MACHINIST_TOKEN_USAGE_PATH"; sleep 60`, time.Second)
+	claude := claudeAgentWithCommand(t, []string{"--print", "--output-format", "text"}, `cat >/dev/null; printf 2468 > "$MACHINIST_TOKEN_USAGE_PATH"; sleep 60`, 5*time.Second)
 	result, err := Execute(t.Context(), Options{
 		Command: claude, Repository: newGitRepository(t), DataDirectory: t.TempDir(), Stdout: io.Discard, Stderr: io.Discard,
 	})


### PR DESCRIPTION
Fixes #451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout used by a test involving the Claude agent fallback scenario.
  * Preserved the expected timeout result and exit code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->