### PR TITLE
fix: reject malformed control plane URLs

### DIFF
--- a/internal/managedworker/client.go
+++ b/internal/managedworker/client.go
@@ -114,6 +114,9 @@ func controlPlaneEndpoint(raw string) (string, error) {
 	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
 		return "", errors.New("control_plane.url must use http or https")
 	}
+	if endpoint.RawQuery != "" || endpoint.ForceQuery || strings.Contains(raw, "#") {
+		return "", errors.New("control_plane.url must not contain a query or fragment")
+	}
 	if endpoint.Scheme == "http" && !loopbackHost(endpoint.Hostname()) {
 		return "", errors.New("control_plane.url must use https for a non-loopback host")
 	}

--- a/internal/managedworker/worker_test.go
+++ b/internal/managedworker/worker_test.go
@@ -219,6 +219,21 @@ func TestManagedWorkerRequiresHTTPSForRemoteControlPlane(t *testing.T) {
 	}
 }
 
+func TestControlPlaneEndpointRejectsQueryAndFragment(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://control.example.com?tenant=machinist",
+		"https://control.example.com?",
+		"https://control.example.com#api",
+		"https://control.example.com#",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			if _, err := controlPlaneEndpoint(endpoint); err == nil {
+				t.Fatalf("controlPlaneEndpoint(%q) succeeded", endpoint)
+			}
+		})
+	}
+}
+
 func TestCompletionDoesNotRetryPermanentClientError(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

- reject control-plane URLs containing query strings or fragments
- cover populated and empty query and fragment suffixes with a regression test
- prevent API paths from being appended into URL query or fragment content

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

Generated from Codex cloud task `task_e_6a98227b4494832c8f684291b0927553`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Control plane URLs containing query strings, forced queries, or fragments are now rejected with an error instead of being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->