### PR TITLE
fix(controlplane): reject non-loopback hosts

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -259,7 +259,33 @@ func (s *Server) routes() (http.Handler, error) {
 	mux.HandleFunc("POST /api/v1/runs/{id}/heartbeat", s.authorizeWorker(s.heartbeat))
 	mux.HandleFunc("POST /api/v1/runs/{id}/complete", s.authorizeWorker(s.complete))
 	mux.Handle("/", http.FileServer(http.FS(dist)))
-	return securityHeaders(mux), nil
+	return securityHeaders(requireLoopbackHost(mux)), nil
+}
+
+func requireLoopbackHost(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if !loopbackRequestHost(request.Host) {
+			writeError(response, http.StatusForbidden, errors.New("request host must be loopback"))
+			return
+		}
+		next.ServeHTTP(response, request)
+	})
+}
+
+func loopbackRequestHost(value string) bool {
+	parsed, err := url.Parse("http://" + value)
+	if err != nil || parsed.Host != value || parsed.User != nil || parsed.Hostname() == "" {
+		return false
+	}
+	if strings.Contains(value, ":") && parsed.Port() == "" && !strings.HasSuffix(value, "]") {
+		return false
+	}
+	host := parsed.Hostname()
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func (s *Server) definitions(response http.ResponseWriter, request *http.Request) {

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -80,6 +80,35 @@ func TestServerProtectsSubmissionAndWorkerAPIs(t *testing.T) {
 	}
 }
 
+func TestServerRejectsNonLoopbackRequestHosts(t *testing.T) {
+	server, webServer := newTestHTTPServer(t)
+	defer webServer.Close()
+
+	for _, test := range []struct {
+		name string
+		host string
+		want int
+	}{
+		{name: "IPv4 with port", host: "127.0.0.1:7331", want: http.StatusOK},
+		{name: "IPv6 with port", host: "[::1]:7331", want: http.StatusOK},
+		{name: "localhost", host: "LOCALHOST:7331", want: http.StatusOK},
+		{name: "DNS rebinding host", host: "attacker.example:7331", want: http.StatusForbidden},
+		{name: "non-loopback IP", host: "192.0.2.1:7331", want: http.StatusForbidden},
+		{name: "invalid port", host: "localhost:not-a-port", want: http.StatusForbidden},
+		{name: "malformed host", host: "localhost:invalid:7331", want: http.StatusForbidden},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/api/v1/status", nil)
+			request.Host = test.host
+			response := httptest.NewRecorder()
+			server.Handler().ServeHTTP(response, request)
+			if response.Code != test.want {
+				t.Fatalf("status = %d, want %d", response.Code, test.want)
+			}
+		})
+	}
+}
+
 func TestServerMarksStaleWorkerDisconnected(t *testing.T) {
 	server, webServer := newTestHTTPServer(t)
 	defer webServer.Close()
@@ -446,6 +475,7 @@ func TestSizeLimitedEndpointsRejectOversizedJSON(t *testing.T) {
 	for _, endpoint := range endpoints {
 		t.Run(endpoint.name+"/known content length", func(t *testing.T) {
 			request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, endpoint.path, strings.NewReader("x"))
+			request.Host = "127.0.0.1:7331"
 			request.ContentLength = endpoint.limit + 1
 			request.Header.Set("Authorization", "Bearer secret")
 			response := httptest.NewRecorder()
@@ -460,6 +490,7 @@ func TestSizeLimitedEndpointsRejectOversizedJSON(t *testing.T) {
 			t.Run(endpoint.name+"/"+stage.name, func(t *testing.T) {
 				body := io.MultiReader(strings.NewReader(stage.prefix), io.LimitReader(repeatingByteReader(stage.fill), endpoint.limit+1))
 				request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, endpoint.path, body)
+				request.Host = "127.0.0.1:7331"
 				request.Header.Set("Authorization", "Bearer secret")
 				response := httptest.NewRecorder()
 
@@ -498,6 +529,7 @@ func TestSizeLimitedEndpointsKeepMalformedJSONAtBadRequest(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			request := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, strings.NewReader(`{`))
+			request.Host = "127.0.0.1:7331"
 			request.Header.Set("Authorization", "Bearer secret")
 			response := httptest.NewRecorder()
 


### PR DESCRIPTION
The control plane is deliberately bound to a loopback interface, but it previously accepted any HTTP `Host` header. That left its unauthenticated read endpoints vulnerable to DNS rebinding: a page served from an attacker-controlled hostname could resolve that hostname to the loopback address and read job prompts, errors, repository names, command definitions, and the CSRF token as same-origin data.

This change validates the request authority before routing API requests or serving the embedded frontend. Requests are accepted only when the host is `localhost` or a loopback IP address; IPv4, bracketed IPv6, and optional valid ports are supported. Arbitrary hostnames, non-loopback addresses, and malformed authorities now receive HTTP 403.

The server tests cover both accepted loopback forms and rejected DNS-rebinding-style or malformed hosts. Existing direct-handler tests now set a realistic loopback host, and the full Go test suite passes with `GOFLAGS=-buildvcs=false go test ./...`.

Closes #463.