### PR TITLE
feat(controlplane): expose stored run output over HTTP

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -75,6 +75,11 @@ type definitionsResponse struct {
 	Commands []commandDefinitionResponse `json:"commands"`
 }
 
+type runOutputResponse struct {
+	Result json.RawMessage `json:"result,omitempty"`
+	Events string          `json:"events,omitempty"`
+}
+
 type catalogResponse struct {
 	Commands     []string `json:"commands"`
 	Repositories []string `json:"repositories"`
@@ -253,6 +258,7 @@ func (s *Server) routes() (http.Handler, error) {
 	mux.HandleFunc("GET /api/v1/status", s.status)
 	mux.HandleFunc("GET /api/v1/catalog", s.catalog)
 	mux.HandleFunc("GET /api/v1/definitions", s.definitions)
+	mux.HandleFunc("GET /api/v1/runs/{id}/output", s.runOutput)
 	mux.HandleFunc("POST /api/v1/jobs", s.authorizeSubmission(s.submit))
 	mux.HandleFunc("DELETE /api/v1/jobs/{id}", s.authorizeSubmission(s.deleteJob))
 	mux.HandleFunc("POST /api/v1/workers/poll", s.authorizeWorker(s.poll))
@@ -329,6 +335,24 @@ func (s *Server) catalog(response http.ResponseWriter, request *http.Request) {
 		Commands:     definition.CommandNames(),
 		Repositories: repositories,
 	})
+}
+
+func (s *Server) runOutput(response http.ResponseWriter, request *http.Request) {
+	output, err := s.store.RunOutput(request.Context(), request.PathValue("id"))
+	if errors.Is(err, sql.ErrNoRows) {
+		writeError(response, http.StatusNotFound, errors.New("run does not exist"))
+		return
+	}
+	if err != nil {
+		writeError(response, http.StatusInternalServerError, err)
+		return
+	}
+	response.Header().Set("Cache-Control", "no-store")
+	body := runOutputResponse{Events: output.Events}
+	if output.Result != "" {
+		body.Result = json.RawMessage(output.Result)
+	}
+	writeJSON(response, http.StatusOK, body)
 }
 
 func (s *Server) submit(response http.ResponseWriter, request *http.Request) {

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -861,3 +861,51 @@ func deleteRequest(t *testing.T, endpoint string, headers map[string]string) *ht
 	}
 	return response
 }
+
+func TestServerReturnsRunOutputAndNotFoundForUnknownRun(t *testing.T) {
+	server, webServer := newTestHTTPServer(t)
+	defer webServer.Close()
+
+	if _, err := server.store.CreateJob(t.Context(), "request", "machinist", "plan", testAgent("plan", "Plan request")); err != nil {
+		t.Fatal(err)
+	}
+	run, err := server.store.Poll(t.Context(), pollRequest("worker-1", []string{"codex"}, []string{"machinist"}))
+	if err != nil || run == nil {
+		t.Fatalf("poll = %v, %v", run, err)
+	}
+	if err := server.store.Complete(t.Context(), run.ID, protocol.Completion{
+		InstanceID: "worker-1",
+		LeaseToken: run.LeaseToken,
+		State:      "succeeded",
+		ExitCode:   0,
+		Result:     json.RawMessage(`{"state":"succeeded"}`),
+		Events:     "{\"type\":\"run.started\"}\n",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := http.Get(webServer.URL + "/api/v1/runs/" + run.ID + "/output")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	var output runOutputResponse
+	if err := json.NewDecoder(response.Body).Decode(&output); err != nil {
+		t.Fatal(err)
+	}
+	if response.StatusCode != http.StatusOK || response.Header.Get("Cache-Control") != "no-store" {
+		t.Fatalf("status = %d, cache-control = %q", response.StatusCode, response.Header.Get("Cache-Control"))
+	}
+	if string(output.Result) != `{"state":"succeeded"}` || output.Events != "{\"type\":\"run.started\"}\n" {
+		t.Fatalf("output = %#v", output)
+	}
+
+	missing, err := http.Get(webServer.URL + "/api/v1/runs/run_missing/output")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer missing.Body.Close()
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing run status = %d", missing.StatusCode)
+	}
+}


### PR DESCRIPTION
`Store.RunOutput` reads a run's persisted `result` and `events` and is covered by `store_test.go`, but no route reaches it. A completed run keeps its full transcript in the database with no way to read it back — the web UI can show state, exit code, duration and token usage, and cannot show a single line of what the command actually produced.

This adds `GET /api/v1/runs/{id}/output` alongside the other read-only endpoints.

### Behaviour

- Returns the stored result document and the raw events log
- `404` for an unknown run, via `sql.ErrNoRows` from the existing store method
- `Cache-Control: no-store`, matching `/api/v1/catalog`
- An empty `result` column is omitted rather than emitted as invalid JSON

### Notes

- Unauthenticated, consistent with the other `GET` read endpoints (`/status`, `/catalog`, `/definitions`) and the loopback-only listener. Happy to move it behind `authorizeSubmission` if you would rather run output were gated differently from the rest of the read surface.
- Named `/output` rather than `/events` because the response carries both the result document and the log.
- No change to the store, the protocol, or the worker.

`go build ./...`, `go vet ./...`, `gofmt -l .` and `go test ./...` all clean.

Found while building a dashboard on top of a local instance — thanks for a genuinely pleasant codebase to read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve the stored output and event details for a run.
  * Responses omit empty result data and prevent caching for current run output.

* **Bug Fixes**
  * Requests for unknown runs now return a clear 404 Not Found response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->