### PR TITLE
docs: document Python eval checks in development guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -44,13 +44,14 @@ just check
 ```
 
 This installs the locked frontend dependencies, runs frontend tests, rebuilds
-the embedded assets, checks and vets the Go code, runs Go tests with the race
-detector, and builds all Go packages.
+the embedded assets, runs Python eval tests, checks and vets the Go code, runs
+Go tests with the race detector, and builds all Go packages.
 
 Focused commands are also available:
 
 ```sh
 just test
+python3 -m unittest discover -s evals -p 'test_*.py'
 cd internal/controlplane/web && npm test
 go test ./internal/runner
 ```


### PR DESCRIPTION
Document the Python eval tests included in `just check` and add their focused command to the development guide. Only `docs/development.md` changes.

Verification: all 59 Python eval tests and `just check` passed. A fresh read-only subagent approved commit `8e1a37d` with no findings.

Created by a live run of the Python flow script from PR #465.
