### PR TITLE
fix(dev): pin local control plane config

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,7 +9,7 @@ build: frontend
 
 # Start the local control plane.
 control-plane: build
-    ./bin/machinist start
+    ./bin/machinist start --config=examples/config.toml
 
 # Start the local managed worker.
 worker: build
@@ -30,7 +30,7 @@ local: build
     trap cleanup EXIT
     trap 'exit 130' INT TERM
 
-    ./bin/machinist start &
+    ./bin/machinist start --config=examples/config.toml &
     control_plane_pid=$!
     ./bin/machinist worker start &
     worker_pid=$!

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,18 @@ assets allow a direct Go build:
 go build ./...
 ```
 
+## Run locally
+
+Start the control plane and managed worker together:
+
+```sh
+just local
+```
+
+The control plane uses the repository's `examples/config.toml`. The managed
+worker continues to use `~/.machinist/worker.toml` because executors,
+credentials, and repository paths are machine-owned configuration.
+
 ## Verify
 
 Run the complete project check before opening a pull request:


### PR DESCRIPTION
## Summary

- make `just control-plane` load the checked-in `examples/config.toml`
- make the control-plane process in `just local` use the same checked-in config
- document the boundary between repo-owned control-plane config and machine-owned worker config

## Verification

- `just --dry-run control-plane`
- `just --dry-run local`
- `just check`
- real control-plane startup probe using `examples/config.toml`
- independent review: Approve, no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for running the control plane and managed worker together locally with `just local`.
  * Clarified which configuration files are used for the control plane and managed worker.

* **Bug Fixes**
  * Updated local startup commands to consistently use the example control-plane configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->