### PR TITLE
Reject query and fragment in control plane URL

### DIFF
--- a/internal/managedworker/client.go
+++ b/internal/managedworker/client.go
@@ -114,6 +114,9 @@ func controlPlaneEndpoint(raw string) (string, error) {
 	if endpoint.Scheme != "http" && endpoint.Scheme != "https" {
 		return "", errors.New("control_plane.url must use http or https")
 	}
+	if endpoint.RawQuery != "" || endpoint.ForceQuery || strings.Contains(raw, "#") {
+		return "", errors.New("control_plane.url must not contain a query or fragment")
+	}
 	if endpoint.Scheme == "http" && !loopbackHost(endpoint.Hostname()) {
 		return "", errors.New("control_plane.url must use https for a non-loopback host")
 	}

--- a/internal/managedworker/worker_test.go
+++ b/internal/managedworker/worker_test.go
@@ -219,6 +219,21 @@ func TestManagedWorkerRequiresHTTPSForRemoteControlPlane(t *testing.T) {
 	}
 }
 
+func TestControlPlaneEndpointRejectsQueryAndFragment(t *testing.T) {
+	for _, endpoint := range []string{
+		"https://control.example.com?tenant=machinist",
+		"https://control.example.com?",
+		"https://control.example.com#api",
+		"https://control.example.com#",
+	} {
+		t.Run(endpoint, func(t *testing.T) {
+			if _, err := controlPlaneEndpoint(endpoint); err == nil {
+				t.Fatalf("controlPlaneEndpoint(%q) succeeded", endpoint)
+			}
+		})
+	}
+}
+
 func TestCompletionDoesNotRetryPermanentClientError(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
### Motivation

- The control-plane URL validator allowed URLs with query strings or fragments, which could cause appended API paths to be interpreted incorrectly and send requests to the wrong endpoint.  

### Description

- Reject query strings and fragments in `controlPlaneEndpoint` by returning an error when `endpoint.RawQuery`, `endpoint.ForceQuery`, or a `#` fragment is present.  
- Add a focused regression test `TestControlPlaneEndpointRejectsQueryAndFragment` in `internal/managedworker/worker_test.go` that covers populated and empty `?` and `#` variants.  
- Modified files: `internal/managedworker/client.go` and `internal/managedworker/worker_test.go`.

### Testing

- Ran the new test with `go test ./internal/managedworker -run TestControlPlaneEndpointRejectsQueryAndFragment -count=1` and it failed before the fix and passes after the change.  
- Verified full test suite with `go test ./...` and static checks with `go vet ./...`, both succeeded.  
- Confirmed repository state with `git diff --check` and `git status --short` after committing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a98227b4494832c8f684291b0927553)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Control-plane URLs containing query parameters or fragments are now rejected to prevent invalid endpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->