### PR TITLE
test(runner): stabilize Claude timeout usage fallback

### DIFF
--- a/internal/runner/claude_usage_test.go
+++ b/internal/runner/claude_usage_test.go
@@ -209,7 +209,7 @@ func TestExecuteUsesClaudeFileFallbackForExplicitText(t *testing.T) {
 }
 
 func TestExecuteUsesClaudeFileFallbackForExplicitTextAfterTimeout(t *testing.T) {
-	claude := claudeAgentWithCommand(t, []string{"--print", "--output-format", "text"}, `cat >/dev/null; printf 2468 > "$MACHINIST_TOKEN_USAGE_PATH"; sleep 60`, time.Second)
+	claude := claudeAgentWithCommand(t, []string{"--print", "--output-format", "text"}, `cat >/dev/null; printf 2468 > "$MACHINIST_TOKEN_USAGE_PATH"; sleep 60`, 5*time.Second)
 	result, err := Execute(t.Context(), Options{
 		Command: claude, Repository: newGitRepository(t), DataDirectory: t.TempDir(), Stdout: io.Discard, Stderr: io.Discard,
 	})

--- a/internal/runner/process_unix.go
+++ b/internal/runner/process_unix.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"runtime"
 	"syscall"
 )
 
@@ -18,10 +19,14 @@ func terminateProcessTree(process *os.Process) error {
 		return nil
 	}
 	err := syscall.Kill(-process.Pid, syscall.SIGKILL)
-	if errors.Is(err, syscall.ESRCH) {
+	if ignorableProcessTreeTerminationError(err) {
 		return nil
 	}
 	return err
+}
+
+func ignorableProcessTreeTerminationError(err error) bool {
+	return errors.Is(err, syscall.ESRCH) || runtime.GOOS == "darwin" && errors.Is(err, syscall.EPERM)
 }
 
 func processExitCode(state *os.ProcessState) int {

--- a/internal/runner/process_unix.go
+++ b/internal/runner/process_unix.go
@@ -19,14 +19,19 @@ func terminateProcessTree(process *os.Process) error {
 		return nil
 	}
 	err := syscall.Kill(-process.Pid, syscall.SIGKILL)
-	if ignorableProcessTreeTerminationError(err) {
+	if ignorableProcessTreeTerminationError(err, func() error {
+		return syscall.Kill(-process.Pid, 0)
+	}) {
 		return nil
 	}
 	return err
 }
 
-func ignorableProcessTreeTerminationError(err error) bool {
-	return errors.Is(err, syscall.ESRCH) || runtime.GOOS == "darwin" && errors.Is(err, syscall.EPERM)
+func ignorableProcessTreeTerminationError(err error, probeProcessGroup func() error) bool {
+	if errors.Is(err, syscall.ESRCH) {
+		return true
+	}
+	return runtime.GOOS == "darwin" && errors.Is(err, syscall.EPERM) && errors.Is(probeProcessGroup(), syscall.ESRCH)
 }
 
 func processExitCode(state *os.ProcessState) int {

--- a/internal/runner/process_unix_test.go
+++ b/internal/runner/process_unix_test.go
@@ -10,13 +10,33 @@ import (
 )
 
 func TestIgnorableProcessTreeTerminationError(t *testing.T) {
-	if !ignorableProcessTreeTerminationError(syscall.ESRCH) {
+	probeCalled := false
+	probe := func() error {
+		probeCalled = true
+		return nil
+	}
+	if !ignorableProcessTreeTerminationError(syscall.ESRCH, probe) {
 		t.Fatal("ESRCH should be ignored")
 	}
-	if got, want := ignorableProcessTreeTerminationError(syscall.EPERM), runtime.GOOS == "darwin"; got != want {
-		t.Fatalf("EPERM ignored = %t, want %t on %s", got, want, runtime.GOOS)
+	if probeCalled {
+		t.Fatal("ESRCH should not probe the process group")
 	}
-	if ignorableProcessTreeTerminationError(errors.New("unexpected")) {
+	for _, test := range []struct {
+		name     string
+		probeErr error
+		want     bool
+	}{
+		{name: "group gone", probeErr: syscall.ESRCH, want: runtime.GOOS == "darwin"},
+		{name: "group accessible", probeErr: nil},
+		{name: "group inaccessible", probeErr: syscall.EPERM},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := ignorableProcessTreeTerminationError(syscall.EPERM, func() error { return test.probeErr }); got != test.want {
+				t.Fatalf("EPERM ignored = %t, want %t on %s", got, test.want, runtime.GOOS)
+			}
+		})
+	}
+	if ignorableProcessTreeTerminationError(errors.New("unexpected"), probe) {
 		t.Fatal("unexpected error should be preserved")
 	}
 }

--- a/internal/runner/process_unix_test.go
+++ b/internal/runner/process_unix_test.go
@@ -1,0 +1,22 @@
+//go:build darwin || linux
+
+package runner
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func TestIgnorableProcessTreeTerminationError(t *testing.T) {
+	if !ignorableProcessTreeTerminationError(syscall.ESRCH) {
+		t.Fatal("ESRCH should be ignored")
+	}
+	if got, want := ignorableProcessTreeTerminationError(syscall.EPERM), runtime.GOOS == "darwin"; got != want {
+		t.Fatalf("EPERM ignored = %t, want %t on %s", got, want, runtime.GOOS)
+	}
+	if ignorableProcessTreeTerminationError(errors.New("unexpected")) {
+		t.Fatal("unexpected error should be preserved")
+	}
+}


### PR DESCRIPTION
Fixes #451


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout used by a Claude fallback test to improve test reliability while preserving timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->