### PR TITLE
fix(triggers): honor explicit unit steps in cron fields

### DIFF
--- a/internal/triggers/cron.go
+++ b/internal/triggers/cron.go
@@ -131,7 +131,7 @@ func parseCronField(input, fieldName string, min, max int, named map[string]int,
 		}
 		// In cron syntax, a step on one value means "from this value through
 		// the field maximum" (for example, 5/15 in the minute field).
-		if step > 1 && base != "*" && !strings.Contains(base, "-") {
+		if strings.Contains(item, "/") && base != "*" && !strings.Contains(base, "-") {
 			end = max
 		}
 		for value := start; value <= end; value += step {

--- a/internal/triggers/cron_test.go
+++ b/internal/triggers/cron_test.go
@@ -20,6 +20,65 @@ func TestCronSupportsNamesListsRangesAndSteps(t *testing.T) {
 	}
 }
 
+func TestCronMinuteUnitStepRunsThroughFieldMaximum(t *testing.T) {
+	schedule, err := ParseCron("5/1 * * * *", "UTC")
+	if err != nil {
+		t.Fatal(err)
+	}
+	after := time.Date(2026, time.September, 7, 10, 4, 0, 0, time.UTC)
+	for minute := 5; minute <= 59; minute++ {
+		want := time.Date(2026, time.September, 7, 10, minute, 0, 0, time.UTC)
+		got := schedule.Next(after)
+		if !got.Equal(want) {
+			t.Fatalf("next after %s = %s, want %s", after, got, want)
+		}
+		after = got
+	}
+	if got, want := schedule.Next(after), time.Date(2026, time.September, 7, 11, 5, 0, 0, time.UTC); !got.Equal(want) {
+		t.Fatalf("next hour = %s, want %s", got, want)
+	}
+}
+
+func TestCronDistinguishesSingleValuesFromUnitSteps(t *testing.T) {
+	after := time.Date(2026, time.September, 7, 10, 5, 0, 0, time.UTC) // Monday
+	tests := []struct {
+		name       string
+		expression string
+		want       time.Time
+	}{
+		{"plain minute", "5 * * * *", time.Date(2026, time.September, 7, 11, 5, 0, 0, time.UTC)},
+		{"stepped minute", "5/1 * * * *", time.Date(2026, time.September, 7, 10, 6, 0, 0, time.UTC)},
+		{"plain hour", "0 5 * * *", time.Date(2026, time.September, 8, 5, 0, 0, 0, time.UTC)},
+		{"stepped hour", "0 5/1 * * *", time.Date(2026, time.September, 7, 11, 0, 0, 0, time.UTC)},
+		{"plain day", "0 0 5 * *", time.Date(2026, time.October, 5, 0, 0, 0, 0, time.UTC)},
+		{"stepped day", "0 0 5/1 * *", time.Date(2026, time.September, 8, 0, 0, 0, 0, time.UTC)},
+		{"plain month", "0 0 1 3 *", time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC)},
+		{"stepped month", "0 0 1 3/1 *", time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC)},
+		{"plain named month", "0 0 1 MAR *", time.Date(2027, time.March, 1, 0, 0, 0, 0, time.UTC)},
+		{"stepped named month", "0 0 1 MAR/1 *", time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC)},
+		{"plain weekday", "0 0 * * 1", time.Date(2026, time.September, 14, 0, 0, 0, 0, time.UTC)},
+		{"stepped weekday", "0 0 * * 1/1", time.Date(2026, time.September, 8, 0, 0, 0, 0, time.UTC)},
+		{"plain named weekday", "0 0 * * MON", time.Date(2026, time.September, 14, 0, 0, 0, 0, time.UTC)},
+		{"stepped named weekday", "0 0 * * MON/1", time.Date(2026, time.September, 8, 0, 0, 0, 0, time.UTC)},
+		{"wildcard unit step", "*/1 * * * *", time.Date(2026, time.September, 7, 10, 6, 0, 0, time.UTC)},
+		{"single value range unit step", "5-5/1 * * * *", time.Date(2026, time.September, 7, 11, 5, 0, 0, time.UTC)},
+		{"range unit step", "4-5/1 * * * *", time.Date(2026, time.September, 7, 11, 4, 0, 0, time.UTC)},
+		{"plain value before unit step in list", "5,10/1 * * * *", time.Date(2026, time.September, 7, 10, 10, 0, 0, time.UTC)},
+		{"unit step before plain value in list", "5/1,10 * * * *", time.Date(2026, time.September, 7, 10, 6, 0, 0, time.UTC)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schedule, err := ParseCron(test.expression, "UTC")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := schedule.Next(after); !got.Equal(test.want) {
+				t.Fatalf("next = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
 func TestCronUsesVixieDayOfMonthWeekdayOR(t *testing.T) {
 	schedule, err := ParseCron("0 0 13 * FRI", "UTC")
 	if err != nil {
@@ -71,6 +130,12 @@ func TestParseCronRejectsNonFiveFieldAndUnsafeForms(t *testing.T) {
 		{"0 0 * * *", " UTC ", "IANA"},
 		{"60 0 * * *", "UTC", "between 0 and 59"},
 		{"*/0 0 * * *", "UTC", "positive"},
+		{"5/0 * * * *", "UTC", "positive"},
+		{"5/-1 * * * *", "UTC", "positive"},
+		{"5/nope * * * *", "UTC", "positive"},
+		{"5/ * * * *", "UTC", "invalid step"},
+		{"/1 * * * *", "UTC", "invalid step"},
+		{"5/1/1 * * * *", "UTC", "invalid step"},
 		{"0 0 * DEC-JAN *", "UTC", "must not precede"},
 		{"0 0 31 2 *", "UTC", "no possible occurrence"},
 	}


### PR DESCRIPTION
## Problem

`5/1 * * * *` incorrectly scheduled 11:05 after 10:05 instead of 10:06 because the parser treated an explicit unit step like a plain value. Fixes #472.

## Changes

Recognize an explicitly supplied step when expanding a single value through the field maximum. Add regression coverage for plain values versus `/1` across all five fields, named months and weekdays, minute rollover, lists, ranges, wildcards, and invalid steps.

## Verification

- Reproduced the reported skip and equivalent failures in the other fields with the new tests before applying the fix.
- `go test ./internal/triggers ./internal/config` passed.
- `just check` passed: frontend tests/build, Go formatting, Python tests, `go vet ./...`, `go test -race ./...`, and `go build ./...`.
- `git diff --check` passed; rebuilding the frontend left its tracked bundle unchanged.
- Fresh read-only subagent review: Approve, no findings. Remote CI was not awaited.

## Risks

Single-value `/1` schedules will run more often, as their expressions request. Plain values retain their existing behavior.

- [x] The change is focused and contains no unrelated cleanup.
- [x] Tests and documentation cover changed behavior.
- [x] Logs, fixtures, and screenshots contain no secrets or private repository data.
