### PR TITLE
fix(managedworker): continue after stale completion

### DIFF
--- a/internal/managedworker/worker.go
+++ b/internal/managedworker/worker.go
@@ -75,6 +75,11 @@ func (w *Worker) Run(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return nil
 			}
+			var responseErr *ResponseError
+			if errors.As(err, &responseErr) && responseErr.Status == 409 {
+				fmt.Fprintf(w.stderr, "machinist: report run %s: %v\n", run.ID, err)
+				continue
+			}
 			return err
 		}
 	}

--- a/internal/managedworker/worker_test.go
+++ b/internal/managedworker/worker_test.go
@@ -238,6 +238,61 @@ func TestCompletionDoesNotRetryPermanentClientError(t *testing.T) {
 	}
 }
 
+func TestManagedWorkerPollsAgainAfterCompletionConflict(t *testing.T) {
+	var polls atomic.Int32
+	polledAgain := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/api/v1/workers/poll":
+			if polls.Add(1) == 1 {
+				if err := json.NewEncoder(response).Encode(protocol.PollResponse{Run: &protocol.RunSpec{ID: "run-test", LeaseToken: "lease-test"}}); err != nil {
+					t.Errorf("encode poll response: %v", err)
+				}
+				return
+			}
+			close(polledAgain)
+			if err := json.NewEncoder(response).Encode(protocol.PollResponse{}); err != nil {
+				t.Errorf("encode poll response: %v", err)
+			}
+		case "/api/v1/runs/run-test/heartbeat":
+			response.WriteHeader(http.StatusNoContent)
+		case "/api/v1/runs/run-test/complete":
+			http.Error(response, "run lease does not match", http.StatusConflict)
+		default:
+			t.Errorf("unexpected request path %q", request.URL.Path)
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	var stderr strings.Builder
+	worker := &Worker{
+		config:     config.Worker{ControlPlane: config.ControlPlane{URL: server.URL}},
+		instanceID: "worker-test",
+		client:     newClient(server.URL, "secret", server.Client()),
+		stderr:     &stderr,
+		executeRun: func(context.Context, protocol.RunSpec) protocol.Completion {
+			return protocol.Completion{InstanceID: "worker-test", LeaseToken: "lease-test", State: "succeeded"}
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- worker.Run(ctx) }()
+
+	select {
+	case <-polledAgain:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not poll again after completion conflict")
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("worker returned error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "machinist: report run run-test: control plane returned HTTP 409 Conflict") {
+		t.Fatalf("completion conflict was not logged: %q", stderr.String())
+	}
+}
+
 func TestManagedWorkerHeartbeatsDuringExecutionAndContinuesAfterFailure(t *testing.T) {
 	if heartbeatInterval != 10*time.Second {
 		t.Fatalf("heartbeat interval = %v", heartbeatInterval)


### PR DESCRIPTION
## Summary

Log stale completion conflicts and keep the managed worker polling after HTTP 409 responses, preventing one expired or reassigned lease from stopping the worker. Add a regression test proving the worker polls again while the stale completion remains rejected.

## Verification

- `go test ./internal/managedworker`
- `go test -race ./internal/managedworker -run TestManagedWorkerPollsAgainAfterCompletionConflict -count=20`
- `just check`

Fixes #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Managed workers now continue polling for new work when a completion report encounters a conflict.
  - Other completion-reporting errors continue to stop processing as before.

- **Tests**
  - Added coverage confirming that workers re-poll after a completion conflict and log the conflict appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->